### PR TITLE
Reference `vello` via workspace dep.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ clippy.doc_markdown = "warn"
 clippy.semicolon_if_nothing_returned = "warn"
 
 [workspace.dependencies]
+vello = { version = "0.1.0", path = "." }
 vello_encoding = { version = "0.1.0", path = "crates/encoding" }
 vello_shaders = { version = "0.1.0", path = "crates/shaders" }
 bytemuck = { version = "1.15.0", features = ["derive"] }

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-vello = { path = "../.." }
+vello = { workspace = true }
 anyhow = { workspace = true }
 
 wgpu = { workspace = true }

--- a/examples/headless/Cargo.toml
+++ b/examples/headless/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-vello = { path = "../../" }
+vello = { workspace = true }
 scenes = { path = "../scenes" }
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }

--- a/examples/scenes/Cargo.toml
+++ b/examples/scenes/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-vello = { path = "../../" }
+vello = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 image = { version = "0.25.1", default-features = false, features = ["jpeg"] }

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -26,7 +26,7 @@ name = "with_winit_bin"
 path = "src/main.rs"
 
 [dependencies]
-vello = { path = "../../", features = ["buffer_labels"] }
+vello = { workspace = true, features = ["buffer_labels"] }
 scenes = { path = "../scenes" }
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
@@ -47,7 +47,7 @@ tracing = { version = "0.1.40", features = ["log-always"] }
 env_logger = "0.11.3"
 
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]
-vello = { path = "../../", features = ["hot_reload"] }
+vello = { workspace = true, features = ["hot_reload"] }
 notify-debouncer-mini = "0.3.0"
 
 


### PR DESCRIPTION
This makes `vello` the same as the other crates like `vello_encoding` and `vello_shaders`.

This change isn't done for `examples/simple/Cargo.toml` as changing that `path` to a `workspace` results in a warning from cargo.