### PR TITLE
headless: Use pollster from workspace.

### DIFF
--- a/examples/headless/Cargo.toml
+++ b/examples/headless/Cargo.toml
@@ -17,7 +17,7 @@ vello = { path = "../../" }
 scenes = { path = "../scenes" }
 
 wgpu = { workspace = true }
-pollster = "0.2.5"
+pollster = { workspace = true }
 env_logger = "0.10.0"
 png = "0.17.7"
 futures-intrusive = "0.5.0"


### PR DESCRIPTION
This prevents having 2 versions of `pollster` pulled into the workspace. The workspace provided `pollster` `0.3`, while `headless` was still using `0.2.5`.