### PR TITLE
clippy: Configure via `lints` table in `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,9 @@ default = ["wgpu"]
 hot_reload = []
 buffer_labels = []
 
+[lints]
+workspace = true
+
 [dependencies]
 vello_encoding = { workspace = true }
 bytemuck = { workspace = true }
@@ -56,6 +59,10 @@ log = { workspace = true }
 raw-window-handle = { workspace = true }
 futures-intrusive = { workspace = true }
 wgpu-profiler = { workspace = true, optional = true }
+
+[workspace.lints]
+clippy.doc_markdown = "warn"
+clippy.semicolon_if_nothing_returned = "warn"
 
 [workspace.dependencies]
 vello_encoding = { version = "0.1.0", path = "crates/encoding" }

--- a/crates/encoding/Cargo.toml
+++ b/crates/encoding/Cargo.toml
@@ -13,6 +13,9 @@ default = ["full"]
 # resources (gradients, images and glyph runs)
 full = ["skrifa", "guillotiere"]
 
+[lints]
+workspace = true
+
 [dependencies]
 bytemuck = { workspace = true }
 skrifa = { workspace = true, optional = true }

--- a/crates/encoding/src/lib.rs
+++ b/crates/encoding/src/lib.rs
@@ -3,8 +3,6 @@
 
 //! Raw scene encoding.
 
-#![warn(clippy::doc_markdown, clippy::semicolon_if_nothing_returned)]
-
 mod binning;
 mod clip;
 mod config;

--- a/crates/shaders/Cargo.toml
+++ b/crates/shaders/Cargo.toml
@@ -30,6 +30,9 @@ force_rw_storage = []
 wgsl = []
 msl = []
 
+[lints]
+workspace = true
+
 [dependencies]
 naga = { version = "0.13", features = ["wgsl-in", "msl-out", "validate"], optional = true }
 thiserror = { version = "1.0.57", optional = true }

--- a/crates/shaders/src/lib.rs
+++ b/crates/shaders/src/lib.rs
@@ -1,8 +1,6 @@
 // Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![warn(clippy::doc_markdown, clippy::semicolon_if_nothing_returned)]
-
 mod types;
 
 #[cfg(feature = "compile")]

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 repository.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 vello = { path = "../.." }
 image = "0.24.9"

--- a/examples/headless/Cargo.toml
+++ b/examples/headless/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 repository.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 vello = { path = "../../" }
 scenes = { path = "../scenes" }

--- a/examples/run_wasm/Cargo.toml
+++ b/examples/run_wasm/Cargo.toml
@@ -5,5 +5,8 @@ license.workspace = true
 repository.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 cargo-run-wasm = "0.3.2"

--- a/examples/scenes/Cargo.toml
+++ b/examples/scenes/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 repository.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 vello = { path = "../../" }
 vello_svg = { path = "../../integrations/vello_svg" }

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -5,6 +5,9 @@ license.workspace = true
 repository.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 # The dependencies here are independent from the workspace versions
 [dependencies]
 # When using this example outside of the original Vello workspace,

--- a/examples/with_bevy/Cargo.toml
+++ b/examples/with_bevy/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 repository.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 vello = { path = "../../" }
 bevy = { version = "0.13", features = [

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -17,6 +17,9 @@ default = ["wgpu-profiler"]
 # wgpu (which means the dependency used in wgpu-profiler would be incompatible)
 wgpu-profiler = ["dep:wgpu-profiler", "vello/wgpu-profiler"]
 
+[lints]
+workspace = true
+
 [[bin]]
 # Stop the PDB collision warning on windows
 name = "with_winit_bin"

--- a/integrations/vello_svg/Cargo.toml
+++ b/integrations/vello_svg/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 vello = { path = "../../" }
 usvg = "0.37.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,6 @@
 // Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![warn(clippy::doc_markdown, clippy::semicolon_if_nothing_returned)]
-
 //! Vello is an experimental 2d graphics rendering engine written in Rust, using [`wgpu`].
 //! It efficiently draws large 2d scenes with interactive or near-interactive performance.
 //!


### PR DESCRIPTION
As of Rust 1.74, lints can be configured within the `Cargo.toml` which allows us to not have to configure them in the source code as well as simplifying having a single configuration across an entire workspace.

This is documented at: https://doc.rust-lang.org/nightly/cargo/reference/manifest.html#the-lints-section