### PR TITLE
[encoding] Inflate estimates for offset curves

### DIFF
--- a/crates/encoding/src/estimate.rs
+++ b/crates/encoding/src/estimate.rs
@@ -158,7 +158,7 @@ impl BumpEstimator {
 
         self.count_stroke_caps(style.start_cap, scaled_width, caps);
         self.count_stroke_caps(style.end_cap, scaled_width, caps);
-        self.count_stroke_joins(style.join, scaled_width, style.miter_limit as f64, joins);
+        self.count_stroke_joins(style.join, scaled_width, style.miter_limit, joins);
     }
 
     /// Produce the final total, applying an optional transform to all content.
@@ -301,7 +301,7 @@ fn approx_arc_length_cubic(p0: Vec2, p1: Vec2, p2: Vec2, p3: Vec2) -> f64 {
     let chord_len = (p3 - p0).length();
     // Length of the control polygon
     let poly_len = (p1 - p0).length() + (p2 - p1).length() + (p3 - p2).length();
-    0.5 * (chord_len + poly_len) as f64
+    0.5 * (chord_len + poly_len)
 }
 
 fn count_segments_for_cubic(p0: Vec2, p1: Vec2, p2: Vec2, p3: Vec2, t: &Transform) -> f64 {


### PR DESCRIPTION
Added a highly crude scale to segment and line counts in the presence of a non-zero offset (i.e. stroked curves). This is done to account for the inflated flattening of an offset curve around high-curvature zones. I believe this could get refined but that requires some work to find the best way to analyze the complexity of the curve with few CPU cycles.

Fixed a bug in join calculation that was wrongfully incrementing the line count instead of segments.

This makes the estimate robust for tricky strokes but also increases the margin of the estimate over the true bump counts. I expect some of this will improve when the estimation moves to resolve time, such that the crude bloating of the counts due to any scale applied to a scene fragment will no longer be necessary.