### PR TITLE
Refactor CI jobs to allow for more concurrency.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,10 +214,9 @@ jobs:
 
   doc:
     name: cargo doc
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-latest, macos-14, ubuntu-latest]
+    # NOTE: We don't have any platform specific docs in this workspace, so we only run on Ubuntu.
+    #       If we get per-platform docs (win/macos/linux/wasm32/..) then doc jobs should match that.
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,14 @@ env:
 #
 # Using cargo-hack also allows us to more easily test the feature matrix of our packages.
 # We use --each-feature & --optional-deps which will run a separate check for every feature.
+#
+# We use macos-14 explictly instead of macos-latest because:
+#   * macos-latest currently points to macos-12
+#   * macos-14 provides us with the GPU support we want for testing
+#   * macos-14 comes with the M1 CPU which compiles our code much faster than the older runners
+# This explicit dependency can be switched back to macos-latest once it points to macos-14,
+# which is expected to happen sometime in Q2 FY24 (April – June 2024).
+# https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/
 
 name: CI
 
@@ -59,7 +67,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        os: [windows-latest, macos-14, ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
 
@@ -119,7 +127,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # We use macos-14 as that is an arm runner. These have the virtgpu support we need
         os: [windows-latest, macos-14, ubuntu-latest]
         include:
           - os: ubuntu-latest
@@ -210,7 +217,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        os: [windows-latest, macos-14, ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,9 @@ on:
   merge_group:
 
 jobs:
-  rustfmt:
-    runs-on: ubuntu-latest
+  fmt:
     name: cargo fmt
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -54,22 +54,12 @@ jobs:
       - name: check copyright headers
         run: bash .github/copyright.sh
 
-  test-stable:
+  clippy-stable:
+    name: cargo clippy
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # We use macos-14 as that is an arm runner. These have the virtgpu support we need
-        os: [windows-latest, macos-14, ubuntu-latest]
-        include:
-          - os: ubuntu-latest
-            gpu: 'yes'
-          - os: macos-14
-            gpu: 'yes'
-          - os: windows-latest
-            # TODO: The windows runners theoretically have CPU fallback for GPUs, but
-            # this failed in initial testing
-            gpu: 'no'
-    name: cargo clippy + test
+        os: [windows-latest, macos-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
 
@@ -91,30 +81,15 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
 
-      # Adapted from https://github.com/bevyengine/bevy/blob/b446374392adc70aceb92621b080d1a6cf7a7392/.github/workflows/validation-jobs.yml#L74-L79
-      - name: install xvfb, llvmpipe and lavapipe
-        if: matrix.os == 'ubuntu-latest'
-        # https://launchpad.net/~kisak/+archive/ubuntu/turtle
-        run: |
-          sudo apt-get update -y -qq
-          sudo add-apt-repository ppa:kisak/turtle -y
-          sudo apt-get update
-          sudo apt install -y xvfb libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
-
       - name: cargo clippy
         run: cargo hack clippy --workspace --each-feature --optional-deps -- -D warnings
-  
+
       - name: cargo clippy (auxiliary)
         run: cargo hack clippy --workspace --each-feature --optional-deps --tests --benches --examples -- -D warnings
 
-      - name: cargo test
-        run: cargo test --workspace --all-features
-        env:
-          VELLO_CI_GPU_SUPPORT: ${{ matrix.gpu }}
-
   clippy-stable-wasm:
+    name: cargo clippy (wasm32)
     runs-on: ubuntu-latest
-    name: cargo clippy + test (wasm32)
     steps:
       - uses: actions/checkout@v4
 
@@ -132,20 +107,83 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-hack
-          
+
       - name: cargo clippy
         run: cargo hack clippy --workspace --target wasm32-unknown-unknown --each-feature --optional-deps -- -D warnings
-  
+
       - name: cargo clippy (auxiliary)
         run: cargo hack clippy --workspace --target wasm32-unknown-unknown --each-feature --optional-deps --tests --benches --examples -- -D warnings
+
+  test-stable:
+    name: cargo test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # We use macos-14 as that is an arm runner. These have the virtgpu support we need
+        os: [windows-latest, macos-14, ubuntu-latest]
+        include:
+          - os: ubuntu-latest
+            gpu: 'yes'
+          - os: macos-14
+            gpu: 'yes'
+          - os: windows-latest
+            # TODO: The windows runners theoretically have CPU fallback for GPUs, but
+            # this failed in initial testing
+            gpu: 'no'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE_VER }}
+          components: clippy
+
+      - name: install native dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+
+      # Adapted from https://github.com/bevyengine/bevy/blob/b446374392adc70aceb92621b080d1a6cf7a7392/.github/workflows/validation-jobs.yml#L74-L79
+      - name: install xvfb, llvmpipe and lavapipe
+        if: matrix.os == 'ubuntu-latest'
+        # https://launchpad.net/~kisak/+archive/ubuntu/turtle
+        run: |
+          sudo apt-get update -y -qq
+          sudo add-apt-repository ppa:kisak/turtle -y
+          sudo apt-get update
+          sudo apt install -y xvfb libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
+
+      - name: cargo test
+        run: cargo test --workspace --all-features
+        env:
+          VELLO_CI_GPU_SUPPORT: ${{ matrix.gpu }}
+
+  test-stable-wasm:
+    name: cargo test (wasm32)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE_VER }}
+          targets: wasm32-unknown-unknown
+          components: clippy
 
       # TODO: Find a way to make tests work. Until then the tests are merely compiled.
       - name: cargo test compile
         run: cargo test --workspace --target wasm32-unknown-unknown --all-features --no-run
 
