### PR TITLE
Remove gitattributes - linguist supports WGSL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,0 @@
-# This is a lie. However, linguist does not support wgsl, so this is good-enough
-# Show the amount of the code which is shader
-shader/*.wgsl linguist-language=glsl
-# Potentially better syntax highlighting
-# shader/*.wgsl linguist-language=Rust


### PR DESCRIPTION
I think we're waiting for https://github.com/github-linguist/linguist/pull/6449 to finish landing - EDIT: Appears done

I think just landing this is fine - having improper numbers and no highlighting for a few days (?) whilst GitHub drifts the updates through should be fine.