### PR TITLE
Restore glyph hinting support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1725,9 +1725,12 @@ dependencies = [
 
 [[package]]
 name = "font-types"
-version = "0.4.3"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b7f6040d337bd44434ab21fc6509154edf2cece88b23758d9d64654c4e7730b"
+checksum = "bd6784a76a9c2b136ea3b8462391e9328252e938eb706eb44d752723b4c3a533"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "fontconfig-parser"
@@ -3012,10 +3015,11 @@ checksum = "3b42e27ef78c35d3998403c1d26f3efd9e135d3e5121b0a4845cc5cc27547f4f"
 
 [[package]]
 name = "read-fonts"
-version = "0.16.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81c524658d3b77930a391f559756d91dbe829ab6cf4687083f615d395df99722"
+checksum = "ea75b5ec052843434d263ef7a4c31cf86db5908c729694afb1ad3c884252a1b6"
 dependencies = [
+ "bytemuck",
  "font-types",
 ]
 
@@ -3371,10 +3375,11 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "skrifa"
-version = "0.16.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf2850423ffb2e837608f7611d8c2d544f11624367fe05359e63126383e8212"
+checksum = "b3f54c6ecbad34b55ea1779389e334fe0d260f2f0c80964a926ffb47918c26e9"
 dependencies = [
+ "bytemuck",
  "read-fonts",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ clippy.semicolon_if_nothing_returned = "warn"
 [workspace.dependencies]
 vello_encoding = { version = "0.1.0", path = "crates/encoding" }
 bytemuck = { version = "1.15.0", features = ["derive"] }
-skrifa = "0.16.0"
+skrifa = "0.19.0"
 peniko = "0.1.0"
 futures-intrusive = "0.5.0"
 raw-window-handle = "0.6.0"

--- a/crates/encoding/src/resolve.rs
+++ b/crates/encoding/src/resolve.rs
@@ -325,6 +325,7 @@ impl Resolver {
                     index,
                     glyphs: _,
                     transform,
+                    scale,
                 } = patch
                 {
                     let run = &resources.glyph_runs[*index];
@@ -338,7 +339,7 @@ impl Resolver {
                             let xform = *transform
                                 * Transform {
                                     matrix: [1.0, 0.0, 0.0, -1.0],
-                                    translation: [glyph.x, glyph.y],
+                                    translation: [glyph.x * scale, glyph.y * scale],
                                 }
                                 * glyph_transform;
                             data.extend_from_slice(bytemuck::bytes_of(&xform));
@@ -348,7 +349,7 @@ impl Resolver {
                             let xform = *transform
                                 * Transform {
                                     matrix: [1.0, 0.0, 0.0, -1.0],
-                                    translation: [glyph.x, glyph.y],
+                                    translation: [glyph.x * scale, glyph.y * scale],
                                 };
                             data.extend_from_slice(bytemuck::bytes_of(&xform));
                         }
@@ -429,6 +430,7 @@ impl Resolver {
                     let mut hint = run.hint;
                     let mut font_size = run.font_size;
                     let mut transform = run.transform;
+                    let mut scale = 1.0;
                     if hint {
                         // If hinting was requested and our transform matrix is just a uniform
                         // scale, then adjust our font size and cancel out the matrix. Otherwise,
@@ -437,7 +439,8 @@ impl Resolver {
                             && transform.matrix[1] == 0.0
                             && transform.matrix[2] == 0.0
                         {
-                            font_size *= transform.matrix[0];
+                            scale = transform.matrix[0];
+                            font_size *= scale;
                             transform.matrix = [1.0, 0.0, 0.0, 1.0];
                         } else {
                             hint = false;
@@ -468,6 +471,7 @@ impl Resolver {
                         index: *index,
                         glyphs: glyph_start..glyph_end,
                         transform,
+                        scale,
                     });
                 }
                 Patch::Image {
@@ -569,6 +573,8 @@ enum ResolvedPatch {
         glyphs: Range<usize>,
         /// Global transform.
         transform: Transform,
+        /// Additional scale factor to apply to translation.
+        scale: f32,
     },
     Image {
         /// Index of pending image element.

--- a/examples/scenes/src/simple_text.rs
+++ b/examples/scenes/src/simple_text.rs
@@ -92,6 +92,7 @@ impl SimpleText {
             .glyph_transform(glyph_transform)
             .normalized_coords(var_loc.coords())
             .brush(brush)
+            .hint(false)
             .draw(
                 style,
                 text.chars().filter_map(|ch| {


### PR DESCRIPTION
Updates skrifa to 0.19.0 and restores hinting support. Our previous glyph scaler came with its own instance cache but skrifa does not, so this also adds a very simple LRU cache to manage instances.

There will likely be adjustments to this when we do "real" glyph caching and start retaining our caches across frames but this should be sufficient for now and will hopefully improve text quality in xilem on low-resolution displays.