### PR TITLE
[encoding] Add feature gate for full pipeline support

### DIFF
--- a/crates/encoding/Cargo.toml
+++ b/crates/encoding/Cargo.toml
@@ -3,8 +3,14 @@ name = "vello_encoding"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = ["full"]
+# Enables support for the full pipeline including late-bound
+# resources (gradients, images and glyph runs)
+full = ["fello", "guillotiere"]
+
 [dependencies]
 bytemuck = { workspace = true }
-fello = { workspace = true }
+fello = { workspace = true, optional = true }
 peniko = { workspace = true }
-guillotiere = "0.6.2"
+guillotiere = { version = "0.6.2", optional = true }

--- a/crates/encoding/src/config.rs
+++ b/crates/encoding/src/config.rs
@@ -196,6 +196,7 @@ impl<T: Sized> BufferSize<T> {
     }
 
     /// Returns the number of elements.
+    #[allow(clippy::len_without_is_empty)]
     pub const fn len(self) -> u32 {
         self.len
     }

--- a/crates/encoding/src/encoding.rs
+++ b/crates/encoding/src/encoding.rs
@@ -1,13 +1,16 @@
 // Copyright 2022 The Vello authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use super::{
-    resolve::Patch, DrawColor, DrawImage, DrawLinearGradient, DrawRadialGradient, DrawTag, Glyph,
-    GlyphRun, PathEncoder, PathTag, Transform,
-};
+use super::{DrawColor, DrawTag, PathEncoder, PathTag, Transform};
 
-use fello::NormalizedCoord;
-use peniko::{kurbo::Shape, BlendMode, BrushRef, ColorStop, Extend, GradientKind, Image};
+use peniko::{kurbo::Shape, BlendMode, BrushRef};
+
+#[cfg(feature = "full")]
+use {
+    super::{DrawImage, DrawLinearGradient, DrawRadialGradient, Glyph, GlyphRun, Patch},
+    fello::NormalizedCoord,
+    peniko::{ColorStop, Extend, GradientKind, Image},
+};
 
 /// Encoded data streams for a scene.
 #[derive(Clone, Default)]
