### PR TITLE
Add space key for transform reset

### DIFF
--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -138,6 +138,9 @@ fn run(
                                         * transform;
                                 }
                             }
+                            Some(VirtualKeyCode::Space) => {
+                                transform = Affine::IDENTITY;
+                            }
                             Some(VirtualKeyCode::Escape) => {
                                 *control_flow = ControlFlow::Exit;
                             }


### PR DESCRIPTION
This adds the missing `SPACE` input handler for resetting the view in the `with_winit` example.

That was an easy fix 🙂

I have no clue about doing pull request, so please tell me if I am doing something wrong...