### PR TITLE
vello_tests: Remove `decode_image()`, dep on `image`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2702,7 +2702,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "futures-intrusive",
- "image",
  "png",
  "pollster",
  "vello",

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -11,7 +11,6 @@ workspace = true
 
 [dependencies]
 vello = { path = "../.." }
-image = "0.24.9"
 anyhow = { workspace = true }
 
 wgpu = { workspace = true }

--- a/crates/tests/src/lib.rs
+++ b/crates/tests/src/lib.rs
@@ -16,17 +16,6 @@ use wgpu::{
     TextureDescriptor, TextureFormat, TextureUsages,
 };
 
-pub fn decode_image(data: &[u8]) -> Result<Image> {
-    let image = image::io::Reader::new(std::io::Cursor::new(data))
-        .with_guessed_format()?
-        .decode()?;
-    let width = image.width();
-    let height = image.height();
-    let data = Arc::new(image.into_rgba8().into_vec());
-    let blob = Blob::new(data);
-    Ok(Image::new(blob, Format::Rgba8, width, height))
-}
-
 pub struct TestParams {
     pub width: u32,
     pub height: u32,


### PR DESCRIPTION
This wasn't used here and shouldn't be needed.