@@ -20,20 +23,13 @@ pub struct Encoding {
     pub draw_tags: Vec<DrawTag>,
     /// The draw data stream.
     pub draw_data: Vec<u8>,
-    /// Draw data patches for late bound resources.
-    pub patches: Vec<Patch>,
-    /// Color stop collection for gradients.
-    pub color_stops: Vec<ColorStop>,
     /// The transform stream.
     pub transforms: Vec<Transform>,
     /// The line width stream.
     pub linewidths: Vec<f32>,
-    /// Positioned glyph buffer.
-    pub glyphs: Vec<Glyph>,
-    /// Sequences of glyphs.
-    pub glyph_runs: Vec<GlyphRun>,
-    /// Normalized coordinate buffer for variable fonts.
-    pub normalized_coords: Vec<NormalizedCoord>,
+    /// Late bound resource data.
+    #[cfg(feature = "full")]
+    pub resources: Resources,
     /// Number of encoded paths.
     pub n_paths: u32,
     /// Number of encoded path segments.
@@ -63,15 +59,12 @@ impl Encoding {
         self.linewidths.clear();
         self.draw_data.clear();
         self.draw_tags.clear();
-        self.glyphs.clear();
-        self.glyph_runs.clear();
-        self.normalized_coords.clear();
         self.n_paths = 0;
         self.n_path_segments = 0;
         self.n_clips = 0;
         self.n_open_clips = 0;
-        self.patches.clear();
-        self.color_stops.clear();
+        #[cfg(feature = "full")]
+        self.resources.reset();
         if !is_fragment {
             self.transforms.push(Transform::IDENTITY);
             self.linewidths.push(-1.0);
@@ -80,62 +73,74 @@ impl Encoding {
 
     /// Appends another encoding to this one with an optional transform.
     pub fn append(&mut self, other: &Self, transform: &Option<Transform>) {
-        let stops_base = self.color_stops.len();
-        let glyph_runs_base = self.glyph_runs.len();
-        let glyphs_base = self.glyphs.len();
-        let coords_base = self.normalized_coords.len();
-        let offsets = self.stream_offsets();
+        #[cfg(feature = "full")]
+        let glyph_runs_base = {
+            let offsets = self.stream_offsets();
+            let stops_base = self.resources.color_stops.len();
+            let glyph_runs_base = self.resources.glyph_runs.len();
+            let glyphs_base = self.resources.glyphs.len();
+            let coords_base = self.resources.normalized_coords.len();
+            self.resources
+                .glyphs
+                .extend_from_slice(&other.resources.glyphs);
+            self.resources
+                .normalized_coords
+                .extend_from_slice(&other.resources.normalized_coords);
+            self.resources
+                .glyph_runs
+                .extend(other.resources.glyph_runs.iter().cloned().map(|mut run| {
+                    run.glyphs.start += glyphs_base;
+                    run.normalized_coords.start += coords_base;
+                    run.stream_offsets.path_tags += offsets.path_tags;
+                    run.stream_offsets.path_data += offsets.path_data;
+                    run.stream_offsets.draw_tags += offsets.draw_tags;
+                    run.stream_offsets.draw_data += offsets.draw_data;
+                    run.stream_offsets.transforms += offsets.transforms;
+                    run.stream_offsets.linewidths += offsets.linewidths;
+                    run
+                }));
+            self.resources
+                .patches
+                .extend(other.resources.patches.iter().map(|patch| match patch {
+                    Patch::Ramp {
+                        draw_data_offset: offset,
+                        stops,
+                    } => {
+                        let stops = stops.start + stops_base..stops.end + stops_base;
+                        Patch::Ramp {
+                            draw_data_offset: offset + offsets.draw_data,
+                            stops,
+                        }
+                    }
+                    Patch::GlyphRun { index } => Patch::GlyphRun {
+                        index: index + glyph_runs_base,
+                    },
+                    Patch::Image {
+                        image,
+                        draw_data_offset,
+                    } => Patch::Image {
+                        image: image.clone(),
+                        draw_data_offset: *draw_data_offset + offsets.draw_data,
+                    },
+                }));
+            self.resources
+                .color_stops
+                .extend_from_slice(&other.resources.color_stops);
+            glyph_runs_base
+        };
         self.path_tags.extend_from_slice(&other.path_tags);
         self.path_data.extend_from_slice(&other.path_data);
         self.draw_tags.extend_from_slice(&other.draw_tags);
         self.draw_data.extend_from_slice(&other.draw_data);
-        self.glyphs.extend_from_slice(&other.glyphs);
-        self.normalized_coords
-            .extend_from_slice(&other.normalized_coords);
-        self.glyph_runs
-            .extend(other.glyph_runs.iter().cloned().map(|mut run| {
-                run.glyphs.start += glyphs_base;
-                run.normalized_coords.start += coords_base;
-                run.stream_offsets.path_tags += offsets.path_tags;
-                run.stream_offsets.path_data += offsets.path_data;
-                run.stream_offsets.draw_tags += offsets.draw_tags;
-                run.stream_offsets.draw_data += offsets.draw_data;
-                run.stream_offsets.transforms += offsets.transforms;
-                run.stream_offsets.linewidths += offsets.linewidths;
-                run
-            }));
         self.n_paths += other.n_paths;
         self.n_path_segments += other.n_path_segments;
         self.n_clips += other.n_clips;
         self.n_open_clips += other.n_open_clips;
-        self.patches
-            .extend(other.patches.iter().map(|patch| match patch {
-                Patch::Ramp {
-                    draw_data_offset: offset,
-                    stops,
-                } => {
-                    let stops = stops.start + stops_base..stops.end + stops_base;
-                    Patch::Ramp {
-                        draw_data_offset: offset + offsets.draw_data,
-                        stops,
-                    }
-                }
-                Patch::GlyphRun { index } => Patch::GlyphRun {
-                    index: index + glyph_runs_base,
-                },
-                Patch::Image {
-                    image,
-                    draw_data_offset,
-                } => Patch::Image {
-                    image: image.clone(),
-                    draw_data_offset: *draw_data_offset + offsets.draw_data,
-                },
-            }));
-        self.color_stops.extend_from_slice(&other.color_stops);
         if let Some(transform) = *transform {
             self.transforms
                 .extend(other.transforms.iter().map(|x| transform * *x));
-            for run in &mut self.glyph_runs[glyph_runs_base..] {
+            #[cfg(feature = "full")]
+            for run in &mut self.resources.glyph_runs[glyph_runs_base..] {
                 run.transform = transform * run.transform;
             }
         } else {
@@ -199,7 +204,9 @@ impl Encoding {
     }
 
     /// Encodes a brush with an optional alpha modifier.
+    #[allow(unused_variables)]
     pub fn encode_brush<'b>(&mut self, brush: impl Into<BrushRef<'b>>, alpha: f32) {
+        #[cfg(feature = "full")]
         use super::math::point_to_f32;
         match brush.into() {
             BrushRef::Solid(color) => {
@@ -210,6 +217,7 @@ impl Encoding {
                 };
                 self.encode_color(DrawColor::new(color));
             }
+            #[cfg(feature = "full")]
             BrushRef::Gradient(gradient) => match gradient.kind {
                 GradientKind::Linear { start, end } => {
                     self.encode_linear_gradient(
@@ -246,9 +254,13 @@ impl Encoding {
                     todo!("sweep gradients aren't supported yet!")
                 }
             },
+            #[cfg(feature = "full")]
             BrushRef::Image(image) => {
+                #[cfg(feature = "full")]
                 self.encode_image(image, alpha);
             }
+            #[cfg(not(feature = "full"))]
+            _ => panic!("brushes other than solid require the 'full' feature to be enabled"),
         }
     }
 
@@ -259,6 +271,7 @@ impl Encoding {
     }
 
     /// Encodes a linear gradient brush.
+    #[cfg(feature = "full")]
     pub fn encode_linear_gradient(
         &mut self,
         gradient: DrawLinearGradient,
@@ -273,6 +286,7 @@ impl Encoding {
     }
 
     /// Encodes a radial gradient brush.
+    #[cfg(feature = "full")]
     pub fn encode_radial_gradient(
         &mut self,
         gradient: DrawRadialGradient,
@@ -287,10 +301,11 @@ impl Encoding {
     }
 
     /// Encodes an image brush.
+    #[cfg(feature = "full")]
     pub fn encode_image(&mut self, image: &Image, _alpha: f32) {
         // TODO: feed the alpha multiplier through the full pipeline for consistency
         // with other brushes?
-        self.patches.push(Patch::Image {
+        self.resources.patches.push(Patch::Image {
             image: image.clone(),
             draw_data_offset: self.draw_data.len(),
         });
@@ -331,19 +346,48 @@ impl Encoding {
         self.path_tags.swap(len - 1, len - 2);
     }
 
+    #[cfg(feature = "full")]
     fn add_ramp(&mut self, color_stops: impl Iterator<Item = ColorStop>, alpha: f32) {
         let offset = self.draw_data.len();
-        let stops_start = self.color_stops.len();
+        let stops_start = self.resources.color_stops.len();
         if alpha != 1.0 {
-            self.color_stops
+            self.resources
+                .color_stops
                 .extend(color_stops.map(|stop| stop.with_alpha_factor(alpha)));
         } else {
-            self.color_stops.extend(color_stops);
+            self.resources.color_stops.extend(color_stops);
         }
-        self.patches.push(Patch::Ramp {
+        self.resources.patches.push(Patch::Ramp {
             draw_data_offset: offset,
-            stops: stops_start..self.color_stops.len(),
+            stops: stops_start..self.resources.color_stops.len(),
         });
+    }
+}
+
+/// Encoded data for late bound resources.
+#[cfg(feature = "full")]
+#[derive(Clone, Default)]
+pub struct Resources {
+    /// Draw data patches for late bound resources.
+    pub patches: Vec<Patch>,
+    /// Color stop collection for gradients.
+    pub color_stops: Vec<ColorStop>,
+    /// Positioned glyph buffer.
+    pub glyphs: Vec<Glyph>,
+    /// Sequences of glyphs.
+    pub glyph_runs: Vec<GlyphRun>,
+    /// Normalized coordinate buffer for variable fonts.
+    pub normalized_coords: Vec<NormalizedCoord>,
+}
+
+#[cfg(feature = "full")]
+impl Resources {
+    fn reset(&mut self) {
+        self.patches.clear();
+        self.color_stops.clear();
+        self.glyphs.clear();
+        self.glyph_runs.clear();
+        self.normalized_coords.clear();
     }
 }
 
@@ -365,6 +409,7 @@ pub struct StreamOffsets {
 }
 
 impl StreamOffsets {
+    #[cfg(feature = "full")]
     pub(crate) fn add(&mut self, other: &Self) {
         self.path_tags += other.path_tags;
         self.path_data += other.path_data;

--- a/crates/encoding/src/image_cache.rs
+++ b/crates/encoding/src/image_cache.rs
@@ -8,6 +8,7 @@ use std::collections::{hash_map::Entry, HashMap};
 const DEFAULT_ATLAS_SIZE: i32 = 1024;
 const MAX_ATLAS_SIZE: i32 = 8192;
 
+#[derive(Default)]
 pub struct Images<'a> {
     pub width: u32,
     pub height: u32,

--- a/crates/encoding/src/lib.rs
+++ b/crates/encoding/src/lib.rs
@@ -8,12 +8,16 @@ mod clip;
 mod config;
 mod draw;
 mod encoding;
+#[cfg(feature = "full")]
 mod glyph;
+#[cfg(feature = "full")]
 mod glyph_cache;
+#[cfg(feature = "full")]
 mod image_cache;
 mod math;
 mod monoid;
 mod path;
+#[cfg(feature = "full")]
 mod ramp_cache;
 mod resolve;
 
@@ -28,11 +32,17 @@ pub use draw::{
     DrawRadialGradient, DrawTag,
 };
 pub use encoding::{Encoding, StreamOffsets};
-pub use glyph::{Glyph, GlyphRun};
 pub use math::Transform;
 pub use monoid::Monoid;
 pub use path::{
     Cubic, Path, PathBbox, PathEncoder, PathMonoid, PathSegment, PathSegmentType, PathTag, Tile,
 };
-pub use ramp_cache::Ramps;
-pub use resolve::{resolve_solid_paths_only, Layout, Patch, Resolver};
+pub use resolve::{resolve_solid_paths_only, Layout};
+
+#[cfg(feature = "full")]
+pub use {
+    encoding::Resources,
+    glyph::{Glyph, GlyphRun},
+    ramp_cache::Ramps,
+    resolve::{Patch, Resolver},
+};

--- a/crates/encoding/src/lib.rs
+++ b/crates/encoding/src/lib.rs
@@ -35,4 +35,4 @@ pub use path::{
     Cubic, Path, PathBbox, PathEncoder, PathMonoid, PathSegment, PathSegmentType, PathTag, Tile,
 };
 pub use ramp_cache::Ramps;
-pub use resolve::{resolve_simple, Layout, Patch, Resolver};
+pub use resolve::{resolve_solid_paths_only, Layout, Patch, Resolver};

--- a/crates/encoding/src/lib.rs
+++ b/crates/encoding/src/lib.rs
@@ -35,4 +35,4 @@ pub use path::{
     Cubic, Path, PathBbox, PathEncoder, PathMonoid, PathSegment, PathSegmentType, PathTag, Tile,
 };
 pub use ramp_cache::Ramps;
-pub use resolve::{Layout, Patch, Resolver};
+pub use resolve::{resolve_simple, Layout, Patch, Resolver};

--- a/crates/encoding/src/math.rs
+++ b/crates/encoding/src/math.rs
@@ -72,6 +72,7 @@ impl Mul for Transform {
     }
 }
 
+#[allow(dead_code)]
 pub fn point_to_f32(point: kurbo::Point) -> [f32; 2] {
     [point.x as f32, point.y as f32]
 }

--- a/crates/encoding/src/path.rs
+++ b/crates/encoding/src/path.rs
@@ -403,6 +403,7 @@ impl<'a> PathEncoder<'a> {
     }
 }
 
+#[cfg(feature = "full")]
 impl fello::scale::Pen for PathEncoder<'_> {
     fn move_to(&mut self, x: f32, y: f32) {
         self.move_to(x, y)


### PR DESCRIPTION
~~Adds a new `resolve_simple` function that doesn't handle late bound resources (gradients, images and glyph runs).~~

Adds a new feature called "full" that gates encoding support for the full pipeline. This is on by default.

Also adds a new `resolve_solid_paths_only` function that resolves and packs encodings that don't contain late bound resources. 

The primary purpose is to reduce code size and remove unnecessary dependencies for users that are only interested in rendering masks for paths.