### PR TITLE
Bug fix: `with_winit` 0-sized canvas on wasm

### DIFF
--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -619,17 +619,25 @@ pub fn main() -> Result<()> {
             let window = create_window(&event_loop);
             // On wasm, append the canvas to the document body
             let canvas = window.canvas().unwrap();
-            let size = window.inner_size();
-            canvas.set_width(size.width);
-            canvas.set_height(size.height);
             web_sys::window()
                 .and_then(|win| win.document())
                 .and_then(|doc| doc.body())
                 .and_then(|body| body.append_child(canvas.as_ref()).ok())
                 .expect("couldn't append canvas to document body");
-            _ = web_sys::HtmlElement::from(canvas).focus();
+
             wasm_bindgen_futures::spawn_local(async move {
-                let size = window.inner_size();
+                let (width, height, scale_factor) = web_sys::window()
+                    .map(|w| {
+                        (
+                            w.inner_width().unwrap().as_f64().unwrap(),
+                            w.inner_height().unwrap().as_f64().unwrap(),
+                            w.device_pixel_ratio(),
+                        )
+                    })
+                    .unwrap();
+                let size =
+                    winit::dpi::PhysicalSize::from_logical::<_, f64>((width, height), scale_factor);
+                _ = window.request_inner_size(size);
                 let surface = render_cx
                     .create_surface(&window, size.width, size.height)
                     .await;

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -624,7 +624,8 @@ pub fn main() -> Result<()> {
                 .and_then(|doc| doc.body())
                 .and_then(|body| body.append_child(canvas.as_ref()).ok())
                 .expect("couldn't append canvas to document body");
-
+            // Best effort to start with the canvas focused, taking input
+            _ = web_sys::HtmlElement::from(canvas).focus();
             wasm_bindgen_futures::spawn_local(async move {
                 let (width, height, scale_factor) = web_sys::window()
                     .map(|w| {


### PR DESCRIPTION
Closes #481 

<img width="1339" alt="image" src="https://github.com/linebender/vello/assets/48108917/172688d4-7d59-4da9-92d3-33f8b9e6150c">
