### PR TITLE
[shaders] More graceful error handling

### DIFF
--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -131,7 +131,12 @@ fn run(
                 num_init_threads: NonZeroUsize::new(1),
             },
         )
-        .expect("Could create renderer");
+        .map_err(|e| {
+            // Pretty-print any renderer creation error using Display formatting before unwrapping.
+            eprintln!("{e}");
+            e
+        })
+        .expect("Failed to create renderer");
         #[cfg(feature = "wgpu-profiler")]
         renderer
             .profiler
@@ -571,7 +576,7 @@ fn run(
                     // We know that the only async here (`pop_error_scope`) is actually sync, so blocking is fine
                     match pollster::block_on(result) {
                         Ok(_) => log::info!("Reloading took {:?}", start.elapsed()),
-                        Err(e) => log::warn!("Failed to reload shaders because of {e}"),
+                        Err(e) => log::error!("Failed to reload shaders: {e}"),
                     }
                 }
             },
@@ -624,7 +629,11 @@ fn run(
                                     num_init_threads: NonZeroUsize::new(args.num_init_threads),
                                 },
                             )
-                            .expect("Could create renderer");
+                            .map_err(|e| {
+                                // Pretty-print any renderer creation error using Display formatting before unwrapping.
+                                anyhow::format_err!("{e}")
+                            })
+                            .expect("Failed to create renderer");
                             log::info!("Creating renderer {id} took {:?}", start.elapsed());
                             #[cfg(feature = "wgpu-profiler")]
                             renderer

