### PR TITLE
Add frame statistics UI to with_winit example

### DIFF
--- a/examples/with_winit/README.md
+++ b/examples/with_winit/README.md
@@ -19,4 +19,5 @@ $ cargo run -p with_winit --release -- [SVG FILES]
 - Arrow keys switch between SVG images in the current set.
 - Space resets the position and zoom of the image.
 - S toggles the frame statistics layer
+- C resets the min/max frame time tracked by statistics
 - Escape exits the program.

--- a/examples/with_winit/README.md
+++ b/examples/with_winit/README.md
@@ -20,4 +20,5 @@ $ cargo run -p with_winit --release -- [SVG FILES]
 - Space resets the position and zoom of the image.
 - S toggles the frame statistics layer
 - C resets the min/max frame time tracked by statistics
+- V toggles VSync on/off (default: on)
 - Escape exits the program.

--- a/examples/with_winit/README.md
+++ b/examples/with_winit/README.md
@@ -18,4 +18,5 @@ $ cargo run -p with_winit --release -- [SVG FILES]
 - Mouse scroll wheel will zoom.
 - Arrow keys switch between SVG images in the current set.
 - Space resets the position and zoom of the image.
+- S toggles the frame statistics layer
 - Escape exits the program.

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -305,7 +305,12 @@ fn run(
             }
             builder.append(&fragment, Some(transform));
             if stats_toggle {
-                snapshot.draw_layer(&mut builder, &mut scene_params.text, width as f64);
+                snapshot.draw_layer(
+                    &mut builder,
+                    &mut scene_params.text,
+                    width as f64,
+                    height as f64,
+                );
             }
             let surface_texture = render_state
                 .surface

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -368,10 +368,11 @@ fn run(
             surface_texture.present();
             device_handle.device.poll(wgpu::Maintain::Poll);
 
+            let new_time = Instant::now();
             stats.add_sample(stats::Sample {
-                frame_time_us: frame_start_time.elapsed().as_micros() as u64,
+                frame_time_us: (new_time - frame_start_time).as_micros() as u64,
             });
-            frame_start_time = Instant::now();
+            frame_start_time = new_time;
         }
         Event::UserEvent(event) => match event {
             #[cfg(not(any(target_arch = "wasm32", target_os = "android")))]

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -158,9 +158,9 @@ fn run(
                                 render_cx.set_present_mode(
                                     &mut render_state.surface,
                                     if vsync_on {
-                                        wgpu::PresentMode::Fifo
+                                        wgpu::PresentMode::AutoVsync
                                     } else {
-                                        wgpu::PresentMode::Immediate
+                                        wgpu::PresentMode::AutoNoVsync
                                     },
                                 );
                             }

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -101,6 +101,7 @@ fn run(
     let mut stats = stats::Stats::new();
     let mut stats_shown = true;
     let mut vsync_on = true;
+    let mut frame_start_time = Instant::now();
     let start = Instant::now();
 
     let mut touch_state = multi_touch::TouchState::new();
@@ -275,7 +276,6 @@ fn run(
             let height = render_state.surface.config.height;
             let device_handle = &render_cx.devices[render_state.surface.dev_id];
             let snapshot = stats.snapshot();
-            let frame_start_time = Instant::now();
 
             // Allow looping forever
             scene_ix = scene_ix.rem_euclid(scenes.scenes.len() as i32);
@@ -371,6 +371,7 @@ fn run(
             stats.add_sample(stats::Sample {
                 frame_time_us: frame_start_time.elapsed().as_micros() as u64,
             });
+            frame_start_time = Instant::now();
         }
         Event::UserEvent(event) => match event {
             #[cfg(not(any(target_arch = "wasm32", target_os = "android")))]

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -260,7 +260,7 @@ fn run(
             let height = render_state.surface.config.height;
             let device_handle = &render_cx.devices[render_state.surface.dev_id];
             let snapshot = stats.snapshot();
-            let _stats_frame = stats.frame_scope();
+            let frame_start_time = Instant::now();
 
             // Allow looping forever
             scene_ix = scene_ix.rem_euclid(scenes.scenes.len() as i32);
@@ -310,6 +310,7 @@ fn run(
                     &mut scene_params.text,
                     width as f64,
                     height as f64,
+                    stats.samples(),
                 );
             }
             let surface_texture = render_state
@@ -350,6 +351,10 @@ fn run(
                 .expect("failed to render to surface");
             surface_texture.present();
             device_handle.device.poll(wgpu::Maintain::Poll);
+
+            stats.add_sample(stats::Sample {
+                frame_time_us: frame_start_time.elapsed().as_micros() as u64,
+            });
         }
         Event::UserEvent(event) => match event {
             #[cfg(not(any(target_arch = "wasm32", target_os = "android")))]

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -99,7 +99,7 @@ fn run(
     let mut simple_text = SimpleText::new();
     let mut images = ImageCache::new();
     let mut stats = stats::Stats::new();
-    let mut stats_toggle = true;
+    let mut stats_shown = true;
     let start = Instant::now();
 
     let mut touch_state = multi_touch::TouchState::new();
@@ -146,7 +146,10 @@ fn run(
                                 transform = Affine::IDENTITY;
                             }
                             Some(VirtualKeyCode::S) => {
-                                stats_toggle = !stats_toggle;
+                                stats_shown = !stats_shown;
+                            }
+                            Some(VirtualKeyCode::C) => {
+                                stats.clear_min_and_max();
                             }
                             Some(VirtualKeyCode::Escape) => {
                                 *control_flow = ControlFlow::Exit;
@@ -304,7 +307,7 @@ fn run(
                 transform = transform * Affine::scale(scale_factor);
             }
             builder.append(&fragment, Some(transform));
-            if stats_toggle {
+            if stats_shown {
                 snapshot.draw_layer(
                     &mut builder,
                     &mut scene_params.text,

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -100,6 +100,7 @@ fn run(
     let mut images = ImageCache::new();
     let mut stats = stats::Stats::new();
     let mut stats_shown = true;
+    let mut vsync_on = true;
     let start = Instant::now();
 
     let mut touch_state = multi_touch::TouchState::new();
@@ -150,6 +151,17 @@ fn run(
                             }
                             Some(VirtualKeyCode::C) => {
                                 stats.clear_min_and_max();
+                            }
+                            Some(VirtualKeyCode::V) => {
+                                vsync_on = !vsync_on;
+                                render_cx.set_present_mode(
+                                    &mut render_state.surface,
+                                    if vsync_on {
+                                        wgpu::PresentMode::Fifo
+                                    } else {
+                                        wgpu::PresentMode::Immediate
+                                    },
+                                );
                             }
                             Some(VirtualKeyCode::Escape) => {
                                 *control_flow = ControlFlow::Exit;
@@ -314,6 +326,7 @@ fn run(
                     width as f64,
                     height as f64,
                     stats.samples(),
+                    vsync_on,
                 );
             }
             let surface_texture = render_state

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -99,7 +99,7 @@ fn run(
     let mut simple_text = SimpleText::new();
     let mut images = ImageCache::new();
     let mut stats = stats::Stats::new();
-    let mut stats_toggle = false;
+    let mut stats_toggle = true;
     let start = Instant::now();
 
     let mut touch_state = multi_touch::TouchState::new();

--- a/examples/with_winit/src/stats.rs
+++ b/examples/with_winit/src/stats.rs
@@ -1,0 +1,148 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Also licensed under MIT license, at your choice.
+
+use scenes::SimpleText;
+use std::{collections::VecDeque, time::Instant};
+use vello::{
+    kurbo::{Affine, Rect},
+    peniko::{Brush, Color, Fill},
+    SceneBuilder,
+};
+
+const SLIDING_WINDOW_SIZE: usize = 100;
+
+#[derive(Debug)]
+pub struct Snapshot {
+    pub fps: f64,
+    pub frame_time_ms: f64,
+    pub frame_time_min_ms: f64,
+    pub frame_time_max_ms: f64,
+}
+
+impl Snapshot {
+    pub fn draw_layer(&self, sb: &mut SceneBuilder, text: &mut SimpleText, width: f64) {
+        let x_offset = width - 450.;
+        sb.fill(
+            Fill::NonZero,
+            Affine::IDENTITY,
+            &Brush::Solid(Color::rgba8(0, 0, 0, 200)),
+            None,
+            &Rect::new(x_offset, 0., width, 115.),
+        );
+        text.add(
+            sb,
+            None,
+            25.,
+            Some(&Brush::Solid(Color::WHITE)),
+            Affine::translate((x_offset + 15., 30.)),
+            &format!("Frame Time: {:.2} ms", self.frame_time_ms),
+        );
+        text.add(
+            sb,
+            None,
+            25.,
+            Some(&Brush::Solid(Color::WHITE)),
+            Affine::translate((x_offset + 15., 60.)),
+            &format!("Frame Time (min): {:.2} ms", self.frame_time_min_ms),
+        );
+        text.add(
+            sb,
+            None,
+            25.,
+            Some(&Brush::Solid(Color::WHITE)),
+            Affine::translate((x_offset + 15., 90.)),
+            &format!("Frame Time (max): {:.2} ms", self.frame_time_max_ms),
+        );
+        text.add(
+            sb,
+            None,
+            25.,
+            Some(&Brush::Solid(Color::WHITE)),
+            Affine::translate((x_offset + 300., 30.)),
+            &format!("FPS: {:.2}", self.fps),
+        );
+    }
+}
+
+pub struct Stats {
+    count: usize,
+    sum: u64,
+    min: u64,
+    max: u64,
+    samples: VecDeque<u64>,
+}
+
+pub struct FrameScope<'a> {
+    stats: &'a mut Stats,
+    start: Instant,
+}
+
+impl<'a> Drop for FrameScope<'a> {
+    fn drop(&mut self) {
+        self.stats
+            .add_sample(self.start.elapsed().as_micros() as u64);
+    }
+}
+
+impl Stats {
+    pub fn new() -> Stats {
+        Stats {
+            count: 0,
+            sum: 0,
+            min: u64::MAX,
+            max: u64::MIN,
+            samples: VecDeque::with_capacity(SLIDING_WINDOW_SIZE),
+        }
+    }
+
+    pub fn snapshot(&self) -> Snapshot {
+        let frame_time_ms = (self.sum as f64 / self.count as f64) * 0.001;
+        let fps = 1000. / frame_time_ms;
+        Snapshot {
+            fps,
+            frame_time_ms,
+            frame_time_min_ms: self.min as f64 * 0.001,
+            frame_time_max_ms: self.max as f64 * 0.001,
+        }
+    }
+
+    pub fn frame_scope<'a>(&'a mut self) -> FrameScope<'a> {
+        FrameScope {
+            stats: self,
+            start: Instant::now(),
+        }
+    }
+
+    fn add_sample(&mut self, micros: u64) {
+        let oldest = if self.count < SLIDING_WINDOW_SIZE {
+            self.count += 1;
+            None
+        } else {
+            self.samples.pop_front()
+        };
+        self.sum += micros;
+        self.samples.push_back(micros);
+        if let Some(oldest) = oldest {
+            self.sum -= oldest;
+        }
+        if micros < self.min {
+            self.min = micros;
+        }
+        if micros > self.max {
+            self.max = micros;
+        }
+    }
+}

--- a/examples/with_winit/src/stats.rs
+++ b/examples/with_winit/src/stats.rs
@@ -105,11 +105,8 @@ impl Snapshot {
         for (i, sample) in samples.enumerate() {
             let t = offset * Affine::translate((i as f64 * bar_extent, graph_max_height));
             // The height of each sample is based on its ratio to the maximum observed frame time.
-            // Currently this maximum scale is sticky and a high temporary spike will permanently
-            // shrink the draw size of the overall average sample, so scale the size non-linearly to
-            // emphasize smaller samples.
             let h = (*sample as f64) * 0.001 / self.frame_time_max_ms;
-            let s = Affine::scale_non_uniform(1., -h.sqrt());
+            let s = Affine::scale_non_uniform(1., -h);
             sb.fill(
                 Fill::NonZero,
                 t * Affine::translate((left_margin, (1 + labels.len()) as f64 * text_height)) * s,

--- a/examples/with_winit/src/stats.rs
+++ b/examples/with_winit/src/stats.rs
@@ -168,6 +168,11 @@ impl Stats {
         }
     }
 
+    pub fn clear_min_and_max(&mut self) {
+        self.min = u64::MAX;
+        self.max = u64::MIN;
+    }
+
     pub fn add_sample(&mut self, sample: Sample) {
         let oldest = if self.count < SLIDING_WINDOW_SIZE {
             self.count += 1;
@@ -181,11 +186,7 @@ impl Stats {
         if let Some(oldest) = oldest {
             self.sum -= oldest;
         }
-        if micros < self.min {
-            self.min = micros;
-        }
-        if micros > self.max {
-            self.max = micros;
-        }
+        self.min = self.min.min(micros);
+        self.max = self.max.max(micros);
     }
 }

--- a/examples/with_winit/src/stats.rs
+++ b/examples/with_winit/src/stats.rs
@@ -84,6 +84,14 @@ impl Snapshot {
             None,
             text_size,
             Some(&Brush::Solid(Color::WHITE)),
+            offset * Affine::translate((left_margin, 4. * text_height)),
+            &format!("Resolution: {viewport_width}x{viewport_height}"),
+        );
+        text.add(
+            sb,
+            None,
+            text_size,
+            Some(&Brush::Solid(Color::WHITE)),
             offset * Affine::translate((width * 0.67, text_height)),
             &format!("FPS: {:.2}", self.fps),
         );

--- a/examples/with_winit/src/stats.rs
+++ b/examples/with_winit/src/stats.rs
@@ -121,19 +121,18 @@ impl Snapshot {
             let sample_ms = ((*sample as f64) * 0.001).min(display_max);
             let h = sample_ms / display_max;
             let s = Affine::scale_non_uniform(1., -h);
+            let color = match *sample {
+                ..=16_667 => Color::rgb8(100, 143, 255),
+                ..=33_334 => Color::rgb8(255, 176, 0),
+                _ => Color::rgb8(220, 38, 127),
+            };
             sb.fill(
                 Fill::NonZero,
                 t * Affine::translate((
                     left_margin_padding,
                     (1 + labels.len()) as f64 * text_height,
                 )) * s,
-                if *sample < 16667 {
-                    Color::rgb8(100, 143, 255)
-                } else if *sample < 33334 {
-                    Color::rgb8(255, 176, 0)
-                } else {
-                    Color::rgb8(220, 38, 127)
-                },
+                color,
                 None,
                 &bar,
             );

--- a/examples/with_winit/src/stats.rs
+++ b/examples/with_winit/src/stats.rs
@@ -33,45 +33,58 @@ pub struct Snapshot {
 }
 
 impl Snapshot {
-    pub fn draw_layer(&self, sb: &mut SceneBuilder, text: &mut SimpleText, width: f64) {
-        let x_offset = width - 450.;
+    pub fn draw_layer(
+        &self,
+        sb: &mut SceneBuilder,
+        text: &mut SimpleText,
+        viewport_width: f64,
+        viewport_height: f64,
+    ) {
+        let width = (viewport_width * 0.4).max(200.).min(400.);
+        let height = width * 0.3;
+        let x_offset = viewport_width - width;
+        let y_offset = viewport_height - height;
+        let offset = Affine::translate((x_offset, y_offset));
+        let text_height = height * 0.2;
+        let left_margin = width * 0.03;
+        let text_size = (text_height * 0.9) as f32;
         sb.fill(
             Fill::NonZero,
-            Affine::IDENTITY,
+            offset,
             &Brush::Solid(Color::rgba8(0, 0, 0, 200)),
             None,
-            &Rect::new(x_offset, 0., width, 115.),
+            &Rect::new(0., 0., width, height),
         );
         text.add(
             sb,
             None,
-            25.,
+            text_size,
             Some(&Brush::Solid(Color::WHITE)),
-            Affine::translate((x_offset + 15., 30.)),
+            offset * Affine::translate((left_margin, text_height)),
             &format!("Frame Time: {:.2} ms", self.frame_time_ms),
         );
         text.add(
             sb,
             None,
-            25.,
+            text_size,
             Some(&Brush::Solid(Color::WHITE)),
-            Affine::translate((x_offset + 15., 60.)),
+            offset * Affine::translate((left_margin, 2. * text_height)),
             &format!("Frame Time (min): {:.2} ms", self.frame_time_min_ms),
         );
         text.add(
             sb,
             None,
-            25.,
+            text_size,
             Some(&Brush::Solid(Color::WHITE)),
-            Affine::translate((x_offset + 15., 90.)),
+            offset * Affine::translate((left_margin, 3. * text_height)),
             &format!("Frame Time (max): {:.2} ms", self.frame_time_max_ms),
         );
         text.add(
             sb,
             None,
-            25.,
+            text_size,
             Some(&Brush::Solid(Color::WHITE)),
-            Affine::translate((x_offset + 300., 30.)),
+            offset * Affine::translate((width * 0.67, text_height)),
             &format!("FPS: {:.2}", self.fps),
         );
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -92,6 +92,13 @@ impl RenderContext {
             .configure(&self.devices[surface.dev_id].device, &surface.config);
     }
 
+    pub fn set_present_mode(&self, surface: &mut RenderSurface, present_mode: wgpu::PresentMode) {
+        surface.config.present_mode = present_mode;
+        surface
+            .surface
+            .configure(&self.devices[surface.dev_id].device, &surface.config);
+    }
+
     /// Finds or creates a compatible device handle id.
     pub async fn device(&mut self, compatible_surface: Option<&Surface>) -> Option<usize> {
         let compatible = match compatible_surface {

--- a/src/util.rs
+++ b/src/util.rs
@@ -70,7 +70,7 @@ impl RenderContext {
             format,
             width,
             height,
-            present_mode: wgpu::PresentMode::Fifo,
+            present_mode: wgpu::PresentMode::AutoVsync,
             alpha_mode: wgpu::CompositeAlphaMode::Auto,
             view_formats: vec![],
         };


### PR DESCRIPTION
Added a module for frame time statistics and a UI layer that displays the average, minimum, and maximum frame time alongside FPS. The UI can be toggled by pressing the `S` key.