### PR TITLE
Re-export wgpu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,7 +951,6 @@ dependencies = [
  "pollster",
  "scenes",
  "vello",
- "wgpu",
 ]
 
 [[package]]
@@ -1926,7 +1925,6 @@ dependencies = [
  "anyhow",
  "pollster",
  "vello",
- "wgpu",
  "winit",
 ]
 
@@ -2301,7 +2299,6 @@ dependencies = [
  "png",
  "pollster",
  "vello",
- "wgpu",
 ]
 
 [[package]]
@@ -3103,7 +3100,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "web-time",
- "wgpu",
  "wgpu-profiler",
  "winit",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,6 @@ static_assertions = "1.1.0"
 thiserror = "1.0.61"
 
 # NOTE: Make sure to keep this in sync with the version badge in README.md
-# as well as examples/simple/Cargo.toml
 wgpu = { version = "0.20.0" }
 log = "0.4.21"
 

--- a/examples/headless/Cargo.toml
+++ b/examples/headless/Cargo.toml
@@ -15,7 +15,6 @@ scenes = { path = "../scenes" }
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 
-wgpu = { workspace = true }
 pollster = { workspace = true }
 env_logger = "0.11.3"
 png = "0.17.13"

--- a/examples/headless/src/main.rs
+++ b/examples/headless/src/main.rs
@@ -10,11 +10,11 @@ use clap::Parser;
 use scenes::{ImageCache, SceneParams, SceneSet, SimpleText};
 use vello::kurbo::{Affine, Vec2};
 use vello::util::RenderContext;
-use vello::{block_on_wgpu, RendererOptions, Scene};
-use wgpu::{
-    BufferDescriptor, BufferUsages, CommandEncoderDescriptor, Extent3d, ImageCopyBuffer,
+use vello::wgpu::{
+    self, BufferDescriptor, BufferUsages, CommandEncoderDescriptor, Extent3d, ImageCopyBuffer,
     TextureDescriptor, TextureFormat, TextureUsages,
 };
+use vello::{block_on_wgpu, RendererOptions, Scene};
 
 fn main() -> Result<()> {
     #[cfg(not(target_arch = "wasm32"))]

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -15,5 +15,4 @@ workspace = true
 vello = { version = "0.1.0", path = "../../vello" }
 anyhow = "1.0.83"
 pollster = "0.3.0"
-wgpu = "0.20.0"
 winit = "0.30.0"

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -13,6 +13,7 @@ use winit::event::*;
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
 use winit::window::Window;
 
+use vello::wgpu;
 // Simple struct to hold the state of the renderer
 pub struct ActiveRenderState<'s> {
     // The fields MUST be in this order, so that the surface is dropped before the window

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -33,7 +33,6 @@ clap = { workspace = true, features = ["derive"] }
 pollster = { workspace = true }
 wgpu-profiler = { workspace = true, optional = true }
 
-wgpu = { workspace = true }
 winit = "0.30.0"
 log = { workspace = true }
 

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -26,6 +26,8 @@ use winit::dpi::LogicalSize;
 use winit::event_loop::EventLoop;
 use winit::window::{Window, WindowAttributes};
 
+use vello::wgpu;
+
 #[cfg(not(any(target_arch = "wasm32", target_os = "android")))]
 mod hot_reload;
 mod multi_touch;

--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -102,6 +102,9 @@ pub use skrifa;
 pub mod glyph;
 
 #[cfg(feature = "wgpu")]
+pub use wgpu;
+
+#[cfg(feature = "wgpu")]
 pub mod util;
 
 pub use render::Render;

--- a/vello_tests/Cargo.toml
+++ b/vello_tests/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 vello = { workspace = true }
 anyhow = { workspace = true }
 
-wgpu = { workspace = true }
 pollster = { workspace = true }
 png = "0.17.13"
 futures-intrusive = { workspace = true }

--- a/vello_tests/src/lib.rs
+++ b/vello_tests/src/lib.rs
@@ -10,11 +10,11 @@ use std::sync::Arc;
 use anyhow::{anyhow, bail, Result};
 use vello::peniko::{Blob, Color, Format, Image};
 use vello::util::RenderContext;
-use vello::{block_on_wgpu, RendererOptions, Scene};
-use wgpu::{
-    BufferDescriptor, BufferUsages, CommandEncoderDescriptor, Extent3d, ImageCopyBuffer,
+use vello::wgpu::{
+    self, BufferDescriptor, BufferUsages, CommandEncoderDescriptor, Extent3d, ImageCopyBuffer,
     TextureDescriptor, TextureFormat, TextureUsages,
 };
+use vello::{block_on_wgpu, RendererOptions, Scene};
 
 pub struct TestParams {
     pub width: u32,


### PR DESCRIPTION
These changes first re-export wgpu under the vello module.
Then, all examples are updated to use vello::wgpu.

Fixes #585