-  android-stable-check:
-    runs-on: ubuntu-latest
+  check-stable-android:
     name: cargo check (aarch64-android)
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -167,7 +205,7 @@ jobs:
           # This is a bit of a hack, but cargo apk doesn't seem to allow customising this
           RUSTFLAGS: '-D warnings'
 
-  docs:
+  doc:
     name: cargo doc
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
With #504 merged we now do Clippy checks for each package and feature separately. That is great for catching issues but it comes with the downside of increasing the wall time our CI takes to run.

The increased wall time comes due to several factors:
* There is just more work to do, as different features mean we need to compile packages multiple times.
* More compilation artifacts means it also takes more time to compress/decompress by the cache step.
* The `cargo test` pass that comes after `cargo clippy` will do feature unification and so is guaranteed to force another compilation pass on a bunch of crates.

This PR here addresses the third point, i.e. that `cargo test` is more decoupled from `cargo clippy` now. That also means that there are fewer reasons to keep it in the same job. Thus this PR splits the `cargo clippy + test` jobs into separate `cargo clippy` and `cargo test` jobs.

Splitting the jobs will have a significant impact on wall time. For wall time what ultimately matters is the slowest job, which is the old `cargo clippy + test` on Windows. I estimate that this PR will cut its wall time by ~40% from 12m30s to 7m30s. (***Edit:** The slowest Windows test on this PR took 7m39s. There will be run-to-run variance of course, but it's the ballpark.*)

The pre- and post-step overhead of the old job is about 17% - most of which is cache related and will be split between jobs now too. Not a clear split as there is some overlap in artifacts, but e.g. for Windows instead of a single 900MB cache we get a 350MB one and a 700MB one. So splitting the cache jobs won't result in a big CPU time increase and helps cut down the wall time even more.

---

I also switched all our macOS jobs to be explictly `macos-14`, because it's just so much faster. The following table shows the time comparison with cold cache runs. N=1 but the difference is huge and matches by previous casual observations, so I'm not concerned with run-to-run variance.

| Job | Time | Diff |
|---|---|---|
| cargo clippy (macos-latest) | 10m 51s | |
| cargo clippy (macos-14) | 2m 53s | -73% |
| &nbsp; | &nbsp; | &nbsp; |
| cargo doc (macos-latest) | 2m 25s | |
| cargo doc (macos-14) | 1m 39s | -32% |