### PR TITLE
Fix NonZero-unchecked mistake in recording

### DIFF
--- a/src/recording.rs
+++ b/src/recording.rs
@@ -15,8 +15,8 @@ impl ResourceId {
         static ID_COUNTER: AtomicU64 = AtomicU64::new(1);
 
         let val = ID_COUNTER.fetch_add(1, Ordering::Relaxed);
-        // SAFETY: Smallest value is 1.
-        ResourceId(unsafe { NonZeroU64::new_unchecked(val + 1) })
+        // SAFETY: We begin with 1.
+        ResourceId(unsafe { NonZeroU64::new_unchecked(val) })
     }
 }
 

--- a/src/recording.rs
+++ b/src/recording.rs
@@ -12,10 +12,10 @@ pub struct ResourceId(pub NonZeroU64);
 
 impl ResourceId {
     pub fn next() -> ResourceId {
-        static ID_COUNTER: AtomicU64 = AtomicU64::new(0);
+        static ID_COUNTER: AtomicU64 = AtomicU64::new(1);
 
         let val = ID_COUNTER.fetch_add(1, Ordering::Relaxed);
-        // SAFETY: Smallest value is 1 because we just incremented.
+        // SAFETY: Smallest value is 1.
         ResourceId(unsafe { NonZeroU64::new_unchecked(val + 1) })
     }
 }


### PR DESCRIPTION
https://doc.rust-lang.org/std/sync/atomic/struct.AtomicU64.html#method.fetch_add
fetch_add actually returns the old value so we actually created a NonZero with a zero..
I wonder why this hasn't been a problem, is the NonZero even necessary?
Also it might be good to have an utility trait to do something like `unwrap_debug_unchecked` for safety.