### PR TITLE
Disable zeroing workgroup memory for compute shaders.

### DIFF
--- a/src/wgpu_engine.rs
+++ b/src/wgpu_engine.rs
@@ -646,7 +646,7 @@ impl WgpuEngine {
             entry_point: "main",
             compilation_options: PipelineCompilationOptions {
                 zero_initialize_workgroup_memory: false,
-                ..PipelineCompilationOptions::default()
+                ..Default::default()
             },
         });
         WgpuShader {

--- a/src/wgpu_engine.rs
+++ b/src/wgpu_engine.rs
@@ -644,7 +644,10 @@ impl WgpuEngine {
             layout: Some(&compute_pipeline_layout),
             module: &shader_module,
             entry_point: "main",
-            compilation_options: PipelineCompilationOptions::default(),
+            compilation_options: PipelineCompilationOptions {
+                zero_initialize_workgroup_memory: false,
+                ..PipelineCompilationOptions::default()
+            },
         });
         WgpuShader {
             pipeline,


### PR DESCRIPTION
This is a performance improvement for shader compilation.

See https://github.com/gfx-rs/wgpu/pull/5508