### PR TITLE
[shaders] Revise access to backend-agnostic metadata

### DIFF
--- a/crates/shaders/src/lib.rs
+++ b/crates/shaders/src/lib.rs
@@ -13,10 +13,15 @@ use std::borrow::Cow;
 #[derive(Clone, Debug)]
 pub struct ComputeShader<'a> {
     pub name: Cow<'a, str>,
-    pub code: Cow<'a, [u8]>,
     pub workgroup_size: [u32; 3],
     pub bindings: Cow<'a, [BindType]>,
     pub workgroup_buffers: Cow<'a, [WorkgroupBufferInfo]>,
+
+    #[cfg(feature = "wgsl")]
+    pub wgsl: Cow<'a, str>,
+
+    #[cfg(feature = "msl")]
+    pub msl: Cow<'a, str>,
 }
 
 pub trait PipelineHost {
@@ -32,3 +37,5 @@ pub trait PipelineHost {
 }
 
 include!(concat!(env!("OUT_DIR"), "/shaders.rs"));
+
+pub use gen::SHADERS;


### PR DESCRIPTION
Previously the generated shader data structures were rooted in backend-specific top-level mods (`mod wgsl`, `mod msl`, etc). This made access to per-shader information that is common to all backends (e.g. workgroup sizes, shader name etc) awkward to access from backend agnostic code, especially when feature-gated conditional compilation is used on the client side.

The data structures have been rearranged such that there is a top-level `ComputeShader` declaration for each stage under a `gen` mod. The `ComputeShader` struct declares feature-gated fields for backend shader sources, such that backend specific data is now a leaf node in the structure rather than the root. This has some additional benefits:

1. Common data doesn't have to be redeclared, saving on code size when multiple backends are enabled.

2. The backend specific source code was previously encoded as a `[u8]`. We can now use types that more closely match the expected format, for example `&str` for WGSL and MSL, `[u32]` for SPIR-V, etc.

3. If we ever need to expose additional backend-specific metadata in the future, we can bundle them alongside the source code in a backend-specific data structure at this level of the tree.