### PR TITLE
Improve numerical robustness in path tiling

### DIFF
--- a/crates/encoding/src/path.rs
+++ b/crates/encoding/src/path.rs
@@ -207,6 +207,7 @@ pub struct SegmentCount {
 #[derive(Clone, Copy, Debug, Zeroable, Pod, Default)]
 #[repr(C)]
 pub struct PathSegment {
+    // Points are relative to tile origin
     pub point0: [f32; 2],
     pub point1: [f32; 2],
     pub y_edge: f32,

--- a/crates/encoding/src/path.rs
+++ b/crates/encoding/src/path.rs
@@ -207,8 +207,8 @@ pub struct SegmentCount {
 #[derive(Clone, Copy, Debug, Zeroable, Pod, Default)]
 #[repr(C)]
 pub struct PathSegment {
-    pub origin: [f32; 2],
-    pub delta: [f32; 2],
+    pub point0: [f32; 2],
+    pub point1: [f32; 2],
     pub y_edge: f32,
     pub _padding: u32,
 }

--- a/examples/scenes/src/test_scenes.rs
+++ b/examples/scenes/src/test_scenes.rs
@@ -1157,16 +1157,41 @@ fn robust_paths(sb: &mut SceneBuilder, _: &mut SceneParams) {
     path.line_to((216.0, 24.0));
     path.line_to((200.0, 24.0));
     path.close_path();
+    path.move_to((241.0, 17.5));
+    path.line_to((255.0, 17.5));
+    path.line_to((255.0, 19.5));
+    path.line_to((241.0, 19.5));
+    path.close_path();
+    path.move_to((241.0, 22.5));
+    path.line_to((256.0, 22.5));
+    path.line_to((256.0, 24.5));
+    path.line_to((241.0, 24.5));
+    path.close_path();
     sb.fill(Fill::NonZero, Affine::IDENTITY, Color::YELLOW, None, &path);
+    sb.fill(
+        Fill::EvenOdd,
+        Affine::translate((300.0, 0.0)),
+        Color::LIME,
+        None,
+        &path,
+    );
+
     path.move_to((8.0, 4.0));
     path.line_to((8.0, 40.0));
-    path.line_to((220.0, 40.0));
-    path.line_to((220.0, 4.0));
+    path.line_to((260.0, 40.0));
+    path.line_to((260.0, 4.0));
     path.close_path();
     sb.fill(
         Fill::NonZero,
         Affine::translate((0.0, 100.0)),
         Color::YELLOW,
+        None,
+        &path,
+    );
+    sb.fill(
+        Fill::EvenOdd,
+        Affine::translate((300.0, 100.0)),
+        Color::LIME,
         None,
         &path,
     );

--- a/examples/scenes/src/test_scenes.rs
+++ b/examples/scenes/src/test_scenes.rs
@@ -44,6 +44,7 @@ pub fn test_scenes() -> SceneSet {
         scene!(blend_grid),
         scene!(conflation_artifacts),
         scene!(labyrinth),
+        scene!(robust_paths),
         scene!(base_color_test: animated),
         scene!(clip_test: animated),
         scene!(longpathdash(Cap::Butt), "longpathdash (butt caps)", false),
@@ -1117,6 +1118,58 @@ fn labyrinth(sb: &mut SceneBuilder, _: &mut SceneParams) {
         None,
         &path,
     )
+}
+
+fn robust_paths(sb: &mut SceneBuilder, _: &mut SceneParams) {
+    let mut path = BezPath::new();
+    path.move_to((16.0, 16.0));
+    path.line_to((32.0, 16.0));
+    path.line_to((32.0, 32.0));
+    path.line_to((16.0, 32.0));
+    path.close_path();
+    path.move_to((48.0, 18.0));
+    path.line_to((64.0, 23.0));
+    path.line_to((64.0, 33.0));
+    path.line_to((48.0, 38.0));
+    path.close_path();
+    path.move_to((80.0, 18.0));
+    path.line_to((82.0, 16.0));
+    path.line_to((94.0, 16.0));
+    path.line_to((96.0, 18.0));
+    path.line_to((96.0, 30.0));
+    path.line_to((94.0, 32.0));
+    path.line_to((82.0, 32.0));
+    path.line_to((80.0, 30.0));
+    path.close_path();
+    path.move_to((112.0, 16.0));
+    path.line_to((128.0, 16.0));
+    path.line_to((128.0, 32.0));
+    path.close_path();
+    path.move_to((144.0, 16.0));
+    path.line_to((160.0, 32.0));
+    path.line_to((144.0, 32.0));
+    path.close_path();
+    path.move_to((168.0, 8.0));
+    path.line_to((184.0, 8.0));
+    path.line_to((184.0, 24.0));
+    path.close_path();
+    path.move_to((200.0, 8.0));
+    path.line_to((216.0, 24.0));
+    path.line_to((200.0, 24.0));
+    path.close_path();
+    sb.fill(Fill::NonZero, Affine::IDENTITY, Color::YELLOW, None, &path);
+    path.move_to((8.0, 4.0));
+    path.line_to((8.0, 40.0));
+    path.line_to((220.0, 40.0));
+    path.line_to((220.0, 4.0));
+    path.close_path();
+    sb.fill(
+        Fill::NonZero,
+        Affine::translate((0.0, 100.0)),
+        Color::YELLOW,
+        None,
+        &path,
+    );
 }
 
 fn base_color_test(sb: &mut SceneBuilder, params: &mut SceneParams) {

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -46,5 +46,7 @@ android_logger = "0.13.0"
 console_error_panic_hook = "0.1.7"
 console_log = "1"
 wasm-bindgen-futures = "0.4.33"
-web-sys = { version = "0.3.60", features = [ "HtmlCollection", "Text" ] }
+# Note: pinning the exact dep here because 0.3.65 broke semver. Update this
+# when revving wgpu.
+web-sys = { version = "=0.3.64", features = [ "HtmlCollection", "Text" ] }
 getrandom = { version = "0.2.10", features = ["js"] }

--- a/shader/fine.wgsl
+++ b/shader/fine.wgsl
@@ -251,7 +251,7 @@ fn fill_path_ms(fill: CmdFill, local_id: vec2<u32>, result: ptr<function, array<
             let zp = floor(a * f32(sub_ix - 1u) + b);
             if sub_ix == 0u {
                 is_delta = y0i == xy0.y && y0i != xy1.y;
-                is_bump = xy0.x == 0.0;
+                is_bump = xy0.x == 0.0 && y0i != xy0.y;
             } else {
                 is_delta = z == zp;
                 is_bump = is_positive_slope && !is_delta;
@@ -590,7 +590,7 @@ fn fill_path_ms_evenodd(fill: CmdFill, local_id: vec2<u32>, result: ptr<function
             let zp = floor(a * f32(sub_ix - 1u) + b);
             if sub_ix == 0u {
                 is_delta = y0i == xy0.y && y0i != xy1.y;
-                is_bump = xy0.x == 0.0 && y0i != xy0.y;
+                is_bump = xy0.x == 0.0;
             } else {
                 is_delta = z == zp;
                 is_bump = is_positive_slope && !is_delta;

--- a/shader/fine.wgsl
+++ b/shader/fine.wgsl
@@ -452,7 +452,7 @@ fn fill_path_ms(fill: CmdFill, local_id: vec2<u32>, result: ptr<function, array<
             // bits 4 * k + 2 and 4 * k + 3 contain 4-reductions
             let xored01_4 = xored01 | (xored01 * 4u);
             let xored2 = (expected_zero * 0x1010101u) ^ samples2;
-            let xored2_2 = xored0 | (xored0 * 2u);
+            let xored2_2 = xored2 | (xored2 * 2u);
             let xored3 = (expected_zero * 0x1010101u) ^ samples3;
             let xored3_2 = xored3 | (xored3 >> 1u);
             // xored23 contains 2-reductions from words 2 and 3, interleaved
@@ -590,7 +590,7 @@ fn fill_path_ms_evenodd(fill: CmdFill, local_id: vec2<u32>, result: ptr<function
             let zp = floor(a * f32(sub_ix - 1u) + b);
             if sub_ix == 0u {
                 is_delta = y0i == xy0.y && y0i != xy1.y;
-                is_bump = xy0.x == 0.0;
+                is_bump = xy0.x == 0.0 && y0i != xy0.y;
             } else {
                 is_delta = z == zp;
                 is_bump = is_positive_slope && !is_delta;

--- a/shader/path_tiling.wgsl
+++ b/shader/path_tiling.wgsl
@@ -150,6 +150,17 @@ fn main(
                 y_edge = p1.y;
             }
         }
+        // Hacky approach to numerical robustness in fine.
+        // This just makes sure there are no vertical lines aligned to
+        // the pixel grid internal to the tile. It's faster to do this
+        // logic here rather than in fine, but at some point we might
+        // rework it.
+        if p0.x == floor(p0.x) && p0.x != 0.0 {
+            p0.x -= EPSILON;
+        }
+        if p1.x == floor(p1.x) && p1.x != 0.0 {
+            p1.x -= EPSILON;
+        }
         if !is_down {
             let tmp = p0;
             p0 = p1;

--- a/shader/path_tiling.wgsl
+++ b/shader/path_tiling.wgsl
@@ -132,7 +132,7 @@ fn main(
             xy0 = xy1;
             xy1 = tmp;
         }
-        let segment = Segment(xy0, xy1 - xy0, y_edge);
+        let segment = Segment(xy0 - tile_xy, xy1 - xy0, y_edge - tile_xy.y);
         segments[seg_start + seg_within_slice] = segment;
     }
 }

--- a/shader/path_tiling.wgsl
+++ b/shader/path_tiling.wgsl
@@ -120,19 +120,42 @@ fn main(
                 xy1 = vec2(x_clip, yt);
             }
         }
-        // See comments in CPU version of shader
         var y_edge = 1e9;
-        if xy0.x == tile_xy.x && xy1.x != tile_xy.x && xy0.y != tile_xy.y {
-            y_edge = xy0.y;
-        } else if xy1.x == tile_xy.x && xy1.y != tile_xy.y {
-            y_edge = xy1.y;
+        // Apply numerical robustness logic
+        var p0 = xy0 - tile_xy;
+        var p1 = xy1 - tile_xy;
+        // When we move to f16, this will be f16::MIN_POSITIVE
+        let EPSILON = 1e-6;
+        if p0.x == 0.0 {
+            if p1.x == 0.0 {
+                p0.x = EPSILON;
+                if p0.y == 0.0 {
+                    // Entire tile
+                    p1.x = EPSILON;
+                    p1.y = f32(TILE_HEIGHT);
+                } else {
+                    // Make segment disappear
+                    p1.x = 2.0 * EPSILON;
+                    p1.y = p0.y;
+                }
+            } else if p0.y == 0.0 {
+                p0.x = EPSILON;
+            } else {
+                y_edge = p0.y;
+            }
+        } else if p1.x == 0.0 {
+            if p1.y == 0.0 {
+                p1.x = EPSILON;
+            } else {
+                y_edge = p1.y;
+            }
         }
         if !is_down {
-            let tmp = xy0;
-            xy0 = xy1;
-            xy1 = tmp;
+            let tmp = p0;
+            p0 = p1;
+            p1 = tmp;
         }
-        let segment = Segment(xy0 - tile_xy, xy1 - xy0, y_edge - tile_xy.y);
+        let segment = Segment(p0, p1, y_edge);
         segments[seg_start + seg_within_slice] = segment;
     }
 }

--- a/shader/shared/segment.wgsl
+++ b/shader/shared/segment.wgsl
@@ -2,8 +2,9 @@
 
 // Segments laid out for contiguous storage
 struct Segment {
-    origin: vec2<f32>,
-    delta: vec2<f32>,
+    // Points are relative to tile origin
+    point0: vec2<f32>,
+    point1: vec2<f32>,
     y_edge: f32,
 }
 

--- a/src/cpu_shader/fine.rs
+++ b/src/cpu_shader/fine.rs
@@ -58,20 +58,24 @@ fn fill_path(area: &mut [f32], segments: &[PathSegment], fill: &CmdFill, x_tile:
         *a = backdrop_f;
     }
     for segment in &segments[fill.seg_data as usize..][..n_segs as usize] {
+        let delta = [
+            segment.point1[0] - segment.point0[0],
+            segment.point1[1] - segment.point0[1],
+        ];
         for yi in 0..TILE_HEIGHT {
-            let y = segment.origin[1] - (y_tile + yi as f32);
+            let y = segment.point0[1] - (y_tile + yi as f32);
             let y0 = y.clamp(0.0, 1.0);
-            let y1 = (y + segment.delta[1]).clamp(0.0, 1.0);
+            let y1 = (y + delta[1]).clamp(0.0, 1.0);
             let dy = y0 - y1;
-            let y_edge = segment.delta[0].signum()
-                * (y_tile + yi as f32 - segment.y_edge + 1.0).clamp(0.0, 1.0);
+            let y_edge =
+                delta[0].signum() * (y_tile + yi as f32 - segment.y_edge + 1.0).clamp(0.0, 1.0);
             if dy != 0.0 {
-                let vec_y_recip = segment.delta[1].recip();
+                let vec_y_recip = delta[1].recip();
                 let t0 = (y0 - y) * vec_y_recip;
                 let t1 = (y1 - y) * vec_y_recip;
-                let startx = segment.origin[0] - x_tile;
-                let x0 = startx + t0 * segment.delta[0];
-                let x1 = startx + t1 * segment.delta[0];
+                let startx = segment.point0[0] - x_tile;
+                let x0 = startx + t0 * delta[0];
+                let x1 = startx + t1 * delta[0];
                 let xmin0 = x0.min(x1);
                 let xmax0 = x0.max(x1);
                 for i in 0..TILE_WIDTH {

--- a/src/cpu_shader/path_tiling.rs
+++ b/src/cpu_shader/path_tiling.rs
@@ -144,6 +144,12 @@ fn path_tiling_main(
                 y_edge = p1.y;
             }
         }
+        if p0.x == p0.x.floor() && p0.x != 0.0 {
+            p0.x -= EPSILON;
+        }
+        if p1.x == p1.x.floor() && p1.x != 0.0 {
+            p1.x -= EPSILON;
+        }
         if !is_down {
             (p0, p1) = (p1, p0);
         }

--- a/src/cpu_shader/path_tiling.rs
+++ b/src/cpu_shader/path_tiling.rs
@@ -128,9 +128,9 @@ fn path_tiling_main(
             1e9
         };
         let segment = PathSegment {
-            origin: xy0.to_array(),
+            origin: (xy0 - tile_xy).to_array(),
             delta: (xy1 - xy0).to_array(),
-            y_edge,
+            y_edge: y_edge - tile_xy.y,
             _padding: Default::default(),
         };
         assert!(xy0.x >= tile_xy.x && xy0.x <= tile_xy1.x);

--- a/src/cpu_shader/path_tiling.rs
+++ b/src/cpu_shader/path_tiling.rs
@@ -115,28 +115,48 @@ fn path_tiling_main(
                 xy1 = Vec2::new(x_clip, yt);
             }
         }
-        if !is_down {
-            (xy0, xy1) = (xy1, xy0);
+        let mut y_edge = 1e9;
+        // Apply numerical robustness logic
+        let mut p0 = xy0 - tile_xy;
+        let mut p1 = xy1 - tile_xy;
+        const EPSILON: f32 = 1e-6;
+        if p0.x == 0.0 {
+            if p1.x == 0.0 {
+                p0.x = EPSILON;
+                if p0.y == 0.0 {
+                    // Entire tile
+                    p1.x = EPSILON;
+                    p1.y = TILE_HEIGHT as f32;
+                } else {
+                    // Make segment disappear
+                    p1.x = 2.0 * EPSILON;
+                    p1.y = p0.y;
+                }
+            } else if p0.y == 0.0 {
+                p0.x = EPSILON;
+            } else {
+                y_edge = p0.y;
+            }
+        } else if p1.x == 0.0 {
+            if p1.y == 0.0 {
+                p1.x = EPSILON;
+            } else {
+                y_edge = p1.y;
+            }
         }
-        // TODO (part of move to 8 byte encoding for segments): don't store y_edge at all,
-        // resolve this in fine.
-        let y_edge = if xy0.x == tile_xy.x && xy1.x != tile_xy.x && xy0.y != tile_xy.y {
-            xy0.y
-        } else if xy1.x == tile_xy.x && xy1.y != tile_xy.y {
-            xy1.y
-        } else {
-            1e9
-        };
+        if !is_down {
+            (p0, p1) = (p1, p0);
+        }
         let segment = PathSegment {
-            origin: (xy0 - tile_xy).to_array(),
-            delta: (xy1 - xy0).to_array(),
-            y_edge: y_edge - tile_xy.y,
+            point0: p0.to_array(),
+            point1: p1.to_array(),
+            y_edge,
             _padding: Default::default(),
         };
-        assert!(xy0.x >= tile_xy.x && xy0.x <= tile_xy1.x);
-        assert!(xy0.y >= tile_xy.y && xy0.y <= tile_xy1.y);
-        assert!(xy1.x >= tile_xy.x && xy1.x <= tile_xy1.x);
-        assert!(xy1.y >= tile_xy.y && xy1.y <= tile_xy1.y);
+        assert!(p0.x >= 0.0 && p0.x <= TILE_WIDTH as f32);
+        assert!(p0.y >= 0.0 && p0.y <= TILE_HEIGHT as f32);
+        assert!(p1.x >= 0.0 && p1.x <= TILE_WIDTH as f32);
+        assert!(p1.y >= 0.0 && p1.y <= TILE_HEIGHT as f32);
         segments[(seg_start + seg_within_slice) as usize] = segment;
     }
 }


### PR DESCRIPTION
This PR fixes a "blocky artifact" bug in area antialiasing, makes changes in the way path segments are represented, and introduces a test scene crafted to expose numerical robustness artifacts.

The artifact was due to a discrepancy in the way numerical robustness was handled between msaa and area antialiasing. This patch moves that logic into tiling, which should help performance as well as consistency. In so doing, it changes the representation from a viewport-relative coordinate of point0 and (point1 - point0) to one where both points are relative to the top left of the tile. That in turn is preparation for a change to f16 coordinates (not done in this PR).

Here is an informal description of the numerical robustness logic for path tiling.

A grid-aligned vertical line (x0 = x1 = 0 in tile coordinates) is handled specially. If y0 = 0, then the crossing is counted for the entire tile. Otherwise, the line is discarded. The "entire tile" case is modeled in the code as drawing a vertical line offset slightly from the left edge of the tile, which has the same effect, and fine code never has to deal with the case where x0 = x1 = 0.

Non-vertical lines touching the left edge of the tile (x0 = 0 xor x1 = 0) are *potentially* a y-edge crossing. If the line touches the top left of the tile, it is not a crossing, otherwise it is. The former case is modeled in the code by displacing the point slightly to the right, so that x0 = 0 or x1 = 0 in fine is a reliable indicator of y-edge crossing. Currently a y-edge value is computed and stored in `Segment`, but it is redundant with zero comparisons of x values, and is intended to go away when those values move to f16.

There are two good ways to understand the numerical robustness logic. One is formally, by counting intersections between the path segments (represented as floating point) against "reference points" which are determined with tiny epsilon values. The reference point corresponding to backdrop is -ε², ε). The reference point for the tile is (ε², ε), which is why a vertical line from the tile origin counts as a crossing for the tile. The reference point for the pixel row y is (ε², ε + y), which is why lines touching the top left corner are not counted as a crossing, while otherwise lines touching the left edge are.

The other way to understand the logic is by cases, and a good way to present those are by illustrations. Unfortunately that's beyond the scope of this PR description, but we will write this up properly.

The added test is very good at triggering numerical robustness issues, and in fact surface errors in msaa that haven't been detected before. Addressing those will be a followup PR. It is believed that area aa is now completely correct.