### PR TITLE
Run the smoke tests on macOS arm runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,12 +39,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        # We use macos-14 as that is an arm runner. These have the virtgpu support we need
+        os: [windows-latest, macos-14, ubuntu-latest]
         include:
           - os: ubuntu-latest
             gpu: 'yes'
-          - os: macos-latest
-            gpu: 'no'
+          - os: macos-14
+            gpu: 'yes'
           - os: windows-latest
             # TODO: The windows runners theoretically have CPU fallback for GPUs, but
             # this failed in initial testing

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 
     "examples/headless",
     "examples/with_winit",
-    "examples/with_bevy",  # Disable for now until bevy is using wpgu 0.19
+    "examples/with_bevy",
     "examples/run_wasm",
     "examples/scenes",
 ]


### PR DESCRIPTION
https://developer.apple.com/documentation/paravirtualizedgraphics?language=objc might work here

This would be running actual Metal on actual GPUs, which is exciting

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories - these are included runners, as far as I can see.
I don't know whether we can accidentally use a chargeable runner - I hope not, but I'm not sure how to confirm that

I've also removed an outdated comment, as it's no longer useful