### PR TITLE
Support image, very basic clip-path for vello_svg and various improvements

### DIFF
--- a/.github/copyright.sh
+++ b/.github/copyright.sh
@@ -7,7 +7,7 @@
 #   -g "!src/special_directory"
 
 # Check all the standard Rust source files
-output=$(rg "^// Copyright (19|20)[\d]{2} (.+ and )?the Vello Authors( and .+)?$\n^// SPDX-License-Identifier: Apache-2\.0 OR MIT$\n\n" --files-without-match --multiline -g "*.rs" -g "!{shader,src/cpu_shader}" .)
+output=$(rg "^// Copyright (19|20)[\d]{2} (.+ and )?the Vello Authors( and .+)?$\n^// SPDX-License-Identifier: Apache-2\.0 OR MIT$\n\n" --files-without-match --multiline -g "*.rs" -g "!{shader,src/cpu_shader}" -g "!integrations/vello_svg/src/geom.rs" .)
 
 if [ -n "$output" ]; then
 	echo -e "The following files lack the correct copyright header:\n"

--- a/examples/scenes/src/svg.rs
+++ b/examples/scenes/src/svg.rs
@@ -10,7 +10,6 @@ use anyhow::{Ok, Result};
 use instant::Instant;
 use vello::{kurbo::Vec2, Scene};
 use vello_svg::usvg;
-use vello_svg::usvg::TreeParsing;
 
 use crate::{ExampleScene, SceneParams, SceneSet};
 
@@ -101,7 +100,7 @@ pub fn svg_function_of<R: AsRef<str>>(
         let start = Instant::now();
         let mut new_scene = Scene::new();
         vello_svg::render_tree(&mut new_scene, &svg);
-        let resolution = Vec2::new(svg.size.width() as f64, svg.size.height() as f64);
+        let resolution = Vec2::new(svg.size().width() as f64, svg.size().height() as f64);
         eprintln!("Encoded svg {name} in {:?}", start.elapsed());
         (new_scene, resolution)
     }

--- a/integrations/vello_svg/Cargo.toml
+++ b/integrations/vello_svg/Cargo.toml
@@ -11,3 +11,4 @@ publish = false
 [dependencies]
 vello = { path = "../../" }
 usvg = { version = "0.40", default-features = false }
+image = { version = "0.24", default-features = false, features = ["png", "jpeg", "gif"] }

--- a/integrations/vello_svg/Cargo.toml
+++ b/integrations/vello_svg/Cargo.toml
@@ -10,4 +10,4 @@ publish = false
 
 [dependencies]
 vello = { path = "../../" }
-usvg = "0.37.0"
+usvg = { version = "0.40", default-features = false }

--- a/integrations/vello_svg/src/geom.rs
+++ b/integrations/vello_svg/src/geom.rs
@@ -1,0 +1,59 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// copied from https://github.com/RazrFalcon/resvg/blob/4d27b8c3be3ecfff3256c9be1b8362eb22533659/crates/resvg/src/geom.rs
+
+/// Converts `viewBox` to `Transform` with an optional clip rectangle.
+///
+/// Unlike `view_box_to_transform`, returns an optional clip rectangle
+/// that should be applied before rendering the image.
+pub fn view_box_to_transform_with_clip(
+    view_box: &usvg::ViewBox,
+    img_size: usvg::tiny_skia_path::IntSize,
+) -> (usvg::Transform, Option<usvg::NonZeroRect>) {
+    let r = view_box.rect;
+
+    let new_size = fit_view_box(img_size.to_size(), view_box);
+
+    let (tx, ty, clip) = if view_box.aspect.slice {
+        let (dx, dy) = usvg::utils::aligned_pos(
+            view_box.aspect.align,
+            0.0,
+            0.0,
+            new_size.width() - r.width(),
+            new_size.height() - r.height(),
+        );
+
+        (r.x() - dx, r.y() - dy, Some(r))
+    } else {
+        let (dx, dy) = usvg::utils::aligned_pos(
+            view_box.aspect.align,
+            r.x(),
+            r.y(),
+            r.width() - new_size.width(),
+            r.height() - new_size.height(),
+        );
+
+        (dx, dy, None)
+    };
+
+    let sx = new_size.width() / img_size.width() as f32;
+    let sy = new_size.height() / img_size.height() as f32;
+    let ts = usvg::Transform::from_row(sx, 0.0, 0.0, sy, tx, ty);
+
+    (ts, clip)
+}
+
+/// Fits size into a viewbox.
+pub fn fit_view_box(size: usvg::Size, vb: &usvg::ViewBox) -> usvg::Size {
+    let s = vb.rect.size();
+
+    if vb.aspect.align == usvg::Align::None {
+        s
+    } else if vb.aspect.slice {
+        size.expand_to(s)
+    } else {
+        size.scale_to(s)
+    }
+}

--- a/integrations/vello_svg/src/geom.rs
+++ b/integrations/vello_svg/src/geom.rs
@@ -1,6 +1,5 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright 2018 Yevhenii Reizner
+// SPDX-License-Identifier: MPL-2.0
 
 // copied from https://github.com/RazrFalcon/resvg/blob/4d27b8c3be3ecfff3256c9be1b8362eb22533659/crates/resvg/src/geom.rs
 

--- a/integrations/vello_svg/src/lib.rs
+++ b/integrations/vello_svg/src/lib.rs
@@ -76,8 +76,8 @@ pub fn render_tree_with(
                 sy,
                 tx,
                 ty,
-            } = ts.pre_concat(node.abs_transform());
-            Affine::new([sx, kx, ky, sy, tx, ty].map(f64::from))
+            } = ts;
+            Affine::new([sx, kx, ky, sy, tx, ty].map(|&x| f64::from(x)))
         };
         match node {
             usvg::Node::Group(g) => {
@@ -99,7 +99,7 @@ pub fn render_tree_with(
                     }
                 }
 
-                render_tree_with(scene, g, &g.transform())?;
+                render_tree_with(scene, g, &ts.pre_concat(g.transform()))?;
 
                 if pushed_clip {
                     scene.pop_layer();

--- a/integrations/vello_svg/src/lib.rs
+++ b/integrations/vello_svg/src/lib.rs
@@ -89,7 +89,7 @@ pub fn render_tree_with(
                         scene.push_layer(
                             BlendMode {
                                 mix: vello::peniko::Mix::Clip,
-                                compose: vello::peniko::Compose::SrcIn,
+                                compose: vello::peniko::Compose::SrcOver,
                             },
                             1.0,
                             transform,
@@ -106,7 +106,6 @@ pub fn render_tree_with(
                 }
             }
             usvg::Node::Path(path) => {
-                path.abs_transform();
                 let local_path = to_bez_path(path);
 
                 // FIXME: let path.paint_order determine the fill/stroke order.


### PR DESCRIPTION
- Bump usvg to v0.40
- Support basic clip-path(`clip-path` with exactly 1 `path`)
- Support embeded image
- Take path/image visibility into consideration
- Support stroke/fill paint order

Due to [upstream bug](https://github.com/RazrFalcon/resvg/issues/722), `abs_transform` is not accurate for `use` with positions in v0.40. So this pr calculate `transform` manually.

TODO:

- [x] try recover original error processing logic
- [x] properly handle error in image related code path
- [x] correct image viewbox & clipping