### PR TITLE
Standardize copyright headers.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,19 @@
+# This is the list of Vello's significant contributors.
+#
+# This does not necessarily list everyone who has contributed code,
+# especially since many employees of one corporation may be contributing.
+# To see the full list of contributors, see the revision history in
+# source control.
+Google LLC
+Raph Levien
+Chad Brokaw
+Arman Uguray
+Elias Naur
+Daniel McNab
+Spencer C. Imbleau
+Bruce Mitchener
+Tatsuyuki Ishi
+Markus Siglreithmaier
+Rose Hudson
+Brian Merchant
+Matt Rice

--- a/README.md
+++ b/README.md
@@ -206,8 +206,9 @@ Licensed under either of
 
 at your option.
 
-In addition, all files in the [`shader`](shader) directory and subdirectories thereof are alternatively
-licensed under the Unlicense ([shader/UNLICENSE](shader/UNLICENSE) or <http://unlicense.org/>).
+In addition, all files in the [`shader`](shader) and [`src/cpu_shader`](src/cpu_shader)
+directories and subdirectories thereof are alternatively licensed under
+the Unlicense ([shader/UNLICENSE](shader/UNLICENSE) or <http://unlicense.org/>).
 For clarity, these files are also licensed under either of the above licenses.
 The intent is for this research to be used in as broad a context as possible.
 

--- a/crates/encoding/src/binning.rs
+++ b/crates/encoding/src/binning.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Vello authors
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use bytemuck::{Pod, Zeroable};

--- a/crates/encoding/src/clip.rs
+++ b/crates/encoding/src/clip.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Vello authors
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use bytemuck::{Pod, Zeroable};

--- a/crates/encoding/src/config.rs
+++ b/crates/encoding/src/config.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Vello authors
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use crate::SegmentCount;

--- a/crates/encoding/src/draw.rs
+++ b/crates/encoding/src/draw.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 The Vello authors
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use bytemuck::{Pod, Zeroable};

--- a/crates/encoding/src/encoding.rs
+++ b/crates/encoding/src/encoding.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 The Vello authors
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use super::{DrawColor, DrawTag, PathEncoder, PathTag, Style, Transform};

--- a/crates/encoding/src/glyph.rs
+++ b/crates/encoding/src/glyph.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Vello authors
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use std::ops::Range;

--- a/crates/encoding/src/glyph_cache.rs
+++ b/crates/encoding/src/glyph_cache.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 The Vello authors
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use std::collections::HashMap;

--- a/crates/encoding/src/image_cache.rs
+++ b/crates/encoding/src/image_cache.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 The Vello authors
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use guillotiere::{size2, AtlasAllocator};

--- a/crates/encoding/src/lib.rs
+++ b/crates/encoding/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Vello authors
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! Raw scene encoding.

--- a/crates/encoding/src/mask.rs
+++ b/crates/encoding/src/mask.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 The Vello authors
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! Create a lookup table of half-plane sample masks.

--- a/crates/encoding/src/math.rs
+++ b/crates/encoding/src/math.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 The Vello authors
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use std::ops::Mul;

--- a/crates/encoding/src/monoid.rs
+++ b/crates/encoding/src/monoid.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 The Vello authors
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 /// Interface for a monoid. The default value must be the identity of

--- a/crates/encoding/src/path.rs
+++ b/crates/encoding/src/path.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 The Vello authors
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use bytemuck::{Pod, Zeroable};

--- a/crates/encoding/src/ramp_cache.rs
+++ b/crates/encoding/src/ramp_cache.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 The Vello authors
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use std::collections::HashMap;

--- a/crates/encoding/src/resolve.rs
+++ b/crates/encoding/src/resolve.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 The Vello authors
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use bytemuck::{Pod, Zeroable};

--- a/crates/shaders/build.rs
+++ b/crates/shaders/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Vello authors
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 #[path = "src/compile/mod.rs"]

--- a/crates/shaders/src/compile/mod.rs
+++ b/crates/shaders/src/compile/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Vello authors
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use {

--- a/crates/shaders/src/compile/msl.rs
+++ b/crates/shaders/src/compile/msl.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Vello authors
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use naga::back::msl as naga_msl;

--- a/crates/shaders/src/compile/permutations.rs
+++ b/crates/shaders/src/compile/permutations.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Vello authors
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use std::collections::HashMap;

--- a/crates/shaders/src/compile/preprocess.rs
+++ b/crates/shaders/src/compile/preprocess.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Vello authors
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use std::{

--- a/crates/shaders/src/lib.rs
+++ b/crates/shaders/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Vello authors
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 #![warn(clippy::doc_markdown, clippy::semicolon_if_nothing_returned)]

--- a/crates/shaders/src/types.rs
+++ b/crates/shaders/src/types.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Vello authors
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! Types that are shared between the main crate and build.

--- a/crates/tests/build.rs
+++ b/crates/tests/build.rs
@@ -1,3 +1,6 @@
+// Copyright 2024 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::env;
 
 fn main() {

--- a/crates/tests/src/lib.rs
+++ b/crates/tests/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2024 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::{env, fs::File, num::NonZeroUsize, path::Path, sync::Arc};
 
 use anyhow::{anyhow, bail, Result};

--- a/crates/tests/tests/smoke.rs
+++ b/crates/tests/tests/smoke.rs
@@ -1,3 +1,6 @@
+// Copyright 2024 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use vello::{
     kurbo::{Affine, Rect},
     peniko::{Brush, Color, Format},

--- a/examples/headless/src/main.rs
+++ b/examples/headless/src/main.rs
@@ -1,3 +1,6 @@
+// Copyright 2023 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::{
     fs::File,
     num::NonZeroUsize,

--- a/examples/run_wasm/src/main.rs
+++ b/examples/run_wasm/src/main.rs
@@ -1,3 +1,6 @@
+// Copyright 2022 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 /// Use [cargo-run-wasm](https://github.com/rukai/cargo-run-wasm) to build an example for web
 ///
 /// Usage:

--- a/examples/scenes/src/download.rs
+++ b/examples/scenes/src/download.rs
@@ -1,3 +1,6 @@
+// Copyright 2022 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::{
     io::Seek,
     path::{Path, PathBuf},

--- a/examples/scenes/src/download/default_downloads.rs
+++ b/examples/scenes/src/download/default_downloads.rs
@@ -1,3 +1,6 @@
+// Copyright 2022 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 // This content cannot be formatted by rustfmt because of the long strings, so it's in its own file
 use super::{BuiltinSvgProps, SVGDownload};
 

--- a/examples/scenes/src/images.rs
+++ b/examples/scenes/src/images.rs
@@ -1,3 +1,6 @@
+// Copyright 2023 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;

--- a/examples/scenes/src/lib.rs
+++ b/examples/scenes/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2022 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 #[cfg(not(target_arch = "wasm32"))]
 pub mod download;
 mod images;

--- a/examples/scenes/src/mmark.rs
+++ b/examples/scenes/src/mmark.rs
@@ -1,3 +1,6 @@
+// Copyright 2023 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! A benchmark based on MotionMark 1.2's path benchmark.
 //! This is roughly comparable to:
 //!

--- a/examples/scenes/src/simple_text.rs
+++ b/examples/scenes/src/simple_text.rs
@@ -1,18 +1,5 @@
-// Copyright 2022 The vello authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// Also licensed under MIT license, at your choice.
+// Copyright 2022 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use std::sync::Arc;
 

--- a/examples/scenes/src/svg.rs
+++ b/examples/scenes/src/svg.rs
@@ -1,3 +1,6 @@
+// Copyright 2022 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::{
     fs::read_dir,
     path::{Path, PathBuf},

--- a/examples/scenes/src/test_scenes.rs
+++ b/examples/scenes/src/test_scenes.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 The Vello authors
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use crate::{ExampleScene, SceneConfig, SceneParams, SceneSet};

--- a/examples/with_bevy/src/main.rs
+++ b/examples/with_bevy/src/main.rs
@@ -1,3 +1,6 @@
+// Copyright 2022 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::num::NonZeroUsize;
 
 use bevy::render::{Render, RenderSet};

--- a/examples/with_winit/src/hot_reload.rs
+++ b/examples/with_winit/src/hot_reload.rs
@@ -1,3 +1,6 @@
+// Copyright 2023 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::{path::Path, time::Duration};
 
 use anyhow::Result;

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -1,18 +1,5 @@
-// Copyright 2022 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// Also licensed under MIT license, at your choice.
+// Copyright 2022 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use instant::{Duration, Instant};
 use std::num::NonZeroUsize;

--- a/examples/with_winit/src/main.rs
+++ b/examples/with_winit/src/main.rs
@@ -1,3 +1,6 @@
+// Copyright 2022 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use anyhow::Result;
 
 fn main() -> Result<()> {

--- a/examples/with_winit/src/multi_touch.rs
+++ b/examples/with_winit/src/multi_touch.rs
@@ -1,3 +1,6 @@
+// Copyright 2023 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 /// Adapted from https://github.com/emilk/egui/blob/212656f3fc6b931b21eaad401e5cec2b0da93baa/crates/egui/src/input_state/touch_state.rs
 use std::{collections::BTreeMap, fmt::Debug};
 

--- a/examples/with_winit/src/stats.rs
+++ b/examples/with_winit/src/stats.rs
@@ -1,18 +1,5 @@
-// Copyright 2023 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// Also licensed under MIT license, at your choice.
+// Copyright 2023 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use scenes::SimpleText;
 use std::{collections::VecDeque, time::Duration};

--- a/integrations/vello_svg/src/lib.rs
+++ b/integrations/vello_svg/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2023 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! Append a [`usvg::Tree`] to a Vello [`Scene`]
 //!
 //! This currently lacks support for a [number of important](crate#unsupported-features) SVG features.

--- a/shader/backdrop.wgsl
+++ b/shader/backdrop.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 // Note: this is the non-atomic version

--- a/shader/backdrop_dyn.wgsl
+++ b/shader/backdrop_dyn.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 // Prefix sum for dynamically allocated backdrops

--- a/shader/bbox_clear.wgsl
+++ b/shader/bbox_clear.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 #import config

--- a/shader/binning.wgsl
+++ b/shader/binning.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 // The binning stage

--- a/shader/clip_leaf.wgsl
+++ b/shader/clip_leaf.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 #import config

--- a/shader/clip_reduce.wgsl
+++ b/shader/clip_reduce.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 #import bbox

--- a/shader/coarse.wgsl
+++ b/shader/coarse.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 // The coarse rasterization stage.

--- a/shader/draw_leaf.wgsl
+++ b/shader/draw_leaf.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 // Finish prefix sum of drawtags, decode draw objects.

--- a/shader/draw_reduce.wgsl
+++ b/shader/draw_reduce.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 #import config

--- a/shader/fine.wgsl
+++ b/shader/fine.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 // Fine rasterizer. This can run in simple (just path rendering) and full

--- a/shader/flatten.wgsl
+++ b/shader/flatten.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 // Flatten curves to lines

--- a/shader/path_count.wgsl
+++ b/shader/path_count.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 // Stage to compute counts of number of segments in each tile

--- a/shader/path_count_setup.wgsl
+++ b/shader/path_count_setup.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 // Set up dispatch size for path count stage.

--- a/shader/path_tiling.wgsl
+++ b/shader/path_tiling.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 // Write path segments

--- a/shader/path_tiling_setup.wgsl
+++ b/shader/path_tiling_setup.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 // Set up dispatch size for path tiling stage.

--- a/shader/pathtag_reduce.wgsl
+++ b/shader/pathtag_reduce.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 #import config

--- a/shader/pathtag_reduce2.wgsl
+++ b/shader/pathtag_reduce2.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 // This shader is the second stage of reduction for the pathtag

--- a/shader/pathtag_scan.wgsl
+++ b/shader/pathtag_scan.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 #import config

--- a/shader/pathtag_scan1.wgsl
+++ b/shader/pathtag_scan1.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 // This shader computes the scan of reduced tag monoids given

--- a/shader/shared/bbox.wgsl
+++ b/shader/shared/bbox.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 // The annotated bounding box for a path. It has been transformed,

--- a/shader/shared/blend.wgsl
+++ b/shader/shared/blend.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 // Color mixing modes

--- a/shader/shared/bump.wgsl
+++ b/shader/shared/bump.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 // Bitflags for each stage that can fail allocation.

--- a/shader/shared/clip.wgsl
+++ b/shader/shared/clip.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
  
 struct Bic {

--- a/shader/shared/config.wgsl
+++ b/shader/shared/config.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 // This must be kept in sync with the struct in src/encoding/resolve.rs

--- a/shader/shared/cubic.wgsl
+++ b/shader/shared/cubic.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 struct Cubic {

--- a/shader/shared/drawtag.wgsl
+++ b/shader/shared/drawtag.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 // The DrawMonoid is computed as a prefix sum to aid in decoding

--- a/shader/shared/pathtag.wgsl
+++ b/shader/shared/pathtag.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 struct TagMonoid {

--- a/shader/shared/ptcl.wgsl
+++ b/shader/shared/ptcl.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 // Layout of per-tile command list

--- a/shader/shared/segment.wgsl
+++ b/shader/shared/segment.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 // Segments laid out for contiguous storage

--- a/shader/shared/tile.wgsl
+++ b/shader/shared/tile.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 // Common datatypes for path and tile intermediate info.

--- a/shader/shared/transform.wgsl
+++ b/shader/shared/transform.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 // Helpers for working with transforms.

--- a/shader/shared/util.wgsl
+++ b/shader/shared/util.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 // This file defines utility functions that interact with host-shareable buffer objects. It should

--- a/shader/tile_alloc.wgsl
+++ b/shader/tile_alloc.wgsl
@@ -1,3 +1,4 @@
+// Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 // Tile allocation (and zeroing of tiles)

--- a/src/cpu_dispatch.rs
+++ b/src/cpu_dispatch.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Vello authors
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! Support for CPU implementations of compute shaders.

--- a/src/cpu_shader/backdrop.rs
+++ b/src/cpu_shader/backdrop.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Vello authors
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 use vello_encoding::{ConfigUniform, Path, Tile};

--- a/src/cpu_shader/bbox_clear.rs
+++ b/src/cpu_shader/bbox_clear.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Vello authors
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 use vello_encoding::{ConfigUniform, PathBbox};

--- a/src/cpu_shader/binning.rs
+++ b/src/cpu_shader/binning.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Vello authors
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 use vello_encoding::{BinHeader, BumpAllocators, ConfigUniform, DrawMonoid, PathBbox};

--- a/src/cpu_shader/clip_leaf.rs
+++ b/src/cpu_shader/clip_leaf.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Vello authors
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 use vello_encoding::{Clip, ConfigUniform, DrawMonoid, PathBbox};

--- a/src/cpu_shader/clip_reduce.rs
+++ b/src/cpu_shader/clip_reduce.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Vello authors
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 use vello_encoding::{Clip, ClipBic, ClipElement, PathBbox};

--- a/src/cpu_shader/coarse.rs
+++ b/src/cpu_shader/coarse.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Vello authors
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 use vello_encoding::{

--- a/src/cpu_shader/draw_leaf.rs
+++ b/src/cpu_shader/draw_leaf.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Vello authors
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 use vello_encoding::{Clip, ConfigUniform, DrawMonoid, DrawTag, Monoid, PathBbox};

--- a/src/cpu_shader/draw_reduce.rs
+++ b/src/cpu_shader/draw_reduce.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Vello authors
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 use vello_encoding::{ConfigUniform, DrawMonoid, DrawTag, Monoid};

--- a/src/cpu_shader/fine.rs
+++ b/src/cpu_shader/fine.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Vello authors
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 use vello_encoding::{ConfigUniform, PathSegment, Tile};

--- a/src/cpu_shader/flatten.rs
+++ b/src/cpu_shader/flatten.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Vello authors
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 use crate::cpu_dispatch::CpuBinding;

--- a/src/cpu_shader/mod.rs
+++ b/src/cpu_shader/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Vello authors
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 //! CPU implementations of shader stages.

--- a/src/cpu_shader/path_count.rs
+++ b/src/cpu_shader/path_count.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Vello authors
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 use vello_encoding::{BumpAllocators, LineSoup, Path, SegmentCount, Tile};

--- a/src/cpu_shader/path_count_setup.rs
+++ b/src/cpu_shader/path_count_setup.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Vello authors
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 use vello_encoding::{BumpAllocators, IndirectCount};

--- a/src/cpu_shader/path_tiling.rs
+++ b/src/cpu_shader/path_tiling.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Vello authors
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 use vello_encoding::{BumpAllocators, LineSoup, Path, PathSegment, SegmentCount, Tile};

--- a/src/cpu_shader/path_tiling_setup.rs
+++ b/src/cpu_shader/path_tiling_setup.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Vello authors
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 use vello_encoding::{BumpAllocators, IndirectCount};

--- a/src/cpu_shader/pathtag_reduce.rs
+++ b/src/cpu_shader/pathtag_reduce.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Vello authors
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 use vello_encoding::{ConfigUniform, Monoid, PathMonoid};

--- a/src/cpu_shader/pathtag_scan.rs
+++ b/src/cpu_shader/pathtag_scan.rs
@@ -1,5 +1,5 @@
-// Copyright 2023 The Vello authors
-// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright 2023 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 use vello_encoding::{ConfigUniform, Monoid, PathMonoid};
 

--- a/src/cpu_shader/tile_alloc.rs
+++ b/src/cpu_shader/tile_alloc.rs
@@ -1,5 +1,5 @@
-// Copyright 2023 The Vello authors
-// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright 2023 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 use vello_encoding::{BumpAllocators, ConfigUniform, DrawTag, Path, Tile};
 

--- a/src/cpu_shader/util.rs
+++ b/src/cpu_shader/util.rs
@@ -1,5 +1,5 @@
-// Copyright 2023 The Vello authors
-// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright 2023 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
 //! Utility types
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,18 +1,5 @@
-// Copyright 2022 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// Also licensed under MIT license, at your choice.
+// Copyright 2022 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use std::{
     num::NonZeroU64,

--- a/src/glyph.rs
+++ b/src/glyph.rs
@@ -1,18 +1,5 @@
-// Copyright 2022 The vello authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// Also licensed under MIT license, at your choice.
+// Copyright 2022 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! Support for glyph rendering.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,5 @@
-// Copyright 2022 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// Also licensed under MIT license, at your choice.
+// Copyright 2022 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 #![warn(clippy::doc_markdown, clippy::semicolon_if_nothing_returned)]
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,3 +1,6 @@
+// Copyright 2022 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! Take an encoded scene and create a graph to render it
 
 use crate::{

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -1,18 +1,5 @@
-// Copyright 2022 The vello authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// Also licensed under MIT license, at your choice.
+// Copyright 2022 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use peniko::kurbo::{Affine, Rect, Shape, Stroke};
 use peniko::{BlendMode, BrushRef, Color, Fill, Font, Image, StyleRef};

--- a/src/shaders.rs
+++ b/src/shaders.rs
@@ -1,18 +1,5 @@
-// Copyright 2022 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// Also licensed under MIT license, at your choice.
+// Copyright 2022 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! Load rendering shaders.
 

--- a/src/shaders/preprocess.rs
+++ b/src/shaders/preprocess.rs
@@ -1,3 +1,6 @@
+// Copyright 2022 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::{
     collections::{HashMap, HashSet},
     fs,

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,18 +1,5 @@
-// Copyright 2022 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// Also licensed under MIT license, at your choice.
+// Copyright 2022 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! Simple helpers for managing wgpu state and surfaces.
 

--- a/src/wgpu_engine.rs
+++ b/src/wgpu_engine.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Vello authors
+// Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use std::{


### PR DESCRIPTION
The Linebender standard for copyright headers was decided last year in [kurbo#207](https://github.com/linebender/kurbo/issues/207) as the following:
```
// Copyright <year of file creation> the <Project> Authors
// SPDX-License-Identifier: Apache-2.0 OR MIT
```

 With Vello 0.1 approaching fast it makes sense to get this done now.

This PR converts all file headers to this standard form, including the standard capitalization.

Additionally, three CPU shader files didn't specify Unlicense in the headers which seems like a mistake. I added the Unlicense identifier to match all the other shaders.