### PR TITLE
Support setting AA method dynamically

### DIFF
--- a/examples/headless/src/main.rs
+++ b/examples/headless/src/main.rs
@@ -91,7 +91,7 @@ async fn render(mut scenes: SceneSet, index: usize, args: &Args) -> Result<()> {
             surface_format: None,
             timestamp_period: queue.get_timestamp_period(),
             use_cpu: false,
-            preferred_antialiasing_method: Some(vello::AaConfig::Area),
+            antialiasing_support: vello::AaSupport::area_only(),
         },
     )
     .or_else(|_| bail!("Got non-Send/Sync error from creating renderer"))?;

--- a/examples/headless/src/main.rs
+++ b/examples/headless/src/main.rs
@@ -87,10 +87,11 @@ async fn render(mut scenes: SceneSet, index: usize, args: &Args) -> Result<()> {
     let queue = &device_handle.queue;
     let mut renderer = vello::Renderer::new(
         device,
-        &RendererOptions {
+        RendererOptions {
             surface_format: None,
             timestamp_period: queue.get_timestamp_period(),
             use_cpu: false,
+            preferred_antialiasing_method: Some(vello::AaConfig::Area),
         },
     )
     .or_else(|_| bail!("Got non-Send/Sync error from creating renderer"))?;
@@ -140,6 +141,7 @@ async fn render(mut scenes: SceneSet, index: usize, args: &Args) -> Result<()> {
             .unwrap_or(vello::peniko::Color::BLACK),
         width,
         height,
+        antialiasing_method: vello::AaConfig::Area,
     };
     let mut scene = Scene::new();
     let mut builder = SceneBuilder::for_scene(&mut scene);

--- a/examples/scenes/src/test_scenes.rs
+++ b/examples/scenes/src/test_scenes.rs
@@ -1246,10 +1246,11 @@ fn splash_screen(sb: &mut SceneBuilder, params: &mut SceneParams) {
         "  Space: reset transform",
         "  S: toggle stats",
         "  V: toggle vsync",
+        "  M: cycle AA method",
         "  Q, E: rotate",
     ];
     // Tweak to make it fit with tiger
-    let a = Affine::scale(0.12) * Affine::translate((-90.0, -50.0));
+    let a = Affine::scale(0.11) * Affine::translate((-90.0, -50.0));
     for (i, s) in strings.iter().enumerate() {
         let text_size = if i == 0 { 60.0 } else { 40.0 };
         params.text.add(

--- a/examples/with_bevy/src/main.rs
+++ b/examples/with_bevy/src/main.rs
@@ -30,7 +30,7 @@ impl FromWorld for VelloRenderer {
                 &RendererOptions {
                     surface_format: None,
                     timestamp_period: queue.0.get_timestamp_period(),
-                    preferred_antialiasing_method: Some(vello::AaConfig::Area),
+                    antialiasing_support: vello::AaSupport::area_only(),
                 },
             )
             .unwrap(),

--- a/examples/with_bevy/src/main.rs
+++ b/examples/with_bevy/src/main.rs
@@ -30,6 +30,7 @@ impl FromWorld for VelloRenderer {
                 &RendererOptions {
                     surface_format: None,
                     timestamp_period: queue.0.get_timestamp_period(),
+                    preferred_antialiasing_method: Some(vello::AaConfig::Area),
                 },
             )
             .unwrap(),
@@ -65,6 +66,7 @@ fn render_scenes(
             base_color: vello::peniko::Color::AQUAMARINE,
             width: gpu_image.size.x as u32,
             height: gpu_image.size.y as u32,
+            antialiasing_method: vello::AaConfig::Area,
         };
         renderer
             .0

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -365,16 +365,17 @@ fn run(
 
             // If the user specifies a base color in the CLI we use that. Otherwise we use any
             // color specified by the scene. The default is black.
-            let aa_config = AA_CONFIGS[aa_config_ix as usize];
+            let base_color = args
+                .args
+                .base_color
+                .or(scene_params.base_color)
+                .unwrap_or(Color::BLACK);
+            let antialiasing_method = AA_CONFIGS[aa_config_ix as usize];
             let render_params = vello::RenderParams {
-                base_color: args
-                    .args
-                    .base_color
-                    .or(scene_params.base_color)
-                    .unwrap_or(Color::BLACK),
+                base_color,
                 width,
                 height,
-                antialiasing_method: aa_config,
+                antialiasing_method,
             };
             let mut builder = SceneBuilder::for_scene(&mut scene);
             let mut transform = transform;
@@ -395,7 +396,7 @@ fn run(
                     stats.samples(),
                     complexity_shown.then_some(scene_complexity).flatten(),
                     vsync_on,
-                    aa_config,
+                    antialiasing_method,
                 );
                 if let Some(profiling_result) = renderers[render_state.surface.dev_id]
                     .as_mut()

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -89,7 +89,7 @@ fn run(
                     surface_format: Some(render_state.surface.format),
                     timestamp_period: render_cx.devices[id].queue.get_timestamp_period(),
                     use_cpu: use_cpu,
-                    preferred_antialiasing_method: None,
+                    antialiasing_support: vello::AaSupport::all(),
                 },
             )
             .expect("Could create renderer"),
@@ -518,7 +518,7 @@ fn run(
                                     .queue
                                     .get_timestamp_period(),
                                 use_cpu,
-                                preferred_antialiasing_method: None,
+                                antialiasing_support: vello::AaSupport::all(),
                             },
                         )
                         .expect("Could create renderer")

--- a/examples/with_winit/src/stats.rs
+++ b/examples/with_winit/src/stats.rs
@@ -19,7 +19,7 @@ use std::{collections::VecDeque, time::Duration};
 use vello::{
     kurbo::{Affine, Line, PathEl, Rect, Stroke},
     peniko::{Brush, Color, Fill},
-    BumpAllocators, SceneBuilder,
+    AaConfig, BumpAllocators, SceneBuilder,
 };
 use wgpu_profiler::GpuTimerScopeResult;
 
@@ -44,6 +44,7 @@ impl Snapshot {
         samples: T,
         bump: Option<BumpAllocators>,
         vsync: bool,
+        aa_config: AaConfig,
     ) where
         T: Iterator<Item = &'a u64>,
     {
@@ -67,6 +68,14 @@ impl Snapshot {
             format!("Frame Time (min): {:.2} ms", self.frame_time_min_ms),
             format!("Frame Time (max): {:.2} ms", self.frame_time_max_ms),
             format!("VSync: {}", if vsync { "on" } else { "off" }),
+            format!(
+                "AA method: {}",
+                match aa_config {
+                    AaConfig::Area => "Analytic Area",
+                    AaConfig::Msaa16 => "16xMSAA",
+                    AaConfig::Msaa8 => "8xMSAA",
+                }
+            ),
             format!("Resolution: {viewport_width}x{viewport_height}"),
         ];
         if let Some(bump) = &bump {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,8 +110,8 @@ pub struct RendererOptions {
     pub timestamp_period: f32,
 
     /// If true, run all stages up to fine rasterization on the CPU.
-    /// TODO: Consider evolving this so that the CPU stages can be configured dynamically via
-    /// `RenderParams`.
+    // TODO: Consider evolving this so that the CPU stages can be configured dynamically via
+    // `RenderParams`.
     pub use_cpu: bool,
 
     /// The anti-aliasing specialization that should be used when creating the pipelines. `None`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,7 @@ impl Renderer {
         let blit = options
             .surface_format
             .map(|surface_format| BlitPipeline::new(device, surface_format));
+        #[cfg(feature = "wgpu-profiler")]
         let timestamp_period = options.timestamp_period;
         Ok(Self {
             options,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,12 +62,37 @@ pub type Error = Box<dyn std::error::Error>;
 /// Specialization of `Result` for our catch-all error type.
 pub type Result<T> = std::result::Result<T, Error>;
 
-/// Possible configurations for antialiasing.
+/// Represents the antialiasing method to use during a render pass.
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum AaConfig {
     Area,
     Msaa8,
     Msaa16,
+}
+
+/// Represents the set of antialiasing configurations to enable during pipeline creation.
+pub struct AaSupport {
+    pub area: bool,
+    pub msaa8: bool,
+    pub msaa16: bool,
+}
+
+impl AaSupport {
+    pub fn all() -> Self {
+        Self {
+            area: true,
+            msaa8: true,
+            msaa16: true,
+        }
+    }
+
+    pub fn area_only() -> Self {
+        Self {
+            area: true,
+            msaa8: false,
+            msaa16: false,
+        }
+    }
 }
 
 /// Renders a scene into a texture or surface.
@@ -114,9 +139,9 @@ pub struct RendererOptions {
     // `RenderParams`.
     pub use_cpu: bool,
 
-    /// The anti-aliasing specialization that should be used when creating the pipelines. `None`
-    /// initializes all variants.
-    pub preferred_antialiasing_method: Option<AaConfig>,
+    /// Represents the enabled set of AA configurations. This will be used to determine which
+    /// pipeline permutations should be compiled at startup.
+    pub antialiasing_support: AaSupport,
 }
 
 #[cfg(feature = "wgpu")]

--- a/src/render.rs
+++ b/src/render.rs
@@ -3,7 +3,7 @@
 use crate::{
     engine::{BufProxy, ImageFormat, ImageProxy, Recording, ResourceProxy},
     shaders::FullShaders,
-    AaConfig, RenderParams, Scene, ANTIALIASING,
+    AaConfig, RenderParams, Scene,
 };
 use vello_encoding::{Encoding, WorkgroupSize};
 
@@ -16,6 +16,8 @@ pub struct Render {
 
 /// Resources produced by pipeline, needed for fine rasterization.
 struct FineResources {
+    aa_config: AaConfig,
+
     config_buf: ResourceProxy,
     bump_buf: ResourceProxy,
     tile_buf: ResourceProxy,
@@ -393,6 +395,7 @@ impl Render {
         let out_image = ImageProxy::new(params.width, params.height, ImageFormat::Rgba8);
         self.fine_wg_count = Some(wg_counts.fine);
         self.fine_resources = Some(FineResources {
+            aa_config: params.antialiasing_method,
             config_buf,
             bump_buf,
             tile_buf,
@@ -414,10 +417,10 @@ impl Render {
     pub fn record_fine(&mut self, shaders: &FullShaders, recording: &mut Recording) {
         let fine_wg_count = self.fine_wg_count.take().unwrap();
         let fine = self.fine_resources.take().unwrap();
-        match ANTIALIASING {
+        match fine.aa_config {
             AaConfig::Area => {
                 recording.dispatch(
-                    shaders.fine,
+                    shaders.fine_area.expect("unsupported AA mode: area"),
                     fine_wg_count,
                     [
                         fine.config_buf,
@@ -432,7 +435,7 @@ impl Render {
             }
             _ => {
                 if self.mask_buf.is_none() {
-                    let mask_lut = match ANTIALIASING {
+                    let mask_lut = match fine.aa_config {
                         AaConfig::Msaa16 => crate::mask::make_mask_lut_16(),
                         AaConfig::Msaa8 => crate::mask::make_mask_lut(),
                         _ => unreachable!(),
@@ -440,8 +443,13 @@ impl Render {
                     let buf = recording.upload("mask lut", mask_lut);
                     self.mask_buf = Some(buf.into());
                 }
+                let shader = match fine.aa_config {
+                    AaConfig::Msaa16 => shaders.fine_msaa16.expect("unsupported AA mode: msaa16"),
+                    AaConfig::Msaa8 => shaders.fine_msaa8.expect("unsupported AA mode: msaa8"),
+                    _ => unreachable!(),
+                };
                 recording.dispatch(
-                    shaders.fine,
+                    shader,
                     fine_wg_count,
                     [
                         fine.config_buf,

--- a/src/render.rs
+++ b/src/render.rs
@@ -420,7 +420,9 @@ impl Render {
         match fine.aa_config {
             AaConfig::Area => {
                 recording.dispatch(
-                    shaders.fine_area.expect("unsupported AA mode: area"),
+                    shaders
+                        .fine_area
+                        .expect("shaders not configured to support AA mode: area"),
                     fine_wg_count,
                     [
                         fine.config_buf,
@@ -443,13 +445,17 @@ impl Render {
                     let buf = recording.upload("mask lut", mask_lut);
                     self.mask_buf = Some(buf.into());
                 }
-                let shader = match fine.aa_config {
-                    AaConfig::Msaa16 => shaders.fine_msaa16.expect("unsupported AA mode: msaa16"),
-                    AaConfig::Msaa8 => shaders.fine_msaa8.expect("unsupported AA mode: msaa8"),
+                let fine_shader = match fine.aa_config {
+                    AaConfig::Msaa16 => shaders
+                        .fine_msaa16
+                        .expect("shaders not configured to support AA mode: msaa16"),
+                    AaConfig::Msaa8 => shaders
+                        .fine_msaa8
+                        .expect("shaders not configured to support AA mode: msaa8"),
                     _ => unreachable!(),
                 };
                 recording.dispatch(
-                    shader,
+                    fine_shader,
                     fine_wg_count,
                     [
                         fine.config_buf,

--- a/src/shaders.rs
+++ b/src/shaders.rs
@@ -283,23 +283,21 @@ pub fn full_shaders(
         // Mask LUT buffer, used only when MSAA is enabled.
         BindType::BufReadOnly,
     ];
-    let fine_variants = {
-        const AA_MODES: [AaConfig; 3] = [AaConfig::Area, AaConfig::Msaa8, AaConfig::Msaa16];
-        const MSAA_INFO: [Option<(&str, &str)>; 3] = [
-            None,
-            Some(("fine_msaa8", "msaa8")),
-            Some(("fine_msaa16", "msaa16")),
+    let [fine_area, fine_msaa8, fine_msaa16] = {
+        const AA_MODES: [(AaConfig, Option<(&str, &str)>); 3] = [
+            (AaConfig::Area, None),
+            (AaConfig::Msaa8, Some(("fine_msaa8", "msaa8"))),
+            (AaConfig::Msaa16, Some(("fine_msaa16", "msaa16"))),
         ];
         let mut pipelines = [None, None, None];
-        for (i, aa_mode) in AA_MODES.iter().enumerate() {
+        for (i, (aa_mode, msaa_info)) in AA_MODES.iter().enumerate() {
             if options
                 .preferred_antialiasing_method
-                .as_ref()
-                .map_or(false, |m| m != aa_mode)
+                .map_or(false, |m| m != *aa_mode)
             {
                 continue;
             }
-            let (range_end_offset, label, aa_config) = match MSAA_INFO[i] {
+            let (range_end_offset, label, aa_config) = match *msaa_info {
                 Some((label, config)) => (0, label, Some(config)),
                 None => (1, "fine_area", None),
             };
@@ -338,9 +336,9 @@ pub fn full_shaders(
         coarse,
         path_tiling_setup,
         path_tiling,
-        fine_area: fine_variants[0],
-        fine_msaa8: fine_variants[1],
-        fine_msaa16: fine_variants[2],
+        fine_area,
+        fine_msaa8,
+        fine_msaa16,
         pathtag_is_cpu: options.use_cpu,
     })
 }

--- a/src/shaders.rs
+++ b/src/shaders.rs
@@ -26,7 +26,6 @@ use wgpu::Device;
 use crate::{
     cpu_shader,
     engine::{BindType, Error, ImageFormat, ShaderId},
-    AaConfig,
 };
 
 #[cfg(feature = "wgpu")]
@@ -284,17 +283,15 @@ pub fn full_shaders(
         BindType::BufReadOnly,
     ];
     let [fine_area, fine_msaa8, fine_msaa16] = {
-        const AA_MODES: [(AaConfig, Option<(&str, &str)>); 3] = [
-            (AaConfig::Area, None),
-            (AaConfig::Msaa8, Some(("fine_msaa8", "msaa8"))),
-            (AaConfig::Msaa16, Some(("fine_msaa16", "msaa16"))),
+        let aa_support = &options.antialiasing_support;
+        let aa_modes = [
+            (aa_support.area, None),
+            (aa_support.msaa8, Some(("fine_msaa8", "msaa8"))),
+            (aa_support.msaa16, Some(("fine_msaa16", "msaa16"))),
         ];
         let mut pipelines = [None, None, None];
-        for (i, (aa_mode, msaa_info)) in AA_MODES.iter().enumerate() {
-            if options
-                .preferred_antialiasing_method
-                .map_or(false, |m| m != *aa_mode)
-            {
+        for (i, (enabled, msaa_info)) in aa_modes.iter().enumerate() {
+            if !enabled {
                 continue;
             }
             let (range_end_offset, label, aa_config) = match *msaa_info {


### PR DESCRIPTION
This replaces the static anti-aliasing setting with a dynamic option in the form of two new settings (one used during pipeline creation and one used during a render):

- The `FullShaders` collection now maintains up to 3 `fine` stage pipeline variants. This can be driven using a new optional `RendererOptions` field called `preferred_antialiasing_method`, which determines which fine stage pipeline variants should get  instantiated at start up.

- `RenderParams` now requires an `AaConfig` which selects which `fine` stage variant to use.

- Added a new key binding (`M`) to the `with_winit` example to dynamically cycle through all 3 AA methods.