### PR TITLE
Update to wgpu 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ version = "0.1.0"
 [patch.crates-io]
 # Required for metal support to work on wgpu
 # TODO: remove when wgpu is upgraded to 0.15
-naga = { git = "https://github.com/gfx-rs/naga", rev = "ddcd5d3121150b2b1beee6e54e9125ff31aaa9a2" }
+# naga = { git = "https://github.com/gfx-rs/naga", rev = "ddcd5d3121150b2b1beee6e54e9125ff31aaa9a2" }
+wgpu = {git = "https://github.com/gfx-rs/wgpu", rev = "5a999e624a2f86cac30db48e333458942f0e3660"}
 
 [package]
 name = "vello"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,19 @@
 [workspace]
 resolver = "2"
 
-members = ["examples/with_winit", "examples/with_bevy", "examples/run_wasm", "examples/usvg_viewer"]
+members = [
+    "examples/with_winit",
+    "examples/with_bevy",
+    "examples/run_wasm",
+    "examples/usvg_viewer",
+]
 
 [workspace.package]
 edition = "2021"
 version = "0.1.0"
 
-[patch.crates-io]
-# Required for metal support to work on wgpu
-# TODO: remove when wgpu is upgraded to 0.15
-# naga = { git = "https://github.com/gfx-rs/naga", rev = "ddcd5d3121150b2b1beee6e54e9125ff31aaa9a2" }
-wgpu = {git = "https://github.com/gfx-rs/wgpu", rev = "5a999e624a2f86cac30db48e333458942f0e3660"}
+[workspace.dependencies]
+wgpu = "0.15"
 
 [package]
 name = "vello"
@@ -20,7 +22,7 @@ license = "MIT/Apache-2.0"
 edition = "2021"
 
 [dependencies]
