### PR TITLE
Bring in Linebender wide `rustfmt` settings

### DIFF
--- a/crates/encoding/src/encoding.rs
+++ b/crates/encoding/src/encoding.rs
@@ -3,10 +3,8 @@
 
 use super::{DrawColor, DrawTag, PathEncoder, PathTag, Style, Transform};
 
-use peniko::{
-    kurbo::{Shape, Stroke},
-    BlendMode, BrushRef, Fill,
-};
+use peniko::kurbo::{Shape, Stroke};
+use peniko::{BlendMode, BrushRef, Fill};
 
 #[cfg(feature = "full")]
 use {

--- a/crates/encoding/src/glyph_cache.rs
+++ b/crates/encoding/src/glyph_cache.rs
@@ -5,11 +5,11 @@ use std::collections::HashMap;
 
 use super::{Encoding, StreamOffsets};
 
-use peniko::{
-    kurbo::{BezPath, Shape},
-    Fill, Style,
-};
-use skrifa::{instance::NormalizedCoord, outline::OutlinePen, GlyphId, OutlineGlyphCollection};
+use peniko::kurbo::{BezPath, Shape};
+use peniko::{Fill, Style};
+use skrifa::instance::NormalizedCoord;
+use skrifa::outline::OutlinePen;
+use skrifa::{GlyphId, OutlineGlyphCollection};
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Default, Debug)]
 pub struct GlyphKey {

--- a/crates/encoding/src/image_cache.rs
+++ b/crates/encoding/src/image_cache.rs
@@ -3,7 +3,8 @@
 
 use guillotiere::{size2, AtlasAllocator};
 use peniko::Image;
-use std::collections::{hash_map::Entry, HashMap};
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
 
 const DEFAULT_ATLAS_SIZE: i32 = 1024;
 const MAX_ATLAS_SIZE: i32 = 8192;

--- a/crates/encoding/src/path.rs
+++ b/crates/encoding/src/path.rs
@@ -2,10 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use bytemuck::{Pod, Zeroable};
-use peniko::{
-    kurbo::{Cap, Join, Shape, Stroke},
-    Fill,
-};
+use peniko::kurbo::{Cap, Join, Shape, Stroke};
+use peniko::Fill;
 
 use super::Monoid;
 

--- a/crates/shaders/src/compile/mod.rs
+++ b/crates/shaders/src/compile/mod.rs
@@ -1,18 +1,12 @@
 // Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use {
-    naga::{
-        front::wgsl,
-        valid::{Capabilities, ModuleInfo, ValidationError, ValidationFlags},
-        AddressSpace, ArraySize, ImageClass, Module, StorageAccess, WithSpan,
-    },
-    std::{
-        collections::{HashMap, HashSet},
-        path::Path,
-    },
-    thiserror::Error,
-};
+use naga::front::wgsl;
+use naga::valid::{Capabilities, ModuleInfo, ValidationError, ValidationFlags};
+use naga::{AddressSpace, ArraySize, ImageClass, Module, StorageAccess, WithSpan};
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+use thiserror::Error;
 
 pub mod permutations;
 pub mod preprocess;

--- a/crates/shaders/src/compile/msl.rs
+++ b/crates/shaders/src/compile/msl.rs
@@ -1,11 +1,9 @@
 // Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use super::{BindType, ShaderInfo};
+use crate::types::msl::BindingIndex;
 use naga::back::msl as naga_msl;
