### PR TITLE
feat: GitHub Pages web demo

### DIFF
--- a/.github/workflows/web-demo.yml
+++ b/.github/workflows/web-demo.yml
@@ -1,0 +1,66 @@
+env:
+  # We aim to always test with the latest stable Rust toolchain, however we pin to a specific
+  # version like 1.70. Note that we only specify MAJOR.MINOR and not PATCH so that bugfixes still
+  # come automatically. If the version specified here is no longer the latest stable version,
+  # then please feel free to submit a PR that adjusts it along with the potential clippy fixes.
+  RUST_STABLE_VER: "1.76" # In quotes because otherwise (e.g.) 1.70 would be interpreted as 1.7
+
+name: Web Demo Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  rustfmt:
+    runs-on: ubuntu-latest
+    name: cargo fmt
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE_VER }}
+          targets: wasm32-unknown-unknown
+
+      - name: install wasm-bindgen
+        uses: jetli/wasm-bindgen-action@v0.2.0
+        with:
+          version: 'latest'
+
+      - name: build (wasm)
+        run: cargo build -p with_winit --bin with_winit_bin --release --target wasm32-unknown-unknown
+        env:
+          RUSTFLAGS: '--cfg=web_sys_unstable_apis'
+
+      - name: package wasm
+        run: |
+          mkdir public
+          wasm-bindgen --target web --out-dir public target/wasm32-unknown-unknown/release/with_winit_bin.wasm --no-typescript
+          cat << EOF > public/index.html
+            <html>
+              <title>Vello Web Demo</title>
+              <meta content=no-cache http-equiv=Cache-control>
+              <meta content=-1 http-equiv=Expires>
+              <script type=module>import initSync from"/vello/with_winit_bin.js";initSync(`/vello/with_winit_bin_bg.wasm`);</script>
+              <link as=fetch crossorigin href=/vello/with_winit_bin_bg.wasm rel=preload type=application/wasm>
+              <link crossorigin href=/vello/with_winit_bin.js rel=modulepreload>
+              </head>
+              <body>
+                <style>
+                  body {
+                    margin: 0;
+                    padding: 0;
+                  }
+                </style>
+              </body>
+            </html>
+          EOF
+
+      - name: deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public

--- a/.github/workflows/web-demo.yml
+++ b/.github/workflows/web-demo.yml
@@ -51,6 +51,7 @@ jobs:
             </html>
           EOF
 
+      # TODO: Once actions/upload-pages-artifact is stable, we can switch to actions/deploy-pages
       - name: deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/web-demo.yml
+++ b/.github/workflows/web-demo.yml
@@ -5,7 +5,7 @@ env:
   # then please feel free to submit a PR that adjusts it along with the potential clippy fixes.
   RUST_STABLE_VER: "1.76" # In quotes because otherwise (e.g.) 1.70 would be interpreted as 1.7
 
-name: Web Demo Release
+name: Web Demo Update
 
 on:
   push:

--- a/.github/workflows/web-demo.yml
+++ b/.github/workflows/web-demo.yml
@@ -6,9 +6,15 @@ on:
       - main
 
 jobs:
-  rustfmt:
+  release-web:
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    name: cargo fmt
     steps:
       - uses: actions/checkout@v4
 
@@ -51,9 +57,14 @@ jobs:
             </html>
           EOF
 
-      # TODO: Once actions/upload-pages-artifact is stable, we can switch to actions/deploy-pages
-      - name: deploy
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./public
+          path: './public'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/web-demo.yml
+++ b/.github/workflows/web-demo.yml
@@ -1,10 +1,3 @@
-env:
-  # We aim to always test with the latest stable Rust toolchain, however we pin to a specific
-  # version like 1.70. Note that we only specify MAJOR.MINOR and not PATCH so that bugfixes still
-  # come automatically. If the version specified here is no longer the latest stable version,
-  # then please feel free to submit a PR that adjusts it along with the potential clippy fixes.
-  RUST_STABLE_VER: "1.76" # In quotes because otherwise (e.g.) 1.70 would be interpreted as 1.7
-
 name: Web Demo Update
 
 on:
@@ -20,9 +13,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: ${{ env.RUST_STABLE_VER }}
           targets: wasm32-unknown-unknown
 
       - name: install wasm-bindgen

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Examples must be selected using the `--package` (or `-p`) Cargo flag.
 
 ### Winit
 
+This example has a demo [available here](https://linebender.github.io/vello) on supporting web browsers.
+
 Our [winit] example ([examples/with_winit](examples/with_winit)) demonstrates rendering to a [winit] window.
 By default, this renders [GhostScript Tiger] all SVG files in [examples/assets/downloads](examples/assets/downloads) directory (using [`vello_svg`](#svg)).
 A custom list of SVG file paths (and directories to render all SVG files from) can be provided as arguments instead.

--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@ Examples must be selected using the `--package` (or `-p`) Cargo flag.
 
 ### Winit
 
-This example has a demo [available here](https://linebender.github.io/vello) on supporting web browsers.
-
 Our [winit] example ([examples/with_winit](examples/with_winit)) demonstrates rendering to a [winit] window.
 By default, this renders [GhostScript Tiger] all SVG files in [examples/assets/downloads](examples/assets/downloads) directory (using [`vello_svg`](#svg)).
 A custom list of SVG file paths (and directories to render all SVG files from) can be provided as arguments instead.
@@ -90,7 +88,7 @@ Other platforms are more tricky, and may require special building/running proced
 Because Vello relies heavily on compute shaders, we rely on the emerging WebGPU standard to run on the web.
 Until browser support becomes widespread, it will probably be necessary to use development browser versions (e.g. Chrome Canary) and explicitly enable WebGPU.
 
-The following command builds and runs a web version of the [winit demo](#winit). 
+The following command builds and runs a web version of the [winit demo](#winit).
 This uses [`cargo-run-wasm`](https://github.com/rukai/cargo-run-wasm) to build the example for web, and host a local server for it
 
 ```shell
@@ -101,7 +99,9 @@ rustup target add wasm32-unknown-unknown
 cargo run_wasm -p with_winit --bin with_winit_bin
 ```
 
-> [!WARNING]  
+There is also a web demo [available here](https://linebender.github.io/vello) on supporting web browsers.
+
+> [!WARNING]
 > The web is not currently a primary target for Vello, and WebGPU implementations are incomplete, so you might run into issues running this example.
 
 ### Android


### PR DESCRIPTION
This will likely need attention from @raphlinus or someone who has administrative privileges on the repo to setup GitHub Pages.

This PR is aimed to package the `with_winit` demo to WASM and serve it with GitHub Pages!
(As soon as #482 is closed - I put a PR for that)

Tasks:
- [x] Wait for WASM to work - #482 
- [x] Enable environments in Admin settings - Needs @raphlinus or @DJMcNab 
- [x] Approve and Merge this PR
- [ ] Update the repo link to https://linebender.github.io/vello

The end result will look like this, except be available on [https://linebender.github.io/vello](https://linebender.github.io/vello)

<img width="1344" alt="image" src="https://github.com/linebender/vello/assets/48108917/5c9ea2b0-c9e6-4779-a590-60db758291fd">