### PR TITLE
Multi-adapter support

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -26,13 +26,13 @@ use wgpu::{
 /// Simple render context that maintains wgpu state for rendering the pipeline.
 pub struct RenderContext {
     pub instance: Instance,
-    devices: Vec<DeviceHandle>,
+    pub devices: Vec<DeviceHandle>,
 }
 
-struct DeviceHandle {
+pub struct DeviceHandle {
     adapter: Adapter,
-    device: Device,
-    queue: Queue,
+    pub device: Device,
+    pub queue: Queue,
 }
 
 impl RenderContext {
@@ -131,5 +131,5 @@ impl RenderContext {
 pub struct RenderSurface {
     pub surface: Surface,
     pub config: SurfaceConfiguration,
-    dev_id: usize,
+    pub dev_id: usize,
 }


### PR DESCRIPTION
Now Adapter, Device, Queue are bundled into DeviceHandle and created alongside Surface, or reused if we already created a compatible handle.

I'm open to design complaints, just wanted to prove that the logic would solve my problem from #224, and it does :). Now on x11 (through xwayland) the winit example works fine, and on wayland I get a different error message than before 🥳

All of this comes at the cost of a little extra user-side juggling, but in the winit example it's not much extra effort.