### PR TITLE
[encoding] Fix path_reduced_scan buffer size

### DIFF
--- a/crates/encoding/src/config.rs
+++ b/crates/encoding/src/config.rs
@@ -368,7 +368,7 @@ impl BufferSizes {
         };
         let path_reduced = BufferSize::new(reduced_size);
         let path_reduced2 = BufferSize::new(PATH_REDUCE_WG);
-        let path_reduced_scan = BufferSize::new(path_tag_wgs);
+        let path_reduced_scan = BufferSize::new(reduced_size);
         let path_monoids = BufferSize::new(path_tag_wgs * PATH_REDUCE_WG);
         let path_bboxes = BufferSize::new(n_paths);
         let binning_wgs = workgroups.binning.0;


### PR DESCRIPTION
This is the intermediate TagMonoid buffer that is used by the two-stage scan in the "use_large_path_scan" case. This needs to be the same size as the overall path_reduce output buffer, which gets rounded up to a multiple of the path_reduce workgroup size.

This hasn't been a problem until now because src/wgpu_engine.rs allocates Buffers that are generally larger than the entries returned in the BufferSizes structure, due its quantized size class / pooling strategy. The bindings get their view size assigned based on the whole size of the buffer.

Skia uses a similar allocation strategy but assigns view size to be the precise value from BufferSizes. This causes incorrect behavior as WGSL clamps buffer accesses to the view size.

The now corrected buffer size fixes this issue.