### PR TITLE
Support for larger pathtags

### DIFF
--- a/shader/pathtag_reduce2.wgsl
+++ b/shader/pathtag_reduce2.wgsl
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
+
+// This shader is the second stage of reduction for the pathtag
+// monoid scan, needed when the number of tags is large.
+
+#import config
+#import pathtag
+
+@group(0) @binding(0)
+var<storage> reduced_in: array<TagMonoid>;
+
+@group(0) @binding(1)
+var<storage, read_write> reduced: array<TagMonoid>;
+
+let LG_WG_SIZE = 8u;
+let WG_SIZE = 256u;
+
+var<workgroup> sh_scratch: array<TagMonoid, WG_SIZE>;
+
+@compute @workgroup_size(256)
+fn main(
+    @builtin(global_invocation_id) global_id: vec3<u32>,
+    @builtin(local_invocation_id) local_id: vec3<u32>,
+) {
+    let ix = global_id.x;
+    var agg = reduced_in[ix];
+    sh_scratch[local_id.x] = agg;
+    for (var i = 0u; i < firstTrailingBit(WG_SIZE); i += 1u) {
+        workgroupBarrier();
+        if local_id.x + (1u << i) < WG_SIZE {
+            let other = sh_scratch[local_id.x + (1u << i)];
+            agg = combine_tag_monoid(agg, other);
+        }
+        workgroupBarrier();
+        sh_scratch[local_id.x] = agg;
+    }
+    if local_id.x == 0u {
+        reduced[ix >> LG_WG_SIZE] = agg;
+    }
+}

--- a/shader/pathtag_scan1.wgsl
+++ b/shader/pathtag_scan1.wgsl
@@ -1,26 +1,24 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
+// This shader computes the scan of reduced tag monoids given
+// two levels of reduction.
+
 #import config
 #import pathtag
 
 @group(0) @binding(0)
-var<uniform> config: Config;
-
-@group(0) @binding(1)
-var<storage> scene: array<u32>;
-
-@group(0) @binding(2)
 var<storage> reduced: array<TagMonoid>;
 
-@group(0) @binding(3)
+@group(0) @binding(1)
+var<storage> reduced2: array<TagMonoid>;
+
+@group(0) @binding(2)
 var<storage, read_write> tag_monoids: array<TagMonoid>;
 
 let LG_WG_SIZE = 8u;
 let WG_SIZE = 256u;
 
-#ifdef small
 var<workgroup> sh_parent: array<TagMonoid, WG_SIZE>;
-#endif
 // These could be combined?
 var<workgroup> sh_monoid: array<TagMonoid, WG_SIZE>;
 
@@ -30,10 +28,9 @@ fn main(
     @builtin(local_invocation_id) local_id: vec3<u32>,
     @builtin(workgroup_id) wg_id: vec3<u32>,
 ) {
-#ifdef small
     var agg = tag_monoid_identity();
     if local_id.x < wg_id.x {
-        agg = reduced[local_id.x];
+        agg = reduced2[local_id.x];
     }
     sh_parent[local_id.x] = agg;
     for (var i = 0u; i < LG_WG_SIZE; i += 1u) {
@@ -45,30 +42,24 @@ fn main(
         workgroupBarrier();
         sh_parent[local_id.x] = agg;
     }
-#endif
 
     let ix = global_id.x;
-    let tag_word = scene[config.pathtag_base + ix];
-    var agg_part = reduce_tag(tag_word);
-    sh_monoid[local_id.x] = agg_part;
+    agg = reduced[ix];
+    sh_monoid[local_id.x] = agg;
     for (var i = 0u; i < LG_WG_SIZE; i += 1u) {
         workgroupBarrier();
         if local_id.x >= 1u << i {
             let other = sh_monoid[local_id.x - (1u << i)];
-            agg_part = combine_tag_monoid(other, agg_part);
+            agg = combine_tag_monoid(other, agg);
         }
         workgroupBarrier();
-        sh_monoid[local_id.x] = agg_part;
+        sh_monoid[local_id.x] = agg;
     }
     // prefix up to this workgroup
-#ifdef small
     var tm = sh_parent[0];
-#else
-    var tm = reduced[wg_id.x];
-#endif
     if local_id.x > 0u {
         tm = combine_tag_monoid(tm, sh_monoid[local_id.x - 1u]);
     }
-    // exclusive prefix sum, granularity of 4 tag bytes
+    // exclusive prefix sum, granularity of 4 tag bytes * workgroup size
     tag_monoids[ix] = tm;
 }

--- a/src/shaders.rs
+++ b/src/shaders.rs
@@ -47,7 +47,10 @@ pub struct Shaders {
 // Shaders for the full pipeline
 pub struct FullShaders {
     pub pathtag_reduce: ShaderId,
+    pub pathtag_reduce2: ShaderId,
+    pub pathtag_scan1: ShaderId,
     pub pathtag_scan: ShaderId,
+    pub pathtag_scan_large: ShaderId,
     pub bbox_clear: ShaderId,
     pub pathseg: ShaderId,
     pub draw_reduce: ShaderId,
@@ -129,12 +132,39 @@ pub fn full_shaders(device: &Device, engine: &mut Engine) -> Result<FullShaders,
     let empty = HashSet::new();
     let mut full_config = HashSet::new();
     full_config.insert("full".into());
+    let mut small_config = HashSet::new();
+    small_config.insert("full".into());
+    small_config.insert("small".into());
     let pathtag_reduce = engine.add_shader(
         device,
         preprocess::preprocess(shader!("pathtag_reduce"), &full_config, &imports).into(),
         &[BindType::Uniform, BindType::BufReadOnly, BindType::Buffer],
     )?;
+    let pathtag_reduce2 = engine.add_shader(
+        device,
+        preprocess::preprocess(shader!("pathtag_reduce2"), &full_config, &imports).into(),
+        &[BindType::BufReadOnly, BindType::Buffer],
+    )?;
+    let pathtag_scan1 = engine.add_shader(
+        device,
+        preprocess::preprocess(shader!("pathtag_scan1"), &full_config, &imports).into(),
+        &[
+            BindType::BufReadOnly,
+            BindType::BufReadOnly,
+            BindType::Buffer,
+        ],
+    )?;
     let pathtag_scan = engine.add_shader(
+        device,
+        preprocess::preprocess(shader!("pathtag_scan"), &small_config, &imports).into(),
+        &[
+            BindType::Uniform,
+            BindType::BufReadOnly,
+            BindType::BufReadOnly,
+            BindType::Buffer,
+        ],
+    )?;
+    let pathtag_scan_large = engine.add_shader(
         device,
         preprocess::preprocess(shader!("pathtag_scan"), &full_config, &imports).into(),
         &[
@@ -278,7 +308,10 @@ pub fn full_shaders(device: &Device, engine: &mut Engine) -> Result<FullShaders,
     )?;
     Ok(FullShaders {
         pathtag_reduce,
+        pathtag_reduce2,
         pathtag_scan,
+        pathtag_scan1,
+        pathtag_scan_large,
         bbox_clear,
         pathseg,
         draw_reduce,


### PR DESCRIPTION
Previously there was a limit of 256k pathtags in a scene, due to the need for multi-dispatch prefix sum for the pathtag monoid. This patch increases the limit to 64M, which ought to be enough for most applications.

It works by having 4 dispatches for the pathtag prefix sum: 2 to reduce, then 2 to scan.