### PR TITLE
Update references to piet-gpu where it makes sense

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ naga = { git = "https://github.com/gfx-rs/naga", rev = "ddcd5d3121150b2b1beee6e5
 [package]
 name = "vello"
 version = "0.1.0"
-authors = ["Raph Levien <raph@google.com>"]
 license = "MIT/Apache-2.0"
 edition = "2021"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["examples/with_winit", "examples/with_bevy", "examples/run_wasm"]
 [workspace.package]
 edition = "2021"
 version = "0.1.0"
-authors = ["piet-gpu developers"]
+authors = ["vello developers"]
 
 [patch.crates-io]
 # Required for metal support to work on wgpu

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ members = ["examples/with_winit", "examples/with_bevy", "examples/run_wasm"]
 [workspace.package]
 edition = "2021"
 version = "0.1.0"
-authors = ["vello developers"]
 
 [patch.crates-io]
 # Required for metal support to work on wgpu

--- a/doc/shader_compilation.md
+++ b/doc/shader_compilation.md
@@ -2,7 +2,7 @@
 
 We use git branches to support shader compilation in the cloud. The `dev` branch contains only shader source files (in GLSL format), while the `main` branch contains generated shaders. On every push to the `dev` branch, a GitHub action runs which compiles the shaders and pushes those to `main`.
 
-Thus, you can run vello from the `main` branch without requiring any shader compilation tools. Also, the `dev` branch has a relatively clean history, and PRs can be made against it without having to worry about merge conflicts in the generated shader files.
+Thus, you can run piet-gpu from the `main` branch without requiring any shader compilation tools. Also, the `dev` branch has a relatively clean history, and PRs can be made against it without having to worry about merge conflicts in the generated shader files.
 
 If you do want to make changes to the shaders, you'll need some tools installed:
 
@@ -10,7 +10,7 @@ If you do want to make changes to the shaders, you'll need some tools installed:
 * [Vulkan SDK] (mostly for glslangValidate, spirv-cross)
 * [DirectX Shader Compiler][DXC]
 
-The GitHub action runs on Windows so the DXC signing can succeed (note that [hassle-rs] may provide an alternate solution). We currently only compile to MSL on Metal, not AIR, due to tooling friction. The Metal shader compiler is available on Windows, but a barrier to running in CI is that downloading it appears to require an Apple account. Longer term we will want to figure out a solution to this, because the vello vision involves ahead-of-time compilation of shaders as much as possible.
+The GitHub action runs on Windows so the DXC signing can succeed (note that [hassle-rs] may provide an alternate solution). We currently only compile to MSL on Metal, not AIR, due to tooling friction. The Metal shader compiler is available on Windows, but a barrier to running in CI is that downloading it appears to require an Apple account. Longer term we will want to figure out a solution to this, because the piet-gpu vision involves ahead-of-time compilation of shaders as much as possible.
 
 Right now the scripts for compiling shaders are done in hand-written ninja files. This is likely to change, as the number of permutations will increase, and we also may want access to metadata from the shader compilation process.
 

--- a/doc/shader_compilation.md
+++ b/doc/shader_compilation.md
@@ -2,7 +2,7 @@
 
 We use git branches to support shader compilation in the cloud. The `dev` branch contains only shader source files (in GLSL format), while the `main` branch contains generated shaders. On every push to the `dev` branch, a GitHub action runs which compiles the shaders and pushes those to `main`.
 
-Thus, you can run piet-gpu from the `main` branch without requiring any shader compilation tools. Also, the `dev` branch has a relatively clean history, and PRs can be made against it without having to worry about merge conflicts in the generated shader files.
+Thus, you can run vello from the `main` branch without requiring any shader compilation tools. Also, the `dev` branch has a relatively clean history, and PRs can be made against it without having to worry about merge conflicts in the generated shader files.
 
 If you do want to make changes to the shaders, you'll need some tools installed:
 
@@ -10,7 +10,7 @@ If you do want to make changes to the shaders, you'll need some tools installed:
 * [Vulkan SDK] (mostly for glslangValidate, spirv-cross)
 * [DirectX Shader Compiler][DXC]
 
-The GitHub action runs on Windows so the DXC signing can succeed (note that [hassle-rs] may provide an alternate solution). We currently only compile to MSL on Metal, not AIR, due to tooling friction. The Metal shader compiler is available on Windows, but a barrier to running in CI is that downloading it appears to require an Apple account. Longer term we will want to figure out a solution to this, because the piet-gpu vision involves ahead-of-time compilation of shaders as much as possible.
+The GitHub action runs on Windows so the DXC signing can succeed (note that [hassle-rs] may provide an alternate solution). We currently only compile to MSL on Metal, not AIR, due to tooling friction. The Metal shader compiler is available on Windows, but a barrier to running in CI is that downloading it appears to require an Apple account. Longer term we will want to figure out a solution to this, because the vello vision involves ahead-of-time compilation of shaders as much as possible.
 
 Right now the scripts for compiling shaders are done in hand-written ninja files. This is likely to change, as the number of permutations will increase, and we also may want access to metadata from the shader compilation process.
 

--- a/doc/vision.md
+++ b/doc/vision.md
@@ -2,6 +2,8 @@
 
 Raph Levien, 2020-12-10
 
+Note: `vello` was previously called `piet-gpu`.
+
 I’ve done several [blog posts](./blogs.md) about piet-gpu already, and more generally GPU compute, but this document is a little different in scope. Rather than showing off a prototype and presenting a research result, it will set forth a bold and ambitious plan for where this might go. I find this vision compelling, and it’s motivated me to spend a lot of energy mastering some difficult material. The grand vision is much more than one person can do, so I’ll do some of it myself and maybe inspire collaboration for the rest of it.
 
 The full vision for piet-gpu is a 2D rendering engine that is considerably faster, higher quality, and more flexible than the current state of the art, and runs on a wide variety of hardware. I’ll go into some detail about why I think this goal is possible and what kind of work is needed to get there.

--- a/examples/run_wasm/Cargo.toml
+++ b/examples/run_wasm/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "run-wasm"
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 publish = false
 

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "with_winit"
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 publish = false
 

--- a/examples/with_winit/src/simple_text.rs
+++ b/examples/with_winit/src/simple_text.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 The piet-gpu authors.
+// Copyright 2022 The vello authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/with_winit/src/test_scene.rs
+++ b/examples/with_winit/src/test_scene.rs
@@ -280,7 +280,7 @@ pub fn render_anim_frame(sb: &mut SceneBuilder, text: &mut SimpleText, i: usize)
         &rect,
     );
     let text_size = 60.0 + 40.0 * (0.01 * i as f32).sin();
