### PR TITLE
Transition all pipelines to new `draw_flags` field for fill rule

### DIFF
--- a/crates/encoding/src/draw.rs
+++ b/crates/encoding/src/draw.rs
@@ -41,6 +41,11 @@ impl DrawTag {
     }
 }
 
+/// The first word of each draw info stream entry contains the flags. This is not part of the
+/// draw object stream but gets used after the draw objects get reduced on the GPU.
+/// 0 represents a non-zero fill. 1 represents an even-odd fill.
+pub const DRAW_INFO_FLAGS_FILL_RULE_BIT: u32 = 1;
+
 /// Draw object bounding box.
 #[derive(Copy, Clone, Pod, Zeroable, Debug, Default)]
 #[repr(C)]

--- a/crates/encoding/src/lib.rs
+++ b/crates/encoding/src/lib.rs
@@ -29,7 +29,7 @@ pub use config::{
 };
 pub use draw::{
     DrawBbox, DrawBeginClip, DrawColor, DrawImage, DrawLinearGradient, DrawMonoid,
-    DrawRadialGradient, DrawTag,
+    DrawRadialGradient, DrawTag, DRAW_INFO_FLAGS_FILL_RULE_BIT,
 };
 pub use encoding::{Encoding, StreamOffsets};
 pub use math::Transform;

--- a/crates/encoding/src/path.rs
+++ b/crates/encoding/src/path.rs
@@ -380,8 +380,8 @@ pub struct PathBbox {
     pub x1: i32,
     /// Maximum y value.
     pub y1: i32,
-    /// Line width.
-    pub linewidth: f32,
+    /// Style flags
+    pub draw_flags: u32,
     /// Index into the transform stream.
     pub trans_ix: u32,
 }

