### PR TITLE
[backdrop_dyn] Handle upstream pipeline failure

### DIFF
--- a/crates/shaders/src/cpu/backdrop.rs
+++ b/crates/shaders/src/cpu/backdrop.rs
@@ -1,11 +1,11 @@
 // Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
-use vello_encoding::{ConfigUniform, Path, Tile};
+use vello_encoding::{BumpAllocators, ConfigUniform, Path, Tile};
 
 use super::CpuBinding;
 
-fn backdrop_main(config: &ConfigUniform, paths: &[Path], tiles: &mut [Tile]) {
+fn backdrop_main(config: &ConfigUniform, _: &BumpAllocators, paths: &[Path], tiles: &mut [Tile]) {
     for drawobj_ix in 0..config.layout.n_draw_objects {
         let path = paths[drawobj_ix as usize];
         let width = path.bbox[2] - path.bbox[0];
@@ -24,7 +24,8 @@ fn backdrop_main(config: &ConfigUniform, paths: &[Path], tiles: &mut [Tile]) {
 
 pub fn backdrop(_n_wg: u32, resources: &[CpuBinding]) {
     let config = resources[0].as_typed();
-    let paths = resources[1].as_slice();
-    let mut tiles = resources[2].as_slice_mut();
-    backdrop_main(&config, &paths, &mut tiles);
+    let bump = resources[1].as_typed();
+    let paths = resources[2].as_slice();
+    let mut tiles = resources[3].as_slice_mut();
+    backdrop_main(&config, &bump, &paths, &mut tiles);
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -358,7 +358,7 @@ impl Render {
         recording.dispatch(
             shaders.backdrop,
             wg_counts.backdrop,
-            [config_buf, path_buf, tile_buf],
+            [config_buf, bump_buf, path_buf, tile_buf],
         );
         recording.dispatch(
             shaders.coarse,

--- a/src/shaders.rs
+++ b/src/shaders.rs
@@ -180,7 +180,7 @@ pub fn full_shaders(
     );
     let backdrop = add_shader!(
         backdrop_dyn,
-        [Uniform, BufReadOnly, Buffer],
+        [Uniform, Buffer, BufReadOnly, Buffer],
         CpuShaderType::Present(vello_shaders::cpu::backdrop)
     );
     let coarse = add_shader!(


### PR DESCRIPTION
Following #537 it is possible for the flatten stage to fail and flag a failure. In some cases this can cause invalid / corrupt bounding box data to propagate downstream, leading to a hang in the per-tile backdrop calculation loop.

Triggering this is highly subtle, so I don't have a test case as part of vello scenes that can reliably reproduce this. Regardless, it makes sense to check for the upstream failures and terminate the work in general.

I made backdrop_dyn check for any upstream failure and I didn't make it signal its own failure flag. I also didn't change the logic in the CPU shader since the other stages I checked (flatten, coarse) do not implement error signaling in their CPU counterparts. Let me know if you'd like me to work on those.