### PR TITLE
Added Clone to SceneFragment

### DIFF
--- a/src/scene.rs
+++ b/src/scene.rs
@@ -39,7 +39,7 @@ impl Scene {
 }
 
 /// Encoded definition of a scene fragment and associated resources.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct SceneFragment {
     data: Encoding,
 }


### PR DESCRIPTION
I made an internal plugin to Bevy that extracts the path data from the app to the render stage and I'm blocked on needing clone here. Is it controversial to add this?