### PR TITLE
[encoding] Do not allow zero-length buffer sizes

### DIFF
--- a/crates/encoding/src/config.rs
+++ b/crates/encoding/src/config.rs
@@ -185,7 +185,12 @@ impl<T: Sized> BufferSize<T> {
     /// Creates a new buffer size from number of elements.
     pub const fn new(len: u32) -> Self {
         Self {
-            len,
+            // Each buffer binding must be large enough to hold at least one element to avoid
+            // triggering validation errors.
+            //
+            // Note: not using `Ord::max` here because it doesn't support const eval yet (except
+            // in nightly)
+            len: if len > 0 { len } else { 1 },
             _phantom: std::marker::PhantomData,
         }
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -552,11 +552,8 @@ impl Recording {
 impl BufProxy {
     pub fn new(size: u64, name: &'static str) -> Self {
         let id = Id::next();
-        BufProxy {
-            id,
-            size: size.max(16),
-            name,
-        }
+        debug_assert!(size > 0);
+        BufProxy { id, size, name }
     }
 }
 


### PR DESCRIPTION
It is possible for a BufferSize of 0 bytes to trigger validation warnings as such buffers still need to get bound to their pipeline. The standard vello engine (src/engine.rs) handles this when a BufProxy is requested by setting the requested size to at least 16.

This is now handled by the encoding crate by selecting a buffer size that can fit at least one element.