### PR TITLE
Configure command line arguments in Android and WASM

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,22 @@
   },
   "wgsl-analyzer.diagnostics.nagaVersion": "main",
   "wgsl-analyzer.preprocessor.shaderDefs": [
-    "full", "msaa16", "msaa"
-  ]
+    "full",
+    "msaa16",
+    "msaa"
+  ],
+  // These settings can be set to get Rust-analyzer working for Android compilation
+  // (unfortunately you need to do the variable expansion manually, because 
+  // rust-analyzer doesn't do this for us)
+  // "rust-analyzer.cargo.target": "aarch64-linux-android",
+  // "rust-analyzer.cargo.extraEnv": {
+  //   "CC_aarch64-linux-android": "${env:ANDROID_SDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android23-clang",
+  //   "CFLAGS_aarch64-linux-android": "--target=aarch64-linux-android23",
+  //   "CXX_aarch64-linux-android": "${env:ANDROID_SDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android23-clang",
+  //   "CXXFLAGS_aarch64-linux-android": "--target=aarch64-linux-android23",
+  //   "CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER": "${env:ANDROID_SDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android23-clang",
+  //   "RUSTFLAGS": "-Clink-arg=${env:ANDROID_SDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android23-clang -L --target=${workspaceFolder}/target/cargo-apk-temp-extra-link-libraries",
+  //   "AR_aarch64-linux-android": "${env:ANDROID_SDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar",
+  //   "CARGO_TARGET_AARCH64_LINUX_ANDROID_AR": "${env:ANDROID_SDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar",
+  // }
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ bytemuck = { workspace = true }
 skrifa = { workspace = true }
 peniko = { workspace = true }
 wgpu = { workspace = true, optional = true }
+log = { workspace = true }
 raw-window-handle = { workspace = true }
 futures-intrusive = { workspace = true }
 wgpu-profiler = { workspace = true, optional = true }
@@ -66,7 +67,7 @@ raw-window-handle = "0.6.0"
 
 # NOTE: Make sure to keep this in sync with the version badge in README.md
 wgpu = { version = "0.19.3" }
-
+log = "0.4.20"
 
 # Used for examples
 clap = "4.5.1"

