### PR TITLE
Disable download feature on wasm

### DIFF
--- a/examples/scenes/Cargo.toml
+++ b/examples/scenes/Cargo.toml
@@ -20,6 +20,7 @@ rand = "0.8.5"
 instant = { workspace = true }
 
 # Used for the `download` command
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 byte-unit = "4.0"
 dialoguer = "0.10"
 ureq = "2.6"

--- a/examples/scenes/src/lib.rs
+++ b/examples/scenes/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(not(target_arch = "wasm32"))]
 pub mod download;
 mod images;
 mod mmark;
@@ -8,6 +9,7 @@ use std::path::PathBuf;
 
 use anyhow::{anyhow, Result};
 use clap::{Args, Subcommand};
+#[cfg(not(target_arch = "wasm32"))]
 use download::Download;
 pub use images::ImageCache;
 pub use simple_text::SimpleText;
@@ -77,6 +79,7 @@ pub struct Arguments {
 #[derive(Subcommand, Debug)]
 enum Command {
     /// Download SVG files for testing. By default, downloads a set of files from wikipedia
+    #[cfg(not(target_arch = "wasm32"))]
     Download(Download),
 }
 
@@ -111,7 +114,10 @@ impl Arguments {
 impl Command {
     fn action(&self) -> Result<()> {
         match self {
+            #[cfg(not(target_arch = "wasm32"))]
             Command::Download(download) => download.action(),
+            #[cfg(target_arch = "wasm32")]
+            _ => unreachable!("downloads not supported on wasm"),
         }
     }
 }


### PR DESCRIPTION
The download feature caused CI failures on wasm, due to dependencies breaking in ways difficult to diagnose. I searched the issues for the relevant dependencies and didn't find other people running into the same problem.

Since I worry that these deps may continue to be unstable, I think the best thing is to disable them on wasm builds. This shouldn't affect any functionality we actually care about.

Longer term, we probably want to move these more sophisticated examples out of the vello crate proper.

Fixes #394