### PR TITLE
Add proper attribution to egui authors.

### DIFF
--- a/examples/with_winit/src/multi_touch.rs
+++ b/examples/with_winit/src/multi_touch.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 the Vello Authors
+// Copyright 2021 the egui Authors and Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 /// Adapted from https://github.com/emilk/egui/blob/212656f3fc6b931b21eaad401e5cec2b0da93baa/crates/egui/src/input_state/touch_state.rs

--- a/examples/with_winit/src/multi_touch.rs
+++ b/examples/with_winit/src/multi_touch.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 the egui Authors and Vello Authors
+// Copyright 2021 the egui Authors and the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 /// Adapted from https://github.com/emilk/egui/blob/212656f3fc6b931b21eaad401e5cec2b0da93baa/crates/egui/src/input_state/touch_state.rs


### PR DESCRIPTION
The multi touch example should have a clearer attribution to the original authors. The licenses still match.