### PR TITLE
deps: Update and sync direct dep versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,9 +720,9 @@ dependencies = [
 
 [[package]]
 name = "font-types"
-version = "0.5.3"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf6aa1de86490d8e39e04589bd04eb5953cc2a5ef0c25e389e807f44fd24e41"
+checksum = "34fd7136aca682873d859ef34494ab1a7d3f57ecd485ed40eb6437ee8c85aa29"
 dependencies = [
  "bytemuck",
 ]
@@ -1534,9 +1534,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "peniko"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caaf7fec601d640555d9a4cab7343eba1e1c7a5a71c9993ff63b4c26bc5d50c5"
+checksum = "3c28d7294093837856bb80ad191cc46a2fcec8a30b43b7a3b0285325f0a917a9"
 dependencies = [
  "kurbo",
  "smallvec",
@@ -1732,9 +1732,9 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "read-fonts"
-version = "0.19.1"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4749db2bd1c853db31a7ae5ee2fc6c30bbddce353ea8fedf673fed187c68c7"
+checksum = "e8b8af39d1f23869711ad4cea5e7835a20daa987f80232f7f2a2374d648ca64d"
 dependencies = [
  "bytemuck",
  "font-types",
@@ -1944,9 +1944,9 @@ dependencies = [
 
 [[package]]
 name = "skrifa"
-version = "0.19.1"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dbed6a0c9addb84c2c8f66f35f504bb875b901e2a022419173e6ee2adfd0fb4"
+checksum = "0ab45fb68b53576a43d4fc0e9ec8ea64e29a4d2cc7f44506964cb75f288222e9"
 dependencies = [
  "bytemuck",
  "read-fonts",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,13 +75,13 @@ vello = { version = "0.1.0", path = "." }
 vello_encoding = { version = "0.1.0", path = "crates/encoding" }
 vello_shaders = { version = "0.1.0", path = "crates/shaders" }
 bytemuck = { version = "1.16.0", features = ["derive"] }
-skrifa = "0.19.1"
-peniko = "0.1.0"
+skrifa = "0.19.3"
+peniko = "0.1.1"
 futures-intrusive = "0.5.0"
-raw-window-handle = "0.6.1"
+raw-window-handle = "0.6.2"
 smallvec = "1.13.2"
 static_assertions = "1.1.0"
-thiserror = "1.0.57"
+thiserror = "1.0.61"
 
 # NOTE: Make sure to keep this in sync with the version badge in README.md
 # as well as examples/simple/Cargo.toml
@@ -90,7 +90,7 @@ log = "0.4.21"
 
 # Used for examples
 clap = "4.5.4"
-anyhow = "1.0.83"
-instant = { version = "0.1.12", features = ["wasm-bindgen"] }
+anyhow = "1.0.86"
+instant = { version = "0.1.13", features = ["wasm-bindgen"] }
 pollster = "0.3.0"
 wgpu-profiler = "0.17.0"


### PR DESCRIPTION
We now state that we depend on the same version of direct dependencies as is used in the `Cargo.lock`.

Also, update to the latest versions of our direct dependencies.