-wgpu = "0.14"
+wgpu = { workspace = true }
 raw-window-handle = "0.5"
 futures-intrusive = "0.5.0"
 parking_lot = "0.12"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Xi Zulip](https://img.shields.io/badge/Xi%20Zulip-%23gpu-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/stream/197075-gpu)
 [![dependency status](https://deps.rs/repo/github/linebender/vello/status.svg)](https://deps.rs/repo/github/linebender/vello)
 [![MIT/Apache 2.0](https://img.shields.io/badge/license-MIT%2FApache-blue.svg)](#license)
-[![wgpu version](https://img.shields.io/badge/wgpu-v0.14-orange.svg)](https://crates.io/crates/wgpu)
+[![wgpu version](https://img.shields.io/badge/wgpu-v0.15-orange.svg)](https://crates.io/crates/wgpu)
 <!-- [![Crates.io](https://img.shields.io/crates/v/vello.svg)](https://crates.io/crates/vello) -->
 <!-- [![Docs](https://docs.rs/vello/badge.svg)](https://docs.rs/vello) -->
 <!-- [![Build status](https://github.com/linebender/vello/workflows/CI/badge.svg)](https://github.com/linebender/vello/actions) -->

--- a/examples/usvg_viewer/Cargo.toml
+++ b/examples/usvg_viewer/Cargo.toml
@@ -18,5 +18,5 @@ sha2 = "0.10"
 ureq = "2.6"
 usvg = "0.28"
 vello = { path = "../../" }
-wgpu = "0.14"
+wgpu = { workspace = true }
 winit = "0.27.5"

--- a/examples/with_bevy/Cargo.toml
+++ b/examples/with_bevy/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.9"
+bevy = { git = "https://github.com/bevyengine/bevy", rev = "5d514fb24f2459700f68d8e57d4791bdf5b1b595" }
 vello = { path = "../../" }

--- a/examples/with_bevy/src/main.rs
+++ b/examples/with_bevy/src/main.rs
@@ -91,12 +91,16 @@ impl ExtractComponent for VelloScene {
 
     type Filter = ();
 
-    fn extract_component((fragment, target): bevy::ecs::query::QueryItem<'_, Self::Query>) -> Self {
+    type Out = Self;
+
+    fn extract_component(
+        (fragment, target): bevy::ecs::query::QueryItem<'_, Self::Query>,
+    ) -> Option<Self> {
         let mut scene = Scene::default();
         let mut builder = SceneBuilder::for_scene(&mut scene);
         builder.append(&fragment.0, None);
         builder.finish();
-        Self(scene, target.0.clone())
+        Some(Self(scene, target.0.clone()))
     }
 }
 
@@ -124,6 +128,7 @@ fn setup(
             usage: TextureUsages::TEXTURE_BINDING
                 | TextureUsages::COPY_DST
                 | TextureUsages::STORAGE_BINDING,
+            view_formats: &[],
         },
         ..default()
     };

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wgpu = "0.14"
+wgpu = { workspace = true }
 vello = { path = "../../", features = ["buffer_labels"] }
 winit = "0.27.5"
 pollster = "0.2.5"

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -293,7 +293,7 @@ impl Engine {
                         dimension: wgpu::TextureDimension::D2,
                         usage: TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST,
                         format,
-                        view_formats: &[format],
+                        view_formats: &[],
                     });
                     let texture_view = texture.create_view(&wgpu::TextureViewDescriptor {
                         label: None,
@@ -647,7 +647,7 @@ impl BindMap {
                             dimension: wgpu::TextureDimension::D2,
                             usage: TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST,
                             format,
-                            view_formats: &[format],
+                            view_formats: &[],
                         });
                         let texture_view = texture.create_view(&wgpu::TextureViewDescriptor {
                             label: None,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -280,6 +280,7 @@ impl Engine {
                         contents: bytes,
                         usage: wgpu::BufferUsages::COPY_SRC,
                     });
+                    let format = image_proxy.format.to_wgpu();
                     let texture = device.create_texture(&wgpu::TextureDescriptor {
                         label: None,
                         size: wgpu::Extent3d {
@@ -291,7 +292,8 @@ impl Engine {
                         sample_count: 1,
                         dimension: wgpu::TextureDimension::D2,
                         usage: TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST,
-                        format: image_proxy.format.to_wgpu(),
+                        format,
+                        view_formats: &[format],
                     });
                     let texture_view = texture.create_view(&wgpu::TextureViewDescriptor {
                         label: None,
@@ -632,6 +634,7 @@ impl BindMap {
                         continue;
                     }
                     if let Entry::Vacant(v) = self.image_map.entry(proxy.id) {
+                        let format = proxy.format.to_wgpu();
                         let texture = device.create_texture(&wgpu::TextureDescriptor {
                             label: None,
                             size: wgpu::Extent3d {
@@ -643,7 +646,8 @@ impl BindMap {
                             sample_count: 1,
                             dimension: wgpu::TextureDimension::D2,
                             usage: TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST,
-                            format: proxy.format.to_wgpu(),
+                            format,
+                            view_formats: &[format],
                         });
                         let texture_view = texture.create_view(&wgpu::TextureViewDescriptor {
                             label: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,7 +286,7 @@ impl TargetTexture {
             dimension: wgpu::TextureDimension::D2,
             usage: wgpu::TextureUsages::STORAGE_BINDING | wgpu::TextureUsages::TEXTURE_BINDING,
             format: wgpu::TextureFormat::Rgba8Unorm,
-            view_formats: &[wgpu::TextureFormat::Rgba8Unorm],
+            view_formats: &[],
         });
         let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
         Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,6 +286,7 @@ impl TargetTexture {
             dimension: wgpu::TextureDimension::D2,
             usage: wgpu::TextureUsages::STORAGE_BINDING | wgpu::TextureUsages::TEXTURE_BINDING,
             format: wgpu::TextureFormat::Rgba8Unorm,
+            view_formats: &[wgpu::TextureFormat::Rgba8Unorm],
         });
         let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
         Self {

--- a/src/shaders/preprocess.rs
+++ b/src/shaders/preprocess.rs
@@ -139,10 +139,10 @@ pub fn preprocess(input: &str, defines: &HashSet<String>, imports: &HashMap<&str
             }
         }
         if stack.iter().all(|item| item.active) {
-            // Naga does not yet recognize `const` but web does not allow global `let`. We
+            // wgsl-analyzer does not yet recognize `const` but naga does not allow global `let`. We
             // use `let` in our canonical sources to satisfy wgsl-analyzer but replace with
-            // `const` when targeting web.
-            if cfg!(target_arch = "wasm32") && line.starts_with("let ") {
+            // `const` when using
+            if line.starts_with("let ") {
                 output.push_str("const");
                 output.push_str(&line[3..]);
             } else {

--- a/src/util.rs
+++ b/src/util.rs
@@ -63,6 +63,7 @@ impl RenderContext {
             height,
             present_mode: wgpu::PresentMode::Fifo,
             alpha_mode: wgpu::CompositeAlphaMode::Auto,
+            view_formats: vec![],
         };
         let dev_id = self.device(Some(&surface)).await.unwrap();
         surface.configure(&self.devices[dev_id].device, &config);

--- a/src/util.rs
+++ b/src/util.rs
@@ -39,7 +39,10 @@ pub struct DeviceHandle {
 
 impl RenderContext {
     pub fn new() -> Result<Self> {
-        let instance = Instance::new(wgpu::Backends::PRIMARY);
+        let instance = Instance::new(wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::PRIMARY,
+            dx12_shader_compiler: wgpu::Dx12Compiler::Fxc,
+        });
         Ok(Self {
             instance,
             devices: Vec::new(),
@@ -51,7 +54,7 @@ impl RenderContext {
     where
         W: HasRawWindowHandle + HasRawDisplayHandle,
     {
-        let surface = unsafe { self.instance.create_surface(window) };
+        let surface = unsafe { self.instance.create_surface(window) }.unwrap();
         let format = wgpu::TextureFormat::Bgra8Unorm;
         let config = wgpu::SurfaceConfiguration {
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,


### PR DESCRIPTION
This is just the lowest friction path to wgpu main.

The biggest issue is naga has changed global variables from let to const, in line with the spec. This is not yet supported by wgsl-analyzer.