### PR TITLE
Fix the winit dependency

### DIFF
--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 [dependencies]
 wgpu = "0.14"
-vello = { path = "../../../vello" }
+vello = { path = "../../" }
 winit = "0.27.5"
 pollster = "0.2.5"
 # for picosvg


### PR DESCRIPTION
I believe that this prevents https://deps.rs/repo/github/linebender/vello from working.

This also means that if you clone `vello` into a folder called something other than `vello`, it fails.