### PR TITLE
Update dependencies, and add more metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ repository = "https://github.com/linebender/vello"
 name = "vello"
 description = "An experimental GPU compute-centric 2D renderer"
 categories = ["rendering", "graphics"]
-keywords = ["2d", "vector-graphics"]                            # , "xilem"?
+keywords = ["2d", "vector-graphics"]
 
 # This crate is intended for publishing, but not ready yet
 publish = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,16 +12,29 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.1.0"
-
-[workspace.dependencies]
-wgpu = "0.15"
+version = "0.0.1"
+license = "MIT/Apache-2.0"
+# homepage = "https://vello.dev" - Domain owned by us, but unused at present
+# rust-version = 
+repository = "https://github.com/linebender/vello"
 
 [package]
 name = "vello"
-version = "0.1.0"
-license = "MIT/Apache-2.0"
-edition = "2021"
+description = "An experimental GPU compute-centric 2D renderer"
+categories = ["rendering", "graphics"]
+keywords = ["2d", "vector-graphics"]                            # , "xilem"?
+
+# This crate is intended for publishing, but not ready yet
+publish = false
+
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
+
+[features]
+hot_reload = []
+buffer_labels = []
 
 [dependencies]
 wgpu = { workspace = true }
@@ -33,6 +46,9 @@ smallvec = "1.8.0"
 moscato = { git = "https://github.com/dfrg/pinot", rev = "59db153" }
 peniko = { git = "https://github.com/linebender/peniko", rev = "8cb710f" }
 
-[features]
-hot_reload = []
-buffer_labels = []
+[workspace.dependencies]
+wgpu = "0.15"
+
+# Used for examples
+clap = "4.1.0"
+anyhow = "1.0"

--- a/examples/run_wasm/Cargo.toml
+++ b/examples/run_wasm/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "run_wasm"
-version.workspace = true
-edition.workspace = true
 publish = false
+
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/scenes/Cargo.toml
+++ b/examples/scenes/Cargo.toml
@@ -1,17 +1,22 @@
 [package]
 name = "scenes"
 description = "Vello scenes used in the other examples"
-version.workspace = true
-edition.workspace = true
 publish = false
+
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 vello = { path = "../../" }
 vello_svg = { path = "../../integrations/vello_svg" }
-anyhow = "1.0"
-clap = { version = "4.1.1", features = ["derive"] }
+anyhow = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+
+# Used for the `download` command
+byte-unit = "4.0"
 dialoguer = "0.10"
 ureq = "2.6"
-byte-unit = "4.0"

--- a/examples/with_bevy/Cargo.toml
+++ b/examples/with_bevy/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "with_bevy"
-version = "0.1.0"
-edition = "2021"
 description = "Example of using Vello in a Bevy application"
+
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -1,22 +1,24 @@
 [package]
 name = "with_winit"
 description = "An example using vello to render to a winit window"
-version.workspace = true
-edition.workspace = true
 publish = false
+
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wgpu = { workspace = true }
 vello = { path = "../../", features = ["buffer_labels"] }
 scenes = { path = "../scenes" }
-anyhow = "1.0"
-winit = "0.27.5"
+anyhow = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+
+wgpu = { workspace = true }
+winit = "0.28.1"
 pollster = "0.2.5"
-# for picosvg
-roxmltree = "0.13"
-clap = { version = "4.1.0", features = ["derive"] }
 env_logger = "0.10.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/integrations/vello_svg/Cargo.toml
+++ b/integrations/vello_svg/Cargo.toml
@@ -1,8 +1,13 @@
 [package]
 name = "vello_svg"
 description = "Render a usvg document to a vello scene"
+categories = ["rendering", "graphics"]
+keywords = ["2d", "vector-graphics", "vello"]
+
 version.workspace = true
+license.workspace = true
 edition.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
I've also made sure to use workspace inheritance where it makes sense - this includes any dependencies used in multiple crates.

The only real dependency update is `winit 0.28`, which appears to work fine. I'm intending to update our winit example so it can be used on Android properly, but I need to find a good example of how to do that.

I've left `rust-version` as commented out because we don't have an MSRV policy. We should probably make one, but it's not urgent.

Because of these changes, the root `vello` crate would now be published using `cargo publish`. Because of this, I've added `publish=false` to it, until we're ready.

I've also changed the inherited version to `0.0.1`, as we're still e.g. printing debug information each frame, have no CI, etc.
I've also removed the `roxmltree` dependency from `with_winit`, although it is still used in the tree through usvg anyway