### PR TITLE
Disable the async pipeline by default

### DIFF
--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -462,7 +462,8 @@ fn run(
                             .get_current_texture()
                             .expect("failed to get surface texture");
                         // Note: we don't run the async/"robust" pipeline, as
-                        // it requires more async wiring for the readback.
+                        // it requires more async wiring for the readback. See
+                        // [#gpu > async on wasm](https://xi.zulipchat.com/#narrow/stream/197075-gpu/topic/async.20on.20wasm)
                         if args.async_pipeline && cfg!(not(target_arch = "wasm32")) {
                             scene_complexity = vello::block_on_wgpu(
                                 &device_handle.device,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,6 +362,9 @@ impl Renderer {
                 occlusion_query_set: None,
                 timestamp_writes: None,
             });
+            let mut render_pass = self
+                .profiler
+                .scope("blit to surface", &mut render_pass, device);
             render_pass.set_pipeline(&blit.pipeline);
             render_pass.set_bind_group(0, &bind_group, &[]);
             render_pass.draw(0..6, 0..1);
@@ -521,6 +524,9 @@ impl Renderer {
                 timestamp_writes: None,
                 occlusion_query_set: None,
             });
+            let mut render_pass = self
+                .profiler
+                .scope("blit to surface", &mut render_pass, device);
             render_pass.set_pipeline(&blit.pipeline);
             render_pass.set_bind_group(0, &bind_group, &[]);
             render_pass.draw(0..6, 0..1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -366,8 +366,19 @@ impl Renderer {
             render_pass.set_bind_group(0, &bind_group, &[]);
             render_pass.draw(0..6, 0..1);
         }
+        #[cfg(feature = "wgpu-profiler")]
+        self.profiler.resolve_queries(&mut encoder);
         queue.submit(Some(encoder.finish()));
         self.target = Some(target);
+        #[cfg(feature = "wgpu-profiler")]
+        self.profiler.end_frame().unwrap();
+        #[cfg(feature = "wgpu-profiler")]
+        if let Some(result) = self
+            .profiler
+            .process_finished_frame(queue.get_timestamp_period())
+        {
+            self.profile_result = Some(result);
+        }
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -374,13 +374,14 @@ impl Renderer {
         queue.submit(Some(encoder.finish()));
         self.target = Some(target);
         #[cfg(feature = "wgpu-profiler")]
-        self.profiler.end_frame().unwrap();
-        #[cfg(feature = "wgpu-profiler")]
-        if let Some(result) = self
-            .profiler
-            .process_finished_frame(queue.get_timestamp_period())
         {
-            self.profile_result = Some(result);
+            self.profiler.end_frame().unwrap();
+            if let Some(result) = self
+                .profiler
+                .process_finished_frame(queue.get_timestamp_period())
+            {
+                self.profile_result = Some(result);
+            }
         }
         Ok(())
     }
@@ -536,13 +537,14 @@ impl Renderer {
         queue.submit(Some(encoder.finish()));
         self.target = Some(target);
         #[cfg(feature = "wgpu-profiler")]
-        self.profiler.end_frame().unwrap();
-        #[cfg(feature = "wgpu-profiler")]
-        if let Some(result) = self
-            .profiler
-            .process_finished_frame(queue.get_timestamp_period())
         {
-            self.profile_result = Some(result);
+            self.profiler.end_frame().unwrap();
+            if let Some(result) = self
+                .profiler
+                .process_finished_frame(queue.get_timestamp_period())
+            {
+                self.profile_result = Some(result);
+            }
         }
         Ok(bump)
     }


### PR DESCRIPTION
The async pipeline is not wired up to do robust readback, so it has few advantages (see #366)

This PR also enables the non-async pipeline's interaction with the GPU profiling (which should make it work on wasm)

@simbleau this might also properly fix #494, incidentally.