### PR TITLE
Allow selecting GPU from env

### DIFF
--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -15,6 +15,7 @@ pollster = "0.2.5"
 # for picosvg
 roxmltree = "0.13"
 clap = { version = "4.1.0", features = ["derive"] }
+env_logger = "0.10.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 vello = { path = "../../", features = ["hot_reload"] }

--- a/examples/with_winit/src/main.rs
+++ b/examples/with_winit/src/main.rs
@@ -225,6 +225,7 @@ enum UserEvent {
 
 fn main() {
     let args = Args::parse();
+    env_logger::init();
     #[cfg(not(target_arch = "wasm32"))]
     {
         use winit::{dpi::LogicalSize, window::WindowBuilder};

--- a/src/util.rs
+++ b/src/util.rs
@@ -96,13 +96,12 @@ impl RenderContext {
 
     /// Creates a compatible device handle id.
     async fn new_device(&mut self, compatible_surface: Option<&Surface>) -> Option<usize> {
-        let adapter = self
-            .instance
-            .request_adapter(&RequestAdapterOptions {
-                compatible_surface,
-                ..Default::default()
-            })
-            .await?;
+        let adapter = wgpu::util::initialize_adapter_from_env_or_default(
+            &self.instance,
+            wgpu::Backends::PRIMARY,
+            compatible_surface,
+        )
+        .await?;
         let features = adapter.features();
         let limits = Limits::default();
         let (device, queue) = adapter


### PR DESCRIPTION
Running the `with_winit` example fails on my machine because it chooses the "wrong" gpu and then fails with `[destroyed object]: error 7: importing the supplied dmabufs failed`.

I'm not sure what's the *best* fix for this (i509VCB suggested on the wgpu helix that newer mesas may do this better), but this pr makes it possible to at least override the desired adapter from the environment. So after this pr, `cargo run -p with_winit` still fails for me but

`WGPU_ADAPTER_NAME="AMD RADV DIMGREY_CAVEFISH" cargo run -p with_winit`

succeeds.