### PR TITLE
Add hot reloading of shaders to the winit example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2453,6 +2453,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify-debouncer-mini"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e23e9fa24f094b143c1eb61f90ac6457de87be6987bc70746e0179f7dbc9007b"
+dependencies = [
+ "crossbeam-channel",
+ "notify",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4186,6 +4196,7 @@ dependencies = [
  "clap",
  "console_error_panic_hook",
  "console_log",
+ "notify-debouncer-mini",
  "pollster",
  "roxmltree",
  "vello",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,5 @@ moscato = { git = "https://github.com/dfrg/pinot" }
 peniko = { git = "https://github.com/linebender/peniko" }
 
 [features]
+hot_reload = []
 buffer_labels = []

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -16,6 +16,10 @@ pollster = "0.2.5"
 roxmltree = "0.13"
 clap = { version = "4.1.0", features = ["derive"] }
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+vello = { path = "../../", features = ["hot_reload"] }
+notify-debouncer-mini = "0.2.1"
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.7"
 console_log = "0.2"

--- a/examples/with_winit/src/hot_reload.rs
+++ b/examples/with_winit/src/hot_reload.rs
@@ -1,0 +1,29 @@
+use std::{path::Path, time::Duration};
+
+use notify_debouncer_mini::{new_debouncer, notify::*, DebounceEventResult};
+
+pub(crate) fn hot_reload(mut f: impl FnMut() -> Option<()> + Send + 'static) -> impl Sized {
+    let mut debouncer = new_debouncer(
+        Duration::from_millis(500),
+        None,
+        move |res: DebounceEventResult| match res {
+            Ok(_) => f().unwrap(),
+            Err(errors) => errors.iter().for_each(|e| println!("Error {:?}", e)),
+        },
+    )
+    .unwrap();
+
+    debouncer
+        .watcher()
+        .watch(
+            dbg!(&Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("../../shader")
+                .canonicalize()
+                .unwrap()),
+            // We currently don't support hot reloading the imports, so don't recurse inot there
+            RecursiveMode::Recursive,
+        )
+        .ok()
+        .expect("Could watch shaders directory");
+    debouncer
+}

--- a/examples/with_winit/src/hot_reload.rs
+++ b/examples/with_winit/src/hot_reload.rs
@@ -20,8 +20,8 @@ pub(crate) fn hot_reload(mut f: impl FnMut() -> Option<()> + Send + 'static) -> 
                 .join("../../shader")
                 .canonicalize()
                 .unwrap()),
-            // We currently don't support hot reloading the imports, so don't recurse inot there
-            RecursiveMode::Recursive,
+            // We currently don't support hot reloading the imports, so don't recurse into there
+            RecursiveMode::NonRecursive,
         )
         .expect("Could watch shaders directory");
     debouncer

--- a/examples/with_winit/src/hot_reload.rs
+++ b/examples/with_winit/src/hot_reload.rs
@@ -23,7 +23,6 @@ pub(crate) fn hot_reload(mut f: impl FnMut() -> Option<()> + Send + 'static) -> 
             // We currently don't support hot reloading the imports, so don't recurse inot there
             RecursiveMode::Recursive,
         )
-        .ok()
         .expect("Could watch shaders directory");
     debouncer
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,8 +36,6 @@ use shaders::FullShaders;
 
 use wgpu::{Device, Queue, SurfaceTexture, TextureFormat, TextureView};
 
-use crate::shaders::full_shaders;
-
 /// Catch-all error type.
 pub type Error = Box<dyn std::error::Error>;
 
@@ -157,7 +155,7 @@ impl Renderer {
     pub async fn reload_shaders(&mut self, device: &Device) -> Result<()> {
         device.push_error_scope(wgpu::ErrorFilter::Validation);
         let mut engine = Engine::new();
-        let shaders = full_shaders(device, &mut engine)?;
+        let shaders = shaders::full_shaders(device, &mut engine)?;
         let error = device.pop_error_scope().await;
         if let Some(error) = error {
             return Err(error.into());

--- a/src/shaders.rs
+++ b/src/shaders.rs
@@ -31,9 +31,29 @@ pub const PATH_DRAWOBJ_WG: u32 = 256;
 pub const CLIP_REDUCE_WG: u32 = 256;
 
 macro_rules! shader {
-    ($name:expr) => {
-        include_str!(concat!("../shader/", $name, ".wgsl"))
-    };
+    ($name:expr) => {&{
+        let shader = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/shader/",
+            $name,
+            ".wgsl"
+        ));
+        #[cfg(feature = "hot_reload")]
+        let shader = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/shader/",
+            $name,
+            ".wgsl"
+        ))
+        .unwrap_or_else(|e| {
+            eprintln!(
+                "Failed to read shader {name}, error falling back to version at compilation time. Error: {e:?}",
+                name = $name
+            );
+            shader.to_string()
+        });
+        shader
+    }};
 }
 
 pub struct Shaders {


### PR DESCRIPTION
In theory, this should be useful for debugging. 

Obviously, a good proportion of changes can't be hot-reloaded. But this should make those which can be a bit easier.

I don't believe this can cause memory leaks, since everything created in `reload_shaders` should be properly dropped.