### PR TITLE
Update end of slice when appending with coords

### DIFF
--- a/crates/encoding/src/encoding.rs
+++ b/crates/encoding/src/encoding.rs
@@ -107,6 +107,7 @@ impl Encoding {
                     run.glyphs.start += glyphs_base;
                     run.glyphs.end += glyphs_base;
                     run.normalized_coords.start += coords_base;
+                    run.normalized_coords.end += coords_base;
                     run.stream_offsets.path_tags += offsets.path_tags;
                     run.stream_offsets.path_data += offsets.path_data;
                     run.stream_offsets.draw_tags += offsets.draw_tags;


### PR DESCRIPTION
When appending an encoding containing a glyph run with variation coordinates, the end of the range was not updated correctly.