### PR TITLE
Support `WGPU_BACKEND` and simplify shader util function

### DIFF
--- a/shader/shared/util.wgsl
+++ b/shader/shared/util.wgsl
@@ -13,9 +13,9 @@
 //    * `scene`: array<u32>
 //    * `config`: Config (see config.wgsl)
 fn read_draw_tag_from_scene(ix: u32) -> u32 {
-    let tag_ix = config.drawtag_base + ix;
     var tag_word: u32;
-    if tag_ix < config.drawtag_base + config.n_drawobj {
+    if ix < config.n_drawobj {
+        let tag_ix = config.drawtag_base + ix;
         tag_word = scene[tag_ix];
     } else {
         tag_word = DRAWTAG_NOP;

--- a/src/util.rs
+++ b/src/util.rs
@@ -27,7 +27,7 @@ pub struct DeviceHandle {
 impl RenderContext {
     pub fn new() -> Result<Self> {
         let instance = Instance::new(wgpu::InstanceDescriptor {
-            backends: wgpu::Backends::PRIMARY,
+            backends: wgpu::util::backend_bits_from_env().unwrap_or(wgpu::Backends::PRIMARY),
             dx12_shader_compiler: wgpu::Dx12Compiler::Fxc,
             ..Default::default()
         });


### PR DESCRIPTION
Two mini patches:
* making the `read_draw_tag_from_scene` wgsl function more equal to it's cpu equivalent, just from guessing I think this would safe 2 cycles (because 2 add operations are now either 0 or 1) but that's too much of a microoptimization, I just like to think about that.
* Taking `WGPU_BACKEND` env variable into selection of the backend, which enables me to get rid of the dx12 error spam mentioned in #449 and also bumps my fps from 80-85 on dx12 to 100-120 on vulkan.