--- a/README.md
+++ b/README.md
@@ -217,6 +217,18 @@ path = "$HOME/.android/debug.keystore"
 keystore_password = "android"
 ```
 
+> [!NOTE]  
+> As `cargo apk` does not allow passing command line arguments or environment variables to the app when ran, these can be embedded into the 
+> program at compile time (currently for Android only)
+> `with_winit` currently supports the environment variables:
+>  - `VELLO_STATIC_LOG`, which is equivalent to `RUST_LOG`
+>  - `VELLO_STATIC_ARGS`, which is equivalent to passing in command line arguments
+
+For example (with unix shell environment variable syntax):
+```sh
+VELLO_STATIC_LOG="vello=trace" VELLO_STATIC_ARGS="--test-scenes" cargo apk run -p with_winit --lib
+```
+
 ## Community
 
 Discussion of Vello development happens in the [Xi Zulip](https://xi.zulipchat.com/), specifically the [#gpu stream](https://xi.zulipchat.com/#narrow/stream/197075-gpu). All public content can be read without logging in.

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -38,7 +38,6 @@ notify-debouncer-mini = "0.3"
 [target.'cfg(target_os = "android")'.dependencies]
 winit = { version = "0.29.12", features = ["android-native-activity"] }
 android_logger = "0.13.3"
-jni = "0.21"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.7"

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -28,7 +28,7 @@ wgpu-profiler = { workspace = true }
 wgpu = { workspace = true }
 winit = "0.29.12"
 env_logger = "0.11.2"
-log = "0.4.21"
+log = { workspace = true }
 
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]
 vello = { path = "../../", features = ["hot_reload"] }
@@ -38,10 +38,11 @@ notify-debouncer-mini = "0.3"
 [target.'cfg(target_os = "android")'.dependencies]
 winit = { version = "0.29.12", features = ["android-native-activity"] }
 android_logger = "0.13.3"
+jni = "0.21"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"
 wasm-bindgen-futures = "0.4.41"
-web-sys = { version = "0.3.67", features = [ "HtmlCollection", "Text" ] }
+web-sys = { version = "0.3.67", features = ["HtmlCollection", "Text"] }
 getrandom = { version = "0.2.12", features = ["js"] }

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -27,8 +27,11 @@ wgpu-profiler = { workspace = true }
 
 wgpu = { workspace = true }
 winit = "0.29.12"
-env_logger = "0.11.2"
 log = { workspace = true }
+
+[target.'cfg(not(target_os = "android"))'.dependencies]
+# We use android_logger on Android
+env_logger = "0.11.2"
 
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]
 vello = { path = "../../", features = ["hot_reload"] }

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -727,7 +727,7 @@ fn android_main(app: AndroidApp) {
     let config = android_logger::Config::default();
     // We allow configuring the Android logging with an environment variable at build time
     let config = if let Some(logging_config) = option_env!("VELLO_STATIC_LOG") {
-        let mut filter = env_logger::filter::Builder::new();
+        let mut filter = android_logger::FilterBuilder::new();
         filter.filter_level(log::LevelFilter::Warn);
         filter.parse(logging_config);
         let filter = filter.build();

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -6,7 +6,6 @@ use std::num::NonZeroUsize;
 use std::{collections::HashSet, sync::Arc};
 use wgpu_profiler::GpuProfilerSettings;
 
-use anyhow::Result;
 use clap::{CommandFactory, Parser};
 use scenes::{ImageCache, SceneParams, SceneSet, SimpleText};
 use vello::peniko::Color;
@@ -88,6 +87,15 @@ fn run(
     #[cfg(not(target_arch = "wasm32"))]
     let mut render_state = None::<RenderState>;
     let use_cpu = args.use_cpu;
+    // The available kinds of anti-aliasing
+    #[cfg(not(target_os = "android"))]
+    // TODO: Make this set configurable through the command line
+    // Alternatively, load anti-aliasing shaders on demand/asynchronously
+    let aa_configs = [AaConfig::Area, AaConfig::Msaa8, AaConfig::Msaa16];
+    #[cfg(target_os = "android")]
+    // Hard code to only one on Android whilst we are working on startup speed
+    let aa_configs = [AaConfig::Area];
+
     // The design of `RenderContext` forces delayed renderer initialisation to
     // not work on wasm, as WASM futures effectively must be 'static.
     // Otherwise, this could work by sending the result to event_loop.proxy
@@ -101,7 +109,7 @@ fn run(
             RendererOptions {
                 surface_format: Some(render_state.surface.format),
                 use_cpu,
-                antialiasing_support: vello::AaSupport::all(),
+                antialiasing_support: aa_configs.iter().copied().collect(),
                 // We currently initialise on one thread on WASM, but mark this here
                 // anyway
                 num_init_threads: NonZeroUsize::new(1),
@@ -137,7 +145,6 @@ fn run(
     let mut vsync_on = !args.startup_vsync_off;
     let mut gpu_profiling_on = args.startup_gpu_profiling_on;
 
-    const AA_CONFIGS: [AaConfig; 3] = [AaConfig::Area, AaConfig::Msaa8, AaConfig::Msaa16];
     // We allow cycling through AA configs in either direction, so use a signed index
     let mut aa_config_ix: i32 = 0;
 
@@ -242,7 +249,7 @@ fn run(
                                                                 println!("Wrote trace to path {path:?}");
                                                             }
                                                             Err(e) => {
-                                                                eprintln!("Failed to write trace {e}")
+                                                                log::warn!("Failed to write trace {e}")
                                                             }
                                                         }
                                                     }
@@ -350,7 +357,7 @@ fn run(
                                 * Affine::translate(-prior_position)
                                 * transform;
                         } else {
-                            eprintln!(
+                            log::warn!(
                                 "Scrolling without mouse in window; this shouldn't be possible"
                             );
                         }
@@ -375,7 +382,7 @@ fn run(
 
                         // Allow looping forever
                         scene_ix = scene_ix.rem_euclid(scenes.scenes.len() as i32);
-                        aa_config_ix = aa_config_ix.rem_euclid(AA_CONFIGS.len() as i32);
+                        aa_config_ix = aa_config_ix.rem_euclid(aa_configs.len() as i32);
 
                         let example_scene = &mut scenes.scenes[scene_ix as usize];
                         if prev_scene_ix != scene_ix {
@@ -406,7 +413,7 @@ fn run(
                             .base_color
                             .or(scene_params.base_color)
                             .unwrap_or(Color::BLACK);
-                        let antialiasing_method = AA_CONFIGS[aa_config_ix as usize];
+                        let antialiasing_method = aa_configs[aa_config_ix as usize];
                         let render_params = vello::RenderParams {
                             base_color,
                             width,
@@ -528,7 +535,7 @@ fn run(
                         return;
                     };
                     let device_handle = &render_cx.devices[render_state.surface.dev_id];
-                    eprintln!("==============\nReloading shaders");
+                    log::info!("==============\nReloading shaders");
                     let start = Instant::now();
                     let result = renderers[render_state.surface.dev_id]
                         .as_mut()
@@ -536,13 +543,13 @@ fn run(
                         .reload_shaders(&device_handle.device);
                     // We know that the only async here (`pop_error_scope`) is actually sync, so blocking is fine
                     match pollster::block_on(result) {
-                        Ok(_) => eprintln!("Reloading took {:?}", start.elapsed()),
-                        Err(e) => eprintln!("Failed to reload shaders because of {e}"),
+                        Ok(_) => log::info!("Reloading took {:?}", start.elapsed()),
+                        Err(e) => log::warn!("Failed to reload shaders because of {e}"),
                     }
                 }
             },
             Event::Suspended => {
-                eprintln!("Suspending");
+                log::info!("Suspending");
                 #[cfg(not(target_arch = "wasm32"))]
                 // When we suspend, we need to remove the `wgpu` Surface
                 if let Some(render_state) = render_state.take() {
@@ -576,12 +583,12 @@ fn run(
                                 RendererOptions {
                                     surface_format: Some(render_state.surface.format),
                                     use_cpu,
-                                    antialiasing_support: vello::AaSupport::all(),
+                                    antialiasing_support: aa_configs.iter().copied().collect(),
                                     num_init_threads: NonZeroUsize::new(args.num_init_threads)
                                 },
                             )
                             .expect("Could create renderer");
-                            eprintln!("Creating renderer {id} took {:?}", start.elapsed());
+                            log::info!("Creating renderer {id} took {:?}", start.elapsed());
                             renderer.profiler.change_settings(GpuProfilerSettings{
                                 enable_timer_queries: gpu_profiling_on,
                                 enable_debug_groups: gpu_profiling_on,
@@ -638,11 +645,14 @@ fn display_error_message() -> Option<()> {
     Some(())
 }
 
-pub fn main() -> Result<()> {
+#[cfg(not(target_os = "android"))]
+pub fn main() -> anyhow::Result<()> {
     // TODO: initializing both env_logger and console_logger fails on wasm.
     // Figure out a more principled approach.
     #[cfg(not(target_arch = "wasm32"))]
-    env_logger::init();
+    env_logger::builder()
+        .format_timestamp(Some(env_logger::TimestampPrecision::Millis))
+        .init();
     let args = Args::parse();
     let scenes = args.args.select_scene_set(Args::command)?;
     if let Some(scenes) = scenes {
@@ -651,9 +661,7 @@ pub fn main() -> Result<()> {
         let mut render_cx = RenderContext::new().unwrap();
         #[cfg(not(target_arch = "wasm32"))]
         {
-            #[cfg(not(target_os = "android"))]
             let proxy = event_loop.create_proxy();
-            #[cfg(not(target_os = "android"))]
             let _keep = hot_reload::hot_reload(move || {
                 proxy.send_event(UserEvent::HotReload).ok().map(drop)
             });
@@ -716,16 +724,36 @@ use winit::platform::android::activity::AndroidApp;
 #[no_mangle]
 fn android_main(app: AndroidApp) {
     use winit::platform::android::EventLoopBuilderExtAndroid;
-
-    android_logger::init_once(
-        android_logger::Config::default().with_max_level(log::LevelFilter::Warn),
-    );
-
+    let config = android_logger::Config::default();
+    // We allow configuring the Android logging with an environment variable at build time
+    let config = if let Some(logging_config) = option_env!("VELLO_STATIC_LOG") {
+        let mut filter = env_logger::filter::Builder::new();
+        filter.filter_level(log::LevelFilter::Warn);
+        filter.parse(logging_config);
+        let filter = filter.build();
+        // This shouldn't be needed in theory, but without this the max
+        // level is set to 0 (i.e. Off)
+        let config = config.with_max_level(filter.filter());
+        config.with_filter(filter)
+    } else {
+        config.with_max_level(log::LevelFilter::Warn)
+    };
+    android_logger::init_once(config);
+    let cache_dir = get_cache_directory(&app)
+        .inspect(|path| log::info!("Got cache directory {path:?}"))
+        .inspect_err(|e| log::warn!("Failed to get cache directory: {e}"))
+        .ok();
+    let _ = cache_dir;
     let event_loop = EventLoopBuilder::with_user_event()
         .with_android_app(app)
         .build()
         .expect("Required to continue");
-    let args = Args::parse();
+    let args = if let Some(args) = option_env!("VELLO_STATIC_ARGS") {
+        // We split by whitespace here to allow
+        Args::parse_from(args.split_ascii_whitespace())
+    } else {
+        Args::parse()
+    };
     let scenes = args
         .args
         .select_scene_set(|| Args::command())
@@ -734,4 +762,30 @@ fn android_main(app: AndroidApp) {
     let render_cx = RenderContext::new().unwrap();
 
     run(event_loop, args, scenes, render_cx);
+}
+
+#[cfg(target_os = "android")]
+fn get_cache_directory(app: &AndroidApp) -> anyhow::Result<std::path::PathBuf> {
+    use std::path::PathBuf;
+
+    use anyhow::Context;
+
+    let app_jobject = unsafe { jni::objects::JObject::from_raw(app.activity_as_ptr().cast()) };
+    // If we got a null VM, we can't pass up
+    let jvm = unsafe { jni::JavaVM::from_raw(app.vm_as_ptr().cast()).context("Making VM")? };
+    let mut env = jvm.attach_current_thread().context("Attaching to thread")?;
+    let res = env
+        .call_method(app_jobject, "getCacheDir", "()Ljava/io/File;", &[])
+        .context("Calling GetCacheDir")?;
+    let file = res.l().context("Converting to JObject")?;
+    let directory_path = env
+        .call_method(file, "getAbsolutePath", "()Ljava/lang/String;", &[])
+        .context("Calling `getAbsolutePath`")?;
+    let string = directory_path.l().context("Converting to a string")?.into();
+    let string = env
+        .get_string(&string)
+        .context("Converting into a Rust string")?;
+    let string: String = string.into();
+    // TODO: Also get the quota. This appears to be more involved, requiring a worker thread and being asynchronous
+    Ok(PathBuf::from(string).join("vello"))
 }

--- a/examples/with_winit/src/main.rs
+++ b/examples/with_winit/src/main.rs
@@ -4,5 +4,10 @@
 use anyhow::Result;
 
 fn main() -> Result<()> {
-    with_winit::main()
+    #[cfg(not(target_os = "android"))]
+    {
+        with_winit::main()
+    }
+    #[cfg(target_os = "android")]
+    unreachable!()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,24 @@ impl AaSupport {
     }
 }
 
+impl FromIterator<AaConfig> for AaSupport {
+    fn from_iter<T: IntoIterator<Item = AaConfig>>(iter: T) -> Self {
+        let mut result = Self {
+            area: false,
+            msaa8: false,
+            msaa16: false,
+        };
+        for config in iter {
+            match config {
+                AaConfig::Area => result.area = true,
+                AaConfig::Msaa8 => result.msaa8 = true,
+                AaConfig::Msaa16 => result.msaa16 = true,
+            }
+        }
+        result
+    }
+}
+
 /// Renders a scene into a texture or surface.
 #[cfg(feature = "wgpu")]
 pub struct Renderer {

--- a/src/shaders.rs
+++ b/src/shaders.rs
@@ -80,8 +80,6 @@ pub fn full_shaders(
     engine: &mut WgpuEngine,
     options: &RendererOptions,
 ) -> Result<FullShaders, Error> {
-    use std::time::Instant;
-
     use crate::wgpu_engine::CpuShaderType;
     use BindType::*;
     let imports = SHARED_SHADERS
@@ -98,7 +96,6 @@ pub fn full_shaders(
     let mut force_gpu = false;
 
     let force_gpu_from: Option<&str> = None;
-    let mut previous_done = Instant::now();
 
     // Uncomment this to force use of GPU shaders from the specified shader and later even
     // if `engine.use_cpu` is specified.
@@ -111,13 +108,7 @@ pub fn full_shaders(
             }
             let processed =
                 preprocess::preprocess(shader!(stringify!($name)), &$defines, &imports).into();
-            // Preprocessing is very quick, so we don't need to take this time into account
-            // log::debug!(
-            //     "Pre-processing {} took {:?}",
-            //     $label,
-            //     previous_done.elapsed()
-            // );
-            let shader = engine.add_shader(
+            engine.add_shader(
                 device,
                 $label,
                 processed,
@@ -127,15 +118,7 @@ pub fn full_shaders(
                 } else {
                     $cpu
                 },
-            )?;
-            let now = Instant::now();
-            log::trace!(
-                "Processing and compiling {} took {:?}",
-                $label,
-                now - previous_done
-            );
-            previous_done = now;
-            shader
+            )?
         }};
         ($name:ident, $bindings:expr, $defines:expr, $cpu:expr) => {{
             add_shader!($name, stringify!($name), $bindings, &$defines, $cpu)

--- a/src/wgpu_engine.rs
+++ b/src/wgpu_engine.rs
@@ -5,6 +5,7 @@ use std::{
     borrow::Cow,
     cell::RefCell,
     collections::{hash_map::Entry, HashMap, HashSet},
+    time::Instant,
 };
 
 use wgpu::{
@@ -263,7 +264,10 @@ impl WgpuEngine {
                 CpuShaderType::Missing => {}
             }
         }
-
+        let shader_module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some(label),
+            source: wgpu::ShaderSource::Wgsl(wgsl),
+        });
         let entries = layout
             .iter()
             .enumerate()

--- a/src/wgpu_engine.rs
+++ b/src/wgpu_engine.rs
@@ -5,7 +5,6 @@ use std::{
     borrow::Cow,
     cell::RefCell,
     collections::{hash_map::Entry, HashMap, HashSet},
-    time::Instant,
 };
 
 use wgpu::{
@@ -264,10 +263,7 @@ impl WgpuEngine {
                 CpuShaderType::Missing => {}
             }
         }
-        let shader_module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some(label),
-            source: wgpu::ShaderSource::Wgsl(wgsl),
-        });
+
         let entries = layout
             .iter()
             .enumerate()


### PR DESCRIPTION
Primarily, the two new environment variables are very useful:
1) `VELLO_STATIC_LOG` allows configuring logging for Android (equivalent to `RUST_LOG`, but at compile time)
2) `VELLO_STATIC_ARGS` allows configuring the command line arguments

For example,
```sh
VELLO_STATIC_LOG="with_winit=debug,vello::wgpu_engine=debug" VELLO_STATIC_ARGS="--test-scenes --scene 2 --use-cpu" cargo apk run -p with_winit --lib --release
```
would have debug level logging in `with_winit` and the `wgpu_engine` module, and start at the third test scene, using the CPU shaders