-    let s = "\u{1f600}hello piet-gpu text!";
+    let s = "\u{1f600}hello vello text!";
     text.add(
         sb,
         None,

--- a/shader/fine.wgsl
+++ b/shader/fine.wgsl
@@ -239,7 +239,7 @@ fn main(
                 let rad = read_rad_grad(cmd_ix);
                 for (var i = 0u; i < PIXELS_PER_THREAD; i += 1u) {
                     let my_xy = vec2(xy.x + f32(i), xy.y);
-                    // TODO: can hoist y, but for now stick to piet-gpu
+                    // TODO: can hoist y, but for now stick to vello
                     let xy_xformed = rad.matrx.xz * my_xy.x + rad.matrx.yw * my_xy.y - rad.xlat;
                     let ba = dot(xy_xformed, rad.c1);
                     let ca = rad.ra * dot(xy_xformed, xy_xformed);

--- a/shader/fine.wgsl
+++ b/shader/fine.wgsl
@@ -239,7 +239,7 @@ fn main(
                 let rad = read_rad_grad(cmd_ix);
                 for (var i = 0u; i < PIXELS_PER_THREAD; i += 1u) {
                     let my_xy = vec2(xy.x + f32(i), xy.y);
-                    // TODO: can hoist y, but for now stick to vello
+                    // TODO: can hoist y, but for now stick to the GLSL version
                     let xy_xformed = rad.matrx.xz * my_xy.x + rad.matrx.yw * my_xy.y - rad.xlat;
                     let ba = dot(xy_xformed, rad.c1);
                     let ca = rad.ra * dot(xy_xformed, xy_xformed);

--- a/shader/shared/config.wgsl
+++ b/shader/shared/config.wgsl
@@ -16,7 +16,6 @@ struct Config {
     bin_data_start: u32,
 
     // offsets within scene buffer (in u32 units)
-    // Note: this is a difference from vello, which is in bytes
     pathtag_base: u32,
     pathdata_base: u32,
 

--- a/shader/shared/config.wgsl
+++ b/shader/shared/config.wgsl
@@ -16,7 +16,7 @@ struct Config {
     bin_data_start: u32,
 
     // offsets within scene buffer (in u32 units)
-    // Note: this is a difference from piet-gpu, which is in bytes
+    // Note: this is a difference from vello, which is in bytes
     pathtag_base: u32,
     pathdata_base: u32,
 

--- a/shader/tile_alloc.wgsl
+++ b/shader/tile_alloc.wgsl
@@ -93,8 +93,7 @@ fn main(
     // process fewer draw objects than the number of threads in the wg.
     let total_count = sh_tile_count[WG_SIZE - 1u];
     for (var i = local_id.x; i < total_count; i += WG_SIZE) {
-        // Note: could format output buffer as u32 for even better load
-        // balancing, as does vello.
+        // Note: could format output buffer as u32 for even better load balancing.
         tiles[tile_offset + i] = Tile(0, 0u);
     }
 }

--- a/shader/tile_alloc.wgsl
+++ b/shader/tile_alloc.wgsl
@@ -94,7 +94,7 @@ fn main(
     let total_count = sh_tile_count[WG_SIZE - 1u];
     for (var i = local_id.x; i < total_count; i += WG_SIZE) {
         // Note: could format output buffer as u32 for even better load
-        // balancing, as does piet-gpu.
+        // balancing, as does vello.
         tiles[tile_offset + i] = Tile(0, 0u);
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -90,7 +90,7 @@ pub enum Command {
     UploadImage(ImageProxy, Vec<u8>),
     // Discussion question: third argument is vec of resources?
     // Maybe use tricks to make more ergonomic?
-    // Alternative: provide bufs & images as separate sequences, like piet-gpu.
+    // Alternative: provide bufs & images as separate sequences, like vello.
     Dispatch(ShaderId, (u32, u32, u32), Vec<ResourceProxy>),
     Download(BufProxy),
     Clear(BufProxy, u64, Option<NonZeroU64>),

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -90,6 +90,7 @@ pub enum Command {
     UploadImage(ImageProxy, Vec<u8>),
     // Discussion question: third argument is vec of resources?
     // Maybe use tricks to make more ergonomic?
+    // Alternative: provide bufs & images as separate sequences
     Dispatch(ShaderId, (u32, u32, u32), Vec<ResourceProxy>),
     Download(BufProxy),
     Clear(BufProxy, u64, Option<NonZeroU64>),

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -90,7 +90,6 @@ pub enum Command {
     UploadImage(ImageProxy, Vec<u8>),
     // Discussion question: third argument is vec of resources?
     // Maybe use tricks to make more ergonomic?
-    // Alternative: provide bufs & images as separate sequences, like vello.
     Dispatch(ShaderId, (u32, u32, u32), Vec<ResourceProxy>),
     Download(BufProxy),
     Clear(BufProxy, u64, Option<NonZeroU64>),

--- a/src/glyph.rs
+++ b/src/glyph.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 The piet-gpu authors.
+// Copyright 2022 The vello authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 The piet-gpu authors.
+// Copyright 2022 The vello authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
- Update "piet-gpu authors" to "vello authors"
- Update comments
- Update example text: "hello piet-gpu text" => "hello vello text"
- Preserve vision.md but add explanation to connect "vello" to "piet-gpu"
