### PR TITLE
Switch to CPU-side stroke encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ wgpu-profiler = { workspace = true, optional = true }
 [workspace.dependencies]
 bytemuck = { version = "1.12.1", features = ["derive"] }
 fello = { git = "https://github.com/dfrg/fount", rev = "dadbcf75695f035ca46766bfd60555d05bd421b1" }
-peniko = { git = "https://github.com/linebender/peniko", rev = "cafdac9a211a0fb2fec5656bd663d1ac770bcc81" }
+peniko = { git = "https://github.com/linebender/peniko", rev = "639f18b25048abcf8130397737c24e02bf49cef2" }
 
 # NOTE: Make sure to keep this in sync with the version badge in README.md
 wgpu = { version = "0.17" }                                              

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ wgpu-profiler = { workspace = true, optional = true }
 [workspace.dependencies]
 bytemuck = { version = "1.12.1", features = ["derive"] }
 fello = { git = "https://github.com/dfrg/fount", rev = "dadbcf75695f035ca46766bfd60555d05bd421b1" }
-peniko = { git = "https://github.com/linebender/peniko", rev = "639f18b25048abcf8130397737c24e02bf49cef2" }
+peniko = { git = "https://github.com/linebender/peniko", rev = "629fc3325b016a8c98b1cd6204cb4ddf1c6b3daa" }
 
 # NOTE: Make sure to keep this in sync with the version badge in README.md
 wgpu = { version = "0.17" }                                              

--- a/crates/encoding/src/encoding.rs
+++ b/crates/encoding/src/encoding.rs
@@ -3,7 +3,7 @@
 
 use super::{DrawColor, DrawTag, PathEncoder, PathTag, Transform};
 
-use peniko::{kurbo::Shape, BlendMode, BrushRef, Color};
+use peniko::{kurbo::Shape, BlendMode, BrushRef, Color, Fill};
 
 #[cfg(feature = "full")]
 use {
@@ -163,8 +163,12 @@ impl Encoding {
         }
     }
 
-    /// Encodes a linewidth.
-    pub fn encode_linewidth(&mut self, linewidth: f32) {
+    /// Encodes a fill style.
+    pub fn encode_fill_style(&mut self, fill: Fill) {
+        let linewidth = match fill {
+            Fill::NonZero => -1.0,
+            Fill::EvenOdd => -2.0,
+        };
         if self.linewidths.last() != Some(&linewidth) {
             self.path_tags.push(PathTag::LINEWIDTH);
             self.linewidths.push(linewidth);

--- a/examples/scenes/src/mmark.rs
+++ b/examples/scenes/src/mmark.rs
@@ -11,8 +11,7 @@ use std::cmp::Ordering;
 use rand::{seq::SliceRandom, Rng};
 use vello::peniko::Color;
 use vello::{
-    kurbo::{Affine, BezPath, CubicBez, Line, ParamCurve, PathSeg, Point, QuadBez},
-    peniko::Stroke,
+    kurbo::{Affine, BezPath, CubicBez, Line, ParamCurve, PathSeg, Point, QuadBez, Stroke},
     SceneBuilder,
 };
 
@@ -92,7 +91,7 @@ impl TestScene for MMark {
                 // This gets color and width from the last element, original
                 // gets it from the first, but this should not matter.
                 sb.stroke(
-                    &Stroke::new(element.width as f32),
+                    &Stroke::new(element.width),
                     Affine::IDENTITY,
                     element.color,
                     None,

--- a/examples/scenes/src/test_scenes.rs
+++ b/examples/scenes/src/test_scenes.rs
@@ -1,5 +1,5 @@
 use crate::{ExampleScene, SceneConfig, SceneParams, SceneSet};
-use vello::kurbo::{Affine, BezPath, Ellipse, PathEl, Point, Rect};
+use vello::kurbo::{Affine, BezPath, Ellipse, PathEl, Point, Rect, Stroke};
 use vello::peniko::*;
 use vello::*;
 

--- a/examples/with_winit/src/stats.rs
+++ b/examples/with_winit/src/stats.rs
@@ -17,8 +17,8 @@
 use scenes::SimpleText;
 use std::{collections::VecDeque, time::Duration};
 use vello::{
-    kurbo::{Affine, Line, PathEl, Rect},
-    peniko::{Brush, Color, Fill, Stroke},
+    kurbo::{Affine, Line, PathEl, Rect, Stroke},
+    peniko::{Brush, Color, Fill},
     BumpAllocators, SceneBuilder,
 };
 use wgpu_profiler::GpuTimerScopeResult;
@@ -174,7 +174,7 @@ impl Snapshot {
                 &format!("{}", t),
             );
             sb.stroke(
-                &Stroke::new((graph_max_height * 0.01) as f32),
+                &Stroke::new(graph_max_height * 0.01),
                 offset * Affine::translate((left_margin_padding, (1. - y) * graph_max_height)),
                 Color::WHITE,
                 None,

--- a/integrations/vello_svg/src/lib.rs
+++ b/integrations/vello_svg/src/lib.rs
@@ -35,8 +35,8 @@
 use std::convert::Infallible;
 
 use usvg::NodeExt;
-use vello::kurbo::{Affine, BezPath, Rect};
-use vello::peniko::{Brush, Color, Fill, Stroke};
+use vello::kurbo::{Affine, BezPath, Rect, Stroke};
+use vello::peniko::{Brush, Color, Fill};
 use vello::SceneBuilder;
 
 pub use usvg;
@@ -133,7 +133,7 @@ pub fn render_tree_with<F: FnMut(&mut SceneBuilder, &usvg::Node) -> Result<(), E
                     {
                         // FIXME: handle stroke options such as linecap, linejoin, etc.
                         sb.stroke(
-                            &Stroke::new(stroke.width.get() as f32),
+                            &Stroke::new(stroke.width.get()),
                             transform,
                             &brush,
                             Some(brush_transform),


### PR DESCRIPTION
Don't use GPU-side signed distance field rendering for strokes, but rather expand them on the CPU (using kurbo) during encoding, then render using fill.

This is a significant performance regression, but is on the critical path path for multisampled path rendering and stroke rework (#303).