### PR TITLE
Round join and all cap styles

### DIFF
--- a/shader/flatten.wgsl
+++ b/shader/flatten.wgsl
@@ -294,7 +294,8 @@ fn flatten_arc(
     let radius = max(tol, length(p0 - transform_apply(transform, center)));
     let x = 1. - tol / radius;
     let theta = acos(clamp(2. * x * x - 1., -1., 1.));
-    let n_lines = select(u32(ceil(6.2831853 / theta)), 1u, theta <= EPS);
+    let MAX_LINES = 1000u;
+    let n_lines = select(min(MAX_LINES, u32(ceil(6.2831853 / theta))), MAX_LINES, theta <= EPS);
 
     let th = angle / f32(n_lines);
     let c = cos(th);

--- a/shader/flatten.wgsl
+++ b/shader/flatten.wgsl
@@ -283,6 +283,14 @@ fn flatten_cubic(cubic: CubicPoints, path_ix: u32, local_to_device: Transform, o
 // Flattens the circular arc that subtends the angle begin-center-end. It is assumed that
 // ||begin - center|| == ||end - center||. `begin`, `end`, and `center` are defined in the path's
 // local coordinate space.
+//
+// The direction of the arc is always a counter-clockwise (Y-down) rotation starting from `begin`,
+// towards `end`, centered at `center`, and will be subtended by `angle` (which is assumed to be
+// positive). A line segment will always be drawn from the arc's terminus to `end`, regardless of
+// `angle`.
+//
+// `begin`, `end`, center`, and `angle` should be chosen carefully to ensure a smooth arc with the
+// correct winding.
 fn flatten_arc(
     path_ix: u32, begin: vec2f, end: vec2f, center: vec2f, angle: f32, transform: Transform
 ) {


### PR DESCRIPTION
Implemented the logic for round join and cap styles. The logic generates lines directly from a circular arc. The arc gets flattened in the curve's local coordinate space and gets transformed to device-space coordinates post-flattening.

This completes the initial implementation of all stroke styles. This PR is based on #412.

#303 