-use {
-    super::{BindType, ShaderInfo},
-    crate::types::msl::BindingIndex,
-};
 
 pub fn translate(shader: &ShaderInfo) -> Result<String, naga_msl::Error> {
     let mut map = naga_msl::EntryPointResourceMap::default();

--- a/crates/shaders/src/compile/preprocess.rs
+++ b/crates/shaders/src/compile/preprocess.rs
@@ -1,12 +1,9 @@
 // Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use std::{
-    collections::{HashMap, HashSet},
-    fs,
-    path::Path,
-    vec,
-};
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+use std::{fs, vec};
 
 pub fn get_imports(shader_dir: &Path) -> HashMap<String, String> {
     let mut imports = HashMap::new();

--- a/crates/tests/src/lib.rs
+++ b/crates/tests/src/lib.rs
@@ -1,15 +1,16 @@
 // Copyright 2024 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use std::{env, fs::File, num::NonZeroUsize, path::Path, sync::Arc};
+use std::env;
+use std::fs::File;
+use std::num::NonZeroUsize;
+use std::path::Path;
+use std::sync::Arc;
 
 use anyhow::{anyhow, bail, Result};
-use vello::{
-    block_on_wgpu,
-    peniko::{Blob, Color, Format, Image},
-    util::RenderContext,
-    RendererOptions, Scene,
-};
+use vello::peniko::{Blob, Color, Format, Image};
+use vello::util::RenderContext;
+use vello::{block_on_wgpu, RendererOptions, Scene};
 use wgpu::{
     BufferDescriptor, BufferUsages, CommandEncoderDescriptor, Extent3d, ImageCopyBuffer,
     TextureDescriptor, TextureFormat, TextureUsages,

--- a/crates/tests/tests/smoke.rs
+++ b/crates/tests/tests/smoke.rs
@@ -1,11 +1,9 @@
 // Copyright 2024 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use vello::{
-    kurbo::{Affine, Rect},
-    peniko::{Brush, Color, Format},
-    Scene,
-};
+use vello::kurbo::{Affine, Rect};
+use vello::peniko::{Brush, Color, Format};
+use vello::Scene;
 use vello_tests::TestParams;
 
 #[test]

--- a/examples/headless/src/main.rs
+++ b/examples/headless/src/main.rs
@@ -1,21 +1,16 @@
 // Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use std::{
-    fs::File,
-    num::NonZeroUsize,
-    path::{Path, PathBuf},
-};
+use std::fs::File;
+use std::num::NonZeroUsize;
+use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, bail, Context, Result};
 use clap::{CommandFactory, Parser};
 use scenes::{ImageCache, SceneParams, SceneSet, SimpleText};
-use vello::{
-    block_on_wgpu,
-    kurbo::{Affine, Vec2},
-    util::RenderContext,
-    RendererOptions, Scene,
-};
+use vello::kurbo::{Affine, Vec2};
+use vello::util::RenderContext;
+use vello::{block_on_wgpu, RendererOptions, Scene};
 use wgpu::{
     BufferDescriptor, BufferUsages, CommandEncoderDescriptor, Extent3d, ImageCopyBuffer,
     TextureDescriptor, TextureFormat, TextureUsages,

--- a/examples/scenes/src/download.rs
+++ b/examples/scenes/src/download.rs
@@ -1,10 +1,8 @@
 // Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use std::{
-    io::Seek,
-    path::{Path, PathBuf},
-};
+use std::io::Seek;
+use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
 use byte_unit::Byte;

--- a/examples/scenes/src/lib.rs
+++ b/examples/scenes/src/lib.rs
@@ -19,7 +19,9 @@ pub use simple_text::SimpleText;
 pub use svg::{default_scene, scene_from_files};
 pub use test_scenes::test_scenes;
 
-use vello::{kurbo::Vec2, peniko::Color, Scene};
+use vello::kurbo::Vec2;
+use vello::peniko::Color;
+use vello::Scene;
 
 pub struct SceneParams<'a> {
     pub time: f64,

--- a/examples/scenes/src/mmark.rs
+++ b/examples/scenes/src/mmark.rs
@@ -11,12 +11,11 @@
 
 use std::cmp::Ordering;
 
-use rand::{seq::SliceRandom, Rng};
+use rand::seq::SliceRandom;
+use rand::Rng;
+use vello::kurbo::{Affine, BezPath, CubicBez, Line, ParamCurve, PathSeg, Point, QuadBez, Stroke};
 use vello::peniko::Color;
-use vello::{
-    kurbo::{Affine, BezPath, CubicBez, Line, ParamCurve, PathSeg, Point, QuadBez, Stroke},
-    Scene,
-};
+use vello::Scene;
 
 use crate::{SceneParams, TestScene};
 

--- a/examples/scenes/src/simple_text.rs
+++ b/examples/scenes/src/simple_text.rs
@@ -3,13 +3,12 @@
 
 use std::sync::Arc;
 
-use vello::{
-    glyph::Glyph,
-    kurbo::Affine,
-    peniko::{Blob, Brush, BrushRef, Font, StyleRef},
-    skrifa::{raw::FontRef, MetadataProvider},
-    Scene,
-};
+use vello::glyph::Glyph;
+use vello::kurbo::Affine;
+use vello::peniko::{Blob, Brush, BrushRef, Font, StyleRef};
+use vello::skrifa::raw::FontRef;
+use vello::skrifa::MetadataProvider;
+use vello::Scene;
 
 // This is very much a hack to get things working.
 // On Windows, can set this to "c:\\Windows\\Fonts\\seguiemj.ttf" to get color emoji

