### PR TITLE
`add_shader` on the engine doesn't return a failure.

### DIFF
--- a/src/shaders.rs
+++ b/src/shaders.rs
@@ -121,7 +121,7 @@ pub fn full_shaders(
                 } else {
                     $cpu
                 },
-            )?
+            )
         }};
         ($name:ident, $bindings:expr, $defines:expr, $cpu:expr) => {{
             add_shader!($name, stringify!($name), $bindings, &$defines, $cpu)

--- a/src/wgpu_engine.rs
+++ b/src/wgpu_engine.rs
@@ -235,11 +235,11 @@ impl WgpuEngine {
         wgsl: Cow<'static, str>,
         layout: &[BindType],
         cpu_shader: CpuShaderType,
-    ) -> Result<ShaderId, Error> {
+    ) -> ShaderId {
         let mut add = |shader| {
             let id = self.shaders.len();
             self.shaders.push(shader);
-            Ok(ShaderId(id))
+            ShaderId(id)
         };
 
         if self.use_cpu {
@@ -318,14 +318,14 @@ impl WgpuEngine {
                 label,
                 wgpu: None,
                 cpu: None,
-            })?;
+            });
             uninit.push(UninitialisedShader {
                 wgsl,
                 label,
                 entries,
                 shader_id: id,
             });
-            return Ok(id);
+            return id;
         }
         let wgpu = Self::create_compute_pipeline(device, label, wgsl, entries);
         add(Shader {


### PR DESCRIPTION
Simplify this by recognizing that `Engine::add_shader` won't return an `Error` so it doesn't need to return a `Result`.