### PR TITLE
Quiet warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,14 @@ jobs:
       - run: cargo check --features=hot_reload,buffer_labels
       # --exclude with_bevy # for when bevy has an outdated wgpu version
       # -Dwarnings # for when we have fixed unused code warnings
+
+  clippy:
+    runs-on: ubuntu-latest
+    name: Enforce clippy lints
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo clippy --all-targets --workspace -- -D warnings
   
   wasm:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,8 @@ jobs:
       - name: Install native dependencies
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - run: cargo check --workspace
-      - run: cargo check --features=hot_reload,buffer_labels
+      # Check vello (the default crate) without the features used by `with_winit` for debugging
+      - run: cargo check 
       # --exclude with_bevy # for when bevy has an outdated wgpu version
       # -Dwarnings # for when we have fixed unused code warnings
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install native dependencies
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
-      - run: cargo check --workspace 
+      - run: cargo check --workspace
+      - run: cargo check --features=hot_reload,buffer_labels
       # --exclude with_bevy # for when bevy has an outdated wgpu version
       # -Dwarnings # for when we have fixed unused code warnings
   

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@stable
+      - name: Install native dependencies
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - run: cargo clippy --all-targets --workspace -- -D warnings
   
   wasm:

--- a/crates/shaders/build.rs
+++ b/crates/shaders/build.rs
@@ -26,7 +26,7 @@ fn main() {
         .and_then(|p| Path::new(&p).parent().map(|p| p.to_owned()))
         .unwrap_or(PathBuf::from("../../"));
     let shader_dir = Path::new(&workspace_dir).join("shader");
-    let mut shaders = compile::ShaderInfo::from_dir(&shader_dir);
+    let mut shaders = compile::ShaderInfo::from_dir(shader_dir);
 
     // Drop the HashMap and sort by name so that we get deterministic order.
     let mut shaders = shaders.drain().collect::<Vec<_>>();
@@ -34,7 +34,7 @@ fn main() {
     let mut buf = String::default();
     write_types(&mut buf, &shaders).unwrap();
     write_shaders(&mut buf, &shaders).unwrap();
-    std::fs::write(&dest_path, &buf).unwrap();
+    std::fs::write(dest_path, &buf).unwrap();
     println!("cargo:rerun-if-changed=../shader");
 }
 
@@ -93,12 +93,12 @@ fn write_shaders(
             wg_bufs
         )?;
         if cfg!(feature = "wgsl") {
-            writeln!(buf, "            wgsl: Cow::Borrowed(&{:?}),", info.source)?;
+            writeln!(buf, "            wgsl: Cow::Borrowed({:?}),", info.source)?;
         }
         if cfg!(feature = "msl") {
             writeln!(
                 buf,
-                "            msl: Cow::Borrowed(&{:?}),",
+                "            msl: Cow::Borrowed({:?}),",
                 compile::msl::translate(info).unwrap()
             )?;
         }

--- a/examples/headless/src/main.rs
+++ b/examples/headless/src/main.rs
@@ -21,7 +21,7 @@ fn main() -> Result<()> {
     #[cfg(not(target_arch = "wasm32"))]
     env_logger::init();
     let args = Args::parse();
-    let scenes = args.args.select_scene_set(|| Args::command())?;
+    let scenes = args.args.select_scene_set(Args::command)?;
     if let Some(scenes) = scenes {
         let mut scene_idx = None;
         for (idx, scene) in scenes.scenes.iter().enumerate() {
@@ -41,8 +41,8 @@ fn main() -> Result<()> {
                     args.scene
                 ))?;
 
-                if !(parsed < scenes.scenes.len()) {
-                    if scenes.scenes.len() == 0 {
+                if parsed >= scenes.scenes.len() {
+                    if scenes.scenes.is_empty() {
                         bail!("Cannot select a scene, as there are no scenes")
                     }
                     bail!(
@@ -86,7 +86,7 @@ async fn render(mut scenes: SceneSet, index: usize, args: &Args) -> Result<()> {
     let device = &device_handle.device;
     let queue = &device_handle.queue;
     let mut renderer = vello::Renderer::new(
-        &device,
+        device,
         &RendererOptions {
             surface_format: None,
         },
@@ -117,20 +117,14 @@ async fn render(mut scenes: SceneSet, index: usize, args: &Args) -> Result<()> {
         };
         let factor = Vec2::new(new_width as f64, new_height as f64);
         let scale_factor = (factor.x / resolution.x).min(factor.y / resolution.y);
-        transform = transform * Affine::scale(scale_factor);
+        transform *= Affine::scale(scale_factor);
         (new_width, new_height)
     } else {
         match (args.x_resolution, args.y_resolution) {
             (None, None) => (1000, 1000),
-            (None, Some(y)) => {
-                let y = y.try_into()?;
-                (y, y)
-            }
-            (Some(x), None) => {
-                let x = x.try_into()?;
-                (x, x)
-            }
-            (Some(x), Some(y)) => (x.try_into()?, y.try_into()?),
+            (None, Some(y)) => (y, y),
+            (Some(x), None) => (x, x),
+            (Some(x), Some(y)) => (x, y),
         }
     };
     let render_params = vello::RenderParams {
@@ -162,11 +156,11 @@ async fn render(mut scenes: SceneSet, index: usize, args: &Args) -> Result<()> {
     });
     let view = target.create_view(&wgpu::TextureViewDescriptor::default());
     renderer
-        .render_to_texture(&device, &queue, &scene, &view, &render_params)
+        .render_to_texture(device, queue, &scene, &view, &render_params)
         .or_else(|_| bail!("Got non-Send/Sync error from rendering"))?;
     // (width * 4).next_multiple_of(256)
     let padded_byte_width = {
-        let w = width as u32 * 4;
+        let w = width * 4;
         match w % 256 {
             0 => w,
             r => w + (256 - r),
@@ -199,7 +193,7 @@ async fn render(mut scenes: SceneSet, index: usize, args: &Args) -> Result<()> {
 
     let (sender, receiver) = futures_intrusive::channel::shared::oneshot_channel();
     buf_slice.map_async(wgpu::MapMode::Read, move |v| sender.send(v).unwrap());
-    if let Some(recv_result) = block_on_wgpu(&device, receiver.receive()) {
+    if let Some(recv_result) = block_on_wgpu(device, receiver.receive()) {
         recv_result?;
     } else {
         bail!("channel was closed");

--- a/examples/scenes/src/download.rs
+++ b/examples/scenes/src/download.rs
@@ -40,7 +40,7 @@ impl Download {
         if let Some(downloads) = &self.downloads {
             to_download = downloads
                 .iter()
-                .map(|it| Self::parse_download(&it))
+                .map(|it| Self::parse_download(it))
                 .collect();
         } else {
             let mut accepted = self.auto;
@@ -52,7 +52,7 @@ impl Download {
                 })
                 .collect::<Vec<_>>();
             if !accepted {
-                if downloads.len() != 0 {
+                if !downloads.is_empty() {
                     println!(
                         "Would you like to download a set of default svg files? These files are:"
                     );
@@ -140,7 +140,7 @@ impl SVGDownload {
         let mut file = std::fs::OpenOptions::new()
             .create_new(true)
             .write(true)
-            .open(&self.file_path(directory))
+            .open(self.file_path(directory))
             .context("Creating file")?;
         let mut reader = ureq::get(&self.url).call()?.into_reader();
 
@@ -152,14 +152,8 @@ impl SVGDownload {
         if reader.read_exact(&mut [0]).is_ok() {
             bail!("Size limit exceeded");
         }
-        if limit_exact {
-            if file
-                .seek(std::io::SeekFrom::Current(0))
-                .context("Checking file limit")?
-                != size_limit
-            {
-                bail!("Builtin downloaded file was not as expected");
-            }
+        if limit_exact && file.stream_position().context("Checking file limit")? != size_limit {
+            bail!("Builtin downloaded file was not as expected");
         }
         Ok(())
     }

--- a/examples/scenes/src/lib.rs
+++ b/examples/scenes/src/lib.rs
@@ -34,6 +34,7 @@ pub struct SceneConfig {
 }
 
 pub struct ExampleScene {
+    #[allow(clippy::type_complexity)]
     pub function: Box<dyn FnMut(&mut SceneBuilder, &mut SceneParams)>,
     pub config: SceneConfig,
 }
@@ -87,7 +88,7 @@ impl Arguments {
             if self.test_scenes {
                 Ok(test_scenes())
             } else if let Some(svgs) = &self.svgs {
-                scene_from_files(&svgs)
+                scene_from_files(svgs)
             } else {
                 default_scene(command)
             }

--- a/examples/scenes/src/simple_text.rs
+++ b/examples/scenes/src/simple_text.rs
@@ -37,6 +37,7 @@ pub struct SimpleText {
 }
 
 impl SimpleText {
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self {
             gcx: GlyphContext::new(),
@@ -45,6 +46,7 @@ impl SimpleText {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn add_run<'a>(
         &mut self,
         builder: &mut SceneBuilder,
@@ -69,6 +71,7 @@ impl SimpleText {
         );
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn add_var_run<'a>(
         &mut self,
         builder: &mut SceneBuilder,
@@ -118,7 +121,7 @@ impl SimpleText {
                     }
                     let gid = charmap.map(ch).unwrap_or_default();
                     let advance = glyph_metrics.advance_width(gid).unwrap_or_default();
-                    let x = pen_x as f32;
+                    let x = pen_x;
                     pen_x += advance;
                     Some(Glyph {
                         id: gid.to_u16() as u32,
@@ -139,10 +142,7 @@ impl SimpleText {
         text: &str,
     ) {
         let default_font = FontRef::new(ROBOTO_FONT).unwrap();
-        let font = font
-            .map(|font| to_font_ref(font))
-            .flatten()
-            .unwrap_or(default_font);
+        let font = font.and_then(to_font_ref).unwrap_or(default_font);
         let fello_size = vello::fello::Size::new(size);
         let charmap = font.charmap();
         let metrics = font.metrics(fello_size, Default::default());
@@ -171,7 +171,7 @@ impl SimpleText {
     }
 }
 
-fn to_font_ref<'a>(font: &'a Font) -> Option<FontRef<'a>> {
+fn to_font_ref(font: &Font) -> Option<FontRef<'_>> {
     use vello::fello::raw::FileRef;
     let file_ref = FileRef::new(font.data.as_ref()).ok()?;
     match file_ref {

--- a/examples/scenes/src/svg.rs
+++ b/examples/scenes/src/svg.rs
@@ -75,8 +75,7 @@ fn example_scene_of(file: PathBuf) -> ExampleScene {
         .unwrap_or_else(|| "unknown".to_string());
     ExampleScene {
         function: Box::new(svg_function_of(name.clone(), move || {
-            let contents = std::fs::read_to_string(&file).expect("failed to read svg file");
-            contents
+            std::fs::read_to_string(file).expect("failed to read svg file")
         })),
         config: crate::SceneConfig {
             animated: false,
@@ -91,7 +90,7 @@ pub fn svg_function_of<R: AsRef<str>>(
 ) -> impl FnMut(&mut SceneBuilder, &mut SceneParams) {
     fn render_svg_contents(name: &str, contents: &str) -> (SceneFragment, Vec2) {
         let start = Instant::now();
-        let svg = usvg::Tree::from_str(&contents, &usvg::Options::default())
+        let svg = usvg::Tree::from_str(contents, &usvg::Options::default())
             .expect("failed to parse svg file");
         eprintln!("Parsed svg {name} in {:?}", start.elapsed());
         let start = Instant::now();
@@ -112,7 +111,7 @@ pub fn svg_function_of<R: AsRef<str>>(
     let mut contents = Some(contents);
     move |builder, params| {
         if let Some((scene_frag, resolution)) = cached_scene.as_mut() {
-            builder.append(&scene_frag, None);
+            builder.append(scene_frag, None);
             params.resolution = Some(*resolution);
             return;
         }

--- a/examples/scenes/src/test_scenes.rs
+++ b/examples/scenes/src/test_scenes.rs
@@ -161,7 +161,7 @@ fn animated_text(sb: &mut SceneBuilder, params: &mut SceneParams) {
         Fill::NonZero,
         "And some vello\ntext with a newline",
     );
-    let th = params.time as f64;
+    let th = params.time;
     let center = Point::new(500.0, 500.0);
     let mut p1 = center;
     p1.x += 400.0 * th.cos();
@@ -180,7 +180,7 @@ fn animated_text(sb: &mut SceneBuilder, params: &mut SceneParams) {
         None,
         &rect,
     );
-    let alpha = (params.time as f64).sin() as f32 * 0.5 + 0.5;
+    let alpha = params.time.sin() as f32 * 0.5 + 0.5;
     sb.push_layer(Mix::Normal, alpha, Affine::IDENTITY, &rect);
     sb.fill(
         Fill::NonZero,
@@ -278,12 +278,11 @@ fn gradient_extend(sb: &mut SceneBuilder, params: &mut SceneParams) {
         );
     }
     let extend_modes = [Extend::Pad, Extend::Repeat, Extend::Reflect];
-    for x in 0..3 {
-        let extend = extend_modes[x];
+    for (x, extend) in extend_modes.iter().enumerate() {
         for y in 0..2 {
             let is_radial = y & 1 != 0;
             let transform = Affine::translate((x as f64 * 350.0 + 50.0, y as f64 * 350.0 + 100.0));
-            square(sb, is_radial, transform, extend);
+            square(sb, is_radial, transform, *extend);
         }
     }
     for (i, label) in ["Pad", "Repeat", "Reflect"].iter().enumerate() {
@@ -299,6 +298,7 @@ fn gradient_extend(sb: &mut SceneBuilder, params: &mut SceneParams) {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn two_point_radial(sb: &mut SceneBuilder, _params: &mut SceneParams) {
     fn make(
         sb: &mut SceneBuilder,
@@ -607,7 +607,7 @@ fn render_blend_square(sb: &mut SceneBuilder, blend: BlendMode, transform: Affin
         (125., 200., Color::rgb8(64, 192, 255)),
     ];
     for (x, y, c) in GRADIENTS {
-        let mut color2 = c.clone();
+        let mut color2 = *c;
         color2.a = 0;
         let radial = Gradient::new_radial((*x, *y), 100.0).with_stops([*c, color2]);
         sb.fill(Fill::NonZero, transform, &radial, None, &rect);

--- a/examples/with_bevy/src/main.rs
+++ b/examples/with_bevy/src/main.rs
@@ -63,7 +63,7 @@ fn render_scenes(
             .0
             .render_to_texture(
                 device.wgpu_device(),
-                &*queue,
+                &queue,
                 &scene.0,
                 &gpu_image.texture_view,
                 &params,

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -100,6 +100,8 @@ fn run(
     let mut images = ImageCache::new();
     let mut stats = stats::Stats::new();
     let mut stats_shown = true;
+    // Currently not updated in wasm builds
+    #[allow(unused_mut)]
     let mut scene_complexity: Option<BumpAllocators> = None;
     let mut complexity_shown = false;
     let mut vsync_on = true;

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -323,13 +323,13 @@ fn run(
                 // TODO: Apply svg view_box, somehow
                 let factor = Vec2::new(width as f64, height as f64);
                 let scale_factor = (factor.x / resolution.x).min(factor.y / resolution.y);
-                transform = transform * Affine::scale(scale_factor);
+                transform *= Affine::scale(scale_factor);
             }
             builder.append(&fragment, Some(transform));
             if stats_shown {
                 snapshot.draw_layer(
                     &mut builder,
-                    &mut scene_params.text,
+                    scene_params.text,
                     width as f64,
                     height as f64,
                     stats.samples(),
@@ -451,7 +451,7 @@ fn create_window(event_loop: &winit::event_loop::EventLoopWindowTarget<UserEvent
         .with_inner_size(LogicalSize::new(1044, 800))
         .with_resizable(true)
         .with_title("Vello demo")
-        .build(&event_loop)
+        .build(event_loop)
         .unwrap()
 }
 
@@ -467,7 +467,7 @@ pub fn main() -> Result<()> {
     #[cfg(not(target_arch = "wasm32"))]
     env_logger::init();
     let args = Args::parse();
-    let scenes = args.args.select_scene_set(|| Args::command())?;
+    let scenes = args.args.select_scene_set(Args::command)?;
     if let Some(scenes) = scenes {
         let event_loop = EventLoopBuilder::<UserEvent>::with_user_event().build();
         #[allow(unused_mut)]

--- a/examples/with_winit/src/stats.rs
+++ b/examples/with_winit/src/stats.rs
@@ -33,6 +33,7 @@ pub struct Snapshot {
 }
 
 impl Snapshot {
+    #[allow(clippy::too_many_arguments)]
     pub fn draw_layer<'a, T>(
         &self,
         sb: &mut SceneBuilder,
@@ -69,7 +70,7 @@ impl Snapshot {
         ];
         if let Some(bump) = &bump {
             if bump.failed >= 1 {
-                labels.push(format!("Allocation Failed!"));
+                labels.push("Allocation Failed!".into());
             }
             labels.push(format!("binning: {}", bump.binning));
             labels.push(format!("ptcl: {}", bump.ptcl));
@@ -89,7 +90,7 @@ impl Snapshot {
                 text_size,
                 Some(&Brush::Solid(Color::WHITE)),
                 offset * Affine::translate((left_margin, (i + 1) as f64 * text_height)),
-                &label,
+                label,
             );
         }
         text.add(
@@ -132,6 +133,7 @@ impl Snapshot {
             let sample_ms = ((*sample as f64) * 0.001).min(display_max);
             let h = sample_ms / display_max;
             let s = Affine::scale_non_uniform(1., -h);
+            #[allow(clippy::match_overlapping_arm)]
             let color = match *sample {
                 ..=16_667 => Color::rgb8(100, 143, 255),
                 ..=33_334 => Color::rgb8(255, 176, 0),

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -63,6 +63,7 @@ pub struct BufProxy {
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum ImageFormat {
     Rgba8,
+    #[allow(unused)]
     Bgra8,
 }
 
@@ -81,6 +82,7 @@ pub enum ResourceProxy {
 }
 
 pub enum ExternalResource<'a> {
+    #[allow(unused)]
     Buf(BufProxy, &'a Buffer),
     Image(ImageProxy, &'a TextureView),
 }
@@ -800,7 +802,7 @@ impl ResourcePool {
     fn get_buf(
         &mut self,
         size: u64,
-        name: &'static str,
+        #[allow(unused)] name: &'static str,
         usage: BufferUsages,
         device: &Device,
     ) -> Buffer {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -811,7 +811,7 @@ impl ResourcePool {
             size: rounded_size,
             usages: usage,
             #[cfg(feature = "buffer_labels")]
-            name: name,
+            name,
         };
         if let Some(buf_vec) = self.bufs.get_mut(&props) {
             if let Some(buf) = buf_vec.pop() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,7 +230,7 @@ impl Renderer {
                 return Err("channel was closed".into());
             }
             let mapped = buf_slice.get_mapped_range();
-            bump = Some(bytemuck::pod_read_unaligned(&*mapped));
+            bump = Some(bytemuck::pod_read_unaligned(&mapped));
         }
         // TODO: apply logic to determine whether we need to rerun coarse, and also
         // allocate the blend stack as needed.

--- a/src/render.rs
+++ b/src/render.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     engine::{BufProxy, ImageFormat, ImageProxy, Recording, ResourceProxy},
-    shaders::{self, FullShaders},
+    shaders::FullShaders,
     RenderParams, Scene,
 };
 use vello_encoding::{Encoding, WorkgroupSize};

--- a/src/shaders/preprocess.rs
+++ b/src/shaders/preprocess.rs
@@ -5,6 +5,7 @@ use std::{
     vec,
 };
 
+#[allow(unused)]
 pub fn get_imports(shader_dir: &Path) -> HashMap<String, String> {
     let mut imports = HashMap::new();
     let imports_dir = shader_dir.join("shared");


### PR DESCRIPTION
Fixes the warnings remaining in the code, which should in turn let us check that in CI.

Also checks the optional features, which are easy enough to break.