### PR TITLE
Improve the gitattributes and gitignore files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+shader/*.wgsl linguist-language=wgsl

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
-shader/*.wgsl linguist-language=wgsl
+# This is a lie. However, linguist does not support wgsl, so this is good-enough
+# Show the amount of the code which is shader
+shader/*.wgsl linguist-language=glsl
+# Potentially better syntax highlighting
+# shader/*.wgsl linguist-language=Rust

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,0 @@
-**/shader/* linguist-language=glsl
-**/shader/gen/* linguist-generated
-piet-wgpu/shader/* linguist-language=wgsl

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,1 @@
 /target
-**/*.rs.bk
-.ninja_deps
-.ninja_log
-**/shader/gen


### PR DESCRIPTION
As fallout from #231, our language stats are all wrong. Try to fix that.

This was already done in #216, but that was superceded after the rename.