--- a/examples/scenes/src/svg.rs
+++ b/examples/scenes/src/svg.rs
@@ -1,14 +1,13 @@
 // Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use std::{
-    fs::read_dir,
-    path::{Path, PathBuf},
-};
+use std::fs::read_dir;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Ok, Result};
 use instant::Instant;
-use vello::{kurbo::Vec2, Scene};
+use vello::kurbo::Vec2;
+use vello::Scene;
 use vello_svg::usvg;
 use vello_svg::usvg::TreeParsing;
 

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -8,12 +8,10 @@ use vello::kurbo::{Affine, Circle, Ellipse, Line, RoundedRect, Stroke};
 use vello::peniko::Color;
 use vello::util::{RenderContext, RenderSurface};
 use vello::{AaConfig, Renderer, RendererOptions, Scene};
-use winit::{
-    dpi::LogicalSize,
-    event::*,
-    event_loop::{ControlFlow, EventLoop},
-    window::{Window, WindowBuilder},
-};
+use winit::dpi::LogicalSize;
+use winit::event::*;
+use winit::event_loop::{ControlFlow, EventLoop};
+use winit::window::{Window, WindowBuilder};
 
 // Simple struct to hold the state of the renderer
 pub struct ActiveRenderState<'s> {

--- a/examples/with_bevy/src/main.rs
+++ b/examples/with_bevy/src/main.rs
@@ -9,18 +9,14 @@ use vello::kurbo::{Affine, Point, Rect, Stroke};
 use vello::peniko::{Color, Fill, Gradient};
 use vello::{Renderer, RendererOptions, Scene};
 
