### PR TITLE
Checkpoint pipeline caching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,6 @@ anyhow = "1.0"
 instant = { version = "0.1.12", features = ["wasm-bindgen"] }
 pollster = "0.3.0"
 wgpu-profiler = "0.16"
+
+[patch.crates-io]
+wgpu = { git = "https://github.com/DJMcNab/wgpu", rev = "617567604e8b7f792cec995cd2365b91a78e3da2" }

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -41,6 +41,7 @@ notify-debouncer-mini = "0.3"
 [target.'cfg(target_os = "android")'.dependencies]
 winit = { version = "0.29.10", features = ["android-native-activity"] }
 android_logger = "0.13.0"
+jni = "0.21"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.7"
@@ -49,5 +50,5 @@ wasm-bindgen-futures = "0.4.33"
 # Note: pin web-sys to 0.3.67 because wgpu 0.19 depends on that exact version.
 # Update this when revving wgpu. Remove pin when wgpu no longer demands it.
 # See https://github.com/gfx-rs/wgpu/pull/5224 for more info.
-web-sys = { version = "=0.3.67", features = [ "HtmlCollection", "Text" ] }
+web-sys = { version = "=0.3.67", features = ["HtmlCollection", "Text"] }
 getrandom = { version = "0.2.10", features = ["js"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,6 +182,7 @@ impl Renderer {
             // Use 3 pending frames
             #[cfg(feature = "wgpu-profiler")]
             profiler: GpuProfiler::new(GpuProfilerSettings {
+                enable_timer_queries: false,
                 ..Default::default()
             })?,
             #[cfg(feature = "wgpu-profiler")]


### PR DESCRIPTION
> [!IMPORTANT]
> 
> This PR should not be merged. A proper implementation of pipeline caching will arrive in a future PR, at which point this PR will be closed

- Corresponding wgpu PR: gfx-rs/wgpu#5292
- Resultant wgpu issue: gfx-rs/wgpu#5293 


This is part of the Android Startup work ([#gpu > Android Startup Time Investigation](https://xi.zulipchat.com/#narrow/stream/197075-gpu/topic/Android.20Startup.20Time.20Investigation)).

This PR contains an experiment to validate that Vulkan pipeline caching results in a startup time improvement in Vello on Android. The headline number is that startup is reduced from 2s to ~40ms on a Pixel 6.

This PR exists only to ensure that a stable reference to the head commit of the head branch exist.
The code depends on my fork of wgpu, which can be found in gfx-rs/wgpu#<TODO>