### PR TITLE
Replace fello with skrifa for font rendering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ buffer_labels = []
 
 [dependencies]
 bytemuck = { workspace = true }
-fello = { workspace = true }
+skrifa = { workspace = true }
 peniko = { workspace = true }
 wgpu = { workspace = true, optional = true }
 raw-window-handle = "0.5"
@@ -57,7 +57,7 @@ kurbo = "0.10.4"
 
 [workspace.dependencies]
 bytemuck = { version = "1.12.1", features = ["derive"] }
-fello = { git = "https://github.com/dfrg/fount", rev = "dadbcf75695f035ca46766bfd60555d05bd421b1" }
+skrifa = "0.15.4"
 peniko = { git = "https://github.com/linebender/peniko", rev = "629fc3325b016a8c98b1cd6204cb4ddf1c6b3daa" }
 
 # NOTE: Make sure to keep this in sync with the version badge in README.md

--- a/crates/encoding/Cargo.toml
+++ b/crates/encoding/Cargo.toml
@@ -9,10 +9,10 @@ repository.workspace = true
 default = ["full"]
 # Enables support for the full pipeline including late-bound
 # resources (gradients, images and glyph runs)
-full = ["fello", "guillotiere"]
+full = ["skrifa", "guillotiere"]
 
 [dependencies]
 bytemuck = { workspace = true }
-fello = { workspace = true, optional = true }
+skrifa = { workspace = true, optional = true }
 peniko = { workspace = true }
 guillotiere = { version = "0.6.2", optional = true }

