### PR TITLE
Update for Bevy 0.10 and other dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,4 @@ wgpu = "0.15"
 # Used for examples
 clap = "4.1.0"
 anyhow = "1.0"
+pollster = "0.3.0"

--- a/examples/with_bevy/Cargo.toml
+++ b/examples/with_bevy/Cargo.toml
@@ -10,5 +10,5 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", rev = "4fd092fbec07416fa9b1e2306f61231ae20315ac" }
+bevy = "0.10"
 vello = { path = "../../" }

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -24,10 +24,10 @@ vello = { path = "../../", features = ["buffer_labels"] }
 scenes = { path = "../scenes" }
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
+pollster = { workspace = true }
 
 wgpu = { workspace = true }
 winit = "0.28.1"
-pollster = "0.2.5"
 env_logger = "0.10.0"
 log = "0.4.17"
 
@@ -38,7 +38,7 @@ notify-debouncer-mini = "0.2.1"
 
 [target.'cfg(target_os = "android")'.dependencies]
 winit = { version = "0.28", features = ["android-native-activity"] }
-android_logger = "0.12.0"
+android_logger = "0.13.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.7"

--- a/integrations/vello_svg/Cargo.toml
+++ b/integrations/vello_svg/Cargo.toml
@@ -13,4 +13,4 @@ repository.workspace = true
 
 [dependencies]
 vello = { path = "../../" }
-usvg = "0.28"
+usvg = "0.29"


### PR DESCRIPTION
Very simple changes, to fix [![dependency status](https://deps.rs/repo/github/linebender/vello/status.svg)](https://deps.rs/repo/github/linebender/vello)

No code changes required, since #275 handled that. I have found that headless isn't quite working right, see [#gpu>Headless](https://xi.zulipchat.com/#narrow/stream/197075-gpu/topic/Headless), but that's pre-existing