### PR TITLE
Robust memory redux (GPU side only)

### DIFF
--- a/shader/binning.wgsl
+++ b/shader/binning.wgsl
@@ -127,7 +127,11 @@ fn main(
         sh_count[i][local_id.x] = element_count_packed;
     }
     // element_count is the number of draw objects covering this thread's bin
-    let chunk_offset = atomicAdd(&bump.binning, element_count);
+    var chunk_offset = atomicAdd(&bump.binning, element_count);
+    if chunk_offset > bump.binning_size {
+        chunk_offset = 0u;
+        atomicOr(&bump.failed, STAGE_BINNING);
+    }    
     sh_chunk_offset[local_id.x] = chunk_offset;
     bin_header[global_id.x].element_count = element_count;
     bin_header[global_id.x].chunk_offset = chunk_offset;

--- a/shader/binning.wgsl
+++ b/shader/binning.wgsl
@@ -128,7 +128,7 @@ fn main(
     }
     // element_count is the number of draw objects covering this thread's bin
     var chunk_offset = atomicAdd(&bump.binning, element_count);
-    if chunk_offset > bump.binning_size {
+    if chunk_offset + element_count > config.binning_size {
         chunk_offset = 0u;
         atomicOr(&bump.failed, STAGE_BINNING);
     }    

--- a/shader/coarse.wgsl
+++ b/shader/coarse.wgsl
@@ -178,7 +178,6 @@ fn main(
 
     let blend_offset = cmd_offset;
     cmd_offset += 1u;
-    cmd_limit -= 1u;
 
     while true {
         for (var i = 0u; i < N_SLICE; i += 1u) {

--- a/shader/fine.wgsl
+++ b/shader/fine.wgsl
@@ -27,7 +27,6 @@ var<storage> segments: array<Segment>;
 #import ptcl
 
 let GRADIENT_WIDTH = 512;
-let BLEND_STACK_SPLIT = 4u;
 
 @group(0) @binding(3)
 var output: texture_storage_2d<rgba8unorm, write>;
@@ -192,7 +191,8 @@ fn main(
     var clip_depth = 0u;
     var area: array<f32, PIXELS_PER_THREAD>;
     var cmd_ix = tile_ix * PTCL_INITIAL_ALLOC;
-
+    let blend_offset = ptcl[cmd_ix];
+    cmd_ix += 1u;
     // main interpretation loop
     while true {
         let tag = ptcl[cmd_ix];

--- a/shader/path_coarse_full.wgsl
+++ b/shader/path_coarse_full.wgsl
@@ -94,7 +94,7 @@ fn eval_cubic(p0: vec2<f32>, p1: vec2<f32>, p2: vec2<f32>, p3: vec2<f32>, t: f32
 
 fn alloc_segment() -> u32 {
     var offset = atomicAdd(&bump.segments, 1u) + 1u;
-    if offset > bump.segments_size {
+    if offset + 1u > config.segments_size {
         offset = 0u;
         atomicOr(&bump.failed, STAGE_PATH_COARSE);
     }
@@ -107,6 +107,9 @@ let MAX_QUADS = 16u;
 fn main(
     @builtin(global_invocation_id) global_id: vec3<u32>,
 ) {
+    // Exit early if prior stages failed, as we can't run this stage.
+    // We need to check only prior stages, as if this stage has failed in another workgroup, 
+    // we still want to know this workgroup's memory requirement.   
     if (atomicLoad(&bump.failed) & (STAGE_BINNING | STAGE_TILE_ALLOC)) != 0u {
         return;
     }

--- a/shader/path_coarse_full.wgsl
+++ b/shader/path_coarse_full.wgsl
@@ -93,7 +93,12 @@ fn eval_cubic(p0: vec2<f32>, p1: vec2<f32>, p2: vec2<f32>, p3: vec2<f32>, t: f32
 }
 
 fn alloc_segment() -> u32 {
-    return atomicAdd(&bump.segments, 1u) + 1u;
+    var offset = atomicAdd(&bump.segments, 1u) + 1u;
+    if offset > bump.segments_size {
+        offset = 0u;
+        atomicOr(&bump.failed, STAGE_PATH_COARSE);
+    }
+    return offset;
 }
 
 let MAX_QUADS = 16u;
@@ -102,6 +107,9 @@ let MAX_QUADS = 16u;
 fn main(
     @builtin(global_invocation_id) global_id: vec3<u32>,
 ) {
+    if (atomicLoad(&bump.failed) & (STAGE_BINNING | STAGE_TILE_ALLOC)) != 0u {
+        return;
+    }
     let ix = global_id.x;
     let tag_word = scene[config.pathtag_base + (ix >> 2u)];
     let shift = (ix & 3u) * 8u;

--- a/shader/shared/bump.wgsl
+++ b/shader/shared/bump.wgsl
@@ -6,6 +6,7 @@ let STAGE_TILE_ALLOC: u32 = 0x2u;
 let STAGE_PATH_COARSE: u32 = 0x4u;
 let STAGE_COARSE: u32 = 0x8u;
 
+// This must be kept in sync with the struct in src/render.rs
 struct BumpAllocators {
     // Bitmask of stages that have failed allocation.
     failed: atomic<u32>,

--- a/shader/shared/bump.wgsl
+++ b/shader/shared/bump.wgsl
@@ -1,9 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
-// TODO: robust memory (failure flags)
+// Bitflags for each stage that can fail allocation.
+let STAGE_BINNING: u32 = 0x1u;
+let STAGE_TILE_ALLOC: u32 = 0x2u;
+let STAGE_PATH_COARSE: u32 = 0x4u;
+let STAGE_COARSE: u32 = 0x8u;
+
 struct BumpAllocators {
+    // Bitmask of stages that have failed allocation.
+    failed: atomic<u32>,
+    binning_size: u32,
+    ptcl_size: u32,
+    tiles_size: u32,
+    segments_size: u32,
     binning: atomic<u32>,
     ptcl: atomic<u32>,
     tile: atomic<u32>,
     segments: atomic<u32>,
+    blend: atomic<u32>,
 }

--- a/shader/shared/bump.wgsl
+++ b/shader/shared/bump.wgsl
@@ -10,10 +10,6 @@ let STAGE_COARSE: u32 = 0x8u;
 struct BumpAllocators {
     // Bitmask of stages that have failed allocation.
     failed: atomic<u32>,
-    binning_size: u32,
-    ptcl_size: u32,
-    tiles_size: u32,
-    segments_size: u32,
     binning: atomic<u32>,
     ptcl: atomic<u32>,
     tile: atomic<u32>,

--- a/shader/shared/config.wgsl
+++ b/shader/shared/config.wgsl
@@ -24,6 +24,12 @@ struct Config {
 
     transform_base: u32,
     linewidth_base: u32,
+
+    // Sizes of bump allocated buffers (in element size units)
+    binning_size: u32,
+    tiles_size: u32,
+    segments_size: u32,    
+    ptcl_size: u32,
 }
 
 // Geometry of tiles and bins

--- a/shader/shared/config.wgsl
+++ b/shader/shared/config.wgsl
@@ -35,3 +35,5 @@ let N_TILE_X = 16u;
 let N_TILE_Y = 16u;
 //let N_TILE = N_TILE_X * N_TILE_Y;
 let N_TILE = 256u;
+
+let BLEND_STACK_SPLIT = 4u;

--- a/shader/tile_alloc.wgsl
+++ b/shader/tile_alloc.wgsl
@@ -35,6 +35,9 @@ fn main(
     @builtin(global_invocation_id) global_id: vec3<u32>,
     @builtin(local_invocation_id) local_id: vec3<u32>,
 ) {
+    if (atomicLoad(&bump.failed) & STAGE_BINNING) != 0u {
+        return;
+    }    
     // scale factors useful for converting coordinates to tiles
     // TODO: make into constants
     let SX = 1.0 / f32(TILE_WIDTH);
@@ -72,8 +75,13 @@ fn main(
         sh_tile_count[local_id.x] = total_tile_count;
     }
     if local_id.x == WG_SIZE - 1u {
-        paths[drawobj_ix].tiles = atomicAdd(&bump.tile, sh_tile_count[WG_SIZE - 1u]);
-    }
+        var offset = atomicAdd(&bump.tile, sh_tile_count[WG_SIZE - 1u]);
+        if offset > bump.tiles_size {
+            offset = 0u;
+            atomicOr(&bump.failed, STAGE_TILE_ALLOC);
+        }
+        paths[drawobj_ix].tiles = offset;
+    }    
     // Using storage barriers is a workaround for what appears to be a miscompilation
     // when a normal workgroup-shared variable is used to broadcast the value.
     storageBarrier();

--- a/src/encoding/packed.rs
+++ b/src/encoding/packed.rs
@@ -62,6 +62,14 @@ pub struct Config {
     pub target_height: u32,
     /// Layout of packed scene data.
     pub layout: Layout,
+    /// Size of binning buffer allocation (in u32s).
+    pub binning_size: u32,
+    /// Size of tile buffer allocation (in Tiles).
+    pub tiles_size: u32,
+    /// Size of segment buffer allocation (in PathSegments).
+    pub segments_size: u32,
+    /// Size of per-tile command list buffer allocation (in u32s).
+    pub ptcl_size: u32,
 }
 
 /// Packed encoding of scene data.

--- a/src/render.rs
+++ b/src/render.rs
@@ -61,10 +61,13 @@ pub const fn next_multiple_of(val: u32, rhs: u32) -> u32 {
 #[derive(Clone, Copy, Debug, Default, Zeroable, Pod)]
 struct BumpAllocators {
     failed: u32,
+    // Sizes of the provided buffers
     binning_size: u32,
     ptcl_size: u32,
     tiles_size: u32,
     segments_size: u32,
+    // Final needed dynamic size of the buffers. If any of these are larger than the corresponding `_size` element
+    // reallocation needs to occur
     binning: u32,
     ptcl: u32,
     tile: u32,

--- a/src/render.rs
+++ b/src/render.rs
@@ -56,7 +56,7 @@ pub const fn next_multiple_of(val: u32, rhs: u32) -> u32 {
     }
 }
 
-// This must be kept in sync with the struct in shaders/shared/bump.wgsl
+// This must be kept in sync with the struct in shader/shared/bump.wgsl
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, Zeroable, Pod)]
 struct BumpAllocators {


### PR DESCRIPTION
Initial cut of robust memory for the WGSL port. This currently only handles the GPU side but is missing reading/writing the spilled blend stack in fine.