### PR TITLE
Integrate Android Tracing into with_winit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_trace"
+version = "0.1.0"
+source = "git+https://github.com/DJMcNab/android_trace?rev=74fe8a80937d62bacaea5d47ed1bb11ed998db97#74fe8a80937d62bacaea5d47ed1bb11ed998db97"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,9 +331,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "base64"
@@ -411,7 +419,7 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -459,7 +467,7 @@ checksum = "7de77523d154e220a740e568a89f52fac7de481374bdecbbbeb283a37580ba34"
 dependencies = [
  "bevy_macro_utils",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -507,7 +515,7 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -550,7 +558,7 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -639,7 +647,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc-hash",
- "syn 2.0.53",
+ "syn 2.0.55",
  "toml_edit",
 ]
 
@@ -720,7 +728,7 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
  "uuid",
 ]
 
@@ -778,7 +786,7 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -870,7 +878,7 @@ checksum = "014c80f466ed01821a2e602d63cd5076915c1af5de5fa3c074cc4a9ca898ada7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1057,7 +1065,7 @@ checksum = "4da9a32f3fed317401fa3c862968128267c3106685286e15d5aaa3d7389c2f60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1068,9 +1076,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "calloop"
@@ -1140,9 +1148,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "clap"
-version = "4.5.3"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1162,14 +1170,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.3"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1525,7 +1533,7 @@ checksum = "92959a9e8d13eaa13b8ae8c7b583c3bf1669ca7a8e7708a088d12587ba86effc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1667,9 +1675,9 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "fdeflate"
@@ -1770,7 +1778,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2072,6 +2080,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
 name = "hexasphere"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2156,9 +2170,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.5"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -2186,9 +2200,9 @@ dependencies = [
 
 [[package]]
 name = "inquire"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fca231a35040487041f975afae9272ecd3701cc95a5efbbda36c6ecc22a269c"
