### PR TITLE
Support even-odd fill rule

### DIFF
--- a/examples/with_winit/src/test_scene.rs
+++ b/examples/with_winit/src/test_scene.rs
@@ -271,7 +271,16 @@ fn blend_square(blend: BlendMode) -> SceneFragment {
 
 #[allow(unused)]
 pub fn render_anim_frame(sb: &mut SceneBuilder, text: &mut SimpleText, i: usize) {
+    use PathEl::*;
     let rect = Rect::from_origin_size(Point::new(0.0, 0.0), (1000.0, 1000.0));
+    let star = [
+        MoveTo((50.0, 0.0).into()),
+        LineTo((21.0, 90.0).into()),
+        LineTo((98.0, 35.0).into()),
+        LineTo((2.0, 35.0).into()),
+        LineTo((79.0, 90.0).into()),
+        ClosePath,
+    ];
     sb.fill(
         Fill::NonZero,
         Affine::IDENTITY,
@@ -333,6 +342,20 @@ pub fn render_anim_frame(sb: &mut SceneBuilder, text: &mut SimpleText, i: usize)
         &rect,
     );
     sb.pop_layer();
+    sb.fill(
+        Fill::NonZero,
+        Affine::translate((400.0, 100.0)),
+        Color::PURPLE,
+        None,
+        &star,
+    );
+    sb.fill(
+        Fill::EvenOdd,
+        Affine::translate((500.0, 100.0)),
+        Color::PURPLE,
+        None,
+        &star,
+    );
 }
 
 #[allow(unused)]

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -126,7 +126,7 @@ impl<'a> SceneBuilder<'a> {
     /// Fills a shape using the specified style and brush.
     pub fn fill<'b>(
         &mut self,
-        _style: Fill,
+        style: Fill,
         transform: Affine,
         brush: impl Into<BrushRef<'b>>,
         brush_transform: Option<Affine>,
@@ -134,7 +134,10 @@ impl<'a> SceneBuilder<'a> {
     ) {
         self.scene
             .encode_transform(Transform::from_kurbo(&transform));
-        self.scene.encode_linewidth(-1.0);
+        self.scene.encode_linewidth(match style {
+            Fill::NonZero => -1.0,
+            Fill::EvenOdd => -2.0,
+        });
         if self.scene.encode_shape(shape, true) {
             if let Some(brush_transform) = brush_transform {
                 self.scene


### PR DESCRIPTION
Add logic for the even-odd fill rule to `SceneBuilder` and the coarse and fine shaders.

There is some new unfortunate branching in coarse around `write_path` to handle the case where entire solid tiles are omitted. It might be possible to include this with the other checks for `include_tile` but I'm not sure if that is a win.