--- a/examples/scenes/src/test_scenes.rs
+++ b/examples/scenes/src/test_scenes.rs
@@ -324,7 +324,43 @@ fn fill_types(sb: &mut SceneBuilder, params: &mut SceneParams) {
         sb.fill(
             rule.0,
             Affine::translate((0., 10.)) * t,
-            Color::BLACK,
+            Color::YELLOW,
+            None,
+            &rule.2,
+        );
+    }
+
+    // Draw blends
+    let t = Affine::translate((700., 0.)) * t;
+    for (i, rule) in rules.iter().enumerate() {
+        let t = Affine::translate(((i % 2) as f64 * 306., (i / 2) as f64 * 340.)) * t;
+        params.text.add(sb, None, 24., None, t, rule.1);
+        let t = Affine::translate((0., 5.)) * t * scale;
+        sb.fill(
+            Fill::NonZero,
+            t,
+            &Brush::Solid(Color::rgb8(128, 128, 128)),
+            None,
+            &rect,
+        );
+        sb.fill(
+            rule.0,
+            Affine::translate((0., 10.)) * t,
+            Color::YELLOW,
+            None,
+            &rule.2,
+        );
+        sb.fill(
+            rule.0,
+            Affine::translate((0., 10.)) * t * Affine::rotate(0.06),
+            Color::rgba(0., 1., 0.7, 0.6),
+            None,
+            &rule.2,
+        );
+        sb.fill(
+            rule.0,
+            Affine::translate((0., 10.)) * t * Affine::rotate(-0.06),
+            Color::rgba(0.9, 0.7, 0.5, 0.6),
             None,
             &rule.2,
         );
@@ -373,7 +409,7 @@ fn longpathdash(cap: Cap) -> impl FnMut(&mut SceneBuilder, &mut SceneParams) {
         sb.stroke(
             &Stroke::new(1.0).with_caps(cap).with_dashes(0.0, [1.0, 1.0]),
             Affine::translate((50.0, 50.0)),
-            Color::rgb8(255, 255, 0),
+            Color::YELLOW,
             None,
             &path,
         );

--- a/shader/bbox_clear.wgsl
+++ b/shader/bbox_clear.wgsl
@@ -1,18 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 #import config
+#import bbox
 
 @group(0) @binding(0)
 var<uniform> config: Config;
-
-struct PathBbox {
-    x0: i32,
-    y0: i32,
-    x1: i32,
-    y1: i32,
-    linewidth: f32,
-    trans_ix: u32,
-}
 
 @group(0) @binding(1)
 var<storage, read_write> path_bboxes: array<PathBbox>;

--- a/shader/coarse.wgsl
+++ b/shader/coarse.wgsl
@@ -315,11 +315,8 @@ fn main(
             // If this draw object represents an even-odd fill and we know that no line segment
             // crosses this tile and then this draw object should not contribute to the tile if its
             // backdrop (i.e. the winding number of its top-left corner) is even.
-            //
-            // NOTE: A clip should never get encoded with an even-odd fill.
-            let even_odd_discard = n_segs == 0u && even_odd && (abs(tile.backdrop) & 1) == 0;
-            let include_tile = !even_odd_discard
-                    && (n_segs != 0u || (tile.backdrop == 0) == is_clip || is_blend);
+            let backdrop_clear = select(tile.backdrop, abs(tile.backdrop) & 1, even_odd) == 0;
+            let include_tile = n_segs != 0u || (backdrop_clear == is_clip) || is_blend;
             if include_tile {
                 let el_slice = el_ix / 32u;
                 let el_mask = 1u << (el_ix & 31u);

--- a/shader/draw_leaf.wgsl
+++ b/shader/draw_leaf.wgsl
@@ -109,25 +109,20 @@ fn main(
         // let y1 = f32(bbox.y1);
         // let bbox_f = vec4(x0, y0, x1, y1);
         var transform = Transform();
-        var linewidth = bbox.linewidth;
-        if linewidth >= 0.0 || tag_word == DRAWTAG_FILL_LIN_GRADIENT || tag_word == DRAWTAG_FILL_RAD_GRADIENT ||
+        let draw_flags = bbox.draw_flags;
+        if tag_word == DRAWTAG_FILL_LIN_GRADIENT || tag_word == DRAWTAG_FILL_RAD_GRADIENT ||
             tag_word == DRAWTAG_FILL_IMAGE 
         {
             transform = read_transform(config.transform_base, bbox.trans_ix);
         }
-        if linewidth >= 0.0 {
-            // Note: doesn't deal with anisotropic case
-            let matrx = transform.matrx;
-            linewidth *= sqrt(abs(matrx.x * matrx.w - matrx.y * matrx.z));
-        }
         switch tag_word {
             // DRAWTAG_FILL_COLOR
             case 0x44u: {
-                info[di] = bitcast<u32>(linewidth);
+                info[di] = draw_flags;
             }
             // DRAWTAG_FILL_LIN_GRADIENT
             case 0x114u: {
-                info[di] = bitcast<u32>(linewidth);
+                info[di] = draw_flags;
                 var p0 = bitcast<vec2<f32>>(vec2(scene[dd + 1u], scene[dd + 2u]));
                 var p1 = bitcast<vec2<f32>>(vec2(scene[dd + 3u], scene[dd + 4u]));
                 p0 = transform_apply(transform, p0);
@@ -146,7 +141,7 @@ fn main(
                 // on the algorithm at <https://skia.org/docs/dev/design/conical/>
                 // This epsilon matches what Skia uses
                 let GRADIENT_EPSILON = 1.0 / f32(1 << 12u);
-                info[di] = bitcast<u32>(linewidth);
+                info[di] = draw_flags;
                 var p0 = bitcast<vec2<f32>>(vec2(scene[dd + 1u], scene[dd + 2u]));
                 var p1 = bitcast<vec2<f32>>(vec2(scene[dd + 3u], scene[dd + 4u]));
                 var r0 = bitcast<f32>(scene[dd + 5u]);
@@ -226,7 +221,7 @@ fn main(
             }
             // DRAWTAG_FILL_IMAGE
             case 0x248u: {
-                info[di] = bitcast<u32>(linewidth);
+                info[di] = draw_flags;
                 let inv = transform_inverse(transform);
                 info[di + 1u] = bitcast<u32>(inv.matrx.x);
                 info[di + 2u] = bitcast<u32>(inv.matrx.y);

--- a/shader/shared/bbox.wgsl
+++ b/shader/shared/bbox.wgsl
@@ -4,12 +4,16 @@
 // but contains a link to the active transform, mostly for gradients.
 // Coordinates are integer pixels (for the convenience of atomic update)
 // but will probably become fixed-point fractions for rectangles.
+//
+// TODO: This also carries a `draw_flags` field that contains information that gets propagated to
+// the draw info stream. This is currently only used for the fill rule. If the other bits remain
+// unused we could possibly pack this into some other field, such as the the MSB of `trans_ix`.
 struct PathBbox {
     x0: i32,
     y0: i32,
     x1: i32,
     y1: i32,
-    linewidth: f32,
+    draw_flags: u32,
     trans_ix: u32,
 }
 

--- a/shader/shared/drawtag.wgsl
+++ b/shader/shared/drawtag.wgsl
@@ -23,6 +23,11 @@ let DRAWTAG_FILL_IMAGE = 0x248u;
 let DRAWTAG_BEGIN_CLIP = 0x9u;
 let DRAWTAG_END_CLIP = 0x21u;
 
+/// The first word of each draw info stream entry contains the flags. This is not a part of the
+/// draw object stream but get used after the draw objects have been reduced on the GPU.
+/// 0 represents a non-zero fill. 1 represents an even-odd fill.
+let DRAW_INFO_FLAGS_FILL_RULE_BIT = 1u;
+
 fn draw_monoid_identity() -> DrawMonoid {
     return DrawMonoid();
 }

--- a/src/cpu_shader/coarse.rs
+++ b/src/cpu_shader/coarse.rs
@@ -250,13 +250,12 @@ fn coarse_main(
                     // If this draw object represents an even-odd fill and we know that no line segment
                     // crosses this tile and then this draw object should not contribute to the tile if its
                     // backdrop (i.e. the winding number of its top-left corner) is even.
-                    //
-                    // NOTE: A clip should never get encoded with an even-odd fill.
-                    assert!(!even_odd || !is_clip);
-                    let even_odd_discard =
-                        n_segs == 0 && even_odd && (tile.backdrop.abs() & 1) == 0;
-                    let include_tile = !even_odd_discard
-                        && (n_segs != 0 || (tile.backdrop == 0) == is_clip || is_blend);
+                    let backdrop_clear = if even_odd {
+                        tile.backdrop.abs() & 1
+                    } else {
+                        tile.backdrop
+                    } == 0;
+                    let include_tile = n_segs != 0 || (backdrop_clear == is_clip) || is_blend;
                     if include_tile {
                         match DrawTag(drawtag) {
                             DrawTag::COLOR => {

--- a/src/cpu_shader/coarse.rs
+++ b/src/cpu_shader/coarse.rs
@@ -60,7 +60,6 @@ impl TileState {
         ptcl[(self.cmd_offset + offset) as usize] = value;
     }
 
-    // Returns true if this path should paint the tile.
     fn write_path(
         &mut self,
         config: &ConfigUniform,
@@ -68,8 +67,7 @@ impl TileState {
         ptcl: &mut [u32],
         tile: &mut Tile,
         draw_flags: u32,
-    ) -> bool {
-        let even_odd = (draw_flags & DRAW_INFO_FLAGS_FILL_RULE_BIT) != 0;
+    ) {
         let n_segs = tile.segment_count_or_ix;
         if n_segs != 0 {
             let seg_ix = bump.segments;
@@ -77,29 +75,17 @@ impl TileState {
             bump.segments += n_segs;
             self.alloc_cmd(4, config, bump, ptcl);
             self.write(ptcl, 0, CMD_FILL);
+            let even_odd = (draw_flags & DRAW_INFO_FLAGS_FILL_RULE_BIT) != 0;
             let size_and_rule = (n_segs << 1) | (even_odd as u32);
             self.write(ptcl, 1, size_and_rule);
             self.write(ptcl, 2, seg_ix);
             self.write(ptcl, 3, tile.backdrop as u32);
             self.cmd_offset += 4;
         } else {
-            // If no line segments cross this tile then the tile is completely inside a
-            // subregion of the path. If the rule is non-zero, the tile should get completely
-            // painted based on the draw tag (either a solid fill, gradient fill, or an image fill;
-            // writing CMD_SOLID below ensures that the pixel area coverage is 100%).
-            //
-            // If the rule is even-odd then this path shouldn't paint the tile at all if its
-            // winding number is even. We check this by simply looking at the backdrop, which
-            // contains the winding number of the top-left corner of the tile (and in this case, it
-            // applies to the whole tile).
-            if even_odd && (tile.backdrop.abs() & 1) == 0 {
-                return false;
-            }
             self.alloc_cmd(1, config, bump, ptcl);
             self.write(ptcl, 0, CMD_SOLID);
             self.cmd_offset += 1;
         }
-        true
     }
 
     fn write_color(
@@ -256,50 +242,55 @@ fn coarse_main(
                         let blend = scene[dd as usize];
                         is_blend = blend != BLEND_CLIP;
                     }
+
+                    let draw_flags = info_bin_data[di as usize];
+                    let even_odd = (draw_flags & DRAW_INFO_FLAGS_FILL_RULE_BIT) != 0;
                     let n_segs = tile.segment_count_or_ix;
-                    let include_tile = n_segs != 0 || (tile.backdrop == 0) == is_clip || is_blend;
+
+                    // If this draw object represents an even-odd fill and we know that no line segment
+                    // crosses this tile and then this draw object should not contribute to the tile if its
+                    // backdrop (i.e. the winding number of its top-left corner) is even.
+                    //
+                    // NOTE: A clip should never get encoded with an even-odd fill.
+                    assert!(!even_odd || !is_clip);
+                    let even_odd_discard =
+                        n_segs == 0 && even_odd && (tile.backdrop.abs() & 1) == 0;
+                    let include_tile = !even_odd_discard
+                        && (n_segs != 0 || (tile.backdrop == 0) == is_clip || is_blend);
                     if include_tile {
                         match DrawTag(drawtag) {
                             DrawTag::COLOR => {
-                                let draw_flags = info_bin_data[di as usize];
-                                if tile_state.write_path(config, bump, ptcl, tile, draw_flags) {
-                                    let rgba_color = scene[dd as usize];
-                                    tile_state.write_color(config, bump, ptcl, rgba_color);
-                                }
+                                tile_state.write_path(config, bump, ptcl, tile, draw_flags);
+                                let rgba_color = scene[dd as usize];
+                                tile_state.write_color(config, bump, ptcl, rgba_color);
                             }
                             DrawTag::IMAGE => {
-                                let draw_flags = info_bin_data[di as usize];
-                                if tile_state.write_path(config, bump, ptcl, tile, draw_flags) {
-                                    tile_state.write_image(config, bump, ptcl, di + 1);
-                                }
+                                tile_state.write_path(config, bump, ptcl, tile, draw_flags);
+                                tile_state.write_image(config, bump, ptcl, di + 1);
                             }
                             DrawTag::LINEAR_GRADIENT => {
-                                let draw_flags = info_bin_data[di as usize];
-                                if tile_state.write_path(config, bump, ptcl, tile, draw_flags) {
-                                    let index = scene[dd as usize];
-                                    tile_state.write_grad(
-                                        config,
-                                        bump,
-                                        ptcl,
-                                        CMD_LIN_GRAD,
-                                        index,
-                                        di + 1,
-                                    );
-                                }
+                                tile_state.write_path(config, bump, ptcl, tile, draw_flags);
+                                let index = scene[dd as usize];
+                                tile_state.write_grad(
+                                    config,
+                                    bump,
+                                    ptcl,
+                                    CMD_LIN_GRAD,
+                                    index,
+                                    di + 1,
+                                );
                             }
                             DrawTag::RADIAL_GRADIENT => {
-                                let draw_flags = info_bin_data[di as usize];
-                                if tile_state.write_path(config, bump, ptcl, tile, draw_flags) {
-                                    let index = scene[dd as usize];
-                                    tile_state.write_grad(
-                                        config,
-                                        bump,
-                                        ptcl,
-                                        CMD_RAD_GRAD,
-                                        index,
-                                        di + 1,
-                                    );
-                                }
+                                tile_state.write_path(config, bump, ptcl, tile, draw_flags);
+                                let index = scene[dd as usize];
+                                tile_state.write_grad(
+                                    config,
+                                    bump,
+                                    ptcl,
+                                    CMD_RAD_GRAD,
+                                    index,
+                                    di + 1,
+                                );
                             }
                             DrawTag::BEGIN_CLIP => {
                                 if tile.segment_count_or_ix == 0 && tile.backdrop == 0 {

--- a/src/cpu_shader/coarse.rs
+++ b/src/cpu_shader/coarse.rs
@@ -241,7 +241,10 @@ fn coarse_main(
                     let n_segs = tile.segment_count_or_ix;
                     let include_tile = n_segs != 0 || (tile.backdrop == 0) == is_clip || is_blend;
                     if include_tile {
-                        // TODO: get drawinfo (linewidth for fills)
+                        // TODO: The first word of the info buffer (`info[di]`) contains flags that
+                        // indicate the even-odd vs non-zero fill rule. Read that here and pass it
+                        // to `write_path` so it gets propagated to the PTCL (see
+                        // `PathBbox::FLAGS_FILL_STYLE_BIT` for its interpretation).
                         match DrawTag(drawtag) {
                             DrawTag::COLOR => {
                                 tile_state.write_path(config, bump, ptcl, tile);

--- a/src/cpu_shader/draw_leaf.rs
+++ b/src/cpu_shader/draw_leaf.rs
@@ -41,13 +41,13 @@ fn draw_leaf_main(
             {
                 let bbox = path_bbox[m.path_ix as usize];
                 let transform = Transform::read(config.layout.transform_base, bbox.trans_ix, scene);
-                let linewidth = bbox.linewidth;
+                let draw_flags = bbox.draw_flags;
                 match tag_word {
                     DrawTag::COLOR => {
-                        info[di] = f32::to_bits(linewidth);
+                        info[di] = draw_flags;
                     }
                     DrawTag::LINEAR_GRADIENT => {
-                        info[di] = f32::to_bits(linewidth);
+                        info[di] = draw_flags;
                         let p0 = Vec2::new(
                             f32::from_bits(scene[dd as usize + 1]),
                             f32::from_bits(scene[dd as usize + 2]),
@@ -67,7 +67,7 @@ fn draw_leaf_main(
                         info[di + 3] = f32::to_bits(line_c);
                     }
                     DrawTag::RADIAL_GRADIENT => {
-                        info[di] = f32::to_bits(linewidth);
+                        info[di] = draw_flags;
                         let p0 = Vec2::new(
                             f32::from_bits(scene[dd as usize + 1]),
                             f32::from_bits(scene[dd as usize + 2]),
@@ -108,7 +108,7 @@ fn draw_leaf_main(
                         info[di + 19] = f32::to_bits(roff);
                     }
                     DrawTag::IMAGE => {
-                        info[di] = f32::to_bits(linewidth);
+                        info[di] = draw_flags;
                         let z = transform.0;
                         let inv_det = (z[0] * z[3] - z[1] * z[2]).recip();
                         let inv_mat = [

--- a/src/cpu_shader/flatten.rs
+++ b/src/cpu_shader/flatten.rs
@@ -6,6 +6,7 @@ use crate::cpu_dispatch::CpuBinding;
 use super::util::{Transform, Vec2};
 use vello_encoding::{
     BumpAllocators, ConfigUniform, LineSoup, Monoid, PathBbox, PathMonoid, Style,
+    DRAW_INFO_FLAGS_FILL_RULE_BIT,
 };
 
 fn to_minus_one_quarter(x: f32) -> f32 {
@@ -218,13 +219,10 @@ fn flatten_main(
             let out = &mut path_bboxes[tm.path_ix as usize];
             // TODO: We assume all paths are fills at the moment. This is where we will extract the
             // stroke vs fill state using STYLE_FLAGS_STYLE_BIT.
-            // TODO: The downstream pipelines still use the old floating-point linewidth/fill
-            // encoding scheme. This will change to represent the fill rule as a single bit inside
-            // the bounding box and draw info data structures.
-            out.linewidth = if (style_flags & Style::FLAGS_FILL_BIT) == 0 {
-                -1.0
+            out.draw_flags = if (style_flags & Style::FLAGS_FILL_BIT) == 0 {
+                0
             } else {
-                -2.0
+                DRAW_INFO_FLAGS_FILL_RULE_BIT
             };
             out.trans_ix = tm.trans_ix;
         }


### PR DESCRIPTION
This migrates all pipelines downstream of `flatten` away from the old `linewidth` encoding which was only being used for the fill rule, which now gets stored in a `draw_flags` field. I also cleaned up some leftover linewidth transform logic which was no longer used and wired up the new fill rule flag to the CPU version of the `coarse` stage.

This continues the work outlined in #303. For more details please refer to the individual commit messages.