### PR TITLE
Change SceneBuilder to be an owning and cloneable structure that is consumed to produce fragments

### DIFF
--- a/src/encoding/encoding.rs
+++ b/src/encoding/encoding.rs
@@ -22,7 +22,7 @@ use super::{
 use peniko::{kurbo::Shape, BlendMode, BrushRef, Color, ColorStop, Extend};
 
 /// Encoded data streams for a scene.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Encoding {
     /// The path tag stream.
     pub path_tags: Vec<PathTag>,

--- a/src/glyph.rs
+++ b/src/glyph.rs
@@ -18,7 +18,7 @@
 
 pub use moscato::pinot;
 
-use crate::scene::{SceneBuilder, SceneFragment};
+use crate::scene::{FragmentBuilder, SceneFragment};
 use peniko::kurbo::{Affine, Rect};
 use peniko::{Brush, Color, Fill, Mix};
 
@@ -85,8 +85,7 @@ impl<'a> GlyphProvider<'a> {
     pub fn get(&mut self, gid: u16, brush: Option<&Brush>) -> Option<SceneFragment> {
         let glyph = self.scaler.glyph(gid)?;
         let path = glyph.path(0)?;
-        let mut fragment = SceneFragment::default();
-        let mut builder = SceneBuilder::for_fragment(&mut fragment);
+        let mut builder = FragmentBuilder::new();
         builder.fill(
             Fill::NonZero,
             Affine::IDENTITY,
@@ -94,8 +93,7 @@ impl<'a> GlyphProvider<'a> {
             None,
             &convert_path(path.elements()),
         );
-        builder.finish();
-        Some(fragment)
+        Some(builder.finish())
     }
 
     /// Returns a scene fragment containing the commands and resources to
@@ -103,8 +101,7 @@ impl<'a> GlyphProvider<'a> {
     pub fn get_color(&mut self, palette_index: u16, gid: u16) -> Option<SceneFragment> {
         use moscato::Command;
         let glyph = self.scaler.color_glyph(palette_index, gid)?;
-        let mut fragment = SceneFragment::default();
-        let mut builder = SceneBuilder::for_fragment(&mut fragment);
+        let mut builder = FragmentBuilder::new();
         let mut xform_stack: SmallVec<[Affine; 8]> = SmallVec::new();
         for command in glyph.commands() {
             match command {
@@ -188,8 +185,7 @@ impl<'a> GlyphProvider<'a> {
                 }
             }
         }
-        builder.finish();
-        Some(fragment)
+        Some(builder.finish())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ pub mod encoding;
 pub mod glyph;
 pub mod util;
 
-pub use scene::{Scene, SceneBuilder, SceneFragment};
+pub use scene::{Scene, FragmentBuilder, SceneFragment};
 
 use engine::{Engine, ExternalResource};
 use shaders::FullShaders;


### PR DESCRIPTION
This PR implements an API change that allows partially built scenes to be reused by making the `SceneBuilder` an owning and cloneable data structure.

It also makes it possible to store a partially constructed scene in a struct which I think would be impossible with the current API because storing both a `SceneFragment` and a `SceneBuilder<'a>` in a struct makes it self-referential.

The way this allows scene construction work to be reused is demonstrated in the contrived example below:
```
let mut builder = FragmentBuilder::new();
for i in 0..10 {
    builder.line_to(i * a, i * b);
    let fragment = builder.clone().finish();
    scene.append(&fragment);
    renderer.render(&scene);
}
```
In fact, this could be simplified even further by removing `SceneFragments` and allowing a `&SceneBuilder` to be appended directly to a `Scene`. I think that would most accurately convey the performance characteristics of the operation in the API as well.

I would be unsurprised to learn that the API is designed as it is right now with some future changes in mind that make what I suggest in this PR unfeasible. I'm posting this just as a discussion regarding how some scene-in-progress data could be reused out of efficiency, and to bring up the self-referential restrictions I see the current API imposing.