### PR TITLE
[fine] Coverage-mask specialization and some shader feature cleanup

### DIFF
--- a/crates/shaders/Cargo.toml
+++ b/crates/shaders/Cargo.toml
@@ -10,9 +10,13 @@ repository.workspace = true
 publish = false # Remove this when the package is ready for publishing
 
 [features]
-default = ["compile", "wgsl", "msl"]
+default = ["compile", "wgsl", "msl", "full"]
 compile = ["naga", "thiserror"]
 
+# Enables the complete imaging model. When this feature is disabled, the fine rasterization
+# stage only supports drawing paths with a solid brush and clipping, and the shaders can
+# not be run with an encoding that contains gradient fills and images.
+full = []
 
 # Target shading language variants of the vello shaders to link into the library.
 wgsl = []

--- a/crates/shaders/Cargo.toml
+++ b/crates/shaders/Cargo.toml
@@ -13,18 +13,6 @@ publish = false # Remove this when the package is ready for publishing
 default = ["compile", "wgsl", "msl"]
 compile = ["naga", "thiserror"]
 
-# Enabling this feature applies a transformation that converts all storage bindings
-# to have the `read_write` access mode. For WGSL shaders, this affects the bind group
-# layout of all pipelines and changes the usage scope of storage buffers. For MSL shaders,
-# this removes the `const` qualifier from entry-point parameters in the `device` address
-# space. This allows bindings with mixed access modes to be backed by suballocations from
-# the same the buffer object.
-#
-# This feature doesn't apply to the fine stage where all storage bindings are readonly and
-# the same access mode restrictions do not apply.
-#
-# Enabling this feature may have a performance impact and is not recommended.
-force_rw_storage = []
 
 # Target shading language variants of the vello shaders to link into the library.
 wgsl = []

