### PR TITLE
Work around broken JS deps

### DIFF
--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -48,3 +48,6 @@ console_log = "1"
 wasm-bindgen-futures = "0.4.33"
 web-sys = { version = "0.3.60", features = [ "HtmlCollection", "Text" ] }
 getrandom = { version = "0.2.10", features = ["js"] }
+rustls-webpki = "=0.101.4"
+sct = "=0.7.0"
+ureq = "=2.7.1"


### PR DESCRIPTION
CI is failing because of some updated ecosystem crates that we don't care about at all. This patch is a hammer to get it to stop failing, but is clearly not the right thing to do.