### PR TITLE
Fix include_str! compile error in examples/scenes.

### DIFF
--- a/examples/scenes/src/test_scenes.rs
+++ b/examples/scenes/src/test_scenes.rs
@@ -243,7 +243,7 @@ fn included_tiger() -> impl FnMut(&mut SceneBuilder, &mut SceneParams) {
         let (scene_frag, resolution) = cached_scene.get_or_insert_with(|| {
             let contents = include_str!(concat!(
                 env!("CARGO_MANIFEST_DIR"),
-                "../../assets/Ghostscript_Tiger.svg"
+                "/../assets/Ghostscript_Tiger.svg"
             ));
             let svg = usvg::Tree::from_str(&contents, &usvg::Options::default())
                 .expect("failed to parse svg file");


### PR DESCRIPTION
I don't think `CARGO_MANIFEST_DIR` should ever end in "/", though I've only checked on Linux and macOS.