### PR TITLE
Some WASM changes - including a run_wasm alias

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [alias]
-run_wasm = "run --release "
+run_wasm = "run --release --package run_wasm --"
 # Other crates use the alias run-wasm, even though crate names should use `_`s not `-`s
 # Allow this to be used
 run-wasm = "run_wasm"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[alias]
+run_wasm = "run --release "
+# Other crates use the alias run-wasm, even though crate names should use `_`s not `-`s
+# Allow this to be used
+run-wasm = "run_wasm"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-target/
+/target
 Cargo.lock

--- a/README.md
+++ b/README.md
@@ -51,14 +51,16 @@ cargo run -p with_bevy
 Because Vello relies heavily on compute shaders, we rely on the emerging WebGPU standard to run on the web.
 Until browser support becomes widespread, it will probably be necessary to use development browser versions (e.g. Chrome Canary) and explicitly enable WebGPU.
 
+Note: Other examples use the `-p` shorthand, but `cargo-run-wasm` requires the full `--package` to be specified
+
 The following command builds and runs a web version of the [winit demo](#winit). 
-This uses [`cargo-run-wasm`](https://github.com/rukai/cargo-run-wasm) to build and run the wasm example
+This uses [`cargo-run-wasm`](https://github.com/rukai/cargo-run-wasm) to build the example for web, and host a local server for it:
 
 ```shell
-cargo run --release -p run_wasm -- --package with_winit
+cargo run_wasm --package with_winit
 ```
 
-Additionally, the web is not currently a primary target, so other issues are likely to arise.
+The web is not currently a primary target for vello, and WebGPU implementations are incomplete, so you might run into issues running this example.
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -51,10 +51,11 @@ cargo run -p with_bevy
 Because Vello relies heavily on compute shaders, we rely on the emerging WebGPU standard to run on the web.
 Until browser support becomes widespread, it will probably be necessary to use development browser versions (e.g. Chrome Canary) and explicitly enable WebGPU.
 
-The following command builds and runs a web version of the [winit demo](#winit).
+The following command builds and runs a web version of the [winit demo](#winit). 
+This uses [`cargo-run-wasm`](https://github.com/rukai/cargo-run-wasm) to build and run the wasm example
 
 ```shell
-cargo run --release -p run-wasm -- --package with_winit
+cargo run --release -p run_wasm -- --package with_winit
 ```
 
 Additionally, the web is not currently a primary target, so other issues are likely to arise.

--- a/examples/run_wasm/Cargo.toml
+++ b/examples/run_wasm/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cargo-run-wasm = { git = "https://github.com/rukai/cargo-run-wasm", rev = "4913e01537ad103a057352bf7bbb1cd96a1bb4b5" }
+cargo-run-wasm = { git = "https://github.com/rukai/cargo-run-wasm", rev = "ad771ae1bc51d5e6f7a25e031fd3df00345f2362" }

--- a/examples/run_wasm/Cargo.toml
+++ b/examples/run_wasm/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cargo-run-wasm = "0.2.0"
+cargo-run-wasm = "0.3.0"

--- a/examples/run_wasm/Cargo.toml
+++ b/examples/run_wasm/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "run-wasm"
+name = "run_wasm"
 version.workspace = true
 edition.workspace = true
 publish = false
@@ -7,4 +7,4 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cargo-run-wasm = "0.3.0"
+cargo-run-wasm = { git = "https://github.com/rukai/cargo-run-wasm", rev = "4913e01537ad103a057352bf7bbb1cd96a1bb4b5" }

--- a/examples/run_wasm/Cargo.toml
+++ b/examples/run_wasm/Cargo.toml
@@ -7,4 +7,5 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cargo-run-wasm = { git = "https://github.com/rukai/cargo-run-wasm", rev = "ad771ae1bc51d5e6f7a25e031fd3df00345f2362" }
+# We use cargo-run-wasm main because of our workspace layout
+cargo-run-wasm = { git = "https://github.com/rukai/cargo-run-wasm", rev = "d14f73de77eaae44714b4817d660026a31f5f5a9" }

--- a/examples/run_wasm/src/main.rs
+++ b/examples/run_wasm/src/main.rs
@@ -1,4 +1,17 @@
+/// Use [cargo-run-wasm](https://github.com/rukai/cargo-run-wasm) to build an example for web
+///
+/// Usage:
+/// ```
+/// cargo run -p run_wasm -- --package [example_name]
+/// ```
+/// Generally:
+/// ```
+/// cargo run -p run_wasm -- --package with_winit
+/// ```
+
 fn main() {
+    // HACK: We rely heavily on compute shaders; which means we need WebGPU to be supported
+    // However, that requires unstable APIs to be enabled, which are not exposed through a feature
     let current_value = std::env::var("RUSTFLAGS").unwrap_or("".to_owned());
     std::env::set_var(
         "RUSTFLAGS",

--- a/examples/run_wasm/src/main.rs
+++ b/examples/run_wasm/src/main.rs
@@ -2,11 +2,11 @@
 ///
 /// Usage:
 /// ```
-/// cargo run -p run_wasm -- --package [example_name]
+/// cargo run_wasm --package [example_name]
 /// ```
 /// Generally:
 /// ```
-/// cargo run -p run_wasm -- --package with_winit
+/// cargo run_wasm --package with_winit
 /// ```
 
 fn main() {

--- a/examples/run_wasm/src/main.rs
+++ b/examples/run_wasm/src/main.rs
@@ -1,3 +1,8 @@
 fn main() {
+    let current_value = std::env::var("RUSTFLAGS").unwrap_or("".to_owned());
+    std::env::set_var(
+        "RUSTFLAGS",
+        format!("{current_value} --cfg=web_sys_unstable_apis",),
+    );
     cargo_run_wasm::run_wasm_with_css("body { margin: 0px; }");
 }

--- a/examples/with_winit/src/main.rs
+++ b/examples/with_winit/src/main.rs
@@ -41,7 +41,7 @@ struct Args {
     /// Path to the svg file to render. If not set, the GhostScript Tiger will be rendered
     #[arg(long)]
     #[cfg(not(target_arch = "wasm32"))]
-    svg: Option<PathBuf>,
+    svg: Option<std::path::PathBuf>,
     /// When rendering an svg, what scale to use
     #[arg(long)]
     scale: Option<f64>,

--- a/examples/with_winit/src/main.rs
+++ b/examples/with_winit/src/main.rs
@@ -18,7 +18,7 @@ mod pico_svg;
 mod simple_text;
 mod test_scene;
 
-use std::{borrow::Cow, path::PathBuf, time::Instant};
+use std::{borrow::Cow, time::Instant};
 
 use clap::Parser;
 use vello::{

--- a/examples/with_winit/src/test_scene.rs
+++ b/examples/with_winit/src/test_scene.rs
@@ -1,5 +1,3 @@
-use std::time::Instant;
-
 use crate::pico_svg::PicoSvg;
 use crate::simple_text::SimpleText;
 use vello::kurbo::{Affine, BezPath, Ellipse, PathEl, Point, Rect};
@@ -83,7 +81,7 @@ pub fn render_svg_scene(
     let scene_frag = scene.get_or_insert_with(|| {
         use super::pico_svg::*;
         #[cfg(not(target_arch = "wasm32"))]
-        let start = Instant::now();
+        let start = std::time::Instant::now();
         eprintln!("Starting to parse svg");
         let svg = PicoSvg::load(svg, scale).unwrap();
         #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
Blocked on rukai/cargo-run-wasm#19. This PR should be able to move over to `0.4` and then come out of draft when/if that is merged.

Supercedes https://github.com/linebender/vello/pull/248

I've renamed the `run-wasm` package to the more idiomatic crate name `run_wasm`, which also aligns with our other examples.
However, I have added aliases for both forms.

I was hesistant to add aliases, because it makes the workspace root messier, and disallows setting custom `.cargo/config.toml` files.
However, writing out the full command is messy, and hopefully other tools will allow their config files in `.cargo` too, so it's not a special cost just for run-wasm.