### PR TITLE
Add `README.md` for `vello_encoding`.

### DIFF
--- a/crates/encoding/README.md
+++ b/crates/encoding/README.md
@@ -1,0 +1,5 @@
+# Vello Encoding
+
+This package contains types that represent data that [Vello] can render.
+
+[Vello]: https://github.com/linebender/vello


### PR DESCRIPTION
This is a super barebones readme, but it's better than nothing, given that this package is about to be published imminently. 🚀