### PR TITLE
Unify encoding of Scene/SceneFragment

### DIFF
--- a/crates/encoding/src/encoding.rs
+++ b/crates/encoding/src/encoding.rs
@@ -65,7 +65,7 @@ impl Encoding {
     }
 
     /// Clears the encoding.
-    pub fn reset(&mut self, is_fragment: bool) {
+    pub fn reset(&mut self) {
         self.transforms.clear();
         self.path_tags.clear();
         self.path_data.clear();
@@ -79,10 +79,6 @@ impl Encoding {
         self.flags = 0;
         #[cfg(feature = "full")]
         self.resources.reset();
-        if !is_fragment {
-            self.transforms.push(Transform::IDENTITY);
-            self.styles.push(Style::from_fill(Fill::NonZero));
-        }
     }
 
     /// Appends another encoding to this one with an optional transform.

--- a/crates/encoding/src/encoding.rs
+++ b/crates/encoding/src/encoding.rs
@@ -16,6 +16,11 @@ use {
 };
 
 /// Encoded data streams for a scene.
+///
+/// # Invariants
+///
+/// * At least one transform and style must be encoded before any path data
+/// or draw object.
 #[derive(Clone, Default)]
 pub struct Encoding {
     /// The path tag stream.

--- a/crates/encoding/src/glyph_cache.rs
+++ b/crates/encoding/src/glyph_cache.rs
@@ -28,7 +28,7 @@ pub struct GlyphCache {
 
 impl GlyphCache {
     pub fn clear(&mut self) {
-        self.encoding.reset(true);
+        self.encoding.reset();
         self.glyphs.clear();
     }
 

--- a/shader/flatten.wgsl
+++ b/shader/flatten.wgsl
@@ -478,6 +478,8 @@ fn compute_tag_monoid(ix: u32) -> PathTagData {
     var tag_byte = (tag_word >> shift) & 0xffu;
     // We no longer encode an initial transform and style so these
     // are off by one.
+    // Note: an alternative would be to adjust config.transform_base and
+    // config.style_base.
     tm.trans_ix -= 1u;
     tm.style_ix -= STYLE_SIZE_IN_WORDS;
     return PathTagData(tag_byte, tm);

--- a/shader/flatten.wgsl
+++ b/shader/flatten.wgsl
@@ -476,6 +476,10 @@ fn compute_tag_monoid(ix: u32) -> PathTagData {
     // TODO: this can be a read buf overflow. Conditionalize by tag byte?
     tm = combine_tag_monoid(tag_monoids[ix >> 2u], tm);
     var tag_byte = (tag_word >> shift) & 0xffu;
+    // We no longer encode an initial transform and style so these
+    // are off by one.
+    tm.trans_ix -= 1u;
+    tm.style_ix -= STYLE_SIZE_IN_WORDS;
     return PathTagData(tag_byte, tm);
 }
 

--- a/src/cpu_shader/flatten.rs
+++ b/src/cpu_shader/flatten.rs
@@ -524,6 +524,10 @@ fn compute_tag_monoid(ix: usize, pathtags: &[u32], tag_monoids: &[PathMonoid]) -
     if tag_byte != 0 {
         tm = tag_monoids[ix >> 2].combine(&tm);
     }
+    // We no longer encode an initial transform and style so these
+    // are off by one.
+    tm.trans_ix -= 1;
+    tm.style_ix -= core::mem::size_of::<Style>() as u32 / 4;
     PathTagData {
         tag_byte,
         monoid: tm,

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -73,18 +73,18 @@ impl<'a> SceneBuilder<'a> {
     /// Creates a new builder for filling a scene. Any current content in the scene
     /// will be cleared.
     pub fn for_scene(scene: &'a mut Scene) -> Self {
-        Self::new(&mut scene.data, false)
+        Self::new(&mut scene.data)
     }
 
     /// Creates a new builder for filling a scene fragment. Any current content in
     /// the fragment will be cleared.    
     pub fn for_fragment(fragment: &'a mut SceneFragment) -> Self {
-        Self::new(&mut fragment.data, true)
+        Self::new(&mut fragment.data)
     }
 
     /// Creates a new builder for constructing a scene.
-    fn new(scene: &'a mut Encoding, is_fragment: bool) -> Self {
-        scene.reset(is_fragment);
+    fn new(scene: &'a mut Encoding) -> Self {
+        scene.reset();
         Self { scene }
     }
 


### PR DESCRIPTION
In a move toward dropping the SceneFragment and SceneBuilder types, this unifies the underlying encoding of Scene and SceneFragment. Specifically, we no longer encode an initial transform and style for Scene.

This causes the transform and style indices in the path tag monoid to be off by one. I chose the simple approach of subtracting 1 from each in the combine_tag_monoid() functions in both GPU and CPU code to correct this.

@raphlinus does this seem reasonable to you?