### PR TITLE
Workaround to avoid full hang

### DIFF
--- a/crates/shaders/src/cpu/flatten.rs
+++ b/crates/shaders/src/cpu/flatten.rs
@@ -333,7 +333,7 @@ fn flatten_euler(
                 let n_frac = scaled_int;
                 (n_frac, EspcRobust::Normal)
             };
-            let n = (n_frac * scale_multiplier).ceil().max(1.0);
+            let n = (n_frac * scale_multiplier).ceil().clamp(1.0, 100.0);
 
             // Flatten line segments
             log!("@@@   loop: lines: {n}");

--- a/shader/flatten.wgsl
+++ b/shader/flatten.wgsl
@@ -434,7 +434,7 @@ fn flatten_euler(
                 let integrand_peak = sqrt(abs(k_peak * (k_peak * dist_scaled + 1.0)));
                 n_frac = integral * integrand_peak / a;
             }
-            let n = max(ceil(n_frac * scale_multiplier), 1.0);
+            let n = clamp(ceil(n_frac * scale_multiplier), 1.0, 100.0);
             for (var i = 0u; i < u32(n); i++) {
                 var lp1: vec2f;
                 if i + 1u == u32(n) && t1 == 1.0 {


### PR DESCRIPTION
As the scale factor becomes unreasonably large, the number of subdivisions of an Euler spiral into lines grows, making the flatten stage take too long.

This patch just bounds the number of subdivisions, so it will eventually make progress. It will be slow, but not hang.

A better solution would be to aggressively cull so it only generates geometry inside the viewport, but that is considerably more complicated.

Workaround for #548