### PR TITLE
vello_svg: Use affine transformation

### DIFF
--- a/integrations/vello_svg/src/lib.rs
+++ b/integrations/vello_svg/src/lib.rs
@@ -64,15 +64,10 @@ pub fn render_tree_with<F: FnMut(&mut SceneBuilder, &usvg::Node) -> Result<(), E
     mut on_err: F,
 ) -> Result<(), E> {
     for elt in svg.root.descendants() {
-        let transform = elt.abs_transform();
-        let transform = Affine::new([
-            transform.a,
-            transform.b,
-            transform.c,
-            transform.d,
-            transform.e,
-            transform.f,
-        ]);
+        let transform = {
+            let usvg::Transform { a, b, c, d, e, f } = elt.abs_transform();
+            Affine::new([a, b, c, d, e, f])
+        };
         match &*elt.borrow() {
             usvg::NodeKind::Group(_) => {}
             usvg::NodeKind::Path(path) => {


### PR DESCRIPTION
Use the affine transformation option from vello instead of directly transforming the path data.
This correctly applies the transformation for other parameters as well (e.g stroke width).

Test file: https://w3.impa.br/~diego/projects/Neh20/inputs/timings/spiral.svg
| Before  | After |
|---------|------|
|![grafik](https://user-images.githubusercontent.com/7253845/223795027-318a6b8a-990e-4a64-9065-cd034545777b.png) | ![grafik](https://user-images.githubusercontent.com/7253845/223795269-30238b10-7e0a-4dbc-8b6c-90583d98a1e1.png)|

