### PR TITLE
Re-export font API

### DIFF
--- a/src/glyph.rs
+++ b/src/glyph.rs
@@ -29,6 +29,7 @@ use {
     vello_encoding::Encoding,
 };
 
+pub use fello;
 pub use vello_encoding::Glyph;
 
 /// General context for creating scene fragments for glyph outlines.


### PR DESCRIPTION
Just exports fello from the glyph module so we can construct FontRefs in xilem.