### PR TITLE
with_bevy: Update to bevy 0.11 release.

### DIFF
--- a/examples/with_bevy/Cargo.toml
+++ b/examples/with_bevy/Cargo.toml
@@ -10,5 +10,5 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", rev = "4d54ce14aaee8d7432380df37c41c03c28594b27" }
+bevy = "0.11"
 vello = { path = "../../" }

--- a/examples/with_bevy/src/main.rs
+++ b/examples/with_bevy/src/main.rs
@@ -21,8 +21,8 @@ struct VelloRenderer(Renderer);
 
 impl FromWorld for VelloRenderer {
     fn from_world(world: &mut World) -> Self {
-        let device = world.get_resource::<RenderDevice>().unwrap();
-        let queue = world.get_resource::<RenderQueue>().unwrap();
+        let device = world.resource::<RenderDevice>();
+        let queue = world.resource::<RenderQueue>();
 
         VelloRenderer(
             Renderer::new(
@@ -42,9 +42,13 @@ struct VelloPlugin;
 impl Plugin for VelloPlugin {
     fn build(&self, app: &mut App) {
         let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
-        render_app.init_resource::<VelloRenderer>();
         // This should probably use the render graph, but working out the dependencies there is awkward
         render_app.add_systems(Render, render_scenes.in_set(RenderSet::Render));
+    }
+
+    fn finish(&self, app: &mut App) {
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        render_app.init_resource::<VelloRenderer>();
     }
 }
 
@@ -78,11 +82,11 @@ fn render_scenes(
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(VelloPlugin)
+        .add_plugins(VelloPlugin)
         .add_systems(Startup, setup)
         .add_systems(Update, bevy::window::close_on_esc)
         .add_systems(Update, cube_rotator_system)
-        .add_plugin(ExtractComponentPlugin::<VelloScene>::default())
+        .add_plugins(ExtractComponentPlugin::<VelloScene>::default())
         .add_systems(Update, render_fragment)
         .run()
 }


### PR DESCRIPTION
* Use `add_plugins` as `add_plugin` is deprecated.
* Use `world.resource` instead of unwrapping `world.get_resource` as it gives better error messages.
* Add the `VelloRenderer` to the render app in the `finish` method as the `Renderer` is async and may not have initialized by the time that the Vello plugin is being set up.