### PR TITLE
Update `wgpu` to v0.19.3.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,8 +127,6 @@ jobs:
 
       - name: cargo clippy (wasm)
         run: cargo clippy --all-targets --target wasm32-unknown-unknown --workspace -- -D warnings
-        env:
-          RUSTFLAGS: '--cfg=web_sys_unstable_apis'
 
   android-stable-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/web-demo.yml
+++ b/.github/workflows/web-demo.yml
@@ -30,8 +30,6 @@ jobs:
 
       - name: build (wasm)
         run: cargo build -p with_winit --bin with_winit_bin --release --target wasm32-unknown-unknown
-        env:
-          RUSTFLAGS: '--cfg=web_sys_unstable_apis'
 
       - name: package wasm
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,10 +62,10 @@ bytemuck = { version = "1.14.3", features = ["derive"] }
 skrifa = "0.15.5"
 peniko = "0.1.0"
 futures-intrusive = "0.5.0"
-raw-window-handle = "0.6"
+raw-window-handle = "0.6.0"
 
 # NOTE: Make sure to keep this in sync with the version badge in README.md
-wgpu = { version = "0.19" }
+wgpu = { version = "0.19.3" }
 
 
 # Used for examples
@@ -73,4 +73,4 @@ clap = "4.5.1"
 anyhow = "1.0"
 instant = { version = "0.1.12", features = ["wasm-bindgen"] }
 pollster = "0.3.0"
-wgpu-profiler = "0.16"
+wgpu-profiler = "0.16.1"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Xi Zulip](https://img.shields.io/badge/Xi%20Zulip-%23gpu-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/stream/197075-gpu)
 [![dependency status](https://deps.rs/repo/github/linebender/vello/status.svg)](https://deps.rs/repo/github/linebender/vello)
 [![MIT/Apache 2.0](https://img.shields.io/badge/license-MIT%2FApache-blue.svg)](#license)
-[![wgpu version](https://img.shields.io/badge/wgpu-v0.19-orange.svg)](https://crates.io/crates/wgpu)
+[![wgpu version](https://img.shields.io/badge/wgpu-v0.19.3-orange.svg)](https://crates.io/crates/wgpu)
 <!-- [![Crates.io](https://img.shields.io/crates/v/vello.svg)](https://crates.io/crates/vello) -->
 <!-- [![Docs](https://docs.rs/vello/badge.svg)](https://docs.rs/vello) -->
 <!-- [![Build status](https://github.com/linebender/vello/workflows/CI/badge.svg)](https://github.com/linebender/vello/actions) -->

--- a/examples/run_wasm/src/main.rs
+++ b/examples/run_wasm/src/main.rs
@@ -13,12 +13,5 @@
 /// ```
 
 fn main() {
-    // HACK: We rely heavily on compute shaders; which means we need WebGPU to be supported
-    // However, that requires unstable APIs to be enabled, which are not exposed through a feature
-    let current_value = std::env::var("RUSTFLAGS").unwrap_or("".to_owned());
-    std::env::set_var(
-        "RUSTFLAGS",
-        format!("{current_value} --cfg=web_sys_unstable_apis",),
-    );
     cargo_run_wasm::run_wasm_with_css("body { margin: 0px; }");
 }

--- a/examples/scenes/Cargo.toml
+++ b/examples/scenes/Cargo.toml
@@ -17,6 +17,6 @@ instant = { workspace = true }
 
 # Used for the `download` command
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-byte-unit = "4.0"
-dialoguer = "0.10"
-ureq = "2.9"
+byte-unit = "4.0.19"
+dialoguer = "0.10.4"
+ureq = "2.9.6"

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -12,5 +12,5 @@ publish = false
 vello = { version = "0.1.0", path = "../../" }
 anyhow = "1.0.80"
 pollster = "0.3.0"
-wgpu = "0.19.1"
-winit = "0.29.11"
+wgpu = "0.19.3"
+winit = "0.29.12"

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -26,7 +26,7 @@ pollster = { workspace = true }
 wgpu-profiler = { workspace = true }
 
 wgpu = { workspace = true }
-winit = "0.29.11"
+winit = "0.29.12"
 env_logger = "0.11.2"
 log = "0.4.21"
 
@@ -36,15 +36,12 @@ notify-debouncer-mini = "0.3"
 
 
 [target.'cfg(target_os = "android")'.dependencies]
-winit = { version = "0.29.11", features = ["android-native-activity"] }
+winit = { version = "0.29.12", features = ["android-native-activity"] }
 android_logger = "0.13.3"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.7"
 console_log = "1"
 wasm-bindgen-futures = "0.4.41"
-# Note: pin web-sys to 0.3.67 because wgpu 0.19 depends on that exact version.
-# Update this when revving wgpu. Remove pin when wgpu no longer demands it.
-# See https://github.com/gfx-rs/wgpu/pull/5224 for more info.
-web-sys = { version = "=0.3.67", features = [ "HtmlCollection", "Text" ] }
+web-sys = { version = "0.3.67", features = [ "HtmlCollection", "Text" ] }
 getrandom = { version = "0.2.12", features = ["js"] }

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -41,7 +41,7 @@ android_logger = "0.13.3"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.7"
-console_log = "1"
+console_log = "1.0.0"
 wasm-bindgen-futures = "0.4.41"
 web-sys = { version = "0.3.67", features = [ "HtmlCollection", "Text" ] }
 getrandom = { version = "0.2.12", features = ["js"] }

--- a/integrations/vello_svg/Cargo.toml
+++ b/integrations/vello_svg/Cargo.toml
@@ -10,4 +10,4 @@ publish = false
 
 [dependencies]
 vello = { path = "../../" }
-usvg = "0.37"
+usvg = "0.37.0"


### PR DESCRIPTION
Our `web-sys` pinning problems are starting to fade. The source of the issue has a workaround now, i.e. [`wgpu` now vendors the unstable `web-sys` bindings](https://github.com/gfx-rs/wgpu/pull/5325).

This means we can finally remove our own `web-sys` pin. Unfortunately we're still de facto stuck on `0.3.67` because our workspace depends on Bevy and Bevy pins `web-sys`. However they already [merged a patch that I submitted to them](https://github.com/bevyengine/bevy/pull/12247). Once they publish a new version we will finally unlock `web-sys` updates in our workspace.

Another benefit of this development is that we no longer need `--cfg=web_sys_unstable_apis`.