--- a/crates/shaders/src/compile/mod.rs
+++ b/crates/shaders/src/compile/mod.rs
@@ -156,27 +156,18 @@ impl ShaderInfo {
             if let Some(name) = file_name.to_str() {
                 let suffix = ".wgsl";
                 if let Some(shader_name) = name.strip_suffix(suffix) {
-                    let mut options = preprocess::Options::default();
-                    if cfg!(feature = "force_rw_storage") {
-                        // All bindings in the `fine` stage are readonly which means that a usage
-                        // scope warning can never occur. Plus, the bindings must be declared as
-                        // readonly to prevent a failed compilation due to uniformity analysis.
-                        options.force_rw_storage = !name.starts_with("fine");
-                    }
                     let contents = fs::read_to_string(shader_dir.join(&file_name))
                         .expect("Could read shader {shader_name} contents");
                     if let Some(permutations) = permutation_map.get(shader_name) {
                         for permutation in permutations {
                             let mut defines = defines.clone();
                             defines.extend(permutation.defines.iter().cloned());
-                            let source =
-                                preprocess::preprocess(&contents, &options, &defines, &imports);
+                            let source = preprocess::preprocess(&contents, &defines, &imports);
                             let shader_info = Self::new(source.clone(), "main").unwrap();
                             info.insert(permutation.name.clone(), shader_info);
                         }
                     } else {
-                        let source =
-                            preprocess::preprocess(&contents, &options, &defines, &imports);
+                        let source = preprocess::preprocess(&contents, &defines, &imports);
                         let shader_info = Self::new(source.clone(), "main").unwrap();
                         info.insert(shader_name.to_string(), shader_info);
                     }

--- a/crates/shaders/src/compile/mod.rs
+++ b/crates/shaders/src/compile/mod.rs
@@ -142,8 +142,13 @@ impl ShaderInfo {
         println!("{:?}", permutation_map);
         let imports = preprocess::get_imports(shader_dir);
         let mut info = HashMap::default();
-        let mut defines = HashSet::default();
-        defines.insert("full".to_string());
+        let defines: HashSet<_> = if cfg!(feature = "full") {
+            vec!["full".to_string()]
+        } else {
+            vec![]
+        }
+        .into_iter()
+        .collect();
         for entry in shader_dir
             .read_dir()
             .expect("Can read shader import directory")

--- a/crates/shaders/src/compile/preprocess.rs
+++ b/crates/shaders/src/compile/preprocess.rs
@@ -34,14 +34,8 @@ pub struct StackItem {
     else_passed: bool,
 }
 
-#[derive(Default)]
-pub struct Options {
-    pub force_rw_storage: bool,
-}
-
 pub fn preprocess(
     input: &str,
-    options: &Options,
     defines: &HashSet<String>,
     imports: &HashMap<String, String>,
 ) -> String {
@@ -150,7 +144,7 @@ pub fn preprocess(
                         // However, in practise there will only ever be at most 2 stack items, so
                         // it's reasonable to just recompute it every time
                         if stack.iter().all(|item| item.active) {
-                            output.push_str(&preprocess(import, options, defines, imports));
+                            output.push_str(&preprocess(import, defines, imports));
                         }
                     } else {
                         eprintln!("Unknown import `{import_name}` (line {line_number})");
@@ -169,14 +163,6 @@ pub fn preprocess(
             if line.starts_with("let ") {
                 output.push_str("const");
                 output.push_str(&line[3..]);
-            } else if let Some(idx) = line.find("var<storage>") {
-                if options.force_rw_storage {
-                    let mut line = line.to_string();
-                    line.replace_range(idx..(idx + 12), "var<storage, read_write>");
-                    output.push_str(&line);
-                } else {
-                    output.push_str(line);
-                }
             } else {
                 output.push_str(line);
             }

--- a/shader/fine.wgsl
+++ b/shader/fine.wgsl
@@ -33,7 +33,15 @@ var<storage> ptcl: array<u32>;
 var<storage> info: array<u32>;
 
 @group(0) @binding(4)
+#ifdef r8
+// The R8 variant is available via a non-standard extension in Dawn. We can't
+// optionally declare that extension here since naga doesn't understand the
+// `enable` directive (see https://github.com/gfx-rs/wgpu/issues/5476). The
+// directive must be injected by the client via some other means.
+var output: texture_storage_2d<r8unorm, write>;
+#else
 var output: texture_storage_2d<rgba8unorm, write>;
+#endif
 
 #ifdef full
 @group(0) @binding(5)

--- a/shader/permutations
+++ b/shader/permutations
@@ -5,3 +5,6 @@ fine
 + fine_area
 + fine_msaa8: msaa msaa8
 + fine_msaa16: msaa msaa16
++ fine_area_r8: r8
++ fine_msaa8_r8: msaa msaa8 r8
++ fine_msaa16_r8: msaa msaa16 r8

--- a/shader/shared/pathtag.wgsl
+++ b/shader/shared/pathtag.wgsl
@@ -6,10 +6,8 @@ struct TagMonoid {
     // TODO: I don't think pathseg_ix is used.
     pathseg_ix: u32,
     pathseg_offset: u32,
-#ifdef full
     style_ix: u32,
     path_ix: u32,
-#endif
 }
 
 let PATH_TAG_SEG_TYPE = 3u;
@@ -18,10 +16,8 @@ let PATH_TAG_QUADTO = 2u;
 let PATH_TAG_CUBICTO = 3u;
 let PATH_TAG_F32 = 8u;
 let PATH_TAG_TRANSFORM = 0x20u;
-#ifdef full
 let PATH_TAG_PATH = 0x10u;
 let PATH_TAG_STYLE = 0x40u;
-#endif
 let PATH_TAG_SUBPATH_END = 4u;
 
 // Size of the `Style` data structure in words
@@ -54,10 +50,8 @@ fn combine_tag_monoid(a: TagMonoid, b: TagMonoid) -> TagMonoid {
     c.trans_ix = a.trans_ix + b.trans_ix;
     c.pathseg_ix = a.pathseg_ix + b.pathseg_ix;
     c.pathseg_offset = a.pathseg_offset + b.pathseg_offset;
-#ifdef full
     c.style_ix = a.style_ix + b.style_ix;
     c.path_ix = a.path_ix + b.path_ix;
-#endif
     return c;
 }
 
@@ -71,9 +65,7 @@ fn reduce_tag(tag_word: u32) -> TagMonoid {
     a += a >> 8u;
     a += a >> 16u;
     c.pathseg_offset = a & 0xffu;
-#ifdef full
     c.path_ix = countOneBits(tag_word & (PATH_TAG_PATH * 0x1010101u));
     c.style_ix = countOneBits(tag_word & (PATH_TAG_STYLE * 0x1010101u)) * STYLE_SIZE_IN_WORDS;
-#endif
     return c;
 }


### PR DESCRIPTION
This change introduces a variant of the fine rasterizer stage that is geared towards coverage mask rendering. Specifically:

1. The "r8" permutations can be used to define the texel format of the target texture as `r8unorm`, which is supported via a non-standard extension in Dawn.
2. The "full" macro has been repurposed such that it specifically applies to the gradient and image support in the fine stage. The vello_shaders crate now supports a "full" feature flag. When this is omitted,  path rendering with solid brushes and clipping are supported across all pipelines.

This PR also includes some minor cleanups:
- Remove the `force_rw_storage` feature, which is no longer used.
- Remove the case block in fine that handles the `CMD_STROKE` PTCL command, which is now obsolete.

----
###  Background on the "full" variant
Previously the "full" macro was introduced to distinguish the complete imaging model of piet-gpu from the more limited "reduced" variant, which was intended to produce coverage masks for an atlas based path renderer. This reduced variant was limited to only paths without any blends, clips, or other non-path draw objects. This specialization wasn't fully carried forward with the move from piet-gpu to Vello, since some of the excluded features (in particular anti-aliased clipping) turned out to be a desirable feature for atlasing.

While there is still room for pipeline specializations and optimizations geared towards coverage-mask atlas based path renderers, the existing meaning of "full" left some important features out (such as the PTCL and stroke style / path_ix monoids used in stroke expansion).