--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -221,8 +221,8 @@ pub enum Error {
 
     /// Failed to compile the shaders.
     #[cfg(feature = "hot_reload")]
-    #[error("Failed to compile shader: {0}")]
-    ShaderCompilation(#[from] vello_shaders::compile::Error),
+    #[error("Failed to compile shaders:\n{0}")]
+    ShaderCompilation(#[from] vello_shaders::compile::ErrorVec),
 }
 
 #[allow(dead_code)] // this can be unused when wgpu feature is not used

--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -209,11 +209,20 @@ pub enum Error {
     #[error("Failed to async map a buffer")]
     BufferAsyncError(#[from] wgpu::BufferAsyncError),
 
+    #[cfg(feature = "wgpu")]
+    #[error("wgpu Error from scope")]
+    WgpuErrorFromScope(#[from] wgpu::Error),
+
     /// Failed to create [`GpuProfiler`].
     /// See [`wgpu_profiler::CreationError`] for more information.
     #[cfg(feature = "wgpu-profiler")]
     #[error("Couldn't create wgpu profiler")]
     ProfilerCreationError(#[from] wgpu_profiler::CreationError),
+
+    /// Failed to compile the shaders.
+    #[cfg(feature = "hot_reload")]
+    #[error("Failed to compile shader: {0}")]
+    ShaderCompilation(#[from] vello_shaders::compile::Error),
 }
 
 #[allow(dead_code)] // this can be unused when wgpu feature is not used
@@ -293,7 +302,7 @@ impl Renderer {
             #[cfg(not(target_arch = "wasm32"))]
             engine.use_parallel_initialisation();
         }
-        let shaders = shaders::full_shaders(device, &mut engine, &options);
+        let shaders = shaders::full_shaders(device, &mut engine, &options)?;
         #[cfg(not(target_arch = "wasm32"))]
         engine.build_shaders_if_needed(device, options.num_init_threads);
         let blit = options
@@ -435,14 +444,14 @@ impl Renderer {
 
     /// Reload the shaders. This should only be used during `vello` development
     #[cfg(feature = "hot_reload")]
-    pub async fn reload_shaders(&mut self, device: &Device) -> Result<(), wgpu::Error> {
+    pub async fn reload_shaders(&mut self, device: &Device) -> Result<(), Error> {
         device.push_error_scope(wgpu::ErrorFilter::Validation);
         let mut engine = WgpuEngine::new(self.options.use_cpu);
         // We choose not to initialise these shaders in parallel, to ensure the error scope works correctly
-        let shaders = shaders::full_shaders(device, &mut engine, &self.options);
+        let shaders = shaders::full_shaders(device, &mut engine, &self.options)?;
         let error = device.pop_error_scope().await;
         if let Some(error) = error {
-            return Err(error);
+            return Err(error.into());
         }
         self.engine = engine;
         self.shaders = shaders;

--- a/vello/src/shaders.rs
+++ b/vello/src/shaders.rs
@@ -12,7 +12,7 @@ use crate::ShaderId;
 use crate::{
     recording::{BindType, ImageFormat},
     wgpu_engine::WgpuEngine,
-    RendererOptions,
+    Error, RendererOptions,
 };
 
 // Shaders for the full pipeline
@@ -49,7 +49,7 @@ pub fn full_shaders(
     device: &Device,
     engine: &mut WgpuEngine,
     options: &RendererOptions,
-) -> FullShaders {
+) -> Result<FullShaders, Error> {
     use crate::wgpu_engine::CpuShaderType;
     use BindType::*;
 
@@ -60,7 +60,7 @@ pub fn full_shaders(
     //let force_gpu_from = Some("binning");
 
     #[cfg(feature = "hot_reload")]
-    let mut shaders = vello_shaders::compile::ShaderInfo::from_default();
+    let mut shaders = vello_shaders::compile::ShaderInfo::from_default()?;
     #[cfg(not(feature = "hot_reload"))]
     let shaders = vello_shaders::SHADERS;
 
@@ -247,7 +247,7 @@ pub fn full_shaders(
         None
     };
 
-    FullShaders {
+    Ok(FullShaders {
         pathtag_reduce,
         pathtag_reduce2,
         pathtag_scan,
@@ -271,5 +271,5 @@ pub fn full_shaders(
         fine_msaa8,
         fine_msaa16,
         pathtag_is_cpu: options.use_cpu,
-    }
+    })
 }

--- a/vello_shaders/build.rs
+++ b/vello_shaders/build.rs
@@ -18,7 +18,13 @@ fn main() {
 
     println!("cargo:rerun-if-changed={}", compile::shader_dir().display());
 
-    let mut shaders = compile::ShaderInfo::from_default();
+    let mut shaders = match compile::ShaderInfo::from_default() {
+        Ok(s) => s,
+        Err(err) => {
+            eprintln!("{err}");
+            return;
+        }
+    };
 
     // Drop the HashMap and sort by name so that we get deterministic order.
     let mut shaders = shaders.drain().collect::<Vec<_>>();

--- a/vello_shaders/src/compile/mod.rs
+++ b/vello_shaders/src/compile/mod.rs
@@ -232,7 +232,7 @@ impl ShaderInfo {
                         }
                     } else {
                         let source = preprocess::preprocess(&contents, &defines, &imports);
-                        match Self::new(&shader_name, source, "main") {
+                        match Self::new(shader_name, source, "main") {
                             Ok(shader_info) => {
                                 info.insert(shader_name.to_string(), shader_info);
                             }

--- a/vello_shaders/src/compile/mod.rs
+++ b/vello_shaders/src/compile/mod.rs
@@ -58,17 +58,17 @@ impl Error {
         let source = error.into();
         Error {
             name: name.to_owned(),
-            msg: source.emit_msg(wgsl),
+            msg: source.emit_msg(wgsl, &format!("({name} preprocessed)")),
             source,
         }
     }
 }
 
 impl InnerError {
-    fn emit_msg(&self, wgsl: &str) -> String {
+    fn emit_msg(&self, wgsl: &str, name: &str) -> String {
         match self {
-            Self::Parse(e) => e.emit_to_string(wgsl),
-            Self::Validate(e) => e.emit_to_string(wgsl),
+            Self::Parse(e) => e.emit_to_string_with_path(wgsl, name),
+            Self::Validate(e) => e.emit_to_string_with_path(wgsl, name),
             _ => String::default(),
         }
     }


### PR DESCRIPTION
The transition of the vello crate to use the vello_shaders crate regressed developer ergonomics around compilation failures, in which compilation failures always caused a panic and the displayed debug-formatted error message wasn't pretty printed. The panic was particularly bad with hot-reload since it effectively undid its usefulness by crashing the whole process on shader misspellings.

This change alleviates those regressions by adding better display formatting to WGSL parse errors returned from the shaders crate and propagating errors up to clients instead of always panicking. The Debug formatting is still a little wonky so call-sites are currently responsible for formatting errors with Display to get a more readable compiler message. This PR only updates `with_winit` with pretty-printing.