### PR TITLE
Better glyph caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4025,6 +4025,7 @@ dependencies = [
  "guillotiere",
  "peniko",
  "skrifa",
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ skrifa = "0.19.0"
 peniko = "0.1.0"
 futures-intrusive = "0.5.0"
 raw-window-handle = "0.6.0"
+smallvec = "1.13.2"
 
 # NOTE: Make sure to keep this in sync with the version badge in README.md
 wgpu = { version = "0.19.3" }

--- a/crates/encoding/Cargo.toml
+++ b/crates/encoding/Cargo.toml
@@ -27,3 +27,4 @@ bytemuck = { workspace = true }
 skrifa = { workspace = true, optional = true }
 peniko = { workspace = true }
 guillotiere = { version = "0.6.2", optional = true }
+smallvec = { workspace = true }

--- a/crates/encoding/src/ramp_cache.rs
+++ b/crates/encoding/src/ramp_cache.rs
@@ -24,7 +24,7 @@ pub struct RampCache {
 }
 
 impl RampCache {
-    pub fn advance(&mut self) {
+    pub fn maintain(&mut self) {
         self.epoch += 1;
         if self.map.len() > RETAINED_COUNT {
             self.map

--- a/crates/encoding/src/resolve.rs
+++ b/crates/encoding/src/resolve.rs
@@ -14,7 +14,7 @@ use {
     },
     peniko::{Extend, Image},
     std::ops::Range,
-    std::rc::Rc,
+    std::sync::Arc,
 };
 
 /// Layout of a packed encoding.
@@ -164,7 +164,7 @@ pub fn resolve_solid_paths_only(encoding: &Encoding, packed: &mut Vec<u8>) -> La
 #[derive(Default)]
 pub struct Resolver {
     glyph_cache: GlyphCache,
-    glyphs: Vec<Rc<Encoding>>,
+    glyphs: Vec<Arc<Encoding>>,
     ramp_cache: RampCache,
     image_cache: ImageCache,
     pending_images: Vec<PendingImage>,
@@ -438,11 +438,11 @@ impl Resolver {
                     };
                     let glyph_start = self.glyphs.len();
                     for glyph in glyphs {
-                        let Some((index, stream_sizes)) = session.get_or_insert(glyph.id) else {
+                        let Some((encoding, stream_sizes)) = session.get_or_insert(glyph.id) else {
                             continue;
                         };
                         run_sizes.add(&stream_sizes);
-                        self.glyphs.push(index);
+                        self.glyphs.push(encoding);
                     }
                     let glyph_end = self.glyphs.len();
                     run_sizes.path_tags += glyphs.len() + 1;

--- a/crates/encoding/src/resolve.rs
+++ b/crates/encoding/src/resolve.rs
@@ -8,12 +8,11 @@ use super::{DrawTag, Encoding, PathTag, StreamOffsets, Style, Transform};
 #[cfg(feature = "full")]
 use {
     super::{
-        glyph_cache::{CachedRange, GlyphCache, GlyphKey},
+        glyph_cache::GlyphCache,
         image_cache::{ImageCache, Images},
         ramp_cache::{RampCache, Ramps},
     },
     peniko::{Extend, Image},
-    skrifa::MetadataProvider,
     std::ops::Range,
 };
 
@@ -164,7 +163,7 @@ pub fn resolve_solid_paths_only(encoding: &Encoding, packed: &mut Vec<u8>) -> La
 #[derive(Default)]
 pub struct Resolver {
     glyph_cache: GlyphCache,
-    glyph_ranges: Vec<CachedRange>,
+    glyph_indices: Vec<usize>,
     ramp_cache: RampCache,
     image_cache: ImageCache,
     pending_images: Vec<PendingImage>,
@@ -217,10 +216,9 @@ impl Resolver {
                         data.extend_from_slice(bytemuck::cast_slice(&stream[pos..stream_offset]));
                         pos = stream_offset;
                     }
-                    for glyph in &self.glyph_ranges[glyphs.clone()] {
+                    for glyph in &self.glyph_indices[glyphs.clone()] {
                         data.extend_from_slice(bytemuck::bytes_of(&PathTag::TRANSFORM));
-                        let glyph_data = &self.glyph_cache.encoding.path_tags
-                            [glyph.start.path_tags..glyph.end.path_tags];
+                        let glyph_data = &self.glyph_cache.glyphs()[*glyph].encoding.path_tags;
                         data.extend_from_slice(bytemuck::cast_slice(glyph_data));
                     }
                     data.extend_from_slice(bytemuck::bytes_of(&PathTag::PATH));
@@ -248,9 +246,8 @@ impl Resolver {
                         data.extend_from_slice(bytemuck::cast_slice(&stream[pos..stream_offset]));
                         pos = stream_offset;
                     }
-                    for glyph in &self.glyph_ranges[glyphs.clone()] {
-                        let glyph_data = &self.glyph_cache.encoding.path_data
-                            [glyph.start.path_data..glyph.end.path_data];
+                    for &glyph in &self.glyph_indices[glyphs.clone()] {
+                        let glyph_data = &self.glyph_cache.glyphs()[glyph].encoding.path_data;
                         data.extend_from_slice(bytemuck::cast_slice(glyph_data));
                     }
                 }
@@ -372,9 +369,8 @@ impl Resolver {
                         data.extend_from_slice(bytemuck::cast_slice(&stream[pos..stream_offset]));
                         pos = stream_offset;
                     }
-                    for glyph in &self.glyph_ranges[glyphs.clone()] {
-                        let glyph_data =
-                            &self.glyph_cache.encoding.styles[glyph.start.styles..glyph.end.styles];
+                    for &glyph in &self.glyph_indices[glyphs.clone()] {
+                        let glyph_data = &self.glyph_cache.glyphs()[glyph].encoding.styles;
                         data.extend_from_slice(bytemuck::cast_slice(glyph_data));
                     }
                 }
@@ -390,8 +386,8 @@ impl Resolver {
 
     fn resolve_patches(&mut self, encoding: &Encoding) -> StreamOffsets {
         self.ramp_cache.advance();
-        self.glyph_cache.clear();
-        self.glyph_ranges.clear();
+        self.glyph_cache.prune(32);
+        self.glyph_indices.clear();
         self.image_cache.clear();
         self.pending_images.clear();
         self.patches.clear();
@@ -414,17 +410,6 @@ impl Resolver {
                 Patch::GlyphRun { index } => {
                     let mut run_sizes = StreamOffsets::default();
                     let run = &resources.glyph_runs[*index];
-                    let font_id = run.font.data.id();
-                    let Ok(font_file) = skrifa::raw::FileRef::new(run.font.data.as_ref()) else {
-                        continue;
-                    };
-                    let font = match font_file {
-                        skrifa::raw::FileRef::Font(font) => Some(font),
-                        skrifa::raw::FileRef::Collection(collection) => {
-                            collection.get(run.font.index).ok()
-                        }
-                    };
-                    let Some(font) = font else { continue };
                     let glyphs = &resources.glyphs[run.glyphs.clone()];
                     let coords = &resources.normalized_coords[run.normalized_coords.clone()];
                     let mut hint = run.hint;
@@ -446,24 +431,21 @@ impl Resolver {
                             hint = false;
                         }
                     }
-                    let outlines = font.outline_glyphs();
-                    let glyph_start = self.glyph_ranges.len();
+                    let Some(mut session) = self
+                        .glyph_cache
+                        .session(&run.font, coords, font_size, hint, &run.style)
+                    else {
+                        continue;
+                    };
+                    let glyph_start = self.glyph_indices.len();
                     for glyph in glyphs {
-                        let key = GlyphKey {
-                            font_id,
-                            font_index: run.font.index,
-                            font_size_bits: font_size.to_bits(),
-                            glyph_id: glyph.id,
-                            hint,
+                        let Some((index, stream_sizes)) = session.get_or_insert(glyph.id) else {
+                            continue;
                         };
-                        let encoding_range = self
-                            .glyph_cache
-                            .get_or_insert(&outlines, key, &run.style, font_size, coords)
-                            .unwrap_or_default();
-                        run_sizes.add(&encoding_range.len());
-                        self.glyph_ranges.push(encoding_range);
+                        run_sizes.add(&stream_sizes);
+                        self.glyph_indices.push(index);
                     }
-                    let glyph_end = self.glyph_ranges.len();
+                    let glyph_end = self.glyph_indices.len();
                     run_sizes.path_tags += glyphs.len() + 1;
                     run_sizes.transforms += glyphs.len();
                     sizes.add(&run_sizes);

--- a/crates/encoding/src/resolve.rs
+++ b/crates/encoding/src/resolve.rs
@@ -1,8 +1,6 @@
 // Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use std::rc::Rc;
-
 use bytemuck::{Pod, Zeroable};
 
 use super::{DrawTag, Encoding, PathTag, StreamOffsets, Style, Transform};
@@ -16,6 +14,7 @@ use {
     },
     peniko::{Extend, Image},
     std::ops::Range,
+    std::rc::Rc,
 };
 
 /// Layout of a packed encoding.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,7 @@ pub use recording::{
     BufferProxy, Command, ImageFormat, ImageProxy, Recording, ResourceId, ResourceProxy, ShaderId,
 };
 pub use shaders::FullShaders;
+use vello_encoding::Resolver;
 #[cfg(feature = "wgpu")]
 use wgpu_engine::{ExternalResource, WgpuEngine};
 
@@ -190,6 +191,7 @@ pub struct Renderer {
     #[cfg_attr(not(feature = "hot_reload"), allow(dead_code))]
     options: RendererOptions,
     engine: WgpuEngine,
+    resolver: Resolver,
     shaders: FullShaders,
     blit: Option<BlitPipeline>,
     target: Option<TargetTexture>,
@@ -260,6 +262,7 @@ impl Renderer {
         Ok(Self {
             options,
             engine,
+            resolver: Resolver::new(),
             shaders,
             blit,
             target: None,
@@ -286,7 +289,8 @@ impl Renderer {
         texture: &TextureView,
         params: &RenderParams,
     ) -> Result<()> {
-        let (recording, target) = render::render_full(scene, &self.shaders, params);
+        let (recording, target) =
+            render::render_full(scene, &mut self.resolver, &self.shaders, params);
         let external_resources = [ExternalResource::Image(
             *target.as_image().unwrap(),
             texture,
@@ -427,7 +431,13 @@ impl Renderer {
         let encoding = scene.encoding();
         // TODO: turn this on; the download feature interacts with CPU dispatch
         let robust = false;
-        let recording = render.render_encoding_coarse(encoding, &self.shaders, params, robust);
+        let recording = render.render_encoding_coarse(
+            encoding,
+            &mut self.resolver,
+            &self.shaders,
+            params,
+            robust,
+        );
         let target = render.out_image();
         let bump_buf = render.bump_buf();
         self.engine.run_recording(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,8 @@ pub use recording::{
     BufferProxy, Command, ImageFormat, ImageProxy, Recording, ResourceId, ResourceProxy, ShaderId,
 };
 pub use shaders::FullShaders;
+
+#[cfg(feature = "wgpu")]
 use vello_encoding::Resolver;
 #[cfg(feature = "wgpu")]
 use wgpu_engine::{ExternalResource, WgpuEngine};


### PR DESCRIPTION
This enables caching for variable glyphs, adds support for pruning the cache and retains the Resolver in the Renderer struct so that glyphs can be cached across frames.

Still so much to do here but this should remove our performance cliffs and better position us for future changes. 