### PR TITLE
vello_shaders: Use naga 0.12, not git rev.

### DIFF
--- a/crates/shaders/Cargo.toml
+++ b/crates/shaders/Cargo.toml
@@ -10,10 +10,10 @@ wgsl = []
 msl = []
 
 [dependencies]
-naga = { git = "https://github.com/gfx-rs/naga", rev = "53d62b9", features = ["wgsl-in", "msl-out", "validate"], optional = true }
+naga = { version = "0.12", features = ["wgsl-in", "msl-out", "validate"], optional = true }
 thiserror = { version = "1.0.40", optional = true }
 
 [build-dependencies]
-naga = { git = "https://github.com/gfx-rs/naga", rev = "53d62b9",  features = ["wgsl-in", "msl-out", "validate"] }
+naga = { version = "0.12",  features = ["wgsl-in", "msl-out", "validate"] }
 thiserror = "1.0.40"
 


### PR DESCRIPTION
The git revision being used was from `0.11` while the current release is `0.12`. `0.12` is used in `wgpu`, so this lets us have a single `naga` crate being built.