### PR TITLE
Support caching the image, and click and drag motion

### DIFF
--- a/examples/with_winit/src/main.rs
+++ b/examples/with_winit/src/main.rs
@@ -68,7 +68,6 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
                 }
             }
             WindowEvent::MouseWheel { delta, .. } => {
-                dbg!(&delta);
                 if let MouseScrollDelta::PixelDelta(delta) = delta {
                     scale += delta.y * 0.1;
                     scale = scale.clamp(0.1, 10.0);

--- a/examples/with_winit/src/test_scene.rs
+++ b/examples/with_winit/src/test_scene.rs
@@ -1,3 +1,5 @@
+use std::time::Instant;
+
 use crate::pico_svg::PicoSvg;
 use crate::simple_text::SimpleText;
 use vello::kurbo::{Affine, BezPath, Ellipse, PathEl, Point, Rect};
@@ -82,6 +84,21 @@ pub fn render_tiger(sb: &mut SceneBuilder) {
         std::str::from_utf8(include_bytes!("../../assets/Ghostscript_Tiger.svg")).unwrap();
     let svg = PicoSvg::load(xml_str, 6.0).unwrap();
     render_svg(sb, &svg);
+}
+
+pub fn render_paris(sb: &mut SceneBuilder, scene: &mut Option<SceneFragment>, xform: Affine) {
+    if scene.is_none() {
+        use super::pico_svg::*;
+        let start = Instant::now();
+        let xml_str = std::str::from_utf8(include_bytes!("../../assets/paris-30k.svg")).unwrap();
+        let svg = PicoSvg::load(xml_str, 6.0).unwrap();
+        println!("{:?}", start.elapsed());
+        let mut new_scene = SceneFragment::new();
+        let mut builder = SceneBuilder::for_fragment(&mut new_scene);
+        render_svg(&mut builder, &svg);
+        *scene = Some(new_scene);
+    }
+    sb.append(&scene.as_ref().unwrap(), Some(xform));
 }
 
 pub fn render_scene(sb: &mut SceneBuilder) {


### PR DESCRIPTION
The example for paris now caches the `SceneFragment`, and allows dragging and scaling the svg (click and drag, and mouse wheel).

The scaling is centred on the top left, which isn't ideal, but it works for demonstration.

I also added support for closing the window with `Escape`, whilst I was there.

I've opened this against `large_pathtag`, which is the branch for #235

Note that to try this yourself, you need to source the paris-30k svg from somewhere, and make the other changes discussed in #235, namely to the buffer sizes. For reference, I found this diff sufficiently increases the buffer sizes for things to render, although I do still get random seeming artifacts (not consistent frame-to-frame). These numbers were chosen as arbitrary increases on the prior values.

```diff
diff --git a/src/render.rs b/src/render.rs
index eee3d54..8e9c7c5 100644
--- a/src/render.rs
+++ b/src/render.rs
@@ -308,7 +308,7 @@ pub fn render_full(
         [config_buf, scene_buf, draw_reduced_buf],
     );
     let draw_monoid_buf = ResourceProxy::new_buf(n_drawobj as u64 * DRAWMONOID_SIZE);
-    let info_bin_data_buf = ResourceProxy::new_buf(1 << 20);
+    let info_bin_data_buf = ResourceProxy::new_buf(1 << 24);
     let clip_inp_buf = ResourceProxy::new_buf(data.n_clip as u64 * CLIP_INP_SIZE);
     recording.dispatch(
         shaders.draw_leaf,
@@ -382,7 +382,7 @@ pub fn render_full(
     // in storage rather than workgroup memory.
     let n_path_aligned = align_up(n_path as usize, 256);
     let path_buf = ResourceProxy::new_buf(n_path_aligned as u64 * PATH_SIZE);
-    let tile_buf = ResourceProxy::new_buf(1 << 20);
+    let tile_buf = ResourceProxy::new_buf(1 << 23);
     let path_wgs = (n_path + shaders::PATH_BBOX_WG - 1) / shaders::PATH_BBOX_WG;
     recording.dispatch(
         shaders.tile_alloc,
@@ -397,7 +397,7 @@ pub fn render_full(
         ],
     );
 
-    let segments_buf = ResourceProxy::new_buf(1 << 24);
+    let segments_buf = ResourceProxy::new_buf(1 << 27);
     recording.dispatch(
         shaders.path_coarse,
         (path_coarse_wgs, 1, 1),
@@ -417,7 +417,7 @@ pub fn render_full(
         (path_wgs, 1, 1),
         [config_buf, path_buf, tile_buf],
     );
-    let ptcl_buf = ResourceProxy::new_buf(1 << 24);
+    let ptcl_buf = ResourceProxy::new_buf(1 << 26);
     recording.dispatch(
         shaders.coarse,
         (width_in_bins, height_in_bins, 1),

```