--- a/crates/encoding/src/encoding.rs
+++ b/crates/encoding/src/encoding.rs
@@ -11,8 +11,8 @@ use peniko::{
 #[cfg(feature = "full")]
 use {
     super::{DrawImage, DrawLinearGradient, DrawRadialGradient, Glyph, GlyphRun, Patch},
-    fello::NormalizedCoord,
     peniko::{ColorStop, Extend, GradientKind, Image},
+    skrifa::instance::NormalizedCoord,
 };
 
 /// Encoded data streams for a scene.

--- a/crates/encoding/src/glyph_cache.rs
+++ b/crates/encoding/src/glyph_cache.rs
@@ -52,6 +52,8 @@ impl GlyphCache {
             encoding_cache.encode_fill_style(fill);
             let mut path = encoding_cache.encode_path(true);
             let outline = outlines.get(GlyphId::new(key.glyph_id as u16))?;
+            // FIXME: Re-add hinting when skrifa supports it
+            // Tracking issue <https://github.com/googlefonts/fontations/issues/620>
             let draw_settings = skrifa::outline::DrawSettings::unhinted(size, coords);
             match style {
                 Style::Fill(_) => {

--- a/crates/encoding/src/path.rs
+++ b/crates/encoding/src/path.rs
@@ -767,7 +767,7 @@ impl<'a> PathEncoder<'a> {
 }
 
 #[cfg(feature = "full")]
-impl fello::scale::Pen for PathEncoder<'_> {
+impl skrifa::outline::OutlinePen for PathEncoder<'_> {
     fn move_to(&mut self, x: f32, y: f32) {
         self.move_to(x, y);
     }

--- a/examples/scenes/src/simple_text.rs
+++ b/examples/scenes/src/simple_text.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use vello::{
     glyph::{Glyph, GlyphContext},
     kurbo::Affine,
-    peniko::{Blob, Brush, BrushRef, Color, Fill, Font, StyleRef},
+    peniko::{Blob, Brush, BrushRef, Font, StyleRef},
     skrifa::{raw::FontRef, MetadataProvider},
     SceneBuilder,
 };

--- a/examples/scenes/src/simple_text.rs
+++ b/examples/scenes/src/simple_text.rs
@@ -17,11 +17,10 @@
 use std::sync::Arc;
 
 use vello::{
-    fello::meta::MetadataProvider,
-    fello::raw::FontRef,
-    glyph::{Glyph, GlyphContext},
+    glyph::Glyph,
     kurbo::Affine,
-    peniko::{Blob, Brush, BrushRef, Font, StyleRef},
+    peniko::{Blob, Brush, BrushRef, Color, Fill, Font, StyleRef},
+    skrifa::{raw::FontRef, MetadataProvider},
     SceneBuilder,
 };
 
@@ -31,7 +30,6 @@ const ROBOTO_FONT: &[u8] = include_bytes!("../../assets/roboto/Roboto-Regular.tt
 const INCONSOLATA_FONT: &[u8] = include_bytes!("../../assets/inconsolata/Inconsolata.ttf");
 
 pub struct SimpleText {
-    gcx: GlyphContext,
     roboto: Font,
     inconsolata: Font,
 }
@@ -40,7 +38,6 @@ impl SimpleText {
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self {
-            gcx: GlyphContext::new(),
             roboto: Font::new(Blob::new(Arc::new(ROBOTO_FONT)), 0),
             inconsolata: Font::new(Blob::new(Arc::new(INCONSOLATA_FONT)), 0),
         }
@@ -94,14 +91,12 @@ impl SimpleText {
         let brush = brush.into();
         let style = style.into();
         let axes = font_ref.axes();
-        let fello_size = vello::fello::Size::new(size);
-        let coords = axes
-            .normalize(variations.iter().copied())
-            .collect::<Vec<_>>();
+        let font_size = vello::skrifa::instance::Size::new(size);
+        let var_loc = axes.location(variations.iter().copied());
         let charmap = font_ref.charmap();
-        let metrics = font_ref.metrics(fello_size, coords.as_slice().into());
+        let metrics = font_ref.metrics(font_size, &var_loc);
         let line_height = metrics.ascent - metrics.descent + metrics.leading;
-        let glyph_metrics = font_ref.glyph_metrics(fello_size, coords.as_slice().into());
+        let glyph_metrics = font_ref.glyph_metrics(font_size, &var_loc);
         let mut pen_x = 0f32;
         let mut pen_y = 0f32;
         builder
@@ -109,7 +104,7 @@ impl SimpleText {
             .font_size(size)
             .transform(transform)
             .glyph_transform(glyph_transform)
-            .normalized_coords(&coords)
+            .normalized_coords(var_loc.coords())
             .brush(brush)
             .draw(
                 style,
@@ -141,38 +136,22 @@ impl SimpleText {
         transform: Affine,
         text: &str,
     ) {
-        let default_font = FontRef::new(ROBOTO_FONT).unwrap();
-        let font = font.and_then(to_font_ref).unwrap_or(default_font);
-        let fello_size = vello::fello::Size::new(size);
-        let charmap = font.charmap();
-        let metrics = font.metrics(fello_size, Default::default());
-        let line_height = metrics.ascent - metrics.descent + metrics.leading;
-        let glyph_metrics = font.glyph_metrics(fello_size, Default::default());
-        let mut pen_x = 0f64;
-        let mut pen_y = 0f64;
-        let vars: [(&str, f32); 0] = [];
-        let mut provider = self.gcx.new_provider(&font, None, size, false, vars);
-        for ch in text.chars() {
-            if ch == '\n' {
-                pen_y += line_height as f64;
-                pen_x = 0.0;
-                continue;
-            }
-            let gid = charmap.map(ch).unwrap_or_default();
-            let advance = glyph_metrics.advance_width(gid).unwrap_or_default() as f64;
-            if let Some(glyph) = provider.get(gid.to_u16(), brush) {
-                let xform = transform
-                    * Affine::translate((pen_x, pen_y))
-                    * Affine::scale_non_uniform(1.0, -1.0);
-                builder.append(&glyph, Some(xform));
-            }
-            pen_x += advance;
-        }
+        let brush = brush.unwrap_or(&Brush::Solid(Color::WHITE));
+        self.add_run(
+            builder,
+            font,
+            size,
+            brush,
+            transform,
+            None,
+            Fill::NonZero,
+            text,
+        );
     }
 }
 
 fn to_font_ref(font: &Font) -> Option<FontRef<'_>> {
-    use vello::fello::raw::FileRef;
+    use vello::skrifa::raw::FileRef;
     let file_ref = FileRef::new(font.data.as_ref()).ok()?;
     match file_ref {
         FileRef::Font(font) => Some(font),

--- a/examples/scenes/src/simple_text.rs
+++ b/examples/scenes/src/simple_text.rs
@@ -17,7 +17,7 @@
 use std::sync::Arc;
 
 use vello::{
-    glyph::Glyph,
+    glyph::{Glyph, GlyphContext},
     kurbo::Affine,
     peniko::{Blob, Brush, BrushRef, Color, Fill, Font, StyleRef},
     skrifa::{raw::FontRef, MetadataProvider},
@@ -136,17 +136,35 @@ impl SimpleText {
         transform: Affine,
         text: &str,
     ) {
-        let brush = brush.unwrap_or(&Brush::Solid(Color::WHITE));
-        self.add_run(
-            builder,
-            font,
-            size,
-            brush,
-            transform,
-            None,
-            Fill::NonZero,
-            text,
-        );
+        let default_font = FontRef::new(ROBOTO_FONT).unwrap();
+        let font = font.and_then(to_font_ref).unwrap_or(default_font);
+        let font_size = vello::skrifa::instance::Size::new(size);
+        let var_loc = vello::skrifa::instance::LocationRef::default();
+        let charmap = font.charmap();
+        let metrics = font.metrics(font_size, var_loc);
+        let line_height = metrics.ascent - metrics.descent + metrics.leading;
+        let glyph_metrics = font.glyph_metrics(font_size, var_loc);
+        let mut pen_x = 0f64;
+        let mut pen_y = 0f64;
+        let vars: [(&str, f32); 0] = [];
+        let mut gcx = GlyphContext::new();
+        let mut provider = gcx.new_provider(&font, size, false, &vars);
+        for ch in text.chars() {
+            if ch == '\n' {
+                pen_y += line_height as f64;
+                pen_x = 0.0;
+                continue;
+            }
+            let gid = charmap.map(ch).unwrap_or_default();
+            let advance = glyph_metrics.advance_width(gid).unwrap_or_default() as f64;
+            if let Some(glyph) = provider.get(gid.to_u16(), brush) {
+                let xform = transform
+                    * Affine::translate((pen_x, pen_y))
+                    * Affine::scale_non_uniform(1.0, -1.0);
+                builder.append(&glyph, Some(xform));
+            }
+            pen_x += advance;
+        }
     }
 }
 

--- a/src/glyph.rs
+++ b/src/glyph.rs
@@ -36,14 +36,9 @@ use skrifa::{outline::DrawSettings, MetadataProvider};
 pub use vello_encoding::Glyph;
 
 /// General context for creating scene fragments for glyph outlines.
+#[derive(Default)]
 pub struct GlyphContext {
     coords: Vec<NormalizedCoord>,
-}
-
-impl Default for GlyphContext {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 impl GlyphContext {

--- a/src/glyph.rs
+++ b/src/glyph.rs
@@ -18,24 +18,26 @@
 
 use crate::scene::{SceneBuilder, SceneFragment};
 use {
-    fello::{
-        raw::types::GlyphId,
-        raw::FontRef,
-        scale::{Context, Pen, Scaler},
-        FontKey, Setting, Size,
-    },
     peniko::kurbo::Affine,
     peniko::{Brush, Color, Fill, Style},
+    skrifa::{
+        instance::{NormalizedCoord, Size},
+        outline::OutlinePen,
+        raw::FontRef,
+        setting::Setting,
+        GlyphId, OutlineGlyphCollection,
+    },
     vello_encoding::Encoding,
 };
 
-pub use fello;
 use peniko::kurbo::Shape;
+pub use skrifa;
+use skrifa::{outline::DrawSettings, MetadataProvider};
 pub use vello_encoding::Glyph;
 
 /// General context for creating scene fragments for glyph outlines.
 pub struct GlyphContext {
-    ctx: Context,
+    coords: Vec<NormalizedCoord>,
 }
 
 impl Default for GlyphContext {
@@ -47,9 +49,7 @@ impl Default for GlyphContext {
 impl GlyphContext {
     /// Creates a new context.
     pub fn new() -> Self {
-        Self {
-            ctx: Context::new(),
-        }
+        Self::default()
     }
 
     /// Creates a new provider for generating scene fragments for glyphs from
@@ -57,31 +57,38 @@ impl GlyphContext {
     pub fn new_provider<'a, V>(
         &'a mut self,
         font: &FontRef<'a>,
-        font_id: Option<FontKey>,
         ppem: f32,
-        hint: bool,
+        _hint: bool,
         variations: V,
     ) -> GlyphProvider<'a>
     where
         V: IntoIterator,
         V::Item: Into<Setting<f32>>,
     {
-        let scaler = self
-            .ctx
-            .new_scaler()
-            .size(Size::new(ppem))
-            .hint(hint.then_some(fello::scale::Hinting::VerticalSubpixel))
-            .key(font_id)
-            .variations(variations)
-            .build(font);
-        GlyphProvider { scaler }
+        let outlines = font.outline_glyphs();
+        let size = Size::new(ppem);
+        let axes = font.axes();
+        let axis_count = axes.len();
+        self.coords.clear();
+        self.coords.resize(axis_count, Default::default());
+        axes.location_to_slice(variations, &mut self.coords);
+        if self.coords.iter().all(|x| *x == NormalizedCoord::default()) {
+            self.coords.clear();
+        }
+        GlyphProvider {
+            outlines,
+            size,
+            coords: &self.coords,
+        }
     }
 }
 
 /// Generator for scene fragments containing glyph outlines for a specific
 /// font.
 pub struct GlyphProvider<'a> {
-    scaler: Scaler<'a>,
+    outlines: OutlineGlyphCollection<'a>,
+    size: Size,
+    coords: &'a [NormalizedCoord],
 }
 
 impl<'a> GlyphProvider<'a> {
@@ -91,7 +98,9 @@ impl<'a> GlyphProvider<'a> {
         let mut fragment = SceneFragment::default();
         let mut builder = SceneBuilder::for_fragment(&mut fragment);
         let mut path = BezPathPen::default();
-        self.scaler.outline(GlyphId::new(gid), &mut path).ok()?;
+        let outline = self.outlines.get(GlyphId::new(gid))?;
+        let draw_settings = DrawSettings::unhinted(self.size, self.coords);
+        outline.draw(draw_settings, &mut path).ok()?;
         builder.fill(
             Fill::NonZero,
             Affine::IDENTITY,
@@ -109,14 +118,16 @@ impl<'a> GlyphProvider<'a> {
         };
         encoding.encode_fill_style(fill);
         let mut path = encoding.encode_path(true);
+        let outline = self.outlines.get(GlyphId::new(gid))?;
+        let draw_settings = DrawSettings::unhinted(self.size, self.coords);
         match style {
             Style::Fill(_) => {
-                self.scaler.outline(GlyphId::new(gid), &mut path).ok()?;
+                outline.draw(draw_settings, &mut path).ok()?;
             }
             Style::Stroke(stroke) => {
                 const STROKE_TOLERANCE: f64 = 0.01;
                 let mut pen = BezPathPen::default();
-                self.scaler.outline(GlyphId::new(gid), &mut pen).ok()?;
+                outline.draw(draw_settings, &mut pen).ok()?;
                 let stroked = peniko::kurbo::stroke(
                     pen.0.path_elements(STROKE_TOLERANCE),
                     stroke,
@@ -137,7 +148,7 @@ impl<'a> GlyphProvider<'a> {
 #[derive(Default)]
 struct BezPathPen(peniko::kurbo::BezPath);
 
-impl Pen for BezPathPen {
+impl OutlinePen for BezPathPen {
     fn move_to(&mut self, x: f32, y: f32) {
         self.0.move_to((x as f64, y as f64));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ pub use peniko;
 pub use peniko::kurbo;
 
 #[doc(hidden)]
-pub use fello;
+pub use skrifa;
 
 pub mod glyph;
 

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -14,9 +14,9 @@
 //
 // Also licensed under MIT license, at your choice.
 
-use fello::NormalizedCoord;
 use peniko::kurbo::{Affine, Rect, Shape, Stroke};
 use peniko::{BlendMode, BrushRef, Color, Fill, Font, Image, StyleRef};
+use skrifa::instance::NormalizedCoord;
 use vello_encoding::{Encoding, Glyph, GlyphRun, Patch, Transform};
 
 /// Encoded definition of a scene and associated resources.


### PR DESCRIPTION
This replaces our bespoke fello lib with skrifa from crates.io which brings us one step closer to being able to release.

Causes a slight regression since we no longer support hinting but that will be fixed when support lands upstream (soon!)