### PR TITLE
Add gradient support to SVG integration

### DIFF
--- a/integrations/vello_svg/src/lib.rs
+++ b/integrations/vello_svg/src/lib.rs
@@ -182,7 +182,7 @@ fn paint_to_brush(paint: &usvg::Paint, opacity: usvg::Opacity) -> Option<(Brush,
                 color.blue,
                 opacity.to_u8(),
             )),
-            Affine::default(),
+            Affine::IDENTITY,
         )),
         usvg::Paint::LinearGradient(gr) => {
             let stops: Vec<vello::peniko::ColorStop> = gr

--- a/integrations/vello_svg/src/lib.rs
+++ b/integrations/vello_svg/src/lib.rs
@@ -120,7 +120,7 @@ pub fn render_tree_with<F: FnMut(&mut SceneBuilder, &usvg::Node) -> Result<(), E
                             Fill::NonZero,
                             transform,
                             &brush,
-                            brush_transform,
+                            Some(brush_transform),
                             &local_path,
                         );
                     } else {
@@ -136,7 +136,7 @@ pub fn render_tree_with<F: FnMut(&mut SceneBuilder, &usvg::Node) -> Result<(), E
                             &Stroke::new(stroke.width.get() as f32),
                             transform,
                             &brush,
-                            brush_transform,
+                            Some(brush_transform),
                             &local_path,
                         );
                     } else {
@@ -176,7 +176,7 @@ pub fn default_error_handler(sb: &mut SceneBuilder, node: &usvg::Node) -> Result
     Ok(())
 }
 
-fn paint_to_brush(paint: &usvg::Paint, opacity: usvg::Opacity) -> Option<(Brush, Option<Affine>)> {
+fn paint_to_brush(paint: &usvg::Paint, opacity: usvg::Opacity) -> Option<(Brush, Affine)> {
     match paint {
         usvg::Paint::Color(color) => Some((
             Brush::Solid(Color::rgba8(
@@ -185,7 +185,7 @@ fn paint_to_brush(paint: &usvg::Paint, opacity: usvg::Opacity) -> Option<(Brush,
                 color.blue,
                 opacity.to_u8(),
             )),
-            None,
+            Affine::IDENTITY,
         )),
         usvg::Paint::LinearGradient(gr) => {
             let stops: Vec<vello::peniko::ColorStop> = gr
@@ -213,7 +213,7 @@ fn paint_to_brush(paint: &usvg::Paint, opacity: usvg::Opacity) -> Option<(Brush,
             ]);
             let gradient =
                 vello::peniko::Gradient::new_linear(start, end).with_stops(stops.as_slice());
-            Some((Brush::Gradient(gradient), Some(transform)))
+            Some((Brush::Gradient(gradient), transform))
         }
         usvg::Paint::RadialGradient(gr) => {
             let stops: Vec<vello::peniko::ColorStop> = gr
@@ -249,7 +249,7 @@ fn paint_to_brush(paint: &usvg::Paint, opacity: usvg::Opacity) -> Option<(Brush,
                 end_radius,
             )
             .with_stops(stops.as_slice());
-            Some((Brush::Gradient(gradient), Some(transform)))
+            Some((Brush::Gradient(gradient), transform))
         }
         usvg::Paint::Pattern(_) => None,
     }

--- a/integrations/vello_svg/src/lib.rs
+++ b/integrations/vello_svg/src/lib.rs
@@ -196,8 +196,8 @@ fn paint_to_brush(paint: &usvg::Paint, opacity: usvg::Opacity) -> Option<(Brush,
                     cstop.color.r = stop.color.red;
                     cstop.color.g = stop.color.green;
                     cstop.color.b = stop.color.blue;
-                    cstop.color.a = stop.opacity.to_u8();
-                    cstop.offset = (stop.offset * opacity).get() as f32;
+                    cstop.color.a = (stop.opacity * opacity).to_u8();
+                    cstop.offset = stop.offset.get() as f32;
                     cstop
                 })
                 .collect();
@@ -224,8 +224,8 @@ fn paint_to_brush(paint: &usvg::Paint, opacity: usvg::Opacity) -> Option<(Brush,
                     cstop.color.r = stop.color.red;
                     cstop.color.g = stop.color.green;
                     cstop.color.b = stop.color.blue;
-                    cstop.color.a = stop.opacity.to_u8();
-                    cstop.offset = (stop.offset * opacity).get() as f32;
+                    cstop.color.a = (stop.opacity * opacity).to_u8();
+                    cstop.offset = stop.offset.get() as f32;
                     cstop
                 })
                 .collect();


### PR DESCRIPTION
Adds radial and linear gradient support.

<img width="582" alt="image" src="https://github.com/linebender/vello/assets/48108917/2dc31648-844c-4ceb-b993-e24035b8e2b6">
