### PR TITLE
Fix shader compilation on Chrome

### DIFF
--- a/shader/fine.wgsl
+++ b/shader/fine.wgsl
@@ -182,9 +182,9 @@ fn fill_path_ms(fill: CmdFill, wg_id: vec2<u32>, local_id: vec2<u32>) -> array<f
             let idxdy = 1.0 / (dx + dy);
             var a = dx * idxdy;
             let is_positive_slope = xy1.x >= xy0.x;
-            let sign = select(-1.0, 1.0, is_positive_slope);
-            let xt0 = floor(xy0.x * sign);
-            let c = xy0.x * sign - xt0;
+            let x_sign = select(-1.0, 1.0, is_positive_slope);
+            let xt0 = floor(xy0.x * x_sign);
+            let c = xy0.x * x_sign - xt0;
             let y0i = floor(xy0.y);
             let ytop = y0i + 1.0;
             let b = min((dy * c + dx * (ytop - xy0.y)) * idxdy, ONE_MINUS_ULP);
@@ -194,12 +194,12 @@ fn fill_path_ms(fill: CmdFill, wg_id: vec2<u32>, local_id: vec2<u32>) -> array<f
             if robust_err != 0.0 {
                 a -= ROBUST_EPSILON * sign(robust_err);
             }
-            let x0i = i32(xt0 * sign + 0.5 * (sign - 1.0));
+            let x0i = i32(xt0 * x_sign + 0.5 * (x_sign - 1.0));
             // Use line equation to plot pixel coordinates
 
             let zf = a * f32(sub_ix) + b;
             let z = floor(zf);
-            let x = x0i + i32(sign * z);
+            let x = x0i + i32(x_sign * z);
             let y = i32(y0i) + i32(sub_ix) - i32(z);
             var is_delta: bool;
             // We need to adjust winding number if slope is positive and there
@@ -305,7 +305,7 @@ fn fill_path_ms(fill: CmdFill, wg_id: vec2<u32>, local_id: vec2<u32>) -> array<f
     packed_y += (packed_y - 0x888888u) << 8u;
     packed_y += (packed_y - 0x8888u) << 16u;
     if th_ix == 0u {
-        atomicStore(&sh_winding_y[0], packed_y);        
+        atomicStore(&sh_winding_y[0], packed_y);
     }
     workgroupBarrier();
     var wind_y = (packed_y >> ((local_id.y & 7u) << 2u)) - 8u;

--- a/shader/path_count.wgsl
+++ b/shader/path_count.wgsl
@@ -79,9 +79,9 @@ fn main(
         let idxdy = 1.0 / (dx + dy);
         var a = dx * idxdy;
         let is_positive_slope = s1.x >= s0.x;
-        let sign = select(-1.0, 1.0, is_positive_slope);
-        let xt0 = floor(s0.x * sign);
-        let c = s0.x * sign - xt0;
+        let x_sign = select(-1.0, 1.0, is_positive_slope);
+        let xt0 = floor(s0.x * x_sign);
+        let c = s0.x * x_sign - xt0;
         let y0 = floor(s0.y);
         let ytop = select(y0 + 1.0, ceil(s0.y), s0.y == s1.y);
         let b = min((dy * c + dx * (ytop - s0.y)) * idxdy, ONE_MINUS_ULP);
@@ -89,7 +89,7 @@ fn main(
         if robust_err != 0.0 {
             a -= ROBUST_EPSILON * sign(robust_err);
         }
-        let x0 = xt0 * sign + select(-1.0, 0.0, is_positive_slope);
+        let x0 = xt0 * x_sign + select(-1.0, 0.0, is_positive_slope);
 
         let path = paths[line.path_ix];
         let bbox = vec4<i32>(path.bbox);
@@ -129,8 +129,8 @@ fn main(
         } else {
             let fudge = select(1.0, 0.0, is_positive_slope);
             if xmin < f32(bbox.x) {
-                var f = round((sign * (f32(bbox.x) - x0) - b + fudge) / a);
-                if (x0 + sign * floor(a * f + b) < f32(bbox.x)) == is_positive_slope {
+                var f = round((x_sign * (f32(bbox.x) - x0) - b + fudge) / a);
+                if (x0 + x_sign * floor(a * f + b) < f32(bbox.x)) == is_positive_slope {
                     f += 1.0;
                 }
                 let ynext = i32(y0 + f - floor(a * f + b) + 1.0);
@@ -149,8 +149,8 @@ fn main(
                 }
             }
             if max(s0.x, s1.x) > f32(bbox.z) {
-                var f = round((sign * (f32(bbox.z) - x0) - b + fudge) / a);
-                if (x0 + sign * floor(a * f + b) < f32(bbox.z)) == is_positive_slope {
+                var f = round((x_sign * (f32(bbox.z) - x0) - b + fudge) / a);
+                if (x0 + x_sign * floor(a * f + b) < f32(bbox.z)) == is_positive_slope {
                     f += 1.0;
                 }
                 if is_positive_slope {
@@ -178,7 +178,7 @@ fn main(
             let z = floor(zf);
             // x, y are tile coordinates relative to render target
             let y = i32(y0 + f32(subix) - z);
-            let x = i32(x0 + sign * z);
+            let x = i32(x0 + x_sign * z);
             let base = i32(path.tiles) + (y - bbox.y) * stride - bbox.x;
             let top_edge = select(last_z == z, y0 == s0.y, subix == 0u);
             if top_edge && x + 1 < bbox.z {

--- a/shader/path_count_setup.wgsl
+++ b/shader/path_count_setup.wgsl
@@ -5,7 +5,7 @@
 #import bump
 
 @group(0) @binding(0)
-var<storage> bump: BumpAllocators;
+var<storage, read_write> bump: BumpAllocators;
 
 @group(0) @binding(1)
 var<storage, read_write> indirect: IndirectCount;

--- a/shader/path_tiling.wgsl
+++ b/shader/path_tiling.wgsl
@@ -8,7 +8,7 @@
 #import tile
 
 @group(0) @binding(0)
-var<storage> bump: BumpAllocators;
+var<storage, read_write> bump: BumpAllocators;
 
 @group(0) @binding(1)
 var<storage> seg_counts: array<SegmentCount>;
@@ -62,9 +62,9 @@ fn main(
         let idxdy = 1.0 / (dx + dy);
         var a = dx * idxdy;
         let is_positive_slope = s1.x >= s0.x;
-        let sign = select(-1.0, 1.0, is_positive_slope);
-        let xt0 = floor(s0.x * sign);
-        let c = s0.x * sign - xt0;
+        let x_sign = select(-1.0, 1.0, is_positive_slope);
+        let xt0 = floor(s0.x * x_sign);
+        let c = s0.x * x_sign - xt0;
         let y0i = floor(s0.y);
         let ytop = select(y0i + 1.0, ceil(s0.y), s0.y == s1.y);
         let b = min((dy * c + dx * (ytop - s0.y)) * idxdy, ONE_MINUS_ULP);
@@ -72,9 +72,9 @@ fn main(
         if robust_err != 0.0 {
             a -= ROBUST_EPSILON * sign(robust_err);
         }
-        let x0i = i32(xt0 * sign + 0.5 * (sign - 1.0));
+        let x0i = i32(xt0 * x_sign + 0.5 * (x_sign - 1.0));
         let z = floor(a * f32(seg_within_line) + b);
-        let x = x0i + i32(sign * z);
+        let x = x0i + i32(x_sign * z);
         let y = i32(y0i + f32(seg_within_line) - z);
 
         let path = paths[line.path_ix];

--- a/shader/path_tiling_setup.wgsl
+++ b/shader/path_tiling_setup.wgsl
@@ -5,7 +5,7 @@
 #import bump
 
 @group(0) @binding(0)
-var<storage> bump: BumpAllocators;
+var<storage, read_write> bump: BumpAllocators;
 
 @group(0) @binding(1)
 var<storage, read_write> indirect: IndirectCount;

--- a/src/shaders.rs
+++ b/src/shaders.rs
@@ -249,7 +249,7 @@ pub fn full_shaders(device: &Device, engine: &mut WgpuEngine) -> Result<FullShad
         device,
         "path_count_setup",
         preprocess::preprocess(shader!("path_count_setup"), &empty, &imports).into(),
-        &[BindType::BufReadOnly, BindType::Buffer],
+        &[BindType::Buffer, BindType::Buffer],
     )?;
     let path_count = engine.add_shader(
         device,
@@ -290,14 +290,14 @@ pub fn full_shaders(device: &Device, engine: &mut WgpuEngine) -> Result<FullShad
         device,
         "path_tiling_setup",
         preprocess::preprocess(shader!("path_tiling_setup"), &empty, &imports).into(),
-        &[BindType::BufReadOnly, BindType::Buffer],
+        &[BindType::Buffer, BindType::Buffer],
     )?;
     let path_tiling = engine.add_shader(
         device,
         "path_tiling",
         preprocess::preprocess(shader!("path_tiling"), &empty, &imports).into(),
         &[
-            BindType::BufReadOnly,
+            BindType::Buffer,
             BindType::BufReadOnly,
             BindType::BufReadOnly,
             BindType::BufReadOnly,


### PR DESCRIPTION
This has some fixes for shader compilation on Chrome.

The `sign` variable shadows the `sign` function, so it's renamed.

Atomics must have a `read_write` binding so `BumpAllocators` usage is changed.