### PR TITLE
Add a base-color uniform

### DIFF
--- a/examples/headless/src/main.rs
+++ b/examples/headless/src/main.rs
@@ -96,6 +96,7 @@ async fn render(mut scenes: SceneSet, index: usize, args: &Args) -> Result<()> {
         time: args.time.unwrap_or(0.),
         text: &mut text,
         resolution: None,
+        base_color: None,
     };
     (example_scene.function)(&mut builder, &mut scene_params);
     builder.finish();
@@ -130,6 +131,7 @@ async fn render(mut scenes: SceneSet, index: usize, args: &Args) -> Result<()> {
         base_color: args
             .args
             .get_base_color()?
+            .or(scene_params.base_color)
             .unwrap_or(vello::peniko::Color::BLACK),
         width,
         height,

--- a/examples/headless/src/main.rs
+++ b/examples/headless/src/main.rs
@@ -130,7 +130,7 @@ async fn render(mut scenes: SceneSet, index: usize, args: &Args) -> Result<()> {
     let render_params = vello::RenderParams {
         base_color: args
             .args
-            .get_base_color()?
+            .base_color
             .or(scene_params.base_color)
             .unwrap_or(vello::peniko::Color::BLACK),
         width,

--- a/examples/headless/src/main.rs
+++ b/examples/headless/src/main.rs
@@ -126,6 +126,11 @@ async fn render(mut scenes: SceneSet, index: usize, args: &Args) -> Result<()> {
             (Some(x), Some(y)) => (x.try_into()?, y.try_into()?),
         }
     };
+    let params = vello::RenderParams {
+        clear_color: vello::peniko::Color::BLACK,
+        width,
+        height,
+    };
     let mut scene = Scene::new();
     let mut builder = SceneBuilder::for_scene(&mut scene);
     builder.append(&fragment, Some(transform));
@@ -147,7 +152,7 @@ async fn render(mut scenes: SceneSet, index: usize, args: &Args) -> Result<()> {
     });
     let view = target.create_view(&wgpu::TextureViewDescriptor::default());
     renderer
-        .render_to_texture(&device, &queue, &scene, &view, width, height)
+        .render_to_texture(&device, &queue, &scene, &view, &params)
         .or_else(|_| bail!("Got non-Send/Sync error from rendering"))?;
     // (width * 4).next_multiple_of(256)
     let padded_byte_width = {

--- a/examples/scenes/src/lib.rs
+++ b/examples/scenes/src/lib.rs
@@ -19,6 +19,7 @@ pub struct SceneParams<'a> {
     pub time: f64,
     pub text: &'a mut SimpleText,
     pub resolution: Option<Vec2>,
+    pub base_color: Option<vello::peniko::Color>,
 }
 
 pub struct SceneConfig {

--- a/examples/scenes/src/lib.rs
+++ b/examples/scenes/src/lib.rs
@@ -5,7 +5,7 @@ mod svg;
 mod test_scenes;
 use std::path::PathBuf;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use clap::{Args, Subcommand};
 use download::Download;
 pub use simple_text::SimpleText;
@@ -13,7 +13,7 @@ pub use simple_text::SimpleText;
 pub use svg::{default_scene, scene_from_files};
 pub use test_scenes::test_scenes;
 
-use vello::{kurbo::Vec2, SceneBuilder};
+use vello::{kurbo::Vec2, peniko::Color, SceneBuilder};
 
 pub struct SceneParams<'a> {
     pub time: f64,
@@ -46,6 +46,12 @@ pub struct Arguments {
     #[arg(help_heading = "Scene Selection", global(false))]
     /// The svg files paths to render
     svgs: Option<Vec<PathBuf>>,
+    #[arg(help_heading = "Render Parameters")]
+    #[arg(long, global(false))]
+    /// The base color applied as the blend background to the rasterizer.
+    /// Format is CSS style hexidecimal (#RGB, #RGBA, #RRGGBB, #RRGGBBAA) or
+    /// an SVG color name such as "aliceblue"
+    base_color: Option<String>,
     #[clap(subcommand)]
     command: Option<Command>,
 }
@@ -78,6 +84,17 @@ impl Arguments {
             }
             .map(Some)
         }
+    }
+
+    pub fn get_base_color(&self) -> Result<Option<Color>> {
+        self.base_color.as_ref().map_or_else(
+            || Ok(None),
+            |s| {
+                Color::parse(&s)
+                    .ok_or_else(|| anyhow!("malformed color: {}", s))
+                    .map(Some)
+            },
+        )
     }
 }
 

