### PR TITLE
Impl `From<Encoding>` for `Scene`.

### DIFF
--- a/src/scene.rs
+++ b/src/scene.rs
@@ -221,7 +221,8 @@ impl Scene {
 
 impl From<Encoding> for Scene {
     fn from(encoding: Encoding) -> Self {
-        // TODO: Properly update the estimator for the encoding.
+        // It's fine to create a default estimator here, and that field will be
+        // removed at some point - see https://github.com/linebender/vello/issues/541
         Self {
             encoding,
             #[cfg(feature = "bump_estimate")]

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -219,6 +219,17 @@ impl Scene {
     }
 }
 
+impl From<Encoding> for Scene {
+    fn from(encoding: Encoding) -> Self {
+        // TODO: Properly update the estimator for the encoding.
+        Self {
+            encoding,
+            #[cfg(feature = "bump_estimate")]
+            estimator: vello_encoding::BumpEstimator::default(),
+        }
+    }
+}
+
 /// Builder for encoding a glyph run.
 pub struct DrawGlyphs<'a> {
     encoding: &'a mut Encoding,


### PR DESCRIPTION
This allows creating a `Scene` with a pre-existing `Encoding`.

Fixes #530.