-use bevy::{
-    prelude::*,
-    render::{
-        extract_component::{ExtractComponent, ExtractComponentPlugin},
-        render_asset::RenderAssets,
-        render_resource::{
-            Extent3d, TextureDescriptor, TextureDimension, TextureFormat, TextureUsages,
-        },
-        renderer::{RenderDevice, RenderQueue},
-        RenderApp,
-    },
+use bevy::prelude::*;
+use bevy::render::extract_component::{ExtractComponent, ExtractComponentPlugin};
+use bevy::render::render_asset::RenderAssets;
+use bevy::render::render_resource::{
+    Extent3d, TextureDescriptor, TextureDimension, TextureFormat, TextureUsages,
 };
+use bevy::render::renderer::{RenderDevice, RenderQueue};
+use bevy::render::RenderApp;
 
 #[derive(Resource)]
 struct VelloRenderer(SyncCell<Renderer>);

--- a/examples/with_winit/src/hot_reload.rs
+++ b/examples/with_winit/src/hot_reload.rs
@@ -1,10 +1,12 @@
 // Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use std::{path::Path, time::Duration};
+use std::path::Path;
+use std::time::Duration;
 
 use anyhow::Result;
-use notify_debouncer_mini::{new_debouncer, notify::*, DebounceEventResult};
+use notify_debouncer_mini::notify::*;
+use notify_debouncer_mini::{new_debouncer, DebounceEventResult};
 
 pub(crate) fn hot_reload(mut f: impl FnMut() -> Option<()> + Send + 'static) -> Result<impl Sized> {
     let mut debouncer = new_debouncer(

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -2,24 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use instant::Instant;
+use std::collections::HashSet;
 use std::num::NonZeroUsize;
-use std::{collections::HashSet, sync::Arc};
+use std::sync::Arc;
 
 use clap::{CommandFactory, Parser};
 use scenes::{ImageCache, SceneParams, SceneSet, SimpleText};
+use vello::kurbo::{Affine, Vec2};
 use vello::peniko::Color;
-use vello::util::RenderSurface;
-use vello::{
-    kurbo::{Affine, Vec2},
-    util::RenderContext,
-    AaConfig, Renderer, Scene,
-};
-use vello::{BumpAllocators, RendererOptions};
+use vello::util::{RenderContext, RenderSurface};
+use vello::{AaConfig, BumpAllocators, Renderer, RendererOptions, Scene};
 
-use winit::{
-    event_loop::{EventLoop, EventLoopBuilder},
-    window::Window,
-};
+use winit::event_loop::{EventLoop, EventLoopBuilder};
+use winit::window::Window;
 
 #[cfg(not(any(target_arch = "wasm32", target_os = "android")))]
 mod hot_reload;
@@ -90,7 +85,9 @@ fn run(
     render_cx: RenderContext,
     #[cfg(target_arch = "wasm32")] render_state: RenderState,
 ) {
-    use winit::{event::*, event_loop::ControlFlow, keyboard::*};
+    use winit::event::*;
+    use winit::event_loop::ControlFlow;
+    use winit::keyboard::*;
     let mut renderers: Vec<Option<Renderer>> = vec![];
     #[cfg(not(target_arch = "wasm32"))]
     let mut render_cx = render_cx;
@@ -648,7 +645,8 @@ fn store_profiling(
 }
 
 fn create_window(event_loop: &winit::event_loop::EventLoopWindowTarget<UserEvent>) -> Arc<Window> {
-    use winit::{dpi::LogicalSize, window::WindowBuilder};
+    use winit::dpi::LogicalSize;
+    use winit::window::WindowBuilder;
     Arc::new(
         WindowBuilder::new()
             .with_inner_size(LogicalSize::new(1044, 800))

--- a/examples/with_winit/src/stats.rs
+++ b/examples/with_winit/src/stats.rs
@@ -3,11 +3,9 @@
 
 use scenes::SimpleText;
 use std::collections::VecDeque;
-use vello::{
-    kurbo::{Affine, PathEl, Rect, Stroke},
-    peniko::{Brush, Color, Fill},
-    AaConfig, BumpAllocators, Scene,
-};
+use vello::kurbo::{Affine, PathEl, Rect, Stroke};
+use vello::peniko::{Brush, Color, Fill};
+use vello::{AaConfig, BumpAllocators, Scene};
 
 const SLIDING_WINDOW_SIZE: usize = 100;
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+max_width = 100
+use_field_init_shorthand = true
+newline_style = "Unix"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
 max_width = 100
 use_field_init_shorthand = true
 newline_style = "Unix"
+# TODO: imports_granularity = "Module" - Wait for this to be stable.

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,3 @@
-max_width = 100
 use_field_init_shorthand = true
 newline_style = "Unix"
 # TODO: imports_granularity = "Module" - Wait for this to be stable.

--- a/src/cpu_dispatch.rs
+++ b/src/cpu_dispatch.rs
@@ -6,10 +6,8 @@
 //! Note that while this CPU implementation is useful for testing and debugging,
 //! a full CPU fallback for targets without wgpu hasn't been implemented yet.
 
-use std::{
-    cell::{Ref, RefCell, RefMut},
-    ops::{Deref, DerefMut},
-};
+use std::cell::{Ref, RefCell, RefMut};
+use std::ops::{Deref, DerefMut};
 
 use bytemuck::Pod;
 

--- a/src/cpu_shader/draw_leaf.rs
+++ b/src/cpu_shader/draw_leaf.rs
@@ -5,8 +5,8 @@ use vello_encoding::{Clip, ConfigUniform, DrawMonoid, DrawTag, Monoid, PathBbox}
 
 use crate::cpu_dispatch::CpuBinding;
 
+use super::util::{read_draw_tag_from_scene, Transform, Vec2};
 use super::{
-    util::{read_draw_tag_from_scene, Transform, Vec2},
     RAD_GRAD_KIND_CIRCULAR, RAD_GRAD_KIND_CONE, RAD_GRAD_KIND_FOCAL_ON_CIRCLE, RAD_GRAD_KIND_STRIP,
     RAD_GRAD_SWAPPED,
 };

--- a/src/cpu_shader/flatten.rs
+++ b/src/cpu_shader/flatten.rs
@@ -4,9 +4,10 @@
 use crate::cpu_dispatch::CpuBinding;
 
 use super::util::{Transform, Vec2, ROBUST_EPSILON};
+use vello_encoding::math::f16_to_f32;
 use vello_encoding::{
-    math::f16_to_f32, BumpAllocators, ConfigUniform, LineSoup, Monoid, PathBbox, PathMonoid,
-    PathTag, Style, DRAW_INFO_FLAGS_FILL_RULE_BIT,
+    BumpAllocators, ConfigUniform, LineSoup, Monoid, PathBbox, PathMonoid, PathTag, Style,
+    DRAW_INFO_FLAGS_FILL_RULE_BIT,
 };
 
 fn to_minus_one_quarter(x: f32) -> f32 {

--- a/src/cpu_shader/path_tiling.rs
+++ b/src/cpu_shader/path_tiling.rs
@@ -3,10 +3,8 @@
 
 use vello_encoding::{BumpAllocators, LineSoup, Path, PathSegment, SegmentCount, Tile};
 
-use crate::{
-    cpu_dispatch::CpuBinding,
-    cpu_shader::util::{ONE_MINUS_ULP, ROBUST_EPSILON},
-};
+use crate::cpu_dispatch::CpuBinding;
+use crate::cpu_shader::util::{ONE_MINUS_ULP, ROBUST_EPSILON};
 
 use super::util::{span, Vec2};
 

--- a/src/glyph.rs
+++ b/src/glyph.rs
@@ -4,22 +4,19 @@
 //! Support for glyph rendering.
 
 use crate::scene::Scene;
-use {
-    peniko::kurbo::Affine,
-    peniko::{Brush, Color, Fill, Style},
-    skrifa::{
-        instance::{NormalizedCoord, Size},
-        outline::OutlinePen,
-        raw::FontRef,
-        setting::Setting,
-        GlyphId, OutlineGlyphCollection,
-    },
-    vello_encoding::Encoding,
-};
+use peniko::kurbo::Affine;
+use peniko::{Brush, Color, Fill, Style};
+use skrifa::instance::{NormalizedCoord, Size};
+use skrifa::outline::OutlinePen;
+use skrifa::raw::FontRef;
+use skrifa::setting::Setting;
+use skrifa::{GlyphId, OutlineGlyphCollection};
+use vello_encoding::Encoding;
 
 use peniko::kurbo::Shape;
 pub use skrifa;
-use skrifa::{outline::DrawSettings, MetadataProvider};
+use skrifa::outline::DrawSettings;
+use skrifa::MetadataProvider;
 pub use vello_encoding::Glyph;
 
 /// General context for creating scene fragments for glyph outlines.

--- a/src/recording.rs
+++ b/src/recording.rs
@@ -1,10 +1,8 @@
 // Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use std::{
-    num::NonZeroU64,
-    sync::atomic::{AtomicU64, Ordering},
-};
+use std::num::NonZeroU64;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct ShaderId(pub usize);

--- a/src/render.rs
+++ b/src/render.rs
@@ -3,11 +3,9 @@
 
 //! Take an encoded scene and create a graph to render it
 
-use crate::{
-    recording::{BufferProxy, ImageFormat, ImageProxy, Recording, ResourceProxy},
-    shaders::FullShaders,
-    AaConfig, RenderParams,
-};
+use crate::recording::{BufferProxy, ImageFormat, ImageProxy, Recording, ResourceProxy};
+use crate::shaders::FullShaders;
+use crate::{AaConfig, RenderParams};
 
 #[cfg(feature = "wgpu")]
 use crate::Scene;

--- a/src/shaders/preprocess.rs
+++ b/src/shaders/preprocess.rs
@@ -4,7 +4,9 @@
 // TODO (#467) - Remove this file and use vello_shaders crate instead,
 // then update ARCHITECTURE.md.
 
-use std::{collections::HashMap, fs, path::Path};
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
 
 #[cfg(feature = "wgpu")]
 use std::{collections::HashSet, vec};

--- a/src/wgpu_engine.rs
+++ b/src/wgpu_engine.rs
@@ -1,11 +1,10 @@
 // Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use std::{
-    borrow::Cow,
-    cell::RefCell,
-    collections::{hash_map::Entry, HashMap, HashSet},
-};
+use std::borrow::Cow;
+use std::cell::RefCell;
+use std::collections::hash_map::Entry;
+use std::collections::{HashMap, HashSet};
 
 use wgpu::{
     BindGroup, BindGroupLayout, Buffer, BufferUsages, CommandEncoder, CommandEncoderDescriptor,
@@ -13,9 +12,10 @@ use wgpu::{
     TextureViewDimension,
 };
 
+use crate::cpu_dispatch::CpuBinding;
+use crate::recording::BindType;
 use crate::{
-    cpu_dispatch::CpuBinding, recording::BindType, BufferProxy, Command, Error, ImageProxy,
-    Recording, ResourceId, ResourceProxy, ShaderId,
+    BufferProxy, Command, Error, ImageProxy, Recording, ResourceId, ResourceProxy, ShaderId,
 };
 
 #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
Closes #510 

Applies the standard rustfmt settings - But also with a one-time assist from `imports_granularity = "Module"` to get things more consistent there until `imports_granularity` is stable.