### PR TITLE
[test_scenes] Port longpathdash test case from Skia

### DIFF
--- a/examples/scenes/src/test_scenes.rs
+++ b/examples/scenes/src/test_scenes.rs
@@ -1,5 +1,5 @@
 use crate::{ExampleScene, SceneConfig, SceneParams, SceneSet};
-use vello::kurbo::{Affine, BezPath, Ellipse, PathEl, Point, Rect, Stroke};
+use vello::kurbo::{Affine, BezPath, Cap, Ellipse, PathEl, Point, Rect, Stroke};
 use vello::peniko::*;
 use vello::*;
 
@@ -13,37 +13,25 @@ macro_rules! scene {
         scene!($name: true)
     };
     ($name: ident: $animated: literal) => {
+        scene!($name, stringify!($name), $animated)
+    };
+    ($func:expr, $name: expr, $animated: literal) => {
         ExampleScene {
             config: SceneConfig {
                 animated: $animated,
-                name: stringify!($name).to_owned(),
+                name: $name.to_owned(),
             },
-            function: Box::new($name),
+            function: Box::new($func),
         }
     };
 }
 
 pub fn test_scenes() -> SceneSet {
-    let splash_scene = ExampleScene {
-        config: SceneConfig {
-            animated: false,
-            name: "splash_with_tiger".to_owned(),
-        },
-        function: Box::new(splash_with_tiger()),
-    };
-    let mmark_scene = ExampleScene {
-        config: SceneConfig {
-            animated: false,
-            name: "mmark".to_owned(),
-        },
-        function: Box::new(crate::mmark::MMark::new(80_000)),
-    };
     let scenes = vec![
-        splash_scene,
-        mmark_scene,
+        scene!(splash_with_tiger(), "splash_with_tiger", false),
+        scene!(crate::mmark::MMark::new(80_000), "mmark", false),
         scene!(funky_paths),
         scene!(cardioid_and_friends),
-        scene!(longpathdash),
         scene!(animated_text: animated),
         scene!(gradient_extend),
         scene!(two_point_radial),
@@ -53,6 +41,8 @@ pub fn test_scenes() -> SceneSet {
         scene!(labyrinth),
         scene!(base_color_test: animated),
         scene!(clip_test: animated),
+        scene!(longpathdash(Cap::Butt), "longpathdash (butt caps)", false),
+        scene!(longpathdash(Cap::Round), "longpathdash (round caps)", false),
     ];
 
     SceneSet { scenes }
@@ -108,44 +98,46 @@ fn cardioid_and_friends(sb: &mut SceneBuilder, _: &mut SceneParams) {
     //render_tiger(sb, false);
 }
 
-fn longpathdash(sb: &mut SceneBuilder, _: &mut SceneParams) {
+fn longpathdash(cap: Cap) -> impl FnMut(&mut SceneBuilder, &mut SceneParams) {
     use std::f64::consts::PI;
     use PathEl::*;
-    let mut path = BezPath::new();
-    let mut x = 32;
-    while x < 256 {
-        let mut a: f64 = 0.0;
-        while a < PI * 2.0 {
-            let pts = [
-                (256.0 + a.sin() * x as f64, 256.0 + a.cos() * x as f64),
-                (
-                    256.0 + (a + PI / 3.0).sin() * (x + 64) as f64,
-                    256.0 + (a + PI / 3.0).cos() * (x + 64) as f64,
-                ),
-            ];
-            path.push(MoveTo(pts[0].into()));
-            let mut i: f64 = 0.0;
-            while i < 1.0 {
-                path.push(LineTo(
+    move |sb, _| {
+        let mut path = BezPath::new();
+        let mut x = 32;
+        while x < 256 {
+            let mut a: f64 = 0.0;
+            while a < PI * 2.0 {
+                let pts = [
+                    (256.0 + a.sin() * x as f64, 256.0 + a.cos() * x as f64),
                     (
-                        pts[0].0 * (1.0 - i) + pts[1].0 * i,
-                        pts[0].1 * (1.0 - i) + pts[1].1 * i,
-                    )
-                        .into(),
-                ));
-                i += 0.05;
+                        256.0 + (a + PI / 3.0).sin() * (x + 64) as f64,
+                        256.0 + (a + PI / 3.0).cos() * (x + 64) as f64,
+                    ),
+                ];
+                path.push(MoveTo(pts[0].into()));
+                let mut i: f64 = 0.0;
+                while i < 1.0 {
+                    path.push(LineTo(
+                        (
+                            pts[0].0 * (1.0 - i) + pts[1].0 * i,
+                            pts[0].1 * (1.0 - i) + pts[1].1 * i,
+                        )
+                            .into(),
+                    ));
+                    i += 0.05;
+                }
+                a += PI * 0.01;
             }
-            a += PI * 0.01;
+            x += 16;
         }
-        x += 16;
+        sb.stroke(
+            &Stroke::new(1.0).with_caps(cap).with_dashes(0.0, [1.0, 1.0]),
+            Affine::translate((50.0, 50.0)),
+            Color::rgb8(255, 255, 0),
+            None,
+            &path,
+        );
     }
-    sb.stroke(
-        &Stroke::new(1.0).with_dashes(0.0, [1.0, 1.0]),
-        Affine::translate((50.0, 50.0)),
-        Color::rgb8(255, 255, 0),
-        None,
-        &path,
-    );
 }
 
 fn animated_text(sb: &mut SceneBuilder, params: &mut SceneParams) {

--- a/examples/scenes/src/test_scenes.rs
+++ b/examples/scenes/src/test_scenes.rs
@@ -43,6 +43,7 @@ pub fn test_scenes() -> SceneSet {
         mmark_scene,
         scene!(funky_paths),
         scene!(cardioid_and_friends),
+        scene!(longpathdash),
         scene!(animated_text: animated),
         scene!(gradient_extend),
         scene!(two_point_radial),
@@ -105,6 +106,46 @@ fn cardioid_and_friends(sb: &mut SceneBuilder, _: &mut SceneParams) {
     render_clip_test(sb);
     render_alpha_test(sb);
     //render_tiger(sb, false);
+}
+
+fn longpathdash(sb: &mut SceneBuilder, _: &mut SceneParams) {
+    use std::f64::consts::PI;
+    use PathEl::*;
+    let mut path = BezPath::new();
+    let mut x = 32;
+    while x < 256 {
+        let mut a: f64 = 0.0;
+        while a < PI * 2.0 {
+            let pts = [
+                (256.0 + a.sin() * x as f64, 256.0 + a.cos() * x as f64),
+                (
+                    256.0 + (a + PI / 3.0).sin() * (x + 64) as f64,
+                    256.0 + (a + PI / 3.0).cos() * (x + 64) as f64,
+                ),
+            ];
+            path.push(MoveTo(pts[0].into()));
+            let mut i: f64 = 0.0;
+            while i < 1.0 {
+                path.push(LineTo(
+                    (
+                        pts[0].0 * (1.0 - i) + pts[1].0 * i,
+                        pts[0].1 * (1.0 - i) + pts[1].1 * i,
+                    )
+                        .into(),
+                ));
+                i += 0.05;
+            }
+            a += PI * 0.01;
+        }
+        x += 16;
+    }
+    sb.stroke(
+        &Stroke::new(1.0).with_dashes(0.0, [1.0, 1.0]),
+        Affine::translate((50.0, 50.0)),
+        Color::rgb8(255, 255, 0),
+        None,
+        &path,
+    );
 }
 
 fn animated_text(sb: &mut SceneBuilder, params: &mut SceneParams) {


### PR DESCRIPTION
This is a single very long path that results in a large number of line segments when dashing is applied. This demonstrates rendering artifacts.