### PR TITLE
Fixes to winding number accumulation

### DIFF
--- a/shader/fine.wgsl
+++ b/shader/fine.wgsl
@@ -186,9 +186,9 @@ fn fill_path_ms(fill: CmdFill, wg_id: vec2<u32>, local_id: vec2<u32>) -> array<f
             let idxdy = 1.0 / (dx + dy);
             var a = dx * idxdy;
             let is_positive_slope = xy1.x >= xy0.x;
-            let sign = select(-1.0, 1.0, is_positive_slope);
-            let xt0 = floor(xy0.x * sign);
-            let c = xy0.x * sign - xt0;
+            let x_sign = select(-1.0, 1.0, is_positive_slope);
+            let xt0 = floor(xy0.x * x_sign);
+            let c = xy0.x * x_sign - xt0;
             let y0i = floor(xy0.y);
             let ytop = y0i + 1.0;
             let b = min((dy * c + dx * (ytop - xy0.y)) * idxdy, ONE_MINUS_ULP);
@@ -198,12 +198,12 @@ fn fill_path_ms(fill: CmdFill, wg_id: vec2<u32>, local_id: vec2<u32>) -> array<f
             if robust_err != 0.0 {
                 a -= ROBUST_EPSILON * sign(robust_err);
             }
-            let x0i = i32(xt0 * sign + 0.5 * (sign - 1.0));
+            let x0i = i32(xt0 * x_sign + 0.5 * (x_sign - 1.0));
             // Use line equation to plot pixel coordinates
 
             let zf = a * f32(sub_ix) + b;
             let z = floor(zf);
-            let x = x0i + i32(sign * z);
+            let x = x0i + i32(x_sign * z);
             let y = i32(y0i) + i32(sub_ix) - i32(z);
             var is_delta: bool;
             // We need to adjust winding number if slope is positive and there
@@ -473,9 +473,9 @@ fn fill_path_ms_evenodd(fill: CmdFill, wg_id: vec2<u32>, local_id: vec2<u32>) ->
             let idxdy = 1.0 / (dx + dy);
             var a = dx * idxdy;
             let is_positive_slope = xy1.x >= xy0.x;
-            let sign = select(-1.0, 1.0, is_positive_slope);
-            let xt0 = floor(xy0.x * sign);
-            let c = xy0.x * sign - xt0;
+            let x_sign = select(-1.0, 1.0, is_positive_slope);
+            let xt0 = floor(xy0.x * x_sign);
+            let c = xy0.x * x_sign - xt0;
             let y0i = floor(xy0.y);
             let ytop = y0i + 1.0;
             let b = min((dy * c + dx * (ytop - xy0.y)) * idxdy, ONE_MINUS_ULP);
@@ -485,12 +485,12 @@ fn fill_path_ms_evenodd(fill: CmdFill, wg_id: vec2<u32>, local_id: vec2<u32>) ->
             if robust_err != 0.0 {
                 a -= ROBUST_EPSILON * sign(robust_err);
             }
-            let x0i = i32(xt0 * sign + 0.5 * (sign - 1.0));
+            let x0i = i32(xt0 * x_sign + 0.5 * (x_sign - 1.0));
             // Use line equation to plot pixel coordinates
 
             let zf = a * f32(sub_ix) + b;
             let z = floor(zf);
-            let x = x0i + i32(sign * z);
+            let x = x0i + i32(x_sign * z);
             let y = i32(y0i) + i32(sub_ix) - i32(z);
             var is_delta: bool;
             // We need to adjust winding number if slope is positive and there

--- a/shader/fine.wgsl
+++ b/shader/fine.wgsl
@@ -93,7 +93,7 @@ var<workgroup> sh_winding_y_prefix: array<atomic<u32>, 4u>;
 var<workgroup> sh_winding: array<atomic<u32>, 64u>;
 // This array contains winding numbers of multiple sample points within
 // a pixel, relative to the winding number of the top left corner of the
-// pixels. The encoding and packing is the same as `sh_winding_y`.
+// pixel. The encoding and packing is the same as `sh_winding_y`.
 var<workgroup> sh_samples: array<atomic<u32>, SH_SAMPLES_SIZE>;
 
 // number of integer cells spanned by interval defined by a, b

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ enum AaConfig {
 
 /// Configuration of antialiasing. Currently this is static, but could be switched to
 /// a launch option or even finer-grained.
-const ANTIALIASING: AaConfig = AaConfig::Msaa8;
+const ANTIALIASING: AaConfig = AaConfig::Msaa16;
 
 /// Renders a scene into a texture or surface.
 #[cfg(feature = "wgpu")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ enum AaConfig {
 
 /// Configuration of antialiasing. Currently this is static, but could be switched to
 /// a launch option or even finer-grained.
-const ANTIALIASING: AaConfig = AaConfig::Area;
+const ANTIALIASING: AaConfig = AaConfig::Msaa8;
 
 /// Renders a scene into a texture or surface.
 #[cfg(feature = "wgpu")]


### PR DESCRIPTION
This patch fixes rendering artifacts related to winding number accumulation. The first problem is that 4 bits per pixel is not adequate for all test scenes (the cardioid one in particular exercises this). The second problem is that we didn't have a case for even-odd.

This patch is expected to regress performance for the nonzero fill rule, but improve it for even-odd. Some of the performance loss is decreased occupancy because of a larger shared memory footprint for the accumulation, some is because of increased atomic traffic. We should do some performance work as a followup, first characterizing the performance impact, then doing some mitigation. One promising idea is to specialize further based on the number of segments in the slice, using 4 bit accumulation when we can guarantee that won't overflow.

This will have a (small) merge conflict with #382. If that's landed first, I'll happily update this one.

Fixes #380 and #390.