### PR TITLE
Don't encode anything for "empty" brushes

### DIFF
--- a/piet-wgsl/src/util.rs
+++ b/piet-wgsl/src/util.rs
@@ -57,18 +57,7 @@ impl RenderContext {
     where
         W: HasRawWindowHandle + HasRawDisplayHandle,
     {
-        let surface = unsafe { self.instance.create_surface(window) };
-        let format = wgpu::TextureFormat::Bgra8Unorm;
-        let config = wgpu::SurfaceConfiguration {
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-            format,
-            width,
-            height,
-            present_mode: wgpu::PresentMode::Fifo,
-            alpha_mode: wgpu::CompositeAlphaMode::Auto,
-        };
-        surface.configure(&self.device, &config);
-        RenderSurface { surface, config }
+        self.create_surface_with_present_mode(window, width, height, PresentMode::Fifo)
     }
 
     /// Creates a new surface for the specified window and dimensions.

--- a/piet-wgsl/src/util.rs
+++ b/piet-wgsl/src/util.rs
@@ -19,7 +19,7 @@
 use super::Result;
 
 use raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle};
-use wgpu::{Device, Instance, Limits, Queue, Surface, SurfaceConfiguration};
+use wgpu::{Device, Instance, Limits, PresentMode, Queue, Surface, SurfaceConfiguration};
 
 /// Simple render context that maintains wgpu state for rendering the pipeline.
 pub struct RenderContext {
@@ -65,6 +65,31 @@ impl RenderContext {
             width,
             height,
             present_mode: wgpu::PresentMode::Fifo,
+            alpha_mode: wgpu::CompositeAlphaMode::Auto,
+        };
+        surface.configure(&self.device, &config);
+        RenderSurface { surface, config }
+    }
+
+    /// Creates a new surface for the specified window and dimensions.
+    pub fn create_surface_with_present_mode<W>(
+        &self,
+        window: &W,
+        width: u32,
+        height: u32,
+        present_mode: PresentMode,
+    ) -> RenderSurface
+    where
+        W: HasRawWindowHandle + HasRawDisplayHandle,
+    {
+        let surface = unsafe { self.instance.create_surface(window) };
+        let format = wgpu::TextureFormat::Bgra8Unorm;
+        let config = wgpu::SurfaceConfiguration {
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            format,
+            width,
+            height,
+            present_mode,
             alpha_mode: wgpu::CompositeAlphaMode::Auto,
         };
         surface.configure(&self.device, &config);


### PR DESCRIPTION
I was crashing on ramp generation when a gradient contained an empty color stop collection (bug in the lottie importer). This changes `SceneBuilder` to check for that case and prevent encoding anything at all. Does the same for solid brushes with alpha of 0 because might as well.

Also adds a new method for creating a surface with a specific presentation mode to `util::RenderContext`.