### PR TITLE
Remove use of `std::time::Instant` on WASM

### DIFF
--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -534,8 +534,8 @@ fn run(
                         renderers.resize_with(render_cx.devices.len(), || None);
                         let id = render_state.surface.dev_id;
                         renderers[id].get_or_insert_with(|| {
-                            eprintln!("Creating renderer {id}");
-                            Renderer::new(
+                            let start = Instant::now();
+                            let renderer = Renderer::new(
                                 &render_cx.devices[id].device,
                                 RendererOptions {
                                     surface_format: Some(render_state.surface.format),
@@ -544,7 +544,9 @@ fn run(
                                     num_init_threads: NonZeroUsize::new(args.num_init_threads)
                                 },
                             )
-                            .expect("Could create renderer")
+                            .expect("Could create renderer");
+                            eprintln!("Creating renderer {id} took {:?}", start.elapsed());
+                            renderer
                         });
                         Some(render_state)
                     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ mod shaders;
 #[cfg(feature = "wgpu")]
 mod wgpu_engine;
 
-use std::{num::NonZeroUsize, time::Instant};
+use std::num::NonZeroUsize;
 
 /// Styling and composition primitives.
 pub use peniko;
@@ -151,11 +151,9 @@ impl Renderer {
             #[cfg(not(target_arch = "wasm32"))]
             engine.use_parallel_initialisation();
         }
-        let start = Instant::now();
         let shaders = shaders::full_shaders(device, &mut engine, &options)?;
         #[cfg(not(target_arch = "wasm32"))]
         engine.build_shaders_if_needed(device, options.num_init_threads);
-        eprintln!("Building shaders took {:?}", start.elapsed());
         let blit = options
             .surface_format
             .map(|surface_format| BlitPipeline::new(device, surface_format));


### PR DESCRIPTION
Fixes #458