### PR TITLE
Test that `Renderer` + `Scene` are `Send`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3821,6 +3821,7 @@ dependencies = [
  "peniko",
  "raw-window-handle",
  "skrifa",
+ "static_assertions",
  "vello_encoding",
  "wgpu",
  "wgpu-profiler",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ peniko = { workspace = true }
 wgpu = { workspace = true, optional = true }
 log = { workspace = true }
 raw-window-handle = { workspace = true }
+static_assertions = { workspace = true }
 futures-intrusive = { workspace = true }
 wgpu-profiler = { workspace = true, optional = true }
 
@@ -76,6 +77,7 @@ peniko = "0.1.0"
 futures-intrusive = "0.5.0"
 raw-window-handle = "0.6.0"
 smallvec = "1.13.2"
+static_assertions = "1.1.0"
 
 # NOTE: Make sure to keep this in sync with the version badge in README.md
 wgpu = { version = "0.19.3" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,6 +202,13 @@ pub struct Renderer {
     #[cfg(feature = "wgpu-profiler")]
     pub profile_result: Option<Vec<wgpu_profiler::GpuTimerQueryResult>>,
 }
+// This is not `Send` (or `Sync`) on WebAssembly as the
+// underlying wgpu types are not. This can be enabled with the
+// `fragile-send-sync-non-atomic-wasm` feature in wgpu.
+// See https://github.com/gfx-rs/wgpu/discussions/4127 for
+// further discussion of this topic.
+#[cfg(all(feature = "wgpu", not(target_arch = "wasm32")))]
+static_assertions::assert_impl_all!(Renderer: Send);
 
 /// Parameters used in a single render that are configurable by the client.
 pub struct RenderParams {

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -22,6 +22,7 @@ pub struct Scene {
     #[cfg(feature = "bump_estimate")]
     estimator: vello_encoding::BumpEstimator,
 }
+static_assertions::assert_impl_all!(Scene: Send, Sync);
 
 impl Scene {
     /// Creates a new scene.


### PR DESCRIPTION
Usages within Bevy and other frameworks are simpler when these types are `Send`.