--- a/examples/scenes/src/lib.rs
+++ b/examples/scenes/src/lib.rs
@@ -48,11 +48,11 @@ pub struct Arguments {
     /// The svg files paths to render
     svgs: Option<Vec<PathBuf>>,
     #[arg(help_heading = "Render Parameters")]
-    #[arg(long, global(false))]
+    #[arg(long, global(false), value_parser = parse_color)]
     /// The base color applied as the blend background to the rasterizer.
     /// Format is CSS style hexidecimal (#RGB, #RGBA, #RRGGBB, #RRGGBBAA) or
     /// an SVG color name such as "aliceblue"
-    base_color: Option<String>,
+    pub base_color: Option<Color>,
     #[clap(subcommand)]
     command: Option<Command>,
 }
@@ -86,17 +86,6 @@ impl Arguments {
             .map(Some)
         }
     }
-
-    pub fn get_base_color(&self) -> Result<Option<Color>> {
-        self.base_color.as_ref().map_or_else(
-            || Ok(None),
-            |s| {
-                Color::parse(&s)
-                    .ok_or_else(|| anyhow!("malformed color: {}", s))
-                    .map(Some)
-            },
-        )
-    }
 }
 
 impl Command {
@@ -105,4 +94,8 @@ impl Command {
             Command::Download(download) => download.action(),
         }
     }
+}
+
+fn parse_color(s: &str) -> Result<Color> {
+    Color::parse(s).ok_or(anyhow!("'{s}' is not a valid color"))
 }

