### PR TITLE
Fix negative duration panic on macos

### DIFF
--- a/examples/with_winit/src/stats.rs
+++ b/examples/with_winit/src/stats.rs
@@ -384,11 +384,21 @@ pub fn draw_gpu_profiling(
             let text_size = (text_height * 0.9) as f32;
             // Text is specified by the baseline, but the y positions all refer to the top of the text
             cur_text_y = text_y + text_height;
-            let label = format!(
-                "{:.2?} - {:.30}",
-                Duration::from_secs_f64(this_time.max(0.0)),
-                profile.label
-            );
+            let label = {
+                if this_time < 0.0 {
+                    format!(
+                        "-{:.2?}(!!) - {:.30}",
+                        Duration::from_secs_f64(this_time.abs()),
+                        profile.label
+                    )
+                } else {
+                    format!(
+                        "{:.2?} - {:.30}",
+                        Duration::from_secs_f64(this_time),
+                        profile.label
+                    )
+                }
+            };
             scene.fill(
                 Fill::NonZero,
                 offset,

--- a/examples/with_winit/src/stats.rs
+++ b/examples/with_winit/src/stats.rs
@@ -385,6 +385,9 @@ pub fn draw_gpu_profiling(
             // Text is specified by the baseline, but the y positions all refer to the top of the text
             cur_text_y = text_y + text_height;
             let label = {
+                // Sometimes, the duration turns out to be negative
+                // We have not yet debugged this, but display the absolute value in that case
+                // see https://github.com/linebender/vello/pull/475 for more
                 if this_time < 0.0 {
                     format!(
                         "-{:.2?}(!!) - {:.30}",

--- a/examples/with_winit/src/stats.rs
+++ b/examples/with_winit/src/stats.rs
@@ -386,7 +386,7 @@ pub fn draw_gpu_profiling(
             cur_text_y = text_y + text_height;
             let label = format!(
                 "{:.2?} - {:.30}",
-                Duration::from_secs_f64(this_time),
+                Duration::from_secs_f64(this_time.max(0.0)),
                 profile.label
             );
             scene.fill(


### PR DESCRIPTION
The `winit` example sometimes panics when running on macos. This pr fix this by adding a `.max(0.0)` to clip it to 0 before making a `Duration`

```
can not convert float seconds to Duration: value is negative
stack backtrace:
   0: rust_begin_unwind
             at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/std/src/panicking.rs:645:5
   1: core::panicking::panic_fmt
             at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/core/src/panicking.rs:72:14
   2: core::panicking::panic_display
             at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/core/src/panicking.rs:196:5
   3: core::time::Duration::from_secs_f64::panic_cold_display
             at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/core/src/panic.rs:99:13
   4: core::time::Duration::from_secs_f64
             at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/core/src/time.rs:762:23
   5: with_winit::stats::draw_gpu_profiling::{{closure}}
             at ./examples/with_winit/src/stats.rs:389:17
   6: with_winit::stats::traverse_profiling
             at ./examples/with_winit/src/stats.rs:443:9
   7: with_winit::stats::draw_gpu_profiling
             at ./examples/with_winit/src/stats.rs:348:5
   8: with_winit::run::{{closure}}
             at ./examples/with_winit/src/lib.rs:418:33
```