### PR TITLE
Fix brush transforms

### DIFF
--- a/examples/scenes/src/test_scenes.rs
+++ b/examples/scenes/src/test_scenes.rs
@@ -192,14 +192,25 @@ fn brush_transform(sb: &mut SceneBuilder, params: &mut SceneParams) {
     ]);
     sb.fill(
         Fill::NonZero,
-        Affine::translate((200.0, 200.0)),
+        Affine::rotate(25f64.to_radians()) * Affine::scale_non_uniform(2.0, 1.0),
+        &Gradient::new_radial((200.0, 200.0), 80.0).with_stops([
+            Color::RED,
+            Color::GREEN,
+            Color::BLUE,
+        ]),
+        None,
+        &Rect::from_origin_size((100.0, 100.0), (200.0, 200.0)),
+    );
+    sb.fill(
+        Fill::NonZero,
+        Affine::translate((200.0, 600.0)),
         &linear,
         Some(around_center(Affine::rotate(th), Point::new(200.0, 100.0))),
         &Rect::from_origin_size(Point::default(), (400.0, 200.0)),
     );
     sb.stroke(
         &Stroke::new(40.0),
-        Affine::translate((800.0, 200.0)),
+        Affine::translate((800.0, 600.0)),
         &linear,
         Some(around_center(Affine::rotate(th), Point::new(200.0, 100.0))),
         &Rect::from_origin_size(Point::default(), (400.0, 200.0)),

--- a/shader/draw_leaf.wgsl
+++ b/shader/draw_leaf.wgsl
@@ -151,11 +151,7 @@ fn main(
                 let r1 = bitcast<f32>(scene[dd + 6u]);
                 let inv_det = 1.0 / (matrx.x * matrx.w - matrx.y * matrx.z);
                 let inv_mat = inv_det * vec4(matrx.w, -matrx.y, -matrx.z, matrx.x);
-                var inv_tr = inv_det * vec2(
-                    matrx.z * translate.y - matrx.w * translate.x,
-                    matrx.y * translate.x - matrx.x * translate.y,
-                );
-                inv_tr -= p0;
+                let inv_tr = mat2x2(inv_mat.xy, inv_mat.zw) * -translate - p0;
                 let center1 = p1 - p0;
                 let rr = r1 / (r1 - r0);
                 let ra_inv = rr / (r1 * r1 - dot(center1, center1));

--- a/shader/draw_leaf.wgsl
+++ b/shader/draw_leaf.wgsl
@@ -151,9 +151,9 @@ fn main(
                 let r1 = bitcast<f32>(scene[dd + 6u]);
                 let inv_det = 1.0 / (matrx.x * matrx.w - matrx.y * matrx.z);
                 let inv_mat = inv_det * vec4(matrx.w, -matrx.y, -matrx.z, matrx.x);
-                var inv_tr = vec2(
-                    inv_det * (matrx.z * translate.y - matrx.w * translate.x),
-                    inv_det * (matrx.y * translate.x - matrx.x * translate.y),
+                var inv_tr = inv_det * vec2(
+                    matrx.z * translate.y - matrx.w * translate.x,
+                    matrx.y * translate.x - matrx.x * translate.y,
                 );
                 inv_tr -= p0;
                 let center1 = p1 - p0;

--- a/shader/draw_leaf.wgsl
+++ b/shader/draw_leaf.wgsl
@@ -155,7 +155,7 @@ fn main(
                     inv_det * (matrx.z * translate.y - matrx.w * translate.x),
                     inv_det * (matrx.y * translate.x - matrx.x * translate.y),
                 );
-                inv_tr += p0;
+                inv_tr -= p0;
                 let center1 = p1 - p0;
                 let rr = r1 / (r1 - r0);
                 let ra_inv = rr / (r1 * r1 - dot(center1, center1));

--- a/shader/draw_leaf.wgsl
+++ b/shader/draw_leaf.wgsl
@@ -151,7 +151,10 @@ fn main(
                 let r1 = bitcast<f32>(scene[dd + 6u]);
                 let inv_det = 1.0 / (matrx.x * matrx.w - matrx.y * matrx.z);
                 let inv_mat = inv_det * vec4(matrx.w, -matrx.y, -matrx.z, matrx.x);
-                var inv_tr = inv_mat.xz * translate.x + inv_mat.yw * translate.y;
+                var inv_tr = vec2(
+                    inv_det * (matrx.z * translate.y - matrx.w * translate.x),
+                    inv_det * (matrx.y * translate.x - matrx.x * translate.y),
+                );
                 inv_tr += p0;
                 let center1 = p1 - p0;
                 let rr = r1 / (r1 - r0);

--- a/shader/fine.wgsl
+++ b/shader/fine.wgsl
@@ -251,7 +251,7 @@ fn main(
                 for (var i = 0u; i < PIXELS_PER_THREAD; i += 1u) {
                     let my_xy = vec2(xy.x + f32(i), xy.y);
                     // TODO: can hoist y, but for now stick to the GLSL version
-                    let xy_xformed = rad.matrx.xz * my_xy.x + rad.matrx.yw * my_xy.y - rad.xlat;
+                    let xy_xformed = rad.matrx.xy * my_xy.x + rad.matrx.zw * my_xy.y - rad.xlat;
                     let ba = dot(xy_xformed, rad.c1);
                     let ca = rad.ra * dot(xy_xformed, xy_xformed);
                     let t = sqrt(ba * ba + ca) - ba - rad.roff;

--- a/shader/fine.wgsl
+++ b/shader/fine.wgsl
@@ -251,7 +251,7 @@ fn main(
                 for (var i = 0u; i < PIXELS_PER_THREAD; i += 1u) {
                     let my_xy = vec2(xy.x + f32(i), xy.y);
                     // TODO: can hoist y, but for now stick to the GLSL version
-                    let xy_xformed = rad.matrx.xy * my_xy.x + rad.matrx.zw * my_xy.y - rad.xlat;
+                    let xy_xformed = rad.matrx.xy * my_xy.x + rad.matrx.zw * my_xy.y + rad.xlat;
                     let ba = dot(xy_xformed, rad.c1);
                     let ca = rad.ra * dot(xy_xformed, xy_xformed);
                     let t = sqrt(ba * ba + ca) - ba - rad.roff;

--- a/src/encoding/encoding.rs
+++ b/src/encoding/encoding.rs
@@ -120,10 +120,16 @@ impl Encoding {
     }
 
     /// Encodes a transform.
-    pub fn encode_transform(&mut self, transform: Transform) {
+    ///
+    /// If the given transform is different from the current one, encodes it an
+    /// returns true. Otherwise, encodes nothing and returns false.
+    pub fn encode_transform(&mut self, transform: Transform) -> bool {
         if self.transforms.last() != Some(&transform) {
             self.path_tags.push(PathTag::TRANSFORM);
             self.transforms.push(transform);
+            true
+        } else {
+            false
         }
     }
 

--- a/src/encoding/encoding.rs
+++ b/src/encoding/encoding.rs
@@ -121,7 +121,7 @@ impl Encoding {
 
     /// Encodes a transform.
     ///
-    /// If the given transform is different from the current one, encodes it an
+    /// If the given transform is different from the current one, encodes it and
     /// returns true. Otherwise, encodes nothing and returns false.
     pub fn encode_transform(&mut self, transform: Transform) -> bool {
         if self.transforms.last() != Some(&transform) {

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -140,13 +140,14 @@ impl<'a> SceneBuilder<'a> {
         });
         if self.scene.encode_shape(shape, true) {
             if let Some(brush_transform) = brush_transform {
-                self.scene
-                    .encode_transform(Transform::from_kurbo(&(transform * brush_transform)));
-                self.scene.swap_last_path_tags();
-                self.scene.encode_brush(brush, 1.0);
-            } else {
-                self.scene.encode_brush(brush, 1.0);
+                if self
+                    .scene
+                    .encode_transform(Transform::from_kurbo(&(transform * brush_transform)))
+                {
+                    self.scene.swap_last_path_tags();
+                }
             }
+            self.scene.encode_brush(brush, 1.0);
         }
     }
 
@@ -164,13 +165,14 @@ impl<'a> SceneBuilder<'a> {
         self.scene.encode_linewidth(style.width);
         if self.scene.encode_shape(shape, false) {
             if let Some(brush_transform) = brush_transform {
-                self.scene
-                    .encode_transform(Transform::from_kurbo(&(transform * brush_transform)));
-                self.scene.swap_last_path_tags();
-                self.scene.encode_brush(brush, 1.0);
-            } else {
-                self.scene.encode_brush(brush, 1.0);
+                if self
+                    .scene
+                    .encode_transform(Transform::from_kurbo(&(transform * brush_transform)))
+                {
+                    self.scene.swap_last_path_tags();
+                }
             }
+            self.scene.encode_brush(brush, 1.0);
         }
     }
 


### PR DESCRIPTION
This fixes an incorrect application of the inverse transform for radial gradients in fine.

Also fixes an edge case in `SceneBuilder` where supplying a brush transform that is identical to the path transform generates a corrupt encoding.

Discovery of both done by @DJMcNab on [this zulip thread](https://xi.zulipchat.com/#narrow/stream/197075-gpu/topic/Radial.20Blending.20Behaviour.20-.20vello.23281).

Should fix #281 