### PR TITLE
[shaders] Use constants in switch statements

### DIFF
--- a/shader/coarse.wgsl
+++ b/shader/coarse.wgsl
@@ -357,40 +357,34 @@ fn main(
                 let tile_ix = sh_tile_base[el_ix] + sh_tile_stride[el_ix] * tile_y + tile_x;
                 let tile = tiles[tile_ix];
                 switch drawtag {
-                    // DRAWTAG_FILL_COLOR
-                    case 0x44u: {
+                    case DRAWTAG_FILL_COLOR: {
                         write_path(tile, tile_ix, draw_flags);
                         let rgba_color = scene[dd];
                         write_color(CmdColor(rgba_color));
                     }
-                    // DRAWTAG_FILL_LIN_GRADIENT
-                    case 0x114u: {
+                    case DRAWTAG_FILL_LIN_GRADIENT: {
                         write_path(tile, tile_ix, draw_flags);
                         let index = scene[dd];
                         let info_offset = di + 1u;
                         write_grad(CMD_LIN_GRAD, index, info_offset);
                     }
-                    // DRAWTAG_FILL_RAD_GRADIENT
-                    case 0x29cu: {
+                    case DRAWTAG_FILL_RAD_GRADIENT: {
                         write_path(tile, tile_ix, draw_flags);
                         let index = scene[dd];
                         let info_offset = di + 1u;
                         write_grad(CMD_RAD_GRAD, index, info_offset);
                     }
-                    // DRAWTAG_FILL_SWEEP_GRADIENT
-                    case 0x254u: {
+                    case DRAWTAG_FILL_SWEEP_GRADIENT: {
                         write_path(tile, tile_ix, draw_flags);
                         let index = scene[dd];
                         let info_offset = di + 1u;
                         write_grad(CMD_SWEEP_GRAD, index, info_offset);
                     }                    
-                    // DRAWTAG_FILL_IMAGE
-                    case 0x248u: {
+                    case DRAWTAG_FILL_IMAGE: {
                         write_path(tile, tile_ix, draw_flags);
                         write_image(di + 1u);
                     }
-                    // DRAWTAG_BEGIN_CLIP
-                    case 0x9u: {
+                    case DRAWTAG_BEGIN_CLIP: {
                         if tile.segment_count_or_ix == 0u && tile.backdrop == 0 {
                             clip_zero_depth = clip_depth + 1u;
                         } else {
@@ -400,8 +394,7 @@ fn main(
                         }
                         clip_depth += 1u;
                     }
-                    // DRAWTAG_END_CLIP
-                    case 0x21u: {
+                    case DRAWTAG_END_CLIP: {
                         clip_depth -= 1u;
                         // A clip shape is always a non-zero fill (draw_flags=0).
                         write_path(tile, tile_ix, /*draw_flags=*/0u);
@@ -415,12 +408,10 @@ fn main(
             } else {
                 // In "clip zero" state, suppress all drawing
                 switch drawtag {
-                    // DRAWTAG_BEGIN_CLIP
-                    case 0x9u: {
+                    case DRAWTAG_BEGIN_CLIP: {
                         clip_depth += 1u;
                     }
-                    // DRAWTAG_END_CLIP
-                    case 0x21u: {
+                    case DRAWTAG_END_CLIP: {
                         if clip_depth == clip_zero_depth {
                             clip_zero_depth = 0u;
                         }

--- a/shader/draw_leaf.wgsl
+++ b/shader/draw_leaf.wgsl
@@ -117,12 +117,10 @@ fn main(
             transform = read_transform(config.transform_base, bbox.trans_ix);
         }
         switch tag_word {
-            // DRAWTAG_FILL_COLOR
-            case 0x44u: {
+            case DRAWTAG_FILL_COLOR: {
                 info[di] = draw_flags;
             }
-            // DRAWTAG_FILL_LIN_GRADIENT
-            case 0x114u: {
+            case DRAWTAG_FILL_LIN_GRADIENT: {
                 info[di] = draw_flags;
                 var p0 = bitcast<vec2<f32>>(vec2(scene[dd + 1u], scene[dd + 2u]));
                 var p1 = bitcast<vec2<f32>>(vec2(scene[dd + 3u], scene[dd + 4u]));
@@ -136,8 +134,7 @@ fn main(
                 info[di + 2u] = bitcast<u32>(line_xy.y);
                 info[di + 3u] = bitcast<u32>(line_c);
             }
-            // DRAWTAG_FILL_RAD_GRADIENT
-            case 0x29cu: {
+            case DRAWTAG_FILL_RAD_GRADIENT: {
                 // Two-point conical gradient implementation based
                 // on the algorithm at <https://skia.org/docs/dev/design/conical/>
                 // This epsilon matches what Skia uses
@@ -220,8 +217,7 @@ fn main(
                 info[di + 8u] = bitcast<u32>(radius);
                 info[di + 9u] = bitcast<u32>((flags << 3u) | kind);
             }
-            // DRAWTAG_FILL_SWEEP_GRADIENT
-            case 0x254u: {
+            case DRAWTAG_FILL_SWEEP_GRADIENT: {
                 info[di] = draw_flags;
                 let p0 = bitcast<vec2<f32>>(vec2(scene[dd + 1u], scene[dd + 2u]));
                 let xform = transform_mul(transform, Transform(vec4(1.0, 0.0, 0.0, 1.0), p0));
@@ -235,8 +231,7 @@ fn main(
                 info[di + 7u] = scene[dd + 3u];
                 info[di + 8u] = scene[dd + 4u];
             }
-            // DRAWTAG_FILL_IMAGE
-            case 0x248u: {
+            case DRAWTAG_FILL_IMAGE: {
                 info[di] = draw_flags;
                 let inv = transform_inverse(transform);
                 info[di + 1u] = bitcast<u32>(inv.matrx.x);

--- a/shader/shared/blend.wgsl
+++ b/shader/shared/blend.wgsl
@@ -142,64 +142,49 @@ fn set_sat(c: vec3<f32>, s: f32) -> vec3<f32> {
 fn blend_mix(cb: vec3<f32>, cs: vec3<f32>, mode: u32) -> vec3<f32> {
     var b = vec3(0.0);
     switch mode {
-        // MIX_MULTIPLY
-        case 1u: {
+        case MIX_MULTIPLY: {
             b = cb * cs;
         }
-        // MIX_SCREEN
-        case 2u: {
+        case MIX_SCREEN: {
             b = screen(cb, cs);
         }
-        // MIX_OVERLAY
-        case 3u: {
+        case MIX_OVERLAY: {
             b = hard_light(cs, cb);
         }
-        // MIX_DARKEN
-        case 4u: {
+        case MIX_DARKEN: {
             b = min(cb, cs);
         }
-        // MIX_LIGHTEN
-        case 5u: {
+        case MIX_LIGHTEN: {
             b = max(cb, cs);
         }
-        // MIX_COLOR_DODGE
-        case 6u: {
+        case MIX_COLOR_DODGE: {
             b = vec3(color_dodge(cb.x, cs.x), color_dodge(cb.y, cs.y), color_dodge(cb.z, cs.z));
         }
-        // MIX_COLOR_BURN
-        case 7u: {
+        case MIX_COLOR_BURN: {
             b = vec3(color_burn(cb.x, cs.x), color_burn(cb.y, cs.y), color_burn(cb.z, cs.z));
         }
-        // MIX_HARD_LIGHT
-        case 8u: {
+        case MIX_HARD_LIGHT: {
             b = hard_light(cb, cs);
         }
-        // MIX_SOFT_LIGHT
-        case 9u: {
+        case MIX_SOFT_LIGHT: {
             b = soft_light(cb, cs);
         }
-        // MIX_DIFFERENCE
-        case 10u: {
+        case MIX_DIFFERENCE: {
             b = abs(cb - cs);
         }
-        // MIX_EXCLUSION
-        case 11u: {
+        case MIX_EXCLUSION: {
             b = cb + cs - 2.0 * cb * cs;
         }
-        // MIX_HUE
-        case 12u: {
+        case MIX_HUE: {
             b = set_lum(set_sat(cs, sat(cb)), lum(cb));
         }
-        // MIX_SATURATION
-        case 13u: {
+        case MIX_SATURATION: {
             b = set_lum(set_sat(cb, sat(cs)), lum(cb));
         }
-        // MIX_COLOR
-        case 14u: {
+        case MIX_COLOR: {
             b = set_lum(cs, lum(cb));
         }
-        // MIX_LUMINOSITY
-        case 15u: {
+        case MIX_LUMINOSITY: {
             b = set_lum(cb, lum(cs));
         }
         default: {
@@ -238,68 +223,55 @@ fn blend_compose(
     var fa = 0.0;
     var fb = 0.0;
     switch mode {
-        // COMPOSE_COPY
-        case 1u: {
+        case COMPOSE_COPY: {
             fa = 1.0;
             fb = 0.0;
         }
-        // COMPOSE_DEST
-        case 2u: {
+        case COMPOSE_DEST: {
             fa = 0.0;
             fb = 1.0;
         }
-        // COMPOSE_SRC_OVER
-        case 3u: {
+        case COMPOSE_SRC_OVER: {
             fa = 1.0;
             fb = 1.0 - as_;
         }
-        // COMPOSE_DEST_OVER
-        case 4u: {
+        case COMPOSE_DEST_OVER: {
             fa = 1.0 - ab;
             fb = 1.0;
         }
-        // COMPOSE_SRC_IN
-        case 5u: {
+        case COMPOSE_SRC_IN: {
             fa = ab;
             fb = 0.0;
         }
-        // COMPOSE_DEST_IN
-        case 6u: {
+        case COMPOSE_DEST_IN: {
             fa = 0.0;
             fb = as_;
         }
-        // COMPOSE_SRC_OUT
-        case 7u: {
+        case COMPOSE_SRC_OUT: {
             fa = 1.0 - ab;
             fb = 0.0;
         }
-        // COMPOSE_DEST_OUT
-        case 8u: {
+        case COMPOSE_DEST_OUT: {
             fa = 0.0;
             fb = 1.0 - as_;
         }
-        // COMPOSE_SRC_ATOP
-        case 9u: {
+        case COMPOSE_SRC_ATOP: {
             fa = ab;
             fb = 1.0 - as_;
         }
-        // COMPOSE_DEST_ATOP
-        case 10u: {
+        case COMPOSE_DEST_ATOP: {
             fa = 1.0 - ab;
             fb = as_;
         }
-        // COMPOSE_XOR
-        case 11u: {
+        case COMPOSE_XOR: {
             fa = 1.0 - ab;
             fb = 1.0 - as_;
         }
-        // COMPOSE_PLUS
-        case 12u: {
+        case COMPOSE_PLUS: {
             fa = 1.0;
             fb = 1.0;
         }
-        // COMPOSE_PLUS_LIGHTER
-        case 13u: {
+        case COMPOSE_PLUS_LIGHTER: {
             return min(vec4(1.0), vec4(as_ * cs + ab * cb, as_ + ab));
         }
         default: {}


### PR DESCRIPTION
Naga didn't support constant evaluation until recently, which prevented constant declarations from being referenced in switch case statements. Now that naga supports consteval (starting in 0.19) and the feature is available in vello, this PR updates the shaders to reference constants directly instead of numerical literals.