### PR TITLE
Support click and drag for svgs, as well as scene fragment caching

### DIFF
--- a/examples/with_winit/src/main.rs
+++ b/examples/with_winit/src/main.rs
@@ -18,7 +18,11 @@ mod pico_svg;
 mod simple_text;
 mod test_scene;
 
-use vello::{util::RenderContext, Renderer, Scene, SceneBuilder};
+use vello::{
+    kurbo::{Affine, Vec2},
+    util::RenderContext,
+    Renderer, Scene, SceneBuilder,
+};
 use winit::{event_loop::EventLoop, window::Window};
 
 async fn run(event_loop: EventLoop<()>, window: Window) {
@@ -34,6 +38,11 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
     let mut current_frame = 0usize;
     let mut scene_ix = 0usize;
     let mut scene = Scene::new();
+    let mut paris_scene = None;
+    let mut drag = Vec2::default();
+    let mut scale = 1f64;
+    let mut mouse_down = false;
+    let mut prior_position = None;
     event_loop.run(move |event, _, control_flow| match event {
         Event::WindowEvent {
             ref event,
@@ -45,6 +54,9 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
                     match input.virtual_keycode {
                         Some(VirtualKeyCode::Left) => scene_ix = scene_ix.saturating_sub(1),
                         Some(VirtualKeyCode::Right) => scene_ix = scene_ix.saturating_add(1),
+                        Some(VirtualKeyCode::Escape) => {
+                            *control_flow = ControlFlow::Exit;
+                        }
                         _ => {}
                     }
                 }
@@ -52,6 +64,34 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
             WindowEvent::Resized(size) => {
                 render_cx.resize_surface(&mut surface, size.width, size.height);
                 window.request_redraw();
+            }
+            WindowEvent::MouseInput { state, button, .. } => {
+                if button == &MouseButton::Left {
+                    mouse_down = state == &ElementState::Pressed;
+                }
+            }
+            WindowEvent::MouseWheel { delta, .. } => {
+                dbg!(&delta);
+                if let MouseScrollDelta::PixelDelta(delta) = delta {
+                    scale += delta.y * 0.1;
+                    scale = scale.clamp(0.1, 10.0);
+                }
+                if let MouseScrollDelta::LineDelta(_, y) = delta {
+                    scale += *y as f64 * 0.1;
+                    scale = scale.clamp(0.1, 10.0);
+                }
+            }
+            WindowEvent::CursorLeft { .. } => {
+                prior_position = None;
+            }
+            WindowEvent::CursorMoved { position, .. } => {
+                let position = Vec2::new(position.x, position.y);
+                if mouse_down {
+                    if let Some(prior) = prior_position {
+                        drag += (position - prior) * (1.0 / scale);
+                    }
+                }
+                prior_position = Some(position);
             }
             _ => {}
         },
@@ -64,13 +104,18 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
             let height = surface.config.height;
             let device_handle = &render_cx.devices[surface.dev_id];
             let mut builder = SceneBuilder::for_scene(&mut scene);
-            const N_SCENES: usize = 6;
+
+            const N_SCENES: usize = 7;
             match scene_ix % N_SCENES {
                 0 => test_scene::render_anim_frame(&mut builder, &mut simple_text, current_frame),
                 1 => test_scene::render_blend_grid(&mut builder),
                 2 => test_scene::render_tiger(&mut builder),
-                3 => test_scene::render_brush_transform(&mut builder, current_frame),
-                4 => test_scene::render_funky_paths(&mut builder),
+                3 => {
+                    let transform = Affine::scale(scale) * Affine::translate(drag);
+                    test_scene::render_paris(&mut builder, &mut paris_scene, transform)
+                }
+                4 => test_scene::render_brush_transform(&mut builder, current_frame),
+                5 => test_scene::render_funky_paths(&mut builder),
                 _ => test_scene::render_scene(&mut builder),
             }
             builder.finish();

--- a/examples/with_winit/src/main.rs
+++ b/examples/with_winit/src/main.rs
@@ -71,7 +71,6 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
                 }
             }
             WindowEvent::MouseWheel { delta, .. } => {
-                dbg!(&delta);
                 if let MouseScrollDelta::PixelDelta(delta) = delta {
                     scale += delta.y * 0.1;
                     scale = scale.clamp(0.1, 10.0);

--- a/examples/with_winit/src/test_scene.rs
+++ b/examples/with_winit/src/test_scene.rs
@@ -1,3 +1,5 @@
+use std::time::Instant;
+
 use crate::pico_svg::PicoSvg;
 use crate::simple_text::SimpleText;
 use vello::kurbo::{Affine, BezPath, Ellipse, PathEl, Point, Rect};
@@ -82,6 +84,21 @@ pub fn render_tiger(sb: &mut SceneBuilder) {
         std::str::from_utf8(include_bytes!("../../assets/Ghostscript_Tiger.svg")).unwrap();
     let svg = PicoSvg::load(xml_str, 6.0).unwrap();
     render_svg(sb, &svg);
+}
+
+pub fn render_paris(sb: &mut SceneBuilder, scene: &mut Option<SceneFragment>, xform: Affine) {
+    if scene.is_none() {
+        use super::pico_svg::*;
+        let start = Instant::now();
+        let xml_str = std::str::from_utf8(include_bytes!("../../assets/paris-30k.svg")).unwrap();
+        let svg = PicoSvg::load(xml_str, 6.0).unwrap();
+        println!("{:?}", start.elapsed());
+        let mut new_scene = SceneFragment::new();
+        let mut builder = SceneBuilder::for_fragment(&mut new_scene);
+        render_svg(&mut builder, &svg);
+        *scene = Some(new_scene);
+    }
+    sb.append(&scene.as_ref().unwrap(), Some(xform));
 }
 
 pub fn render_scene(sb: &mut SceneBuilder) {


### PR DESCRIPTION
Reopen of #236 after it was accidentally closed by GitHub UX.

The new paris-30k example, in `with_winit`, now caches the `SceneFragment`, and allows dragging and scaling the svg (click and drag, and mouse wheel).

The scaling is centred on the top left, which isn't ideal, but it works for demonstration. Doing the correct maths centered on the cursor should be reasonably easy, but it takes some thinking

I also added support for closing the window with `Escape`, whilst I was editing it.

Note that to try this yourself, you need to source the paris-30k svg from somewhere, and make the other changes discussed in #235, namely to the buffer sizes. 

The intention is to make a CLI flag to select the svg, but this is not yet implemented.

For reference, I found this diff sufficiently increases the buffer sizes for things to render, although I do still get random seeming artifacts (not consistent frame-to-frame). These numbers were chosen as arbitrary increases on the prior values, which it turns out are sufficient.

```diff
diff --git a/src/render.rs b/src/render.rs
index eee3d54..8e9c7c5 100644
--- a/src/render.rs
+++ b/src/render.rs
@@ -308,7 +308,7 @@ pub fn render_full(
         [config_buf, scene_buf, draw_reduced_buf],
     );
     let draw_monoid_buf = ResourceProxy::new_buf(n_drawobj as u64 * DRAWMONOID_SIZE);
-    let info_bin_data_buf = ResourceProxy::new_buf(1 << 20);
+    let info_bin_data_buf = ResourceProxy::new_buf(1 << 24);
     let clip_inp_buf = ResourceProxy::new_buf(data.n_clip as u64 * CLIP_INP_SIZE);
     recording.dispatch(
         shaders.draw_leaf,
@@ -382,7 +382,7 @@ pub fn render_full(
     // in storage rather than workgroup memory.
     let n_path_aligned = align_up(n_path as usize, 256);
     let path_buf = ResourceProxy::new_buf(n_path_aligned as u64 * PATH_SIZE);
-    let tile_buf = ResourceProxy::new_buf(1 << 20);
+    let tile_buf = ResourceProxy::new_buf(1 << 23);
     let path_wgs = (n_path + shaders::PATH_BBOX_WG - 1) / shaders::PATH_BBOX_WG;
     recording.dispatch(
         shaders.tile_alloc,
@@ -397,7 +397,7 @@ pub fn render_full(
         ],
     );
 
-    let segments_buf = ResourceProxy::new_buf(1 << 24);
+    let segments_buf = ResourceProxy::new_buf(1 << 27);
     recording.dispatch(
         shaders.path_coarse,
         (path_coarse_wgs, 1, 1),
@@ -417,7 +417,7 @@ pub fn render_full(
         (path_wgs, 1, 1),
         [config_buf, path_buf, tile_buf],
     );
-    let ptcl_buf = ResourceProxy::new_buf(1 << 24);
+    let ptcl_buf = ResourceProxy::new_buf(1 << 26);
     recording.dispatch(
         shaders.coarse,
         (width_in_bins, height_in_bins, 1),

```