--- a/examples/scenes/src/test_scenes.rs
+++ b/examples/scenes/src/test_scenes.rs
@@ -32,6 +32,7 @@ pub fn test_scenes() -> SceneSet {
         scene!(blend_grid),
         scene!(conflation_artifacts),
         scene!(labyrinth),
+        scene!(base_color_test: animated),
     ];
     #[cfg(target_arch = "wasm32")]
     scenes.push(ExampleScene {
@@ -580,6 +581,21 @@ fn labyrinth(sb: &mut SceneBuilder, _: &mut SceneParams) {
         None,
         &path,
     )
+}
+
+fn base_color_test(sb: &mut SceneBuilder, params: &mut SceneParams) {
+    // Cycle through the hue value every 5 seconds (t % 5) * 360/5
+    let color = Color::hlc((params.time % 5.0) * 72.0, 80.0, 80.0);
+    params.base_color = Some(color);
+
+    // Blend a white square over it.
+    sb.fill(
+        Fill::NonZero,
+        Affine::IDENTITY,
+        Color::rgba8(255, 255, 255, 128),
+        None,
+        &Rect::new(50.0, 50.0, 500.0, 500.0),
+    );
 }
 
 fn around_center(xform: Affine, center: Point) -> Affine {

--- a/examples/with_bevy/src/main.rs
+++ b/examples/with_bevy/src/main.rs
@@ -46,7 +46,11 @@ fn render_scenes(
 ) {
     for scene in &mut scenes {
         let gpu_image = gpu_images.get(&scene.1).unwrap();
-
+        let params = vello::RenderParams {
+            clear_color: vello::peniko::Color::AQUAMARINE,
+            width: gpu_image.size.x as u32,
+            height: gpu_image.size.y as u32,
+        };
         renderer
             .0
             .render_to_texture(
@@ -54,8 +58,7 @@ fn render_scenes(
                 &*queue,
                 &scene.0,
                 &gpu_image.texture_view,
-                gpu_image.size.x as u32,
-                gpu_image.size.y as u32,
+                &params,
             )
             .unwrap();
     }

--- a/examples/with_bevy/src/main.rs
+++ b/examples/with_bevy/src/main.rs
@@ -47,7 +47,7 @@ fn render_scenes(
     for scene in &mut scenes {
         let gpu_image = gpu_images.get(&scene.1).unwrap();
         let params = vello::RenderParams {
-            clear_color: vello::peniko::Color::AQUAMARINE,
+            base_color: vello::peniko::Color::AQUAMARINE,
             width: gpu_image.size.x as u32,
             height: gpu_image.size.y as u32,
         };

--- a/shader/fine.wgsl
+++ b/shader/fine.wgsl
@@ -187,6 +187,9 @@ fn main(
     let xy = vec2(f32(global_id.x * PIXELS_PER_THREAD), f32(global_id.y));
 #ifdef full
     var rgba: array<vec4<f32>, PIXELS_PER_THREAD>;
+    for (var i = 0u; i < PIXELS_PER_THREAD; i += 1u) {
+        rgba[i] = unpack4x8unorm(config.clear_color).wzyx;
+    }
     var blend_stack: array<array<u32, PIXELS_PER_THREAD>, BLEND_STACK_SPLIT>;
     var clip_depth = 0u;
     var area: array<f32, PIXELS_PER_THREAD>;

--- a/shader/fine.wgsl
+++ b/shader/fine.wgsl
@@ -188,7 +188,7 @@ fn main(
 #ifdef full
     var rgba: array<vec4<f32>, PIXELS_PER_THREAD>;
     for (var i = 0u; i < PIXELS_PER_THREAD; i += 1u) {
-        rgba[i] = unpack4x8unorm(config.clear_color).wzyx;
+        rgba[i] = unpack4x8unorm(config.base_color).wzyx;
     }
     var blend_stack: array<array<u32, PIXELS_PER_THREAD>, BLEND_STACK_SPLIT>;
     var clip_depth = 0u;

--- a/shader/shared/config.wgsl
+++ b/shader/shared/config.wgsl
@@ -7,6 +7,11 @@ struct Config {
     target_width: u32,
     target_height: u32,
 
+    // The initial color applied to the pixels in a tile during the fine stage.
+    // This is only used in the full pipeline. The format is packed RGBA8 in MSB
+    // order.
+    clear_color: u32,
+
     n_drawobj: u32,
     n_path: u32,
     n_clip: u32,

--- a/shader/shared/config.wgsl
+++ b/shader/shared/config.wgsl
@@ -10,7 +10,7 @@ struct Config {
     // The initial color applied to the pixels in a tile during the fine stage.
     // This is only used in the full pipeline. The format is packed RGBA8 in MSB
     // order.
-    clear_color: u32,
+    base_color: u32,
 
     n_drawobj: u32,
     n_path: u32,

--- a/src/encoding/packed.rs
+++ b/src/encoding/packed.rs
@@ -48,7 +48,8 @@ pub struct Layout {
     pub linewidth_base: u32,
 }
 
-/// Scene configuration.
+/// Scene configuration. This data structure must be kept in sync with the definition in
+/// shaders/shared/config.wgsl.
 #[derive(Clone, Copy, Debug, Default, Zeroable, Pod)]
 #[repr(C)]
 pub struct Config {
@@ -60,8 +61,8 @@ pub struct Config {
     pub target_width: u32,
     /// Height of the target in pixels.
     pub target_height: u32,
-    /// The initial background color applied to the target
-    pub clear_color: u32,
+    /// The base background color applied to the target before any blends.
+    pub base_color: u32,
     /// Layout of packed scene data.
     pub layout: Layout,
     /// Size of binning buffer allocation (in u32s).

--- a/src/encoding/packed.rs
+++ b/src/encoding/packed.rs
@@ -60,6 +60,8 @@ pub struct Config {
     pub target_width: u32,
     /// Height of the target in pixels.
     pub target_height: u32,
+    /// The initial background color applied to the target
+    pub clear_color: u32,
     /// Layout of packed scene data.
     pub layout: Layout,
     /// Size of binning buffer allocation (in u32s).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@ impl Renderer {
         if target.width != width || target.height != height {
             target = TargetTexture::new(device, width, height);
         }
-        self.render_to_texture(device, queue, scene, &target.view, &params);
+        self.render_to_texture(device, queue, scene, &target.view, &params)?;
         let mut encoder =
             device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
         {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,8 +52,19 @@ pub struct Renderer {
     target: Option<TargetTexture>,
 }
 
+/// Parameters used in a single render that are configurable by the client.
+pub struct RenderParams {
+    /// The background color applied to the target. This value is only applicable to the full
+    /// pipeline.
+    pub clear_color: peniko::Color,
+
+    /// Dimensions of the rasterization target
+    pub width: u32,
+    pub height: u32,
+}
+
 impl Renderer {
-    /// Creates a new renderer for the specified device.
+    /// Creates a new renderer for the specified device with default options.
     pub fn new(device: &Device) -> Result<Self> {
         let mut engine = Engine::new();
         let shaders = shaders::full_shaders(device, &mut engine)?;
@@ -77,10 +88,9 @@ impl Renderer {
         queue: &Queue,
         scene: &Scene,
         texture: &TextureView,
-        width: u32,
-        height: u32,
+        params: &RenderParams,
     ) -> Result<()> {
-        let (recording, target) = render::render_full(scene, &self.shaders, width, height);
+        let (recording, target) = render::render_full(scene, &self.shaders, params);
         let external_resources = [ExternalResource::Image(
             *target.as_image().unwrap(),
             texture,
@@ -103,9 +113,12 @@ impl Renderer {
         queue: &Queue,
         scene: &Scene,
         surface: &SurfaceTexture,
+        params: &RenderParams,
         width: u32,
         height: u32,
     ) -> Result<()> {
+        let width = params.width;
+        let height = params.height;
         let mut target = self
             .target
             .take()
@@ -115,7 +128,7 @@ impl Renderer {
         if target.width != width || target.height != height {
             target = TargetTexture::new(device, width, height);
         }
-        self.render_to_texture(device, queue, scene, &target.view, width, height)?;
+        self.render_to_texture(device, queue, scene, &target.view, &params);
         let mut encoder =
             device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
         {
@@ -177,12 +190,11 @@ impl Renderer {
         queue: &Queue,
         scene: &Scene,
         texture: &TextureView,
-        width: u32,
-        height: u32,
+        params: &RenderParams,
     ) -> Result<()> {
         let mut render = Render::new();
         let encoding = scene.data();
-        let recording = render.render_encoding_coarse(encoding, &self.shaders, width, height, true);
+        let recording = render.render_encoding_coarse(encoding, &self.shaders, params, true);
         let target = render.out_image();
         let bump_buf = render.bump_buf();
         self.engine.run_recording(device, queue, &recording, &[])?;
@@ -216,9 +228,10 @@ impl Renderer {
         queue: &Queue,
         scene: &Scene,
         surface: &SurfaceTexture,
-        width: u32,
-        height: u32,
+        params: &RenderParams,
     ) -> Result<()> {
+        let width = params.width;
+        let height = params.height;
         let mut target = self
             .target
             .take()
@@ -228,7 +241,7 @@ impl Renderer {
         if target.width != width || target.height != height {
             target = TargetTexture::new(device, width, height);
         }
-        self.render_to_texture_async(device, queue, scene, &target.view, width, height)
+        self.render_to_texture_async(device, queue, scene, &target.view, params)
             .await?;
         let mut encoder =
             device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ pub struct Renderer {
 pub struct RenderParams {
     /// The background color applied to the target. This value is only applicable to the full
     /// pipeline.
-    pub clear_color: peniko::Color,
+    pub base_color: peniko::Color,
 
     /// Dimensions of the rasterization target
     pub width: u32,
@@ -64,7 +64,7 @@ pub struct RenderParams {
 }
 
 impl Renderer {
-    /// Creates a new renderer for the specified device with default options.
+    /// Creates a new renderer for the specified device.
     pub fn new(device: &Device) -> Result<Self> {
         let mut engine = Engine::new();
         let shaders = shaders::full_shaders(device, &mut engine)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,8 +114,6 @@ impl Renderer {
         scene: &Scene,
         surface: &SurfaceTexture,
         params: &RenderParams,
-        width: u32,
-        height: u32,
     ) -> Result<()> {
         let width = params.width;
         let height = params.height;

--- a/src/render.rs
+++ b/src/render.rs
@@ -55,6 +55,8 @@ const BIN_HEADER_SIZE: u64 = 8;
 const TILE_SIZE: u64 = 8;
 const SEGMENT_SIZE: u64 = 24;
 
+// This data structure must be kept in sync with encoding::Config and the definition in
+// shaders/shared/config.wgsl.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, Zeroable, Pod)]
 struct Config {
@@ -62,7 +64,7 @@ struct Config {
     height_in_tiles: u32,
     target_width: u32,
     target_height: u32,
-    clear_color: u32,
+    base_color: u32,
     n_drawobj: u32,
     n_path: u32,
     n_clip: u32,
@@ -264,7 +266,7 @@ impl Render {
             height_in_tiles: new_height / 16,
             target_width: params.width,
             target_height: params.height,
-            clear_color: params.clear_color.to_premul_u32(),
+            base_color: params.base_color.to_premul_u32(),
             binning_size: self.binning_info_size - info_size,
             tiles_size: self.tiles_size,
             segments_size: self.segments_size,

--- a/src/render.rs
+++ b/src/render.rs
@@ -5,6 +5,7 @@ use bytemuck::{Pod, Zeroable};
 use crate::{
     encoding::Encoding,
     engine::{BufProxy, ImageFormat, ImageProxy, Recording, ResourceProxy},
+    peniko::Color,
     shaders::{self, FullShaders, Shaders},
     Scene,
 };
@@ -21,6 +22,8 @@ pub struct Render {
     ptcl_size: u32,
     width_in_tiles: u32,
     height_in_tiles: u32,
+    /// The background color applied to the target
+    clear_color: Color,
     fine: Option<FineResources>,
 }
 
@@ -61,6 +64,7 @@ struct Config {
     height_in_tiles: u32,
     target_width: u32,
     target_height: u32,
+    clear_color: u32,
     n_drawobj: u32,
     n_path: u32,
     n_clip: u32,
@@ -216,6 +220,7 @@ impl Render {
             ptcl_size: (1 << 25) / 4 as u32,
             width_in_tiles: 0,
             height_in_tiles: 0,
+            clear_color: Color::BLACK,
             fine: None,
         }
     }
@@ -265,6 +270,7 @@ impl Render {
             height_in_tiles: new_height / 16,
             target_width: width,
             target_height: height,
+            clear_color: self.clear_color.to_premul_u32(),
             binning_size: self.binning_info_size - info_size,
             tiles_size: self.tiles_size,
             segments_size: self.segments_size,


### PR DESCRIPTION
This PR introduces a clear-color to apply as the base color for blends in the fine rasterizer stage. This uniform only has an effect in the full fine pipeline.

This PR also includes a minor reorganization of render-time parameters (the new clear color, target image widht/height) in a new `RenderParams` struct and updates the examples accordingly.