### PR TITLE
`RenderContext::new()` needn't return `Result`.

### DIFF
--- a/crates/tests/src/lib.rs
+++ b/crates/tests/src/lib.rs
@@ -52,8 +52,7 @@ pub fn render_sync(scene: Scene, params: &TestParams) -> Result<Image> {
 }
 
 pub async fn render(scene: Scene, params: &TestParams) -> Result<Image> {
-    let mut context = RenderContext::new()
-        .or_else(|_| bail!("Got non-Send/Sync error from creating render context"))?;
+    let mut context = RenderContext::new();
     let device_id = context
         .device(None)
         .await

--- a/examples/headless/src/main.rs
+++ b/examples/headless/src/main.rs
@@ -75,8 +75,7 @@ fn main() -> Result<()> {
 }
 
 async fn render(mut scenes: SceneSet, index: usize, args: &Args) -> Result<()> {
-    let mut context = RenderContext::new()
-        .or_else(|_| bail!("Got non-Send/Sync error from creating render context"))?;
+    let mut context = RenderContext::new();
     let device_id = context
         .device(None)
         .await

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -30,7 +30,7 @@ fn main() -> Result<()> {
     // Setup a bunch of state:
 
     // The vello RenderContext which is a global context that lasts for the lifetime of the application
-    let mut render_cx = RenderContext::new().unwrap();
+    let mut render_cx = RenderContext::new();
 
     // An array of renderers, one per wgpu device
     let mut renderers: Vec<Option<Renderer>> = vec![];

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -713,7 +713,7 @@ pub fn main() -> anyhow::Result<()> {
     if let Some(scenes) = scenes {
         let event_loop = EventLoopBuilder::<UserEvent>::with_user_event().build()?;
         #[allow(unused_mut)]
-        let mut render_cx = RenderContext::new().unwrap();
+        let mut render_cx = RenderContext::new();
         #[cfg(not(target_arch = "wasm32"))]
         {
             let proxy = event_loop.create_proxy();
@@ -836,7 +836,7 @@ fn android_main(app: AndroidApp) {
         .select_scene_set(|| Args::command())
         .unwrap()
         .unwrap();
-    let render_cx = RenderContext::new().unwrap();
+    let render_cx = RenderContext::new();
 
     run(event_loop, args, scenes, render_cx);
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -25,16 +25,17 @@ pub struct DeviceHandle {
 }
 
 impl RenderContext {
-    pub fn new() -> Result<Self> {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
         let instance = Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::util::backend_bits_from_env().unwrap_or(wgpu::Backends::PRIMARY),
             dx12_shader_compiler: wgpu::Dx12Compiler::Fxc,
             ..Default::default()
         });
-        Ok(Self {
+        Self {
             instance,
             devices: Vec::new(),
-        })
+        }
     }
 
     /// Creates a new surface for the specified window and dimensions.


### PR DESCRIPTION
When the support was added for multiple devices, this function no longer could return an error, so a `Result` is not needed and just makes things more confusing in sample code.