### PR TITLE
[shaders] Support "enable" via post-process directive

### DIFF
--- a/shader/fine.wgsl
+++ b/shader/fine.wgsl
@@ -8,7 +8,7 @@
 // or msaa16.
 
 #ifdef r8
-// The R8 variant is only available via an internal extension in Dawn
+// The R8 variant is only available via an internal extension in Dawn native
 // (see https://dawn.googlesource.com/dawn/+/refs/heads/main/docs/tint/extensions/chromium_internal_graphite.md).
 #enable chromium_internal_graphite;
 #endif

--- a/shader/fine.wgsl
+++ b/shader/fine.wgsl
@@ -7,6 +7,12 @@
 // To enable multisampled rendering, turn on both the msaa ifdef and one of msaa8
 // or msaa16.
 
+#ifdef r8
+// The R8 variant is only available via an internal extension in Dawn
+// (see https://dawn.googlesource.com/dawn/+/refs/heads/main/docs/tint/extensions/chromium_internal_graphite.md).
+#enable chromium_internal_graphite;
+#endif
+
 struct Tile {
     backdrop: i32,
     segments: u32,
@@ -34,10 +40,6 @@ var<storage> info: array<u32>;
 
 @group(0) @binding(4)
 #ifdef r8
-// The R8 variant is available via a non-standard extension in Dawn. We can't
-// optionally declare that extension here since naga doesn't understand the
-// `enable` directive (see https://github.com/gfx-rs/wgpu/issues/5476). The
-// directive must be injected by the client via some other means.
 var output: texture_storage_2d<r8unorm, write>;
 #else
 var output: texture_storage_2d<rgba8unorm, write>;
@@ -816,6 +818,8 @@ fn extend_mode(t: f32, mode: u32) -> f32 {
 
 let PIXELS_PER_THREAD = 4u;
 
+#ifndef msaa
+
 // Analytic area antialiasing.
 //
 // This is currently dead code if msaa is enabled, but it would be fairly straightforward
@@ -877,6 +881,8 @@ fn fill_path(fill: CmdFill, xy: vec2<f32>, result: ptr<function, array<f32, PIXE
     }
     *result = area;
 }
+
+#endif
 
 // The X size should be 16 / PIXELS_PER_THREAD
 @compute @workgroup_size(4, 16)

--- a/src/shaders/preprocess.rs
+++ b/src/shaders/preprocess.rs
@@ -69,7 +69,9 @@ pub fn preprocess(input: &str, defines: &HashSet<String>, imports: &HashMap<&str
             let directive_is_at_start = line.trim_start().starts_with('#');
 
             match directive {
-                if_item @ ("ifdef" | "ifndef" | "else" | "endif") if !directive_is_at_start => {
+                if_item @ ("ifdef" | "ifndef" | "else" | "endif" | "enable")
+                    if !directive_is_at_start =>
+                {
                     eprintln!("#{if_item} directives must be the first non_whitespace items on their line, ignoring (line {line_number})");
                     break;
                 }
@@ -141,6 +143,11 @@ pub fn preprocess(input: &str, defines: &HashSet<String>, imports: &HashMap<&str
                         eprintln!("Unknown import `{import_name}` (line {line_number})");
                     }
                     continue;
+                }
+                "enable" => {
+                    // Ignore post-process directive. This is only supported by the shaders crate
+                    // (see #467)
+                    continue 'all_lines;
                 }
                 val => {
                     eprintln!("Unknown preprocessor directive `{val}` (line {line_number})");


### PR DESCRIPTION
The WGSL source currently cannot contain the "enable" directive as naga doesn't support it (see gfx-rs/wgpu#5476). This patch introduces the "#enable" post-process directive to work around this limitation.

Lines that start with "#enable" get turned into an inline comment during the pre-process stage and converted to a standard "enable" directive following the intermediate module compilation step. This allows us to pass the WGSL shaders with enable directives on to other WebGPU implementations.