### PR TITLE
Migrate to our Standard CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,23 @@
+env:
+  # We aim to always test with the latest stable Rust toolchain, however we pin to a specific
+  # version like 1.70. Note that we only specify MAJOR.MINOR and not PATCH so that bugfixes still
+  # come automatically. If the version specified here is no longer the latest stable version,
+  # then please feel free to submit a PR that adjusts it along with the potential clippy fixes.
+  RUST_STABLE_VER: "1.76" # In quotes because otherwise (e.g.) 1.70 would be interpreted as 1.7
+
+
+# Rationale
+#
+# We don't run clippy with --all-targets because then even --lib and --bins are compiled with
+# dev dependencies enabled, which does not match how they would be compiled by users.
+# A dev dependency might enable a feature of a regular dependency that we need, but testing
+# with --all-targets would not catch that. Thus we split --lib & --bins into a separate step.
+
+name: CI
+
 on:
-  push:
-    branches:
-      - main
   pull_request:
+  merge_group:
 
 jobs:
   rustfmt:
@@ -10,46 +25,93 @@ jobs:
     name: cargo fmt
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - run: cargo fmt --all --check
-  compiles:
-    runs-on: ubuntu-latest
-    name: Check workspace compile
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Install native dependencies
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
-      - run: cargo check --workspace
-      # Check vello (the default crate) without the features used by `with_winit` for debugging
-      - run: cargo check 
-      # Check vello (the default crate) without wgpu
-      - run: cargo check --no-default-features
-      # --exclude with_bevy # for when bevy has an outdated wgpu version
-      # -Dwarnings # for when we have fixed unused code warnings
 
-  clippy:
-    runs-on: ubuntu-latest
-    name: Enforce clippy lints
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Install native dependencies
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
-      - run: cargo clippy --all-targets --workspace -- -D warnings
-  
-  wasm:
-    runs-on: ubuntu-latest
-    name: Ensure with_winit compiles on WASM
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - name: install stable toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUST_STABLE_VER }}
+          components: rustfmt
+
+      - name: cargo fmt
+        run: cargo fmt --all --check
+
+  test-stable:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+    name: cargo clippy + test
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE_VER }}
+          components: clippy
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install native dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+
+      - name: cargo clippy (no default features)
+        run: cargo clippy --workspace --lib --bins --no-default-features -- -D warnings
+
+      - name: cargo clippy (no default features) (auxiliary)
+        run: cargo clippy --workspace --tests --benches --examples --no-default-features -- -D warnings
+
+      - name: cargo clippy (default features)
+        run: cargo clippy --workspace --lib --bins -- -D warnings
+
+      - name: cargo clippy (default features) (auxiliary)
+        run: cargo clippy --workspace --tests --benches --examples -- -D warnings
+
+      - name: cargo clippy (all features)
+        run: cargo clippy --workspace --lib --bins --all-features -- -D warnings
+
+      - name: cargo clippy (all features) (auxiliary)
+        run: cargo clippy --workspace --tests --benches --examples --all-features -- -D warnings
+
+      # At the time of writing, we don't have any tests. Nevertheless, it's better to still run this
+      - name: cargo test
+        run: cargo test --workspace --all-features
+  
+  clippy-stable-wasm:
+    runs-on: ubuntu-latest
+    name: cargo test (wasm32)
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE_VER }}
           targets: wasm32-unknown-unknown
-      # cargo-run-wasm does not provide a way to determine that it failed programmatically.
-      # Ideally, fix this and use:
-      # - run: cargo run_wasm -- -p with_winit --bin with_winit_bin --build-only
-      - name: Allow using WebGPU in web_sys
-        run: |
-          echo "RUSTFLAGS=--cfg=web_sys_unstable_apis" >> "$GITHUB_ENV"
-      - run: cargo check -p with_winit --target wasm32-unknown-unknown
+          components: clippy
+
+      - name: cargo clippy (wasm)
+        run: cargo clippy --all-targets --target wasm32-unknown-unknown -- -D warnings
+        env:
+          RUSTFLAGS: '--cfg=web_sys_unstable_apis'
+
+  docs:
+    name: cargo doc
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+
+      # We test documentation using nightly to match docs.rs. This prevents potential breakages
+      - name: cargo doc
+        run: cargo doc --workspace --all-features --no-deps --document-private-items -Zunstable-options -Zrustdoc-scrape-examples

--- a/crates/shaders/src/lib.rs
+++ b/crates/shaders/src/lib.rs
@@ -43,23 +43,23 @@ pub struct WgslSource<'a> {
     ///
     /// Example:
     /// --------
+    /// ```wgsl
+    /// // An unused binding (i.e. declaration is not reachable from the entry-point)
+    /// @group(0) @binding(0) var<uniform> foo: Foo;
     ///
-    ///   // An unused binding (i.e. declaration is not reachable from the entry-point)
-    ///   @group(0) @binding(0) var<uniform> foo: Foo;
-    ///
-    ///   // Used bindings:
-    ///   @group(0) @binding(1) var<storage> buffer: Buffer;
-    ///   @group(0) @binding(2) var tex: texture_2d<f32>;
-    ///   ...
-    ///
+    /// // Used bindings:
+    /// @group(0) @binding(1) var<storage> buffer: Buffer;
+    /// @group(0) @binding(2) var tex: texture_2d<f32>;
+    /// ```
     /// This results in the following bindings:
