### PR TITLE
clippy CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,22 +6,28 @@ on:
   pull_request:
 
 jobs:
-  rustfmt:
+  lint:
     runs-on: ubuntu-latest
     name: cargo fmt
     steps:
       - uses: actions/checkout@v2
 
-      - name: install stable toolchain
+      - name: Setup | Toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           profile: minimal
-          components: rustfmt
+          components: rustfmt, clippy
           override: true
 
-      - name: cargo fmt
+      - name: Check | Fmt
         uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
+
+      - name: Check | Clippy
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-targets -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup | Toolchain
+      - name: install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    name: cargo fmt
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,13 @@ jobs:
           components: rustfmt, clippy
           override: true
 
-      - name: Check | Fmt
+      - name: cargo fmt
         uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
 
-      - name: Check | Clippy
+      - name: cargo clippy
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I noticed we have fmt as a CI step but not clippy.

This MR would add clippy, but that's an opinion I don't want to enforce, so I'll add it here as a suggestion.

I chose `actions-rs/clippy-check` - pretty standard. Also nicely formats the clippy errors for the reviewer/reviewee through annotations.[ See here](https://github.com/linebender/vello/pull/250/files)