### PR TITLE
Prepare package configurations for publishing.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,13 @@ members = [
 ]
 
 [workspace.package]
+# Vello version, also used by other packages which want to mimic Vello's version.
+# Right now those packages include vello_encoding and vello_shaders.
+#
+# NOTE: When bumping this, remember to also bump the aforementioned other package's
+#       version in the dependencies section at the bottom of this file.
+version = "0.1.0"
+
 edition = "2021"
 rust-version = "1.75"
 license = "Apache-2.0 OR MIT"
@@ -23,7 +30,7 @@ repository = "https://github.com/linebender/vello"
 
 [package]
 name = "vello"
-version = "0.1.0"
+version.workspace = true
 description = "An experimental GPU compute-centric 2D renderer."
 categories = ["rendering", "graphics"]
 keywords = ["2d", "vector-graphics"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 # Vello version, also used by other packages which want to mimic Vello's version.
 # Right now those packages include vello_encoding and vello_shaders.
 #
-# NOTE: When bumping this, remember to also bump the aforementioned other package's
+# NOTE: When bumping this, remember to also bump the aforementioned other packages'
 #       version in the dependencies section at the bottom of this file.
 version = "0.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
 #
 # NOTE: When bumping this, remember to also bump the aforementioned other packages'
 #       version in the dependencies section at the bottom of this file.
+#       Additionally, bump the Vello dependency version in the 'simple' example.
 version = "0.1.0"
 
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [workspace]
 resolver = "2"
-
 members = [
     "crates/encoding",
     "crates/shaders",
@@ -18,22 +17,20 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.0.1"
-license = "MIT OR Apache-2.0"
+rust-version = "1.75"
+license = "Apache-2.0 OR MIT"
 repository = "https://github.com/linebender/vello"
 
 [package]
 name = "vello"
-description = "An experimental GPU compute-centric 2D renderer"
+version = "0.1.0"
+description = "An experimental GPU compute-centric 2D renderer."
 categories = ["rendering", "graphics"]
 keywords = ["2d", "vector-graphics"]
-
-# This crate is intended for publishing, but not ready yet
-publish = false
-
-version.workspace = true
-license.workspace = true
+exclude = ["/.github/", "/doc/", "/examples/", ".gitignore"]
 edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
 repository.workspace = true
 
 [features]
@@ -42,19 +39,22 @@ hot_reload = []
 buffer_labels = []
 
 [dependencies]
+vello_encoding = { workspace = true }
 bytemuck = { workspace = true }
 skrifa = { workspace = true }
 peniko = { workspace = true }
 wgpu = { workspace = true, optional = true }
-raw-window-handle = "0.6"
-futures-intrusive = "0.5.0"
-vello_encoding = { path = "crates/encoding" }
+raw-window-handle = { workspace = true }
+futures-intrusive = { workspace = true }
 wgpu-profiler = { workspace = true, optional = true }
 
 [workspace.dependencies]
+vello_encoding = { version = "0.1.0", path = "crates/encoding" }
 bytemuck = { version = "1.14.3", features = ["derive"] }
 skrifa = "0.15.5"
 peniko = "0.1.0"
+futures-intrusive = "0.5.0"
+raw-window-handle = "0.6"
 
 # NOTE: Make sure to keep this in sync with the version badge in README.md
 wgpu = { version = "0.19" }

--- a/crates/encoding/Cargo.toml
+++ b/crates/encoding/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "vello_encoding"
 version = "0.1.0"
+description = "Vello types that represent the data that needs to be rendered."
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 

--- a/crates/encoding/Cargo.toml
+++ b/crates/encoding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vello_encoding"
-version = "0.1.0"
+version.workspace = true # We mimic Vello's version
 description = "Vello types that represent the data that needs to be rendered."
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/shaders/Cargo.toml
+++ b/crates/shaders/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vello_shaders"
 version.workspace = true # We mimic Vello's version
-description = "Vello infrastructure to compile pipelines and shaders."
+description = "Vello infrastructure to preprocess and cross-compile shaders at compile time."
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/shaders/Cargo.toml
+++ b/crates/shaders/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "vello_shaders"
 version = "0.1.0"
+description = "Vello infrastructure to compile pipelines and shaders."
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+
+publish = false # Remove this when the package is ready for publishing
 
 [features]
 default = ["compile", "wgsl", "msl"]

--- a/crates/shaders/Cargo.toml
+++ b/crates/shaders/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vello_shaders"
-version = "0.1.0"
+version.workspace = true # We mimic Vello's version
 description = "Vello infrastructure to compile pipelines and shaders."
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "vello_tests"
+description = "Helper code for writing Vello tests."
 edition.workspace = true
-version.workspace = true
 license.workspace = true
 repository.workspace = true
 publish = false
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 vello = { path = "../.." }
@@ -16,4 +14,4 @@ anyhow = { workspace = true }
 wgpu = { workspace = true }
 pollster = { workspace = true }
 png = "0.17.13"
-futures-intrusive = "0.5.0"
+futures-intrusive = { workspace = true }

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vello_tests"
-description = "Helper code for writing Vello tests."
+description = "Integration tests for Vello."
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/examples/headless/Cargo.toml
+++ b/examples/headless/Cargo.toml
@@ -1,23 +1,19 @@
 [package]
 name = "headless"
-description = "An example showing how to use `vello` to create raster images"
+description = "An example showing how to use `vello` to create raster images."
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 publish = false
 
-version.workspace = true
-license.workspace = true
-edition.workspace = true
-repository.workspace = true
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-anyhow = { workspace = true }
-clap = { workspace = true, features = ["derive"] }
 vello = { path = "../../" }
 scenes = { path = "../scenes" }
+anyhow = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
 
 wgpu = { workspace = true }
 pollster = { workspace = true }
 env_logger = "0.11.2"
 png = "0.17.13"
-futures-intrusive = "0.5.0"
+futures-intrusive = { workspace = true }

--- a/examples/headless/Cargo.toml
+++ b/examples/headless/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headless"
-description = "An example showing how to use `vello` to create raster images."
+description = "An example showing how to use Vello to create raster images."
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/examples/run_wasm/Cargo.toml
+++ b/examples/run_wasm/Cargo.toml
@@ -1,13 +1,9 @@
 [package]
 name = "run_wasm"
-publish = false
-
-version.workspace = true
-license.workspace = true
 edition.workspace = true
+license.workspace = true
 repository.workspace = true
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 cargo-run-wasm = "0.3.2"

--- a/examples/scenes/Cargo.toml
+++ b/examples/scenes/Cargo.toml
@@ -1,14 +1,10 @@
 [package]
 name = "scenes"
-description = "Vello scenes used in the other examples"
-publish = false
-
-version.workspace = true
-license.workspace = true
+description = "Vello scenes used in the other examples."
 edition.workspace = true
+license.workspace = true
 repository.workspace = true
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 vello = { path = "../../" }

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -1,17 +1,16 @@
 [package]
 name = "simple"
 edition.workspace = true
-version.workspace = true
 license.workspace = true
 repository.workspace = true
 publish = false
 
 # The dependencies here are independent from the workspace versions
 [dependencies]
+vello = { path = "../../" }
+# When using, replace the above line with this:
+#vello = { git = "https://github.com/linebender/vello" }
 anyhow = "1.0.80"
 pollster = "0.3.0"
 wgpu = "0.19.1"
 winit = "0.29.11"
-vello = { path = "../../" }
-# When using, replace the above line with this:
-#vello = { git = "https://github.com/linebender/vello" }

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -7,9 +7,9 @@ publish = false
 
 # The dependencies here are independent from the workspace versions
 [dependencies]
-vello = { path = "../../" }
-# When using, replace the above line with this:
-#vello = { git = "https://github.com/linebender/vello" }
+# When using this example outside of the original Vello workspace,
+# remove the path property of the following Vello dependency requirement.
+vello = { version = "0.1.0", path = "../../" }
 anyhow = "1.0.80"
 pollster = "0.3.0"
 wgpu = "0.19.1"

--- a/examples/with_bevy/Cargo.toml
+++ b/examples/with_bevy/Cargo.toml
@@ -1,15 +1,13 @@
 [package]
 name = "with_bevy"
-description = "Example of using Vello in a Bevy application"
-
-version.workspace = true
-license.workspace = true
+description = "Example of using Vello in a Bevy application."
 edition.workspace = true
+license.workspace = true
 repository.workspace = true
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
+vello = { path = "../../" }
 bevy = { version = "0.13", features = [
   "bevy_winit",
   "bevy_core_pipeline",
@@ -19,5 +17,3 @@ bevy = { version = "0.13", features = [
   "x11",
   "tonemapping_luts",
 ], default-features = false }
-
-vello = { path = "../../" }

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -1,14 +1,10 @@
 [package]
 name = "with_winit"
 description = "An example using vello to render to a winit window"
-publish = false
-
-version.workspace = true
-license.workspace = true
 edition.workspace = true
+license.workspace = true
 repository.workspace = true
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [lib]
 name = "with_winit"

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "with_winit"
+version = "0.0.0"
 description = "An example using vello to render to a winit window"
 edition.workspace = true
 license.workspace = true

--- a/integrations/vello_svg/Cargo.toml
+++ b/integrations/vello_svg/Cargo.toml
@@ -3,13 +3,10 @@ name = "vello_svg"
 description = "Render a usvg document to a Vello scene"
 categories = ["rendering", "graphics"]
 keywords = ["2d", "vector-graphics", "vello"]
-
-version.workspace = true
-license.workspace = true
 edition.workspace = true
+license.workspace = true
 repository.workspace = true
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 vello = { path = "../../" }


### PR DESCRIPTION
I went over all the `Cargo.toml` files to get them ready for the upcoming publishing.

* Enabled `publish` for `vello` itself.
* Bumped `vello` version to `0.1.0`.
* Removed the workspace version. Every published crate gets its own dedicated version, which for now only means `vello` & `vello_encoding`.
* Added `rust-version` to document the reality of 1.75 being needed to compile `vello` at this moment.
* Excluded some needless files from being bundled when publishing, which is going to reduce the size of the published package by ~1MB !!
* Promoted some dependencies to workspace dependencies.
* Reordered some properties to get them into consistent order in all files.