### PR TITLE
Basic GPU stroke rendering with support for caps and joins

### DIFF
--- a/crates/encoding/src/encoding.rs
+++ b/crates/encoding/src/encoding.rs
@@ -3,7 +3,10 @@
 
 use super::{DrawColor, DrawTag, PathEncoder, PathTag, Style, Transform};
 
-use peniko::{kurbo::Shape, BlendMode, BrushRef, Color, Fill};
+use peniko::{
+    kurbo::{Shape, Stroke},
+    BlendMode, BrushRef, Color, Fill,
+};
 
 #[cfg(feature = "full")]
 use {
@@ -166,6 +169,15 @@ impl Encoding {
     /// Encodes a fill style.
     pub fn encode_fill_style(&mut self, fill: Fill) {
         let style = Style::from_fill(fill);
+        if self.styles.last() != Some(&style) {
+            self.path_tags.push(PathTag::STYLE);
+            self.styles.push(style);
+        }
+    }
+
+    /// Encodes a stroke style.
+    pub fn encode_stroke_style(&mut self, stroke: &Stroke) {
+        let style = Style::from_stroke(stroke);
         if self.styles.last() != Some(&style) {
             self.path_tags.push(PathTag::STYLE);
             self.styles.push(style);

--- a/crates/encoding/src/path.rs
+++ b/crates/encoding/src/path.rs
@@ -523,7 +523,13 @@ impl<'a> PathEncoder<'a> {
             self.move_to(self.first_point[0], self.first_point[1]);
         }
         if self.state == PathState::MoveTo {
-            // TODO: Drop the segment if its length is zero
+            let x0 = self.first_point[0];
+            let y0 = self.first_point[1];
+            // TODO: should this be an exact match?
+            if (x - x0).abs() < 1e-12 && (y - y0).abs() < 1e-12 {
+                // Drop the segment if its length is zero
+                return;
+            }
             self.first_start_tangent_end = [x, y];
         }
         let buf = [x, y];
@@ -544,9 +550,18 @@ impl<'a> PathEncoder<'a> {
             self.move_to(self.first_point[0], self.first_point[1]);
         }
         if self.state == PathState::MoveTo {
-            // TODO: Drop the segment if its length is zero
-            // TODO: Pick (x2, y2) if [(x0, y0), (x1, y1)] has a length of zero
-            self.first_start_tangent_end = [x1, y1];
+            let x0 = self.first_point[0];
+            let y0 = self.first_point[1];
+            // TODO clean this up
+            let (x, y) = if (x1 - x0).abs() > 1e-12 || (y1 - y0).abs() > 1e-12 {
+                (x1, y1)
+            } else if (x2 - x0).abs() > 1e-12 || (y2 - y0).abs() > 1e-12 {
+                (x2, y2)
+            } else {
+                // Drop the segment if its length is zero
+                return;
+            };
+            self.first_start_tangent_end = [x, y];
         }
         let buf = [x1, y1, x2, y2];
         let bytes = bytemuck::bytes_of(&buf);
@@ -566,10 +581,20 @@ impl<'a> PathEncoder<'a> {
             self.move_to(self.first_point[0], self.first_point[1]);
         }
         if self.state == PathState::MoveTo {
-            // TODO: Drop the segment if its length is zero
-            // TODO: Pick (x2, y2) if [(x0, y0), (x1, y1)] has a length of zero
-            //       Pick (x3, y3) if [(x0, y0), (x2, y2)] has a length of zero
-            self.first_start_tangent_end = [x1, y1];
+            let x0 = self.first_point[0];
+            let y0 = self.first_point[1];
+            // TODO clean this up
+            let (x, y) = if (x1 - x0).abs() > 1e-12 || (y1 - y0).abs() > 1e-12 {
+                (x1, y1)
+            } else if (x2 - x0).abs() > 1e-12 || (y2 - y0).abs() > 1e-12 {
+                (x2, y2)
+            } else if (x3 - x0).abs() > 1e-12 || (y3 - y0).abs() > 1e-12 {
+                (x3, y3)
+            } else {
+                // Drop the segment if its length is zero
+                return;
+            };
+            self.first_start_tangent_end = [x, y];
         }
         let buf = [x1, y1, x2, y2, x3, y3];
         let bytes = bytemuck::bytes_of(&buf);

--- a/crates/encoding/src/path.rs
+++ b/crates/encoding/src/path.rs
@@ -525,9 +525,11 @@ impl<'a> PathEncoder<'a> {
         if self.state == PathState::MoveTo {
             let x0 = self.first_point[0];
             let y0 = self.first_point[1];
-            // TODO: should this be an exact match?
-            if (x - x0).abs() < 1e-12 && (y - y0).abs() < 1e-12 {
+            // Ensure that we don't end up with a zero-length start tangent.
+            const EPS: f32 = 1e-12;
+            if (x - x0).abs() < EPS && (y - y0).abs() < EPS {
                 // Drop the segment if its length is zero
+                // TODO: do this for all not segments, not just start?
                 return;
             }
             self.first_start_tangent_end = [x, y];
@@ -552,13 +554,15 @@ impl<'a> PathEncoder<'a> {
         if self.state == PathState::MoveTo {
             let x0 = self.first_point[0];
             let y0 = self.first_point[1];
-            // TODO clean this up
-            let (x, y) = if (x1 - x0).abs() > 1e-12 || (y1 - y0).abs() > 1e-12 {
+            // Ensure that we don't end up with a zero-length start tangent.
+            const EPS: f32 = 1e-12;
+            let (x, y) = if (x1 - x0).abs() > EPS || (y1 - y0).abs() > EPS {
                 (x1, y1)
-            } else if (x2 - x0).abs() > 1e-12 || (y2 - y0).abs() > 1e-12 {
+            } else if (x2 - x0).abs() > EPS || (y2 - y0).abs() > EPS {
                 (x2, y2)
             } else {
                 // Drop the segment if its length is zero
+                // TODO: do this for all not segments, not just start?
                 return;
             };
             self.first_start_tangent_end = [x, y];
@@ -583,15 +587,17 @@ impl<'a> PathEncoder<'a> {
         if self.state == PathState::MoveTo {
             let x0 = self.first_point[0];
             let y0 = self.first_point[1];
-            // TODO clean this up
-            let (x, y) = if (x1 - x0).abs() > 1e-12 || (y1 - y0).abs() > 1e-12 {
+            // Ensure that we don't end up with a zero-length start tangent.
+            const EPS: f32 = 1e-12;
+            let (x, y) = if (x1 - x0).abs() > EPS || (y1 - y0).abs() > EPS {
                 (x1, y1)
-            } else if (x2 - x0).abs() > 1e-12 || (y2 - y0).abs() > 1e-12 {
+            } else if (x2 - x0).abs() > EPS || (y2 - y0).abs() > EPS {
                 (x2, y2)
-            } else if (x3 - x0).abs() > 1e-12 || (y3 - y0).abs() > 1e-12 {
+            } else if (x3 - x0).abs() > EPS || (y3 - y0).abs() > EPS {
                 (x3, y3)
             } else {
                 // Drop the segment if its length is zero
+                // TODO: do this for all not segments, not just start?
                 return;
             };
             self.first_start_tangent_end = [x, y];

--- a/examples/scenes/src/test_scenes.rs
+++ b/examples/scenes/src/test_scenes.rs
@@ -125,6 +125,9 @@ fn stroke_styles(sb: &mut SceneBuilder, params: &mut SceneParams) {
         MoveTo((200., 0.).into()),
         CurveTo((100., 42.).into(), (300., 42.).into(), (200., 0.).into()),
         ClosePath,
+        MoveTo((290., 0.).into()),
+        CurveTo((200., 42.).into(), (400., 42.).into(), (310., 0.).into()),
+        ClosePath,
     ];
     let cap_styles = [Cap::Butt, Cap::Square, Cap::Round];
     let join_styles = [Join::Bevel, Join::Miter, Join::Round];
@@ -208,8 +211,6 @@ fn stroke_styles(sb: &mut SceneBuilder, params: &mut SceneParams) {
     }
 
     // Closed paths
-    let t = Affine::translate((500., 0.)) * t;
-    y = 0.;
     for (i, join) in join_styles.iter().enumerate() {
         params.text.add(
             sb,
@@ -221,7 +222,10 @@ fn stroke_styles(sb: &mut SceneBuilder, params: &mut SceneParams) {
         );
         // The cap style is not important since a closed path shouldn't have any caps.
         sb.stroke(
-            &Stroke::new(10.).with_caps(cap_styles[i]).with_join(*join),
+            &Stroke::new(10.)
+                .with_caps(cap_styles[i])
+                .with_join(*join)
+                .with_miter_limit(5.),
             Affine::translate((0., y + 30.)) * t,
             colors[color_idx],
             None,

--- a/examples/scenes/src/test_scenes.rs
+++ b/examples/scenes/src/test_scenes.rs
@@ -106,12 +106,13 @@ fn stroke_styles(sb: &mut SceneBuilder, params: &mut SceneParams) {
         Color::rgb8(201, 147, 206),
         Color::rgb8(150, 195, 160),
     ];
-    let simple_stroke = [LineTo((100., 0.).into())];
+    let simple_stroke = [MoveTo((0., 0.).into()), LineTo((100., 0.).into())];
     let join_stroke = [
+        MoveTo((0., 0.).into()),
         CurveTo((20., 0.).into(), (42.5, 5.).into(), (50., 25.).into()),
         CurveTo((57.5, 5.).into(), (80., 0.).into(), (100., 0.).into()),
     ];
-    let miter_stroke = [LineTo((90., 21.).into()), LineTo((0., 42.).into())];
+    let miter_stroke = [MoveTo((0., 0.).into()), LineTo((90., 21.).into()), LineTo((0., 42.).into())];
     let cap_styles = [Cap::Butt, Cap::Square, Cap::Round];
     let join_styles = [Join::Bevel, Join::Miter, Join::Round];
     let miter_limits = [4., 5., 0.1, 10.];

--- a/examples/scenes/src/test_scenes.rs
+++ b/examples/scenes/src/test_scenes.rs
@@ -112,7 +112,20 @@ fn stroke_styles(sb: &mut SceneBuilder, params: &mut SceneParams) {
         CurveTo((20., 0.).into(), (42.5, 5.).into(), (50., 25.).into()),
         CurveTo((57.5, 5.).into(), (80., 0.).into(), (100., 0.).into()),
     ];
-    let miter_stroke = [MoveTo((0., 0.).into()), LineTo((90., 21.).into()), LineTo((0., 42.).into())];
+    let miter_stroke = [
+        MoveTo((0., 0.).into()),
+        LineTo((90., 21.).into()),
+        LineTo((0., 42.).into()),
+    ];
+    let closed_strokes = [
+        MoveTo((0., 0.).into()),
+        LineTo((90., 21.).into()),
+        LineTo((0., 42.).into()),
+        ClosePath,
+        MoveTo((200., 0.).into()),
+        CurveTo((100., 42.).into(), (300., 42.).into(), (200., 0.).into()),
+        ClosePath,
+    ];
     let cap_styles = [Cap::Butt, Cap::Square, Cap::Round];
     let join_styles = [Join::Bevel, Join::Miter, Join::Round];
     let miter_limits = [4., 5., 0.1, 10.];
@@ -189,6 +202,30 @@ fn stroke_styles(sb: &mut SceneBuilder, params: &mut SceneParams) {
             colors[color_idx],
             None,
             &miter_stroke,
+        );
+        y += 180.;
+        color_idx = (color_idx + 1) % colors.len();
+    }
+
+    // Closed paths
+    let t = Affine::translate((500., 0.)) * t;
+    y = 0.;
+    for (i, join) in join_styles.iter().enumerate() {
+        params.text.add(
+            sb,
+            None,
+            12.,
+            None,
+            Affine::translate((0., y)) * t,
+            &format!("Closed path with join: {:?}", join),
+        );
+        // The cap style is not important since a closed path shouldn't have any caps.
+        sb.stroke(
+            &Stroke::new(10.).with_caps(cap_styles[i]).with_join(*join),
+            Affine::translate((0., y + 30.)) * t,
+            colors[color_idx],
+            None,
+            &closed_strokes,
         );
         y += 180.;
         color_idx = (color_idx + 1) % colors.len();

--- a/shader/flatten.wgsl
+++ b/shader/flatten.wgsl
@@ -354,23 +354,26 @@ fn main(
         var stroke = vec2(0.0, 0.0);
         let is_stroke = (style_flags & STYLE_FLAGS_STYLE_BIT) != 0u;
         if is_stroke {
-            // TODO: WIP
-            let linewidth = bitcast<f32>(scene[config.style_base + tm.style_ix + 1u]);
-            // See https://www.iquilezles.org/www/articles/ellipses/ellipses.htm
-            // This is the correct bounding box, but we're not handling rendering
-            // in the isotropic case, so it may mismatch.
-            stroke = 0.5 * linewidth * vec2(length(transform.mat.xz), length(transform.mat.yw));
-            bbox += vec4(-stroke, stroke);
+            // TODO: FIX
+            if (tag_byte & PATH_TAG_SUBPATH_END_BIT) == 0u {
+                // TODO: WIP
+                let linewidth = bitcast<f32>(scene[config.style_base + tm.style_ix + 1u]);
+                // See https://www.iquilezles.org/www/articles/ellipses/ellipses.htm
+                // This is the correct bounding box, but we're not handling rendering
+                // in the isotropic case, so it may mismatch.
+                stroke = 0.5 * linewidth * vec2(length(transform.mat.xz), length(transform.mat.yw));
+                bbox += vec4(-stroke, stroke);
 
-            flatten_cubic(Cubic(p0, p1, p2, p3, stroke, tm.path_ix, u32(is_stroke)));
+                flatten_cubic(Cubic(p0, p1, p2, p3, stroke, tm.path_ix, u32(is_stroke)));
 
-            // TODO: proper caps
-            let n0 = normalize(cubic_start_normal(p0, p1, p2, p3)) * stroke;
-            let n1 = normalize(cubic_end_normal(p0, p1, p2, p3)) * stroke;
+                // TODO: proper caps
+                let n0 = normalize(cubic_start_normal(p0, p1, p2, p3)) * stroke;
+                let n1 = normalize(cubic_end_normal(p0, p1, p2, p3)) * stroke;
 
-            let line_ix = atomicAdd(&bump.lines, 2u);
-            lines[line_ix]      = LineSoup(tm.path_ix, p0 - n0, p0 + n0);
-            lines[line_ix + 1u] = LineSoup(tm.path_ix, p3 + n1, p3 - n1);
+                let line_ix = atomicAdd(&bump.lines, 2u);
+                lines[line_ix]      = LineSoup(tm.path_ix, p0 - n0, p0 + n0);
+                lines[line_ix + 1u] = LineSoup(tm.path_ix, p3 + n1, p3 - n1);
+            }
         } else {
             flatten_cubic(Cubic(p0, p1, p2, p3, stroke, tm.path_ix, u32(is_stroke)));
         }

--- a/shader/flatten.wgsl
+++ b/shader/flatten.wgsl
@@ -328,7 +328,13 @@ fn read_path_segment(tag: PathTagData, transform: Transform, is_stroke: bool) ->
     }
 
     if is_stroke_cap_marker && is_open {
-        // TODO: document
+        // The stroke cap marker for an open path is encoded as a quadto where the p1 and p2 store
+        // the start control point of the subpath and together with p2 forms the start tangent. p0
+        // is ignored.
+        //
+        // This is encoded this way because encoding this as a lineto would require adding a moveto,
+        // which would terminate the subpath too early (by setting the SUBPATH_END_BIT on the
+        // segment preceding the cap marker). This scheme is only used for strokes.
         p0 = transform_apply(transform, p1);
         p1 = transform_apply(transform, p2);
         seg_type = PATH_TAG_LINETO;

--- a/shader/flatten.wgsl
+++ b/shader/flatten.wgsl
@@ -89,18 +89,6 @@ fn eval_cubic(p0: vec2<f32>, p1: vec2<f32>, p2: vec2<f32>, p3: vec2<f32>, t: f32
     return p0 * (mt * mt * mt) + (p1 * (mt * mt * 3.0) + (p2 * (mt * 3.0) + p3 * t) * t) * t;
 }
 
-fn eval_cubic_tangent(p0: vec2<f32>, p1: vec2<f32>, p2: vec2<f32>, p3: vec2<f32>, t: f32) -> vec2<f32> {
-    let dp0 = 3. * (p1 - p0);
-    let dp1 = 3. * (p2 - p1);
-    let dp2 = 3. * (p3 - p2);
-    return eval_quad(dp0, dp1, dp2, t);
-}
-
-fn eval_cubic_normal(p0: vec2<f32>, p1: vec2<f32>, p2: vec2<f32>, p3: vec2<f32>, t: f32) -> vec2<f32> {
-    let tangent = eval_cubic_tangent(p0, p1, p2, p3, t);
-    return vec2(-tangent.y, tangent.x);
-}
-
 fn eval_quad_tangent(p0: vec2<f32>, p1: vec2<f32>, p2: vec2<f32>, t: f32) -> vec2<f32> {
     let dp0 = 2. * (p1 - p0);
     let dp1 = 2. * (p2 - p1);
@@ -210,6 +198,10 @@ fn flatten_cubic(cubic: Cubic) {
                 lp1 = eval_quad(qp0, qp1, qp2, t);
             }
 
+            // TODO: Instead of outputting two offset segments here, restructure this function as
+            // "flatten_cubic_at_offset" such that it outputs one cubic at an offset. That should
+            // more closely resemble the end state of this shader which will work like a state
+            // machine.
             if cubic.flags == 1u {
                 var n1: vec2f;
                 if all(lp1 == p3) {
@@ -437,6 +429,8 @@ fn main(
                 } else {
                     // Don't draw anything if the path is closed.
                 }
+                // The stroke cap marker does not contribute to the path's bounding box. The stroke
+                // width is accounted for when computing the bbox for regular segments.
                 bbox = vec4(1., 1., -1., -1.);
             } else {
                 // Render offset curves

--- a/shader/shared/pathtag.wgsl
+++ b/shader/shared/pathtag.wgsl
@@ -21,12 +21,12 @@ let PATH_TAG_TRANSFORM = 0x20u;
 let PATH_TAG_PATH = 0x10u;
 let PATH_TAG_STYLE = 0x40u;
 #endif
-let PATH_TAG_SUBPATH_END_BIT = 4u;
+let PATH_TAG_SUBPATH_END = 4u;
 
 // Size of the `Style` data structure in words
 let STYLE_SIZE_IN_WORDS: u32 = 2u;
-let STYLE_FLAGS_STYLE_BIT: u32 = 0x80000000u;
-let STYLE_FLAGS_FILL_BIT: u32 = 0x40000000u;
+let STYLE_FLAGS_STYLE: u32 = 0x80000000u;
+let STYLE_FLAGS_FILL: u32 = 0x40000000u;
 
 // TODO: Declare the remaining STYLE flags here.
 

--- a/shader/shared/pathtag.wgsl
+++ b/shader/shared/pathtag.wgsl
@@ -21,6 +21,7 @@ let PATH_TAG_TRANSFORM = 0x20u;
 let PATH_TAG_PATH = 0x10u;
 let PATH_TAG_STYLE = 0x40u;
 #endif
+let PATH_TAG_SUBPATH_END_BIT = 4u;
 
 // Size of the `Style` data structure in words
 let STYLE_SIZE_IN_WORDS: u32 = 2u;

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -149,26 +149,45 @@ impl<'a> SceneBuilder<'a> {
         brush_transform: Option<Affine>,
         shape: &impl Shape,
     ) {
-        // The setting for tolerance are a compromise. For most applications,
-        // shape tolerance doesn't matter, as the input is likely Bézier paths,
-        // which is exact. Note that shape tolerance is hard-coded as 0.1 in
-        // the encoding crate.
-        //
-        // Stroke tolerance is a different matter. Generally, the cost scales
-        // with inverse O(n^6), so there is moderate rendering cost to setting
-        // too fine a value. On the other hand, error scales with the transform
-        // applied post-stroking, so may exceed visible threshold. When we do
-        // GPU-side stroking, the transform will be known. In the meantime,
-        // this is a compromise.
-        const SHAPE_TOLERANCE: f64 = 0.01;
-        const STROKE_TOLERANCE: f64 = SHAPE_TOLERANCE;
-        let stroked = peniko::kurbo::stroke(
-            shape.path_elements(SHAPE_TOLERANCE),
-            style,
-            &Default::default(),
-            STROKE_TOLERANCE,
-        );
-        self.fill(Fill::NonZero, transform, brush, brush_transform, &stroked);
+        const GPU_STROKES: bool = true;
+        if GPU_STROKES {
+            // TODO: handle dashing by using a DashIterator
+            self.scene
+                .encode_transform(Transform::from_kurbo(&transform));
+            self.scene.encode_stroke_style(style);
+            if self.scene.encode_shape(shape, false) {
+                if let Some(brush_transform) = brush_transform {
+                    if self
+                        .scene
+                        .encode_transform(Transform::from_kurbo(&(transform * brush_transform)))
+                    {
+                        self.scene.swap_last_path_tags();
+                    }
+                }
+                self.scene.encode_brush(brush, 1.0);
+            }
+        } else {
+            // The setting for tolerance are a compromise. For most applications,
+            // shape tolerance doesn't matter, as the input is likely Bézier paths,
+            // which is exact. Note that shape tolerance is hard-coded as 0.1 in
+            // the encoding crate.
+            //
+            // Stroke tolerance is a different matter. Generally, the cost scales
+            // with inverse O(n^6), so there is moderate rendering cost to setting
+            // too fine a value. On the other hand, error scales with the transform
+            // applied post-stroking, so may exceed visible threshold. When we do
+            // GPU-side stroking, the transform will be known. In the meantime,
+            // this is a compromise.
+            const SHAPE_TOLERANCE: f64 = 0.01;
+            const STROKE_TOLERANCE: f64 = SHAPE_TOLERANCE;
+            let stroked = peniko::kurbo::stroke(
+                shape.path_elements(SHAPE_TOLERANCE),
+                style,
+                &Default::default(),
+                STROKE_TOLERANCE,
+            );
+            self.fill(Fill::NonZero, transform, brush, brush_transform, &stroked);
+        }
     }
 
     /// Draws an image at its natural size with the given transform.

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -149,7 +149,7 @@ impl<'a> SceneBuilder<'a> {
         brush_transform: Option<Affine>,
         shape: &impl Shape,
     ) {
-        const GPU_STROKES: bool = true;
+        const GPU_STROKES: bool = false;
         if GPU_STROKES {
             // TODO: handle dashing by using a DashIterator
             self.scene


### PR DESCRIPTION
This PR implements support for GPU-side stroke expansion with initial support for caps and joins. This is further progress towards implementing the design outlined in #303  

- The flatten stage implements rudimentary stroke offsetting based on displacing the endpoints of lines that result from flattening the baseline curve along their (transformed) normal vector. This results in a crude subdivision estimate for the offset curves but this is initially acceptable as it unblocks follow-up stroke work. @dragostis suggested [a solution](https://github.com/linebender/vello/commit/c96ccb7766df80f8db7246732c098409b1709ee2#r131800029) that sounds promising, which we could use until Euler Spiral based offsetting arrives.

- The scheme described in #303 involving a "stroke cap marker" segment to detect when to render a start vs end cap on the GPU has been implemented with a slight tweak. For an open path, the start position and tangent require two points to be encoded in the marker which cannot be done with a `lineTo` without first inserting a `moveTo`. Since inserting a `moveTo` would terminate the subpath prematurely and because we want to preserve the invariant that only one segment has the `SUBPATH_END_BIT` set, the marker for an open path gets encoded as a `quadTo` instead. The marker for a closed path is encoded as a `lineTo` since the final control point of the preceding segment (i.e. the `close`) should already match the start control point.

  Since we can distinguish between an open and close path based on whether the marker is encoded as a `quadTo` or a `lineTo`, adding a "close vs open" bit to the encoding wasn't necessary.

- Currently only butt caps and bevel joins are supported. Support for other stroke styles will be added as a follow-up.

- `PathEncoder` has some new handling for zero-length segments to avoid encoding a cap marker with a degenerate start tangent. If the lengths of all possible tangent vectors are within an epsilon threshold (currently `1e-12`) then the segment is dropped. This will get extended to all segments in a follow-up PR to avoid encoding zero-length segments for strokes in general.

- Added additional stroke test cases for closed paths, including a single curve with a co-incident start and end control point.