### PR TITLE
Allow initialising shaders in parallel

### DIFF
--- a/crates/tests/src/lib.rs
+++ b/crates/tests/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{env, fs::File, path::Path, sync::Arc};
+use std::{env, fs::File, num::NonZeroUsize, path::Path, sync::Arc};
 
 use anyhow::{anyhow, bail, Result};
 use vello::{
@@ -62,7 +62,7 @@ pub async fn render(scene: Scene, params: &TestParams) -> Result<Image> {
         RendererOptions {
             surface_format: None,
             use_cpu: params.use_cpu,
-            initialise_in_parallel: false,
+            num_init_threads: NonZeroUsize::new(1),
             antialiasing_support: vello::AaSupport::area_only(),
         },
     )

--- a/crates/tests/src/lib.rs
+++ b/crates/tests/src/lib.rs
@@ -62,6 +62,7 @@ pub async fn render(scene: Scene, params: &TestParams) -> Result<Image> {
         RendererOptions {
             surface_format: None,
             use_cpu: params.use_cpu,
+            initialise_in_parallel: false,
             antialiasing_support: vello::AaSupport::area_only(),
         },
     )

--- a/examples/headless/src/main.rs
+++ b/examples/headless/src/main.rs
@@ -1,5 +1,6 @@
 use std::{
     fs::File,
+    num::NonZeroUsize,
     path::{Path, PathBuf},
 };
 
@@ -90,7 +91,7 @@ async fn render(mut scenes: SceneSet, index: usize, args: &Args) -> Result<()> {
         RendererOptions {
             surface_format: None,
             use_cpu: args.use_cpu,
-            initialise_in_parallel: false,
+            num_init_threads: NonZeroUsize::new(1),
             antialiasing_support: vello::AaSupport::area_only(),
         },
     )

--- a/examples/headless/src/main.rs
+++ b/examples/headless/src/main.rs
@@ -90,6 +90,7 @@ async fn render(mut scenes: SceneSet, index: usize, args: &Args) -> Result<()> {
         RendererOptions {
             surface_format: None,
             use_cpu: args.use_cpu,
+            initialise_in_parallel: false,
             antialiasing_support: vello::AaSupport::area_only(),
         },
     )

--- a/examples/scenes/src/svg.rs
+++ b/examples/scenes/src/svg.rs
@@ -76,7 +76,8 @@ fn example_scene_of(file: PathBuf) -> ExampleScene {
         .unwrap_or_else(|| "unknown".to_string());
     ExampleScene {
         function: Box::new(svg_function_of(name.clone(), move || {
-            std::fs::read_to_string(file).expect("failed to read svg file")
+            std::fs::read_to_string(&file)
+                .unwrap_or_else(|e| panic!("failed to read svg file {file:?}: {e}"))
         })),
         config: crate::SceneConfig {
             animated: false,

--- a/examples/with_bevy/src/main.rs
+++ b/examples/with_bevy/src/main.rs
@@ -29,6 +29,7 @@ impl FromWorld for VelloRenderer {
                 device.wgpu_device(),
                 RendererOptions {
                     surface_format: None,
+                    initialise_in_parallel: false,
                     antialiasing_support: vello::AaSupport::area_only(),
                     use_cpu: false,
                 },

--- a/examples/with_bevy/src/main.rs
+++ b/examples/with_bevy/src/main.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroUsize;
+
 use bevy::render::{Render, RenderSet};
 use bevy::utils::synccell::SyncCell;
 use vello::kurbo::{Affine, Point, Rect, Stroke};
@@ -29,7 +31,8 @@ impl FromWorld for VelloRenderer {
                 device.wgpu_device(),
                 RendererOptions {
                     surface_format: None,
-                    initialise_in_parallel: false,
+                    // TODO: We should ideally use the Bevy threadpool here
+                    num_init_threads: NonZeroUsize::new(1),
                     antialiasing_support: vello::AaSupport::area_only(),
                     use_cpu: false,
                 },

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -545,7 +545,8 @@ fn run(
                                     // We exclude macOS because it (supposedly) makes pipeline compilation slower
                                     // see https://github.com/bevyengine/bevy/pull/10812#discussion_r1496138004
                                     // In theory, we should only exclude metal adapters, but the difference is very minor
-                                    initialise_in_parallel: args.serial_initialisation && cfg!(all(not(target_arch="wasm32"), not(target_os="mac")))
+                                    // wasm isn't supported
+                                    initialise_in_parallel: args.serial_initialisation && cfg!(not(target_os="mac"))
                                 },
                             )
                             .expect("Could create renderer")

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -53,7 +53,7 @@ struct Args {
     use_cpu: bool,
     /// Whether to force initialising the shaders serially (rather than spawning threads)
     /// This has no effect on wasm, and on macOS for performance reasons
-    #[arg(long, action = clap::ArgAction::SetFalse)]
+    #[arg(long)]
     serial_initialisation: bool,
 }
 
@@ -546,7 +546,7 @@ fn run(
                                     // see https://github.com/bevyengine/bevy/pull/10812#discussion_r1496138004
                                     // In theory, we should only exclude metal adapters, but the difference is very minor
                                     // wasm isn't supported
-                                    initialise_in_parallel: args.serial_initialisation && cfg!(not(target_os="mac"))
+                                    initialise_in_parallel: !args.serial_initialisation && cfg!(not(target_os="mac"))
                                 },
                             )
                             .expect("Could create renderer")

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -538,6 +538,7 @@ fn run(
                                     surface_format: Some(render_state.surface.format),
                                     use_cpu,
                                     antialiasing_support: vello::AaSupport::all(),
+                                    initialise_in_parallel: cfg!(all(not(target_arch="wasm32"), not(target_os="mac")))
                                 },
                             )
                             .expect("Could create renderer")

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -542,8 +542,9 @@ fn run(
                                     surface_format: Some(render_state.surface.format),
                                     use_cpu,
                                     antialiasing_support: vello::AaSupport::all(),
-                                    // We exclude macOS because it (supposedly) makes compilation slower
+                                    // We exclude macOS because it (supposedly) makes pipeline compilation slower
                                     // see https://github.com/bevyengine/bevy/pull/10812#discussion_r1496138004
+                                    // In theory, we should only exclude metal adapters, but the difference is very minor
                                     initialise_in_parallel: args.serial_initialisation && cfg!(all(not(target_arch="wasm32"), not(target_os="mac")))
                                 },
                             )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,6 +144,8 @@ pub struct RendererOptions {
     pub antialiasing_support: AaSupport,
 
     /// Whether to initialise shaders in parallel
+    ///
+    /// Has no effect on WebAssembly
     pub initialise_in_parallel: bool,
 }
 
@@ -153,10 +155,12 @@ impl Renderer {
     pub fn new(device: &Device, options: RendererOptions) -> Result<Self> {
         let mut engine = WgpuEngine::new(options.use_cpu);
         if options.initialise_in_parallel {
+            #[cfg(not(target_arch = "wasm32"))]
             engine.use_parallel_initialisation();
         }
         let start = Instant::now();
         let shaders = shaders::full_shaders(device, &mut engine, &options)?;
+        #[cfg(not(target_arch = "wasm32"))]
         engine.build_shaders_if_needed(device);
         eprintln!("Building shaders took {:?}", start.elapsed());
         let blit = options

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,8 @@ mod shaders;
 #[cfg(feature = "wgpu")]
 mod wgpu_engine;
 
+use std::time::Instant;
+
 /// Styling and composition primitives.
 pub use peniko;
 /// 2D geometry, with a focus on curves.
@@ -140,6 +142,9 @@ pub struct RendererOptions {
     /// Represents the enabled set of AA configurations. This will be used to determine which
     /// pipeline permutations should be compiled at startup.
     pub antialiasing_support: AaSupport,
+
+    /// Whether to initialise shaders in parallel
+    pub initialise_in_parallel: bool,
 }
 
 #[cfg(feature = "wgpu")]
@@ -147,7 +152,13 @@ impl Renderer {
     /// Creates a new renderer for the specified device.
     pub fn new(device: &Device, options: RendererOptions) -> Result<Self> {
         let mut engine = WgpuEngine::new(options.use_cpu);
+        if options.initialise_in_parallel {
+            engine.use_parallel_initialisation();
+        }
+        let start = Instant::now();
         let shaders = shaders::full_shaders(device, &mut engine, &options)?;
+        engine.build_shaders_if_needed(device);
+        eprintln!("Building shaders took {:?}", start.elapsed());
         let blit = options
             .surface_format
             .map(|surface_format| BlitPipeline::new(device, surface_format));
@@ -272,6 +283,7 @@ impl Renderer {
     pub async fn reload_shaders(&mut self, device: &Device) -> Result<()> {
         device.push_error_scope(wgpu::ErrorFilter::Validation);
         let mut engine = WgpuEngine::new(self.options.use_cpu);
+        // We choose not to initialise these shaders in parallel, to ensure the error scope works correctly
         let shaders = shaders::full_shaders(device, &mut engine, &self.options)?;
         let error = device.pop_error_scope().await;
         if let Some(error) = error {

--- a/src/wgpu_engine.rs
+++ b/src/wgpu_engine.rs
@@ -151,15 +151,24 @@ impl WgpuEngine {
 
     #[cfg(not(target_arch = "wasm32"))]
     /// Initialise (in parallel) any shaders which are yet to be created
-    pub fn build_shaders_if_needed(&mut self, device: &Device) {
+    pub fn build_shaders_if_needed(
+        &mut self,
+        device: &Device,
+        num_threads: Option<std::num::NonZeroUsize>,
+    ) {
+        use std::num::NonZeroUsize;
+
         if let Some(mut new_shaders) = self.shaders_to_initialise.take() {
-            // Try and not to use all threads
-            // (This choice is arbitrary, and could be tuned, although a 'proper' work stealing system should be used instead)
-            let threads_to_use =
-                std::thread::available_parallelism().map_or(2, |it| it.get().max(4) - 2);
-            eprintln!("Initialising in parallel using {threads_to_use} threads");
-            let remainder =
-                new_shaders.split_off(new_shaders.len().max(threads_to_use) - threads_to_use);
+            let num_threads = num_threads.map(NonZeroUsize::get).unwrap_or_else(|| {
+                // Fallback onto a heuristic. This tries to not to use all threads.
+                // We keep the main thread blocked and not doing much whilst this is running,
+                // so we broadly leave two cores unused at the point of maximum parallelism
+                // (This choice is arbitrary, and could be tuned, although a 'proper' threadpool
+                // should probably be used instead)
+                std::thread::available_parallelism().map_or(2, |it| it.get().max(4) - 2)
+            });
+            eprintln!("Initialising in parallel using {num_threads} threads");
+            let remainder = new_shaders.split_off(new_shaders.len().max(num_threads) - num_threads);
             let (tx, rx) = std::sync::mpsc::channel::<(ShaderId, WgpuShader)>();
 
             // We expect each initialisation to take much longer than acquiring a lock, so we just use a mutex for our work queue


### PR DESCRIPTION
Headline stats: Reduces shader initialisation time from ~5seconds on Pixel 6 to ~2 seconds (with no compromises on runtime performance)

This is disabled on wasm because there are no threads.
This is disabled on macOS, following the prior art in Bevy (https://github.com/bevyengine/bevy/pull/10812#discussion_r1496138004)

This work queuing system is not intended to be the final form of this, which is why I have made this optional.
This would not be suitable for many consumers, who will likely already have their own thread pool.
We currently just create short lived threads using [`std::thread::scope`](https://doc.rust-lang.org/std/thread/fn.scope.html).

I still think this is useful to have for experimental purposes, and I think it should also be useful in Xilem in its current form. @xorgy might need you to confirm that

This is not async shader initialisation, which I do also plan to add. This is a useful first step towards that, however