### PR TITLE
[shaders][msl] Enable `zero_initialize_workgroup_memory` setting

### DIFF
--- a/crates/shaders/src/compile/mod.rs
+++ b/crates/shaders/src/compile/mod.rs
@@ -47,11 +47,8 @@ pub struct ShaderInfo {
 impl ShaderInfo {
     pub fn new(source: String, entry_point: &str) -> Result<ShaderInfo, Error> {
         let module = wgsl::parse_str(&source)?;
-        let module_info = naga::valid::Validator::new(
-            ValidationFlags::all() & !ValidationFlags::CONTROL_FLOW_UNIFORMITY,
-            Capabilities::all(),
-        )
-        .validate(&module)?;
+        let module_info = naga::valid::Validator::new(ValidationFlags::all(), Capabilities::all())
+            .validate(&module)?;
         let (entry_index, entry) = module
             .entry_points
             .iter()

--- a/crates/shaders/src/compile/msl.rs
+++ b/crates/shaders/src/compile/msl.rs
@@ -43,7 +43,7 @@ pub fn translate(shader: &ShaderInfo) -> Result<String, naga_msl::Error> {
         spirv_cross_compatibility: false,
         fake_missing_bindings: false,
         bounds_check_policies: naga::proc::BoundsCheckPolicies::default(),
-        zero_initialize_workgroup_memory: false,
+        zero_initialize_workgroup_memory: true,
     };
     let (source, _) = naga_msl::write_string(
         &shader.module,


### PR DESCRIPTION
Zero-initializing workgroup memory works around a Metal driver bug that can cause the tile_alloc and coarse stages to freeze up the system when running natively on Metal due to their use of `workgroupUniformLoad`. See gfx-rs/naga#2482 for more details about this bug.

Zero-initializing workgroup memory also makes the native Metal shaders match the behavior of the current wgpu runner and the invariants of the original WGSL that the shaders were authored in.

In addition, this PR enables the `CONTROL_FLOW_UNIFORMITY` validation check.