### PR TITLE
New "style" encoding to replace "linewidth"

### DIFF
--- a/crates/encoding/src/encoding.rs
+++ b/crates/encoding/src/encoding.rs
@@ -67,7 +67,7 @@ impl Encoding {
         self.resources.reset();
         if !is_fragment {
             self.transforms.push(Transform::IDENTITY);
-            self.styles.push(Style::from_fill(&Fill::NonZero));
+            self.styles.push(Style::from_fill(Fill::NonZero));
         }
     }
 
@@ -165,7 +165,7 @@ impl Encoding {
 
     /// Encodes a fill style.
     pub fn encode_fill_style(&mut self, fill: Fill) {
-        let style = Style::from_fill(&fill);
+        let style = Style::from_fill(fill);
         if self.styles.last() != Some(&style) {
             self.path_tags.push(PathTag::STYLE);
             self.styles.push(style);

--- a/crates/encoding/src/glyph_cache.rs
+++ b/crates/encoding/src/glyph_cache.rs
@@ -105,7 +105,7 @@ impl CachedRange {
             draw_tags: self.end.draw_tags - self.start.draw_tags,
             draw_data: self.end.draw_data - self.start.draw_data,
             transforms: self.end.transforms - self.start.transforms,
-            linewidths: self.end.linewidths - self.start.linewidths,
+            styles: self.end.styles - self.start.styles,
         }
     }
 }

--- a/crates/encoding/src/lib.rs
+++ b/crates/encoding/src/lib.rs
@@ -36,7 +36,7 @@ pub use math::Transform;
 pub use monoid::Monoid;
 pub use path::{
     Cubic, LineSoup, Path, PathBbox, PathEncoder, PathMonoid, PathSegment, PathSegmentType,
-    PathTag, SegmentCount, Tile,
+    PathTag, SegmentCount, Style, Tile,
 };
 pub use resolve::{resolve_solid_paths_only, Layout};
 

--- a/crates/encoding/src/math.rs
+++ b/crates/encoding/src/math.rs
@@ -76,3 +76,100 @@ impl Mul for Transform {
 pub fn point_to_f32(point: kurbo::Point) -> [f32; 2] {
     [point.x as f32, point.y as f32]
 }
+
+/// Converts an f32 to IEEE-754 binary16 format represented as the bits of a u16.
+/// This implementation was adapted from Fabian Giesen's float_to_half_fast3()
+/// function which can be found at https://gist.github.com/rygorous/2156668#file-gistfile1-cpp-L285
+///
+/// TODO: We should consider adopting https://crates.io/crates/half as a dependency since it nicely
+/// wraps native ARM and x86 instructions for floating-point conversion.
+#[allow(unused)] // for now
+pub(crate) fn f32_to_f16(val: f32) -> u16 {
+    const INF_32: u32 = 255 << 23;
+    const INF_16: u32 = 31 << 23;
+    const MAGIC: u32 = 15 << 23;
+    const SIGN_MASK: u32 = 0x8000_0000u32;
+    const ROUND_MASK: u32 = !0xFFFu32;
+
+    let u = val.to_bits();
+    let sign = u & SIGN_MASK;
+    let u = u ^ sign;
+
+    // NOTE all the integer compares in this function can be safely
+    // compiled into signed compares since all operands are below
+    // 0x80000000. Important if you want fast straight SSE2 code
+    // (since there's no unsigned PCMPGTD).
+
+    // Inf or NaN (all exponent bits set)
+    let output: u16 = if u >= INF_32 {
+        // NaN -> qNaN and Inf->Inf
+        if u > INF_32 {
+            0x7E00
+        } else {
+            0x7C00
+        }
+    } else {
+        // (De)normalized number or zero
+        let mut u = u & ROUND_MASK;
+        u = (f32::from_bits(u) * f32::from_bits(MAGIC)).to_bits();
+        u = u.overflowing_sub(ROUND_MASK).0;
+
+        // Clamp to signed infinity if exponent overflowed
+        if u > INF_16 {
+            u = INF_16;
+        }
+        (u >> 13) as u16 // Take the bits!
+    };
+    output | (sign >> 16) as u16
+}
+
+#[cfg(test)]
+mod tests {
+    use super::f32_to_f16;
+
+    #[test]
+    fn test_f32_to_f16_simple() {
+        let input: f32 = std::f32::consts::PI;
+        let output: u16 = f32_to_f16(input);
+        assert_eq!(0x4248u16, output) // 3.141
+    }
+
+    #[test]
+    fn test_f32_to_f16_nan_overflow() {
+        // A signaling NaN with unset high bits but a low bit that could get accidentally masked
+        // should get converted to a quiet NaN and not infinity.
+        let input: f32 = f32::from_bits(0x7F800001u32);
+        assert!(input.is_nan());
+        let output: u16 = f32_to_f16(input);
+        assert_eq!(0x7E00, output);
+    }
+
+    #[test]
+    fn test_f32_to_16_inf() {
+        let input: f32 = f32::from_bits(0x7F800000u32);
+        assert!(input.is_infinite());
+        let output: u16 = f32_to_f16(input);
+        assert_eq!(0x7C00, output);
+    }
+
+    #[test]
+    fn test_f32_to_16_exponent_rebias() {
+        let input: f32 = 0.00003051758;
+        let output: u16 = f32_to_f16(input);
+        assert_eq!(0x0200, output); // 0.00003052
+    }
+
+    #[test]
+    fn test_f32_to_16_exponent_overflow() {
+        let input: f32 = 1.701412e38;
+        let output: u16 = f32_to_f16(input);
+        assert_eq!(0x7C00, output); // +inf
+    }
+
+    #[test]
+    fn test_f32_to_16_exponent_overflow_neg_inf() {
+        let input: f32 = -1.701412e38;
+        let output: u16 = f32_to_f16(input);
+        assert_eq!(0xFC00, output); // -inf
+    }
+}

--- a/crates/encoding/src/path.rs
+++ b/crates/encoding/src/path.rs
@@ -267,8 +267,8 @@ impl PathTag {
     /// Path marker.
     pub const PATH: Self = Self(0x10);
 
-    /// Line width setting.
-    pub const LINEWIDTH: Self = Self(0x40);
+    /// Style setting.
+    pub const STYLE: Self = Self(0x40);
 
     /// Bit for path segments that are represented as f32 values. If unset
     /// they are represented as i16.
@@ -316,8 +316,8 @@ pub struct PathMonoid {
     pub pathseg_ix: u32,
     /// Offset into path segment stream.
     pub pathseg_offset: u32,
-    /// Index into linewidth stream.
-    pub linewidth_ix: u32,
+    /// Index into style stream.
+    pub style_ix: u32,
     /// Index of containing path.
     pub path_ix: u32,
 }
@@ -337,7 +337,8 @@ impl Monoid for PathMonoid {
         a += a >> 16;
         c.pathseg_offset = a & 0xff;
         c.path_ix = (tag_word & (PathTag::PATH.0 as u32 * 0x1010101)).count_ones();
-        c.linewidth_ix = (tag_word & (PathTag::LINEWIDTH.0 as u32 * 0x1010101)).count_ones();
+        let style_size = (std::mem::size_of::<Style>() / std::mem::size_of::<u32>()) as u32;
+        c.style_ix = (tag_word & (PathTag::STYLE.0 as u32 * 0x1010101)).count_ones() * style_size;
         c
     }
 
@@ -347,7 +348,7 @@ impl Monoid for PathMonoid {
             trans_ix: self.trans_ix + other.trans_ix,
             pathseg_ix: self.pathseg_ix + other.pathseg_ix,
             pathseg_offset: self.pathseg_offset + other.pathseg_offset,
-            linewidth_ix: self.linewidth_ix + other.linewidth_ix,
+            style_ix: self.style_ix + other.style_ix,
             path_ix: self.path_ix + other.path_ix,
         }
     }

--- a/crates/encoding/src/path.rs
+++ b/crates/encoding/src/path.rs
@@ -25,8 +25,9 @@ pub struct Style {
     /// ```
     ///
     /// - miter_limit: u16 - The miter limit for a stroke, encoded in binary16 (half) floating
-    ///                      point representation. This field is on meaningful for the `Join::Miter`
-    ///                      join style. It's ignored for other stroke styles and fills.
+    ///                      point representation. This field is only meaningful for the
+    ///                      `Join::Miter` join style. It's ignored for other stroke styles and
+    ///                      fills.
     pub flags_and_miter_limit: u32,
 
     /// Encodes the stroke width. This field is ignored for fills.
@@ -66,7 +67,7 @@ impl Style {
     pub const FLAGS_END_CAP_MASK: u32 = 0x0300_0000;
     pub const MITER_LIMIT_MASK: u32 = 0xFFFF;
 
-    pub fn from_fill(fill: &Fill) -> Self {
+    pub fn from_fill(fill: Fill) -> Self {
         let fill_bit = match fill {
             Fill::NonZero => 0,
             Fill::EvenOdd => Self::FLAGS_FILL_BIT,
@@ -102,7 +103,7 @@ impl Style {
     }
 
     #[cfg(test)]
-    fn get_fill(&self) -> Option<Fill> {
+    fn fill(&self) -> Option<Fill> {
         if self.is_fill() {
             Some(
                 if (self.flags_and_miter_limit & Self::FLAGS_FILL_BIT) == 0 {
@@ -117,7 +118,7 @@ impl Style {
     }
 
     #[cfg(test)]
-    fn get_stroke_width(&self) -> Option<f64> {
+    fn stroke_width(&self) -> Option<f64> {
         if self.is_fill() {
             return None;
         }
@@ -125,7 +126,7 @@ impl Style {
     }
 
     #[cfg(test)]
-    fn get_stroke_join(&self) -> Option<Join> {
+    fn stroke_join(&self) -> Option<Join> {
         if self.is_fill() {
             return None;
         }
@@ -139,7 +140,7 @@ impl Style {
     }
 
     #[cfg(test)]
-    fn get_stroke_start_cap(&self) -> Option<Cap> {
+    fn stroke_start_cap(&self) -> Option<Cap> {
         if self.is_fill() {
             return None;
         }
@@ -153,7 +154,7 @@ impl Style {
     }
 
     #[cfg(test)]
-    fn get_stroke_end_cap(&self) -> Option<Cap> {
+    fn stroke_end_cap(&self) -> Option<Cap> {
         if self.is_fill() {
             return None;
         }
@@ -167,7 +168,7 @@ impl Style {
     }
 
     #[cfg(test)]
-    fn get_stroke_miter_limit(&self) -> Option<u16> {
+    fn stroke_miter_limit(&self) -> Option<u16> {
         if self.is_fill() {
             return None;
         }
@@ -632,21 +633,15 @@ mod tests {
 
     #[test]
     fn test_fill_style() {
-        assert_eq!(
-            Some(Fill::NonZero),
-            Style::from_fill(&Fill::NonZero).get_fill()
-        );
-        assert_eq!(
-            Some(Fill::EvenOdd),
-            Style::from_fill(&Fill::EvenOdd).get_fill()
-        );
-        assert_eq!(None, Style::from_stroke(&Stroke::default()).get_fill());
+        assert_eq!(Some(Fill::NonZero), Style::from_fill(Fill::NonZero).fill());
+        assert_eq!(Some(Fill::EvenOdd), Style::from_fill(Fill::EvenOdd).fill());
+        assert_eq!(None, Style::from_stroke(&Stroke::default()).fill());
     }
 
     #[test]
     fn test_stroke_style() {
-        assert_eq!(None, Style::from_fill(&Fill::NonZero).get_stroke_width());
-        assert_eq!(None, Style::from_fill(&Fill::EvenOdd).get_stroke_width());
+        assert_eq!(None, Style::from_fill(Fill::NonZero).stroke_width());
+        assert_eq!(None, Style::from_fill(Fill::EvenOdd).stroke_width());
         let caps = [Cap::Butt, Cap::Square, Cap::Round];
         let joins = [Join::Bevel, Join::Miter, Join::Round];
         for start in caps {
@@ -658,11 +653,11 @@ mod tests {
                         .with_join(join)
                         .with_miter_limit(0.);
                     let encoded = Style::from_stroke(&stroke);
-                    assert_eq!(Some(stroke.width), encoded.get_stroke_width());
-                    assert_eq!(Some(stroke.join), encoded.get_stroke_join());
-                    assert_eq!(Some(stroke.start_cap), encoded.get_stroke_start_cap());
-                    assert_eq!(Some(stroke.end_cap), encoded.get_stroke_end_cap());
-                    assert_eq!(Some(0), encoded.get_stroke_miter_limit());
+                    assert_eq!(Some(stroke.width), encoded.stroke_width());
+                    assert_eq!(Some(stroke.join), encoded.stroke_join());
+                    assert_eq!(Some(stroke.start_cap), encoded.stroke_start_cap());
+                    assert_eq!(Some(stroke.end_cap), encoded.stroke_end_cap());
+                    assert_eq!(Some(0), encoded.stroke_miter_limit());
                 }
             }
         }

--- a/examples/scenes/src/test_scenes.rs
+++ b/examples/scenes/src/test_scenes.rs
@@ -32,10 +32,10 @@ macro_rules! scene {
 pub fn test_scenes() -> SceneSet {
     let scenes = vec![
         scene!(splash_with_tiger(), "splash_with_tiger", false),
-        scene!(crate::mmark::MMark::new(80_000), "mmark", false),
         scene!(funky_paths),
         scene!(stroke_styles),
         scene!(tricky_strokes),
+        scene!(fill_types),
         scene!(cardioid_and_friends),
         scene!(animated_text: animated),
         scene!(gradient_extend),
@@ -48,6 +48,7 @@ pub fn test_scenes() -> SceneSet {
         scene!(clip_test: animated),
         scene!(longpathdash(Cap::Butt), "longpathdash (butt caps)", false),
         scene!(longpathdash(Cap::Round), "longpathdash (round caps)", false),
+        scene!(crate::mmark::MMark::new(80_000), "mmark", false),
     ];
 
     SceneSet { scenes }
@@ -279,6 +280,54 @@ fn tricky_strokes(sb: &mut SceneBuilder, _: &mut SceneParams) {
             ],
         );
         color_idx = (color_idx + 1) % colors.len();
+    }
+}
+
+fn fill_types(sb: &mut SceneBuilder, params: &mut SceneParams) {
+    use PathEl::*;
+    let rect = Rect::from_origin_size(Point::new(0., 0.), (500., 500.));
+    let star = [
+        MoveTo((250., 0.).into()),
+        LineTo((105., 450.).into()),
+        LineTo((490., 175.).into()),
+        LineTo((10., 175.).into()),
+        LineTo((395., 450.).into()),
+        ClosePath,
+    ];
+    let arcs = [
+        MoveTo((0., 480.).into()),
+        CurveTo((500., 480.).into(), (500., -10.).into(), (0., -10.).into()),
+        ClosePath,
+        MoveTo((500., -10.).into()),
+        CurveTo((0., -10.).into(), (0., 480.).into(), (500., 480.).into()),
+        ClosePath,
+    ];
+    let scale = Affine::scale(0.6);
+    let t = Affine::translate((10., 25.));
+    let rules = [
+        (Fill::NonZero, "Non-Zero", star.as_slice()),
+        (Fill::EvenOdd, "Even-Odd", &star),
+        (Fill::NonZero, "Non-Zero", &arcs),
+        (Fill::EvenOdd, "Even-Odd", &arcs),
+    ];
+    for (i, rule) in rules.iter().enumerate() {
+        let t = Affine::translate(((i % 2) as f64 * 306., (i / 2) as f64 * 340.)) * t;
+        params.text.add(sb, None, 24., None, t, rule.1);
+        let t = Affine::translate((0., 5.)) * t * scale;
+        sb.fill(
+            Fill::NonZero,
+            t,
+            &Brush::Solid(Color::rgb8(128, 128, 128)),
+            None,
+            &rect,
+        );
+        sb.fill(
+            rule.0,
+            Affine::translate((0., 10.)) * t,
+            Color::BLACK,
+            None,
+            &rule.2,
+        );
     }
 }
 

--- a/shader/flatten.wgsl
+++ b/shader/flatten.wgsl
@@ -218,7 +218,13 @@ fn main(
     var tag_byte = (tag_word >> shift) & 0xffu;
 
     let out = &path_bboxes[tm.path_ix];
-    let linewidth = bitcast<f32>(scene[config.linewidth_base + tm.linewidth_ix]);
+    let style_flags = scene[config.style_base + tm.style_ix];
+    // TODO: We assume all paths are fills at the moment. This is where we will extract the stroke
+    // vs fill state using STYLE_FLAGS_STYLE_BIT.
+    // TODO: The downstream pipelines still use the old floating-point linewidth/fill encoding scheme
+    // This will change to represent the fill rule as a single bit inside the bounding box and draw
+    // info data structures.
+    let linewidth = select(-2.0, -1.0, (style_flags & STYLE_FLAGS_FILL_BIT) == 0u);
     if (tag_byte & PATH_TAG_PATH) != 0u {
         (*out).linewidth = linewidth;
         (*out).trans_ix = tm.trans_ix;

--- a/shader/shared/config.wgsl
+++ b/shader/shared/config.wgsl
@@ -29,7 +29,7 @@ struct Config {
     drawdata_base: u32,
 
     transform_base: u32,
-    linewidth_base: u32,
+    style_base: u32,
 
     // Sizes of bump allocated buffers (in element size units)
     binning_size: u32,

--- a/shader/shared/pathtag.wgsl
+++ b/shader/shared/pathtag.wgsl
@@ -6,7 +6,7 @@ struct TagMonoid {
     pathseg_ix: u32,
     pathseg_offset: u32,
 #ifdef full
-    linewidth_ix: u32,
+    style_ix: u32,
     path_ix: u32,
 #endif
 }
@@ -19,8 +19,15 @@ let PATH_TAG_F32 = 8u;
 let PATH_TAG_TRANSFORM = 0x20u;
 #ifdef full
 let PATH_TAG_PATH = 0x10u;
-let PATH_TAG_LINEWIDTH = 0x40u;
+let PATH_TAG_STYLE = 0x40u;
 #endif
+
+// Size of the `Style` data structure in words
+let STYLE_SIZE_IN_WORDS: u32 = 2u;
+let STYLE_FLAGS_STYLE_BIT: u32 = 0x80000000u;
+let STYLE_FLAGS_FILL_BIT: u32 = 0x40000000u;
+
+// TODO: Declare the remaining STYLE flags here.
 
 fn tag_monoid_identity() -> TagMonoid {
     return TagMonoid();
@@ -32,7 +39,7 @@ fn combine_tag_monoid(a: TagMonoid, b: TagMonoid) -> TagMonoid {
     c.pathseg_ix = a.pathseg_ix + b.pathseg_ix;
     c.pathseg_offset = a.pathseg_offset + b.pathseg_offset;
 #ifdef full
-    c.linewidth_ix = a.linewidth_ix + b.linewidth_ix;
+    c.style_ix = a.style_ix + b.style_ix;
     c.path_ix = a.path_ix + b.path_ix;
 #endif
     return c;
@@ -50,7 +57,7 @@ fn reduce_tag(tag_word: u32) -> TagMonoid {
     c.pathseg_offset = a & 0xffu;
 #ifdef full
     c.path_ix = countOneBits(tag_word & (PATH_TAG_PATH * 0x1010101u));
-    c.linewidth_ix = countOneBits(tag_word & (PATH_TAG_LINEWIDTH * 0x1010101u));
+    c.style_ix = countOneBits(tag_word & (PATH_TAG_STYLE * 0x1010101u)) * STYLE_SIZE_IN_WORDS;
 #endif
     return c;
 }


### PR DESCRIPTION
This PR replaces the existing floating-point "linewidth" stream with a new "style" stream based on the proposal in #303. 

- All pipelines up to `flatten` have been wired up to extract the fill style using the new encoding.
- The encoding crate now encodes fills using the new scheme. Strokes still get converted to fills on the CPU but will be updated to optionally use the new encoding in follow-up changes.
- Added a new test scene to specifically exercise even-odd vs non-zero fill rules.