### PR TITLE
CPU-side dashing for GPU strokes & encoding-time filtering of zero-length segments

### DIFF
--- a/crates/encoding/src/encoding.rs
+++ b/crates/encoding/src/encoding.rs
@@ -218,6 +218,18 @@ impl Encoding {
         encoder.finish(true) != 0
     }
 
+    /// Encodes a path element iterator. If `is_fill` is true, all subpaths will be automatically
+    /// closed. Returns true if a non-zero number of segments were encoded.
+    pub fn encode_path_elements(
+        &mut self,
+        path: impl Iterator<Item = peniko::kurbo::PathEl>,
+        is_fill: bool,
+    ) -> bool {
+        let mut encoder = self.encode_path(is_fill);
+        encoder.path_elements(path);
+        encoder.finish(true) != 0
+    }
+
     /// Encodes a brush with an optional alpha modifier.
     #[allow(unused_variables)]
     pub fn encode_brush<'b>(&mut self, brush: impl Into<BrushRef<'b>>, alpha: f32) {

--- a/crates/encoding/src/path.rs
+++ b/crates/encoding/src/path.rs
@@ -628,8 +628,13 @@ impl<'a> PathEncoder<'a> {
 
     /// Encodes a shape.
     pub fn shape(&mut self, shape: &impl Shape) {
+        self.path_elements(shape.path_elements(0.1));
+    }
+
+    /// Encodes a path iterator
+    pub fn path_elements(&mut self, path: impl Iterator<Item = peniko::kurbo::PathEl>) {
         use peniko::kurbo::PathEl;
-        for el in shape.path_elements(0.1) {
+        for el in path {
             match el {
                 PathEl::MoveTo(p0) => self.move_to(p0.x as f32, p0.y as f32),
                 PathEl::LineTo(p0) => self.line_to(p0.x as f32, p0.y as f32),

--- a/examples/scenes/src/test_scenes.rs
+++ b/examples/scenes/src/test_scenes.rs
@@ -70,6 +70,7 @@ pub fn test_scenes() -> SceneSet {
 fn funky_paths(sb: &mut SceneBuilder, _: &mut SceneParams) {
     use PathEl::*;
     let missing_movetos = [
+        MoveTo((0., 0.).into()),
         LineTo((100.0, 100.0).into()),
         LineTo((100.0, 200.0).into()),
         ClosePath,
@@ -171,8 +172,36 @@ fn stroke_styles(transform: Affine) -> impl FnMut(&mut SceneBuilder, &mut SceneP
             }
         }
 
+        // Dashed strokes with cap combinations
+        let t = Affine::translate((450., 0.)) * t;
+        y = 0.;
+        for start in cap_styles {
+            for end in cap_styles {
+                params.text.add(
+                    sb,
+                    None,
+                    12.,
+                    None,
+                    Affine::translate((0., y)) * t,
+                    &format!("Dashing - Start cap: {:?}, End cap: {:?}", start, end),
+                );
+                sb.stroke(
+                    &Stroke::new(20.)
+                        .with_start_cap(start)
+                        .with_end_cap(end)
+                        .with_dashes(0., [10.0, 21.0]),
+                    Affine::translate((0., y + 30.)) * t * transform,
+                    colors[color_idx],
+                    None,
+                    &simple_stroke,
+                );
+                y += 180.;
+                color_idx = (color_idx + 1) % colors.len();
+            }
+        }
+
         // Cap and join combinations
-        let t = Affine::translate((500., 0.)) * t;
+        let t = Affine::translate((550., 0.)) * t;
         y = 0.;
         for cap in cap_styles {
             for join in join_styles {
@@ -463,7 +492,10 @@ fn longpathdash(cap: Cap) -> impl FnMut(&mut SceneBuilder, &mut SceneParams) {
             x += 16;
         }
         sb.stroke(
-            &Stroke::new(1.0).with_caps(cap).with_dashes(0.0, [1.0, 1.0]),
+            &Stroke::new(1.0)
+                .with_caps(cap)
+                .with_join(Join::Bevel)
+                .with_dashes(0.0, [1.0, 1.0]),
             Affine::translate((50.0, 50.0)),
             Color::YELLOW,
             None,


### PR DESCRIPTION
- When GPU-side stroking is enabled, a stroke with a dash style now gets converted to a series of regular strokes which then get encoded separately and in sequence.

- Zero-length segments lead to numerical errors and lead to extra complexity and wasted work (in the form of thread 
   allocation) for GPU flattening. We now detect and drop them at encoding time.
   
   Currently, a path segment is considered zero-length if all of its control points (in local coordinates) are within EPSILON (1e-12) of each other. This may not be the desired behavior under transform.

   Also since the length here isn't in terms of the actual arc length, this won't detect all curves that are within an EPSILON sized bounding box (which may have a larger distance between their control points).

   For stroking purposes, the distance between the control points is what matters most as that's what's used to compute a curve's tangent.

This PR is based on #410 

#303 