### PR TITLE
Vulkan: account for no limit on image count

### DIFF
--- a/piet-gpu-hal/src/vulkan.rs
+++ b/piet-gpu-hal/src/vulkan.rs
@@ -423,7 +423,11 @@ impl VkInstance {
         // Note: can be 2 for non-Android to improve latency, but the real answer is to
         // implement some kind of frame pacing.
         const PREFERRED_IMAGE_COUNT: u32 = 3;
-        let image_count = PREFERRED_IMAGE_COUNT.clamp(capabilities.min_image_count, capabilities.max_image_count);
+        let max_image_count = match capabilities.max_image_count {
+            0 => u32::MAX,
+            x => x,
+        };
+        let image_count = PREFERRED_IMAGE_COUNT.clamp(capabilities.min_image_count, max_image_count);
         let mut extent = capabilities.current_extent;
         if extent.width == u32::MAX || extent.height == u32::MAX {
             // We're deciding the size.


### PR DESCRIPTION
When clamping image count within device bounds, some devices can report max_image_count = 0 to indicate no upper limit. This triggers assertion in clamp because max < min, so we treat 0 as `u32::MAX`.

see https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSurfaceCapabilitiesKHR.html