### PR TITLE
ci: Add typos check for common spelling errors.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,3 +290,12 @@ jobs:
       # We test documentation using nightly to match docs.rs. This prevents potential breakages
       - name: cargo doc
         run: cargo doc --workspace --locked --all-features --no-deps --document-private-items -Zunstable-options -Zrustdoc-scrape-examples
+
+  # If this fails, consider changing your text or adding something to `.typos.toml`
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: check typos
+        uses: crate-ci/typos@v1.21.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,7 +291,7 @@ jobs:
       - name: cargo doc
         run: cargo doc --workspace --locked --all-features --no-deps --document-private-items -Zunstable-options -Zrustdoc-scrape-examples
 
-  # If this fails, consider changing your text or adding something to `.typos.toml`
+  # If this fails, consider changing your text or adding something to .typos.toml
   typos:
     runs-on: ubuntu-latest
     steps:

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,3 +1,6 @@
+# See the configuration reference at
+# https://github.com/crate-ci/typos/blob/master/docs/reference.md
+
 # Corrections take the form of a key/value pair. The key is the incorrect word
 # and the value is the correct word. If the key and value are the same, the
 # word is treated as always correct. If the value is an empty string, the word

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,8 @@
+# Corrections take the form of a key/value pair. The key is the incorrect word
+# and the value is the correct word. If the key and value are the same, the
+# word is treated as always correct. If the value is an empty string, the word
+# is treated as always incorrect.
+
+# Match Inside a Word - Case Insensitive
+[default.extend-words]
+thm = "thm"


### PR DESCRIPTION
This will fail until #490 and #491 land.

I'm not thrilled about the discoverability here if a CI check fails due to this. We don't really have a place for docs about this yet (even a `CONTRIBUTING.md`) ...