-    ///
+    /// ```rust,ignore
     ///   bindings: [BindType::Buffer, BindType::ImageRead],
-    ///   ...
+    ///   // ...
     ///   wgsl: WgslSource {
-    ///       code: ...,
+    ///       code: /* ... */,
     ///       binding_indices: [1, 2],
     ///   },
+    /// ```
     pub binding_indices: Cow<'a, [u8]>,
 }
 
@@ -68,31 +68,31 @@ pub struct WgslSource<'a> {
 pub struct MslSource<'a> {
     pub code: Cow<'a, str>,
 
-    /// Contains the binding index of each resource listed in `ComputeShader::bindings`.
+    /// Contains the binding index of each resource listed in [`ComputeShader::bindings`].
     /// This is guaranteed to have the same element count as `ComputeShader::bindings`.
     ///
     /// In MSL, each index is scoped to the index range of the corresponding resource type.
     ///
     /// Example:
     /// --------
+    /// ```wgsl
+    /// // An unused binding (i.e. declaration is not reachable from the entry-point)
+    /// @group(0) @binding(0) var<uniform> foo: Foo;
     ///
-    ///   // An unused binding (i.e. declaration is not reachable from the entry-point)
-    ///   @group(0) @binding(0) var<uniform> foo: Foo;
-    ///
-    ///   // Used bindings:
-    ///   @group(0) @binding(1) var<storage> buffer: Buffer;
-    ///   @group(0) @binding(2) var tex: texture_2d<f32>;
-    ///   ...
-    ///
+    /// // Used bindings:
+    /// @group(0) @binding(1) var<storage> buffer: Buffer;
+    /// @group(0) @binding(2) var tex: texture_2d<f32>;
+    /// ```
     /// This results in the following bindings:
-    ///
+    /// ```rust,ignore
     ///   bindings: [BindType::Buffer, BindType::ImageRead],
-    ///   ...
+    ///   // ...
     ///   msl: MslSource {
-    ///       code: ...,
+    ///       code: /* ... */,
     ///       // In MSL these would be declared as `[[buffer(0)]]` and `[[texture(0)]]`.
     ///       binding_indices: [msl::BindingIndex::Buffer(0), msl::BindingIndex::Texture(0)],
     ///   },
+    /// ```
     pub binding_indices: Cow<'a, [msl::BindingIndex]>,
 }
 

--- a/crates/shaders/src/types.rs
+++ b/crates/shaders/src/types.rs
@@ -20,6 +20,10 @@ pub enum BindType {
 }
 
 impl BindType {
+    // TODO: This is a public method, which means it definitely is not
+    // "dead code". However, rustc seems insitent that it is, and so to not
+    // block forward progress, I shall humour it
+    #[allow(dead_code)]
     pub fn is_mutable(self) -> bool {
         matches!(self, Self::Buffer | Self::Image)
     }

--- a/examples/headless/src/main.rs
+++ b/examples/headless/src/main.rs
@@ -89,7 +89,7 @@ async fn render(mut scenes: SceneSet, index: usize, args: &Args) -> Result<()> {
         device,
         RendererOptions {
             surface_format: None,
-            use_cpu: false,
+            use_cpu: args.use_cpu,
             antialiasing_support: vello::AaSupport::area_only(),
         },
     )
@@ -244,6 +244,9 @@ struct Args {
     #[arg(long, short, global(false))]
     /// Display a list of all scene names
     print_scenes: bool,
+    #[arg(long)]
+    /// Whether to use CPU shaders
+    use_cpu: bool,
     #[command(flatten)]
     args: scenes::Arguments,
 }

--- a/examples/scenes/src/mmark.rs
+++ b/examples/scenes/src/mmark.rs
@@ -1,7 +1,7 @@
 //! A benchmark based on MotionMark 1.2's path benchmark.
 //! This is roughly comparable to:
 //!
-//! https://browserbench.org/MotionMark1.2/developer.html?warmup-length=2000&warmup-frame-count=30&first-frame-minimum-length=0&test-interval=15&display=minimal&tiles=big&controller=adaptive&frame-rate=50&time-measurement=performance&suite-name=MotionMark&test-name=Paths&complexity=1
+//! <https://browserbench.org/MotionMark1.2/developer.html?warmup-length=2000&warmup-frame-count=30&first-frame-minimum-length=0&test-interval=15&display=minimal&tiles=big&controller=adaptive&frame-rate=50&time-measurement=performance&suite-name=MotionMark&test-name=Paths&complexity=1>
 //!
 //! However, at this point it cannot be directly compared, as we don't accurately
 //! implement the stroke style parameters, and it has not been carefully validated.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,7 @@ impl AaSupport {
 /// Renders a scene into a texture or surface.
 #[cfg(feature = "wgpu")]
 pub struct Renderer {
+    #[cfg_attr(not(feature = "hot_reload"), allow(dead_code))]
     options: RendererOptions,
     engine: WgpuEngine,
     shaders: FullShaders,


### PR DESCRIPTION
See also linebender/peniko#21
I haven't added an MSRV yet, as we're not at that stage

This also lets the headless example use the `--use-cpu` flag. This isn't currently used in CI - I'm planning to make a `tests` crate/PR instead