### PR TITLE
[binning] Do not use numerical operators on atomics

### DIFF
--- a/shader/binning.wgsl
+++ b/shader/binning.wgsl
@@ -65,14 +65,14 @@ fn main(
         atomicStore(&sh_bitmaps[i][local_id.x], 0u);
     }
     if local_id.x == 0u {
-        let failed = bump.lines > config.lines_size;
+        let failed = atomicLoad(&bump.lines) > config.lines_size;
         sh_previous_failed = u32(failed);
     }
     // also functions as barrier to protect zeroing of bitmaps
     let failed = workgroupUniformLoad(&sh_previous_failed);
     if failed != 0u {
         if global_id.x == 0u {
-            bump.failed |= STAGE_FLATTEN;
+            atomicOr(&bump.failed, STAGE_FLATTEN);
         }
         return;
     }


### PR DESCRIPTION
This fixes a comparison expression and a compound-assignment expression that used an atomic as an operand. These should be treated as illegal based on my understanding of the WGSL specification (and are rejected by Tint) but Naga accepts them and injects appropriate atomic operations during code generation.

See https://github.com/gfx-rs/wgpu/issues/5474 for more details.