### PR TITLE
📀 Make `wgpu` an optional dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
       - run: cargo check --workspace
       # Check vello (the default crate) without the features used by `with_winit` for debugging
       - run: cargo check 
+      # Check vello (the default crate) without wgpu
+      - run: cargo check --no-default-features
       # --exclude with_bevy # for when bevy has an outdated wgpu version
       # -Dwarnings # for when we have fixed unused code warnings
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ edition.workspace = true
 repository.workspace = true
 
 [features]
+default = ["wgpu"]
 hot_reload = []
 buffer_labels = []
 
@@ -44,7 +45,7 @@ buffer_labels = []
 bytemuck = { workspace = true }
 fello = { workspace = true }
 peniko = { workspace = true }
-wgpu = { workspace = true }
+wgpu = { workspace = true, optional = true }
 raw-window-handle = "0.5"
 futures-intrusive = "0.5.0"
 vello_encoding = { path = "crates/encoding" }
@@ -54,7 +55,9 @@ wgpu-profiler = { workspace = true, optional = true }
 bytemuck = { version = "1.12.1", features = ["derive"] }
 fello = { git = "https://github.com/dfrg/fount", rev = "dadbcf75695f035ca46766bfd60555d05bd421b1" }
 peniko = { git = "https://github.com/linebender/peniko", rev = "cafdac9a211a0fb2fec5656bd663d1ac770bcc81" }
-wgpu = "0.17"                                                                                               # NOTE: Make sure to keep this in sync with the version badge in README.md
+
+# NOTE: Make sure to keep this in sync with the version badge in README.md
+wgpu = { version = "0.17" }                                              
 
 
 # Used for examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,17 +28,25 @@ pub use peniko::kurbo;
 pub use fello;
 
 pub mod glyph;
+
+#[cfg(feature = "wgpu")]
 pub mod util;
 
-use render::Render;
+pub use render::Render;
 pub use scene::{DrawGlyphs, Scene, SceneBuilder, SceneFragment};
+#[cfg(feature = "wgpu")]
 pub use util::block_on_wgpu;
 
-use engine::{Engine, ExternalResource, Recording};
-use shaders::FullShaders;
+pub use engine::{
+    BufProxy, Command, Id, ImageFormat, ImageProxy, Recording, ResourceProxy, ShaderId,
+};
+#[cfg(feature = "wgpu")]
+use engine::{Engine, ExternalResource};
+pub use shaders::FullShaders;
 
 /// Temporary export, used in with_winit for stats
 pub use vello_encoding::BumpAllocators;
+#[cfg(feature = "wgpu")]
 use wgpu::{Device, Queue, SurfaceTexture, TextureFormat, TextureView};
 #[cfg(feature = "wgpu-profiler")]
 use wgpu_profiler::GpuProfiler;
@@ -50,6 +58,7 @@ pub type Error = Box<dyn std::error::Error>;
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Renders a scene into a texture or surface.
+#[cfg(feature = "wgpu")]
 pub struct Renderer {
     engine: Engine,
     shaders: FullShaders,
@@ -72,6 +81,7 @@ pub struct RenderParams {
     pub height: u32,
 }
 
+#[cfg(feature = "wgpu")]
 pub struct RendererOptions {
     /// The format of the texture used for surfaces with this renderer/device
     /// If None, the renderer cannot be used with surfaces
@@ -81,6 +91,7 @@ pub struct RendererOptions {
     pub timestamp_period: f32,
 }
 
+#[cfg(feature = "wgpu")]
 impl Renderer {
     /// Creates a new renderer for the specified device.
     pub fn new(device: &Device, render_options: &RendererOptions) -> Result<Self> {
@@ -351,12 +362,14 @@ impl Renderer {
     }
 }
 
+#[cfg(feature = "wgpu")]
 struct TargetTexture {
     view: TextureView,
     width: u32,
     height: u32,
 }
 
+#[cfg(feature = "wgpu")]
 impl TargetTexture {
     pub fn new(device: &Device, width: u32, height: u32) -> Self {
         let texture = device.create_texture(&wgpu::TextureDescriptor {
@@ -382,11 +395,13 @@ impl TargetTexture {
     }
 }
 
+#[cfg(feature = "wgpu")]
 struct BlitPipeline {
     bind_layout: wgpu::BindGroupLayout,
     pipeline: wgpu::RenderPipeline,
 }
 
+#[cfg(feature = "wgpu")]
 impl BlitPipeline {
     fn new(device: &Device, format: TextureFormat) -> Self {
         const SHADERS: &str = r#"

--- a/src/render.rs
+++ b/src/render.rs
@@ -51,6 +51,12 @@ pub fn render_encoding_full(
     (recording, out_image.into())
 }
 
+impl Default for Render {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Render {
     pub fn new() -> Self {
         Render {

--- a/src/shaders.rs
+++ b/src/shaders.rs
@@ -20,9 +20,13 @@ mod preprocess;
 
 use std::collections::HashSet;
 
+#[cfg(feature = "wgpu")]
 use wgpu::Device;
 
-use crate::engine::{BindType, Engine, Error, ImageFormat, ShaderId};
+#[cfg(feature = "wgpu")]
+use crate::engine::{BindType, Engine, Error, ImageFormat};
+
+use crate::engine::ShaderId;
 
 macro_rules! shader {
     ($name:expr) => {&{
@@ -71,6 +75,7 @@ pub struct FullShaders {
     pub fine: ShaderId,
 }
 
+#[cfg(feature = "wgpu")]
 pub fn full_shaders(device: &Device, engine: &mut Engine) -> Result<FullShaders, Error> {
     let imports = SHARED_SHADERS
         .iter()


### PR DESCRIPTION
This turns `wgpu` into an optional dependency that's default enabled.

In our project we're not using `wgpu` as the renderer so interop-ing with this library is a bit trick, but I think I've find a way that would work for us. We can take the pre-recorded command buffer `Recording` and convert it to our own abstraction.

As for the shaders, we can use naga and patch files to make them work in our environment.

@raphlinus We disccussed various ways of going about this problem some time ago, but I think this wouldn't be too intrusive on either of our projects. If it is, let me know.