### PR TITLE
Ignore all /target/ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/target
+target/


### PR DESCRIPTION
The run_wasm example will generate additional `target/` directories outside of the root level.
This change ensures all `target` directories are ignored.

<img width="386" alt="image" src="https://user-images.githubusercontent.com/48108917/212425202-d537948e-22af-4725-af4d-220845812e6b.png">