+checksum = "fe95f33091b9b7b517a5849bce4dce1b550b430fc20d58059fcaa319ed895d8b"
 dependencies = [
  "bitflags 2.5.0",
  "crossterm",
@@ -2215,9 +2229,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jni"
@@ -2430,9 +2444,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "memmap2"
@@ -2490,7 +2504,7 @@ dependencies = [
  "bitflags 2.5.0",
  "codespan-reporting",
  "hexf-parse",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "log",
  "num-traits",
  "pp-rs",
@@ -2510,11 +2524,11 @@ dependencies = [
  "bit-set",
  "codespan-reporting",
  "data-encoding",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "naga",
  "once_cell",
  "regex",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.3",
  "rustc-hash",
  "thiserror",
  "tracing",
@@ -2641,7 +2655,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2799,7 +2813,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
 ]
 
 [[package]]
@@ -2846,12 +2860,13 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f040dee2588b4963afb4e420540439d126f73fdacf4a9c486a96d840bac3c9"
+checksum = "e0c976a60b2d7e99d6f229e414670a9b85d13ac305cc6d1e9c134de58c5aaaf6"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
+ "hermit-abi",
  "pin-project-lite",
  "rustix",
  "tracing",
@@ -2908,6 +2923,20 @@ name = "profiling"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d84d1d7a6ac92673717f9f6d1518374ef257669c24ebc5ac25d5033828be58"
+dependencies = [
+ "profiling-procmacros",
+ "tracing",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8021cf59c8ec9c432cfc2526ac6b8aa508ecaf29cd415f271b8406c1b851c3fd"
+dependencies = [
+ "quote",
+ "syn 2.0.55",
+]
 
 [[package]]
 name = "qoi"
@@ -2986,9 +3015,9 @@ checksum = "42a9830a0e1b9fb145ebb365b8bc4ccd75f290f98c0247deafbbe2c75cefb544"
 
 [[package]]
 name = "rayon"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -3039,14 +3068,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata 0.4.6",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -3066,7 +3095,7 @@ checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -3077,9 +3106,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "renderdoc-sys"
@@ -3154,9 +3183,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
+checksum = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c"
 dependencies = [
  "log",
  "ring",
@@ -3168,9 +3197,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8"
+checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
 
 [[package]]
 name = "rustls-webpki"
@@ -3284,14 +3313,14 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",
@@ -3519,9 +3548,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.53"
+version = "2.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
+checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3580,7 +3609,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -3656,7 +3685,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "toml_datetime",
  "winnow",
 ]
@@ -3667,6 +3696,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3680,7 +3710,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -3742,6 +3772,19 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "tracing_android_trace"
+version = "0.1.0"
+source = "git+https://github.com/DJMcNab/android_trace?rev=74fe8a80937d62bacaea5d47ed1bb11ed998db97#74fe8a80937d62bacaea5d47ed1bb11ed998db97"
+dependencies = [
+ "android_trace",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4077,7 +4120,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
  "wasm-bindgen-shared",
 ]
 
@@ -4143,7 +4186,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4323,9 +4366,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.67"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4392,7 +4435,7 @@ dependencies = [
  "bitflags 2.5.0",
  "cfg_aliases",
  "codespan-reporting",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "log",
  "naga",
  "once_cell",
@@ -4454,13 +4497,12 @@ dependencies = [
 
 [[package]]
 name = "wgpu-profiler"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5026bcb9625f0ad9bc0570811b40b4bc5249548a992feb695542d15faeadac"
+checksum = "198b96a1940b527c6e21ab829b3630eb4e8ffb602fd12839d8c5e088c8e06192"
 dependencies = [
  "parking_lot",
  "thiserror",
- "web-sys",
  "wgpu",
 ]
 
@@ -4842,7 +4884,11 @@ dependencies = [
  "log",
  "notify-debouncer-mini",
  "pollster",
+ "profiling",
  "scenes",
+ "tracing",
+ "tracing-subscriber",
+ "tracing_android_trace",
  "vello",
  "wasm-bindgen-futures",
  "web-sys",
@@ -4937,7 +4983,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,8 @@ dependencies = [
 [[package]]
 name = "android_trace"
 version = "0.1.0"
-source = "git+https://github.com/DJMcNab/android_trace?rev=5c4068fe9ca1277b8e407a27c2db36e16c7da4af#5c4068fe9ca1277b8e407a27c2db36e16c7da4af"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ffda51edaddd7de7fd2bbfe7e22eb883bbb606b56bcd2b0ce7f0eae5c1de09"
 dependencies = [
  "libc",
 ]
@@ -3777,7 +3778,8 @@ dependencies = [
 [[package]]
 name = "tracing_android_trace"
 version = "0.1.0"
-source = "git+https://github.com/DJMcNab/android_trace?rev=5c4068fe9ca1277b8e407a27c2db36e16c7da4af#5c4068fe9ca1277b8e407a27c2db36e16c7da4af"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70195e7e4f72dde4d2bf6bbb04594a02df0ec3993c2f4b6cb5f76d13fe35ab46"
 dependencies = [
  "android_trace",
  "smallvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ dependencies = [
 [[package]]
 name = "android_trace"
 version = "0.1.0"
-source = "git+https://github.com/DJMcNab/android_trace?rev=74fe8a80937d62bacaea5d47ed1bb11ed998db97#74fe8a80937d62bacaea5d47ed1bb11ed998db97"
+source = "git+https://github.com/DJMcNab/android_trace?rev=5c4068fe9ca1277b8e407a27c2db36e16c7da4af#5c4068fe9ca1277b8e407a27c2db36e16c7da4af"
 dependencies = [
  "libc",
 ]
@@ -3777,7 +3777,7 @@ dependencies = [
 [[package]]
 name = "tracing_android_trace"
 version = "0.1.0"
-source = "git+https://github.com/DJMcNab/android_trace?rev=74fe8a80937d62bacaea5d47ed1bb11ed998db97#74fe8a80937d62bacaea5d47ed1bb11ed998db97"
+source = "git+https://github.com/DJMcNab/android_trace?rev=5c4068fe9ca1277b8e407a27c2db36e16c7da4af#5c4068fe9ca1277b8e407a27c2db36e16c7da4af"
 dependencies = [
  "android_trace",
  "smallvec",

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -55,7 +55,7 @@ notify-debouncer-mini = "0.3.0"
 winit = { version = "0.29.15", features = ["android-native-activity"] }
 android_logger = "0.13.3"
 
-tracing_android_trace = { git = "https://github.com/DJMcNab/android_trace", rev = "5c4068fe9ca1277b8e407a27c2db36e16c7da4af" }
+tracing_android_trace = "0.1.0"
 tracing-subscriber = { version = "0.3.18", default-features = false, features = [
     "std",
     "registry",
@@ -68,10 +68,3 @@ console_log = "1.0.0"
 wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.67", features = ["HtmlCollection", "Text"] }
 getrandom = { version = "0.2.12", features = ["js"] }
-
-[package.metadata.android.signing.release]
-path = "/home/djmcnab/.android/debug.keystore"
-keystore_password = "android"
-
-[package.metadata.android.application]
-debuggable = true

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -55,7 +55,7 @@ notify-debouncer-mini = "0.3.0"
 winit = { version = "0.29.15", features = ["android-native-activity"] }
 android_logger = "0.13.3"
 
-tracing_android_trace = { git = "https://github.com/DJMcNab/android_trace", rev = "74fe8a80937d62bacaea5d47ed1bb11ed998db97" }
+tracing_android_trace = { git = "https://github.com/DJMcNab/android_trace", rev = "5c4068fe9ca1277b8e407a27c2db36e16c7da4af" }
 tracing-subscriber = { version = "0.3.18", default-features = false, features = [
     "std",
     "registry",
@@ -68,3 +68,10 @@ console_log = "1.0.0"
 wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.67", features = ["HtmlCollection", "Text"] }
 getrandom = { version = "0.2.12", features = ["js"] }
+
+[package.metadata.android.signing.release]
+path = "/home/djmcnab/.android/debug.keystore"
+keystore_password = "android"
+
+[package.metadata.android.application]
+debuggable = true

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -38,6 +38,10 @@ wgpu = { workspace = true }
 winit = "0.29.15"
 log = { workspace = true }
 
+# We're still using env-logger, but we want to use tracing spans to allow using
+# tracing_android_trace
+tracing = { version = "0.1.40", features = ["log-always"] }
+
 [target.'cfg(not(target_os = "android"))'.dependencies]
 # We use android_logger on Android
 env_logger = "0.11.3"
@@ -50,6 +54,12 @@ notify-debouncer-mini = "0.3.0"
 [target.'cfg(target_os = "android")'.dependencies]
 winit = { version = "0.29.15", features = ["android-native-activity"] }
 android_logger = "0.13.3"
+tracing_android_trace = { rev = "5e33f8ae777e58372013ac3273387480e40c0b36", git = "https://github.com/DJMcNab/android_trace" }
+tracing-subscriber = { version = "0.3.18", default-features = false, features = [
+    "std",
+    "registry",
+] }
+profiling = { version = "1.0", features = ["profile-with-tracing"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.7"

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -54,7 +54,8 @@ notify-debouncer-mini = "0.3.0"
 [target.'cfg(target_os = "android")'.dependencies]
 winit = { version = "0.29.15", features = ["android-native-activity"] }
 android_logger = "0.13.3"
-tracing_android_trace = { rev = "5e33f8ae777e58372013ac3273387480e40c0b36", git = "https://github.com/DJMcNab/android_trace" }
+
+tracing_android_trace = { git = "https://github.com/DJMcNab/android_trace", rev = "74fe8a80937d62bacaea5d47ed1bb11ed998db97" }
 tracing-subscriber = { version = "0.3.18", default-features = false, features = [
     "std",
     "registry",

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -800,13 +800,12 @@ mod atrace {
         _private: (),
     }
 
-    #[cfg(target_os = "android")]
-    use std::ffi::c_char;
     // See https://developer.android.com/topic/performance/tracing/custom-events-native
     #[link(name = "android", kind = "dylib")]
+    #[cfg(target_os = "android")]
     extern "C" {
         #[link_name = "ATrace_beginSection"]
-        fn atrace_begin_section(text: *const c_char);
+        fn atrace_begin_section(text: *const std::ffi::c_char);
         #[link_name = "ATrace_endSection"]
         fn atrace_end_section();
     }
@@ -816,7 +815,8 @@ mod atrace {
     }
 
     impl ATraceSpan {
-        fn new(name: &str) -> Self {
+        #[allow(unused_variables)] // Keep correct name even when trace does nothing
+        pub(crate) fn new(name: &str) -> Self {
             #[cfg(target_os = "android")]
             {
                 let name = std::ffi::CString::new(name).unwrap();

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -818,7 +818,7 @@ fn android_main(app: AndroidApp) {
     use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
     tracing_subscriber::registry()
-        .with(tracing_android_trace::ATraceLayer::new())
+        .with(tracing_android_trace::AndroidTraceLayer::new())
         .try_init()
         .unwrap();
     log::info!(

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -194,7 +194,7 @@ fn run(
                     return;
                 }
                 let _span = if !matches!(event, WindowEvent::RedrawRequested) {
-                    Some(atrace::span(&format!("Handling {event:?}")))
+                    Some(tracing::trace_span!("Handling window event", ?event).entered())
                 } else {
                     None
                 };
@@ -380,8 +380,9 @@ fn run(
                         prior_position = Some(position);
                     }
                     WindowEvent::RedrawRequested => {
-                        let _rendering_aspan = atrace::span("Actioning Requested Redraw");
-                        let encoding_aspan = atrace::span("Encoding_scene");
+                        let _rendering_span =
+                            tracing::trace_span!("Actioning Requested Redraw").entered();
+                        let encoding_span = tracing::trace_span!("Encoding scene").entered();
 
                         let width = render_state.surface.config.width;
                         let height = render_state.surface.config.height;
@@ -473,15 +474,15 @@ fn run(
                                 );
                             }
                         }
-                        encoding_aspan.finish();
-                        let texture_aspan = atrace::span("Getting texture");
+                        drop(encoding_span);
+                        let texture_span = tracing::trace_span!("Getting texture").entered();
                         let surface_texture = render_state
                             .surface
                             .surface
                             .get_current_texture()
                             .expect("failed to get surface texture");
-                        texture_aspan.finish();
-                        let render_aspan = atrace::span("Dispatching render");
+                        drop(texture_span);
+                        let render_span = tracing::trace_span!("Dispatching render").entered();
                         // Note: we don't run the async/"robust" pipeline, as
                         // it requires more async wiring for the readback. See
                         // [#gpu > async on wasm](https://xi.zulipchat.com/#narrow/stream/197075-gpu/topic/async.20on.20wasm)
@@ -514,9 +515,9 @@ fn run(
                                 .expect("failed to render to surface");
                         }
                         surface_texture.present();
-                        render_aspan.finish();
+                        drop(render_span);
                         {
-                            let _poll_aspan = atrace::span("Polling wgpu");
+                            let _poll_aspan = tracing::trace_span!("Polling wgpu device").entered();
                             device_handle.device.poll(wgpu::Maintain::Poll);
                         }
                         let new_time = Instant::now();
@@ -793,54 +794,6 @@ fn parse_arguments() -> Args {
 #[cfg(target_os = "android")]
 use winit::platform::android::activity::AndroidApp;
 
-mod atrace {
-
-    #[non_exhaustive]
-    pub struct ATraceSpan {
-        _private: (),
-    }
-
-    // See https://developer.android.com/topic/performance/tracing/custom-events-native
-    #[link(name = "android", kind = "dylib")]
-    #[cfg(target_os = "android")]
-    extern "C" {
-        #[link_name = "ATrace_beginSection"]
-        fn atrace_begin_section(text: *const std::ffi::c_char);
-        #[link_name = "ATrace_endSection"]
-        fn atrace_end_section();
-    }
-
-    pub(crate) fn span(name: &str) -> ATraceSpan {
-        ATraceSpan::new(name)
-    }
-
-    impl ATraceSpan {
-        #[allow(unused_variables)] // Keep correct name even when trace does nothing
-        pub(crate) fn new(name: &str) -> Self {
-            #[cfg(target_os = "android")]
-            {
-                let name = std::ffi::CString::new(name).unwrap();
-                // SAFETY: `name` is a valid C string
-                unsafe { atrace_begin_section(name.as_ptr()) };
-                drop(name);
-            }
-            ATraceSpan { _private: () }
-        }
-        pub(crate) fn finish(self) {
-            drop(self)
-        }
-    }
-    impl Drop for ATraceSpan {
-        fn drop(&mut self) {
-            #[cfg(target_os = "android")]
-            unsafe {
-                // SAFETY: No preconditions
-                atrace_end_section()
-            }
-        }
-    }
-}
-
 #[cfg(target_os = "android")]
 #[no_mangle]
 fn android_main(app: AndroidApp) {
@@ -860,6 +813,18 @@ fn android_main(app: AndroidApp) {
         config.with_max_level(log::LevelFilter::Warn)
     };
     android_logger::init_once(config);
+
+    // Send tracing events to Android Trace
+    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+    tracing_subscriber::registry()
+        .with(tracing_android_trace::ATraceLayer::new())
+        .try_init()
+        .unwrap();
+    log::info!(
+        "Max level: {}",
+        tracing::level_filters::LevelFilter::current()
+    );
 
     let event_loop = EventLoopBuilder::with_user_event()
         .with_android_app(app)

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -802,6 +802,7 @@ mod atrace {
 
     #[cfg(target_os = "android")]
     use std::ffi::c_char;
+    // See https://developer.android.com/topic/performance/tracing/custom-events-native
     #[link(name = "android", kind = "dylib")]
     extern "C" {
         #[link_name = "ATrace_beginSection"]
@@ -819,6 +820,7 @@ mod atrace {
             #[cfg(target_os = "android")]
             {
                 let name = std::ffi::CString::new(name).unwrap();
+                // SAFETY: `name` is a valid C string
                 unsafe { atrace_begin_section(name.as_ptr()) };
                 drop(name);
             }
@@ -832,6 +834,7 @@ mod atrace {
         fn drop(&mut self) {
             #[cfg(target_os = "android")]
             unsafe {
+                // SAFETY: No preconditions
                 atrace_end_section()
             }
         }


### PR DESCRIPTION
This is using our new [Tracing Android Trace](https://github.com/linebender/android_trace/tree/main/tracing_android_trace)

This in turn connects with https://developer.android.com/topic/performance/tracing/custom-events-native

You should use Android GPU Inspector (https://gpuinspector.dev/) to read these events (with the `atrace_apps: "*"` set)

![image](https://github.com/linebender/vello/assets/36049421/2275941a-fb8c-43d9-96c6-fd8091827838)