### PR TITLE
Fix blocky artifacts in area aa

### DIFF
--- a/shader/path_tiling.wgsl
+++ b/shader/path_tiling.wgsl
@@ -122,9 +122,9 @@ fn main(
         }
         // See comments in CPU version of shader
         var y_edge = 1e9;
-        if xy0.x == tile_xy.x {
+        if xy0.x == tile_xy.x && xy1.x != tile_xy.x && xy0.y != tile_xy.y {
             y_edge = xy0.y;
-        } else if xy1.x == tile_xy.x {
+        } else if xy1.x == tile_xy.x && xy1.y != tile_xy.y {
             y_edge = xy1.y;
         }
         if !is_down {

--- a/src/cpu_shader/path_tiling.rs
+++ b/src/cpu_shader/path_tiling.rs
@@ -118,12 +118,11 @@ fn path_tiling_main(
         if !is_down {
             (xy0, xy1) = (xy1, xy0);
         }
-        // TODO: figure out what to if both xy0 and xy1 are at left edge
-        // Also TODO (part of move to 8 byte encoding for segments): don't store y_edge at all,
+        // TODO (part of move to 8 byte encoding for segments): don't store y_edge at all,
         // resolve this in fine.
-        let y_edge = if xy0.x == tile_xy.x {
+        let y_edge = if xy0.x == tile_xy.x && xy1.x != tile_xy.x && xy0.y != tile_xy.y {
             xy0.y
-        } else if xy1.x == tile_xy.x {
+        } else if xy1.x == tile_xy.x && xy1.y != tile_xy.y {
             xy1.y
         } else {
             1e9


### PR DESCRIPTION
The numerical robustness work for multisampled aa was not carried over to the area version. This patch changes the computation of y_edge in the tiling stage so that rendering using area antialiasing in fine will match the multisampled case. See the linked bug for a diagram which explains the cases.

Fixes #393