### PR TITLE
Fixes to get example running in wasm

### DIFF
--- a/examples/with_winit/src/main.rs
+++ b/examples/with_winit/src/main.rs
@@ -225,6 +225,9 @@ enum UserEvent {
 
 fn main() {
     let args = Args::parse();
+    // TODO: initializing both env_logger and console_logger fails on wasm.
+    // Figure out a more principled approach.
+    #[cfg(not(target_arch = "wasm32"))]
     env_logger::init();
     #[cfg(not(target_arch = "wasm32"))]
     {
@@ -261,6 +264,6 @@ fn main() {
             .and_then(|doc| doc.body())
             .and_then(|body| body.append_child(&web_sys::Element::from(canvas)).ok())
             .expect("couldn't append canvas to document body");
-        wasm_bindgen_futures::spawn_local(run(event_loop, window));
+        wasm_bindgen_futures::spawn_local(run(event_loop, window, args));
     }
 }

--- a/examples/with_winit/src/test_scene.rs
+++ b/examples/with_winit/src/test_scene.rs
@@ -82,9 +82,11 @@ pub fn render_svg_scene(
 ) {
     let scene_frag = scene.get_or_insert_with(|| {
         use super::pico_svg::*;
+        #[cfg(not(target_arch = "wasm32"))]
         let start = Instant::now();
         eprintln!("Starting to parse svg");
         let svg = PicoSvg::load(svg, scale).unwrap();
+        #[cfg(not(target_arch = "wasm32"))]
         eprintln!("Parsing svg took {:?}", start.elapsed());
         let mut new_scene = SceneFragment::new();
         let mut builder = SceneBuilder::for_fragment(&mut new_scene);

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -352,7 +352,19 @@ impl Engine {
                 }
                 Command::Clear(proxy, offset, size) => {
                     let buffer = bind_map.get_or_create(*proxy, device, &mut self.pool)?;
+                    #[cfg(not(target_arch = "wasm32"))]
                     encoder.clear_buffer(buffer, *offset, *size);
+                    #[cfg(target_arch = "wasm32")]
+                    {
+                        // TODO: remove this workaround when wgpu implements clear_buffer
+                        // Also note: semantics are wrong, it's queue order rather than encoder.
+                        let size = match size {
+                            Some(size) => size.get(),
+                            None => proxy.size,
+                        };
+                        let zeros = vec![0; size as usize];
+                        queue.write_buffer(buffer, *offset, &zeros);
+                    }
                 }
             }
         }

--- a/src/shaders.rs
+++ b/src/shaders.rs
@@ -160,6 +160,11 @@ pub fn full_shaders(device: &Device, engine: &mut Engine) -> Result<FullShaders,
     let mut small_config = HashSet::new();
     small_config.insert("full".into());
     small_config.insert("small".into());
+    // TODO: remove this workaround when workgroupUniformLoad lands in naga
+    #[allow(unused_mut)]
+    let mut uniform = HashSet::new();
+    #[cfg(target_arch = "wasm32")]
+    uniform.insert("have_uniform".into());
     let pathtag_reduce = engine.add_shader(
         device,
         "pathtag_reduce",
@@ -286,7 +291,7 @@ pub fn full_shaders(device: &Device, engine: &mut Engine) -> Result<FullShaders,
     let tile_alloc = engine.add_shader(
         device,
         "tile_alloc",
-        preprocess::preprocess(shader!("tile_alloc"), &empty, &imports).into(),
+        preprocess::preprocess(shader!("tile_alloc"), &uniform, &imports).into(),
         &[
             BindType::Uniform,
             BindType::BufReadOnly,
@@ -321,7 +326,7 @@ pub fn full_shaders(device: &Device, engine: &mut Engine) -> Result<FullShaders,
     let coarse = engine.add_shader(
         device,
         "coarse",
-        preprocess::preprocess(shader!("coarse"), &empty, &imports).into(),
+        preprocess::preprocess(shader!("coarse"), &uniform, &imports).into(),
         &[
             BindType::Uniform,
             BindType::BufReadOnly,


### PR DESCRIPTION
A number of things were wrong:

* The args were missing to `run`
* The robust memory changes introduced uniformity errors
* `clear_buffer` is a todo for wgpu on wasm
* Some more time calls crept in
* Initializing both env_logger and console_logger fails

In addition, we conditionally opt the shaders into `workgroupUniformLoad`, as that's available on wasm but not yet native.

Some of the things (args, uniformity errors) are important fixes. Other things (clear_buffer, wUL being optional) are workarounds for wgpu limitations and have TODO items to be removed when wgpu catches up.