### PR TITLE
[encoding] Fix bug in join estimate

### DIFF
--- a/crates/encoding/src/estimate.rs
+++ b/crates/encoding/src/estimate.rs
@@ -225,6 +225,10 @@ impl BumpEstimator {
                 self.segments += count * arc_lines * count_segments_for_line_length(line_len);
             }
         }
+
+        // Count inner join lines
+        self.lines.linetos += count;
+        self.segments += count_segments_for_line_length(scaled_width) * count;
     }
 }
 


### PR DESCRIPTION
The buffer size estimator wasn't accounting for the inner-join line segments when counting joins. This resulted in an underestimate which is particularly a problem when the scene content consists only of line-tos (curves mask the problem since they are always over-estimated).