### PR TITLE
examples: Use `web-time` instead of `instant`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1047,18 +1047,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1854,10 +1842,10 @@ dependencies = [
  "clap",
  "getrandom",
  "image",
- "instant",
  "rand",
  "roxmltree",
  "vello",
+ "web-time",
 ]
 
 [[package]]
@@ -3102,7 +3090,6 @@ dependencies = [
  "console_log",
  "env_logger 0.11.3",
  "getrandom",
- "instant",
  "log",
  "notify-debouncer-mini",
  "pollster",
@@ -3114,6 +3101,7 @@ dependencies = [
  "vello",
  "wasm-bindgen-futures",
  "web-sys",
+ "web-time",
  "wgpu",
  "wgpu-profiler",
  "winit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,6 @@ log = "0.4.21"
 # Used for examples
 clap = "4.5.4"
 anyhow = "1.0.86"
-instant = { version = "0.1.13", features = ["wasm-bindgen"] }
 pollster = "0.3.0"
+web-time = "1.1.0"
 wgpu-profiler = "0.17.0"

--- a/examples/scenes/Cargo.toml
+++ b/examples/scenes/Cargo.toml
@@ -15,9 +15,10 @@ anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 image = { version = "0.25.1", default-features = false, features = ["jpeg"] }
 rand = "0.8.5"
-instant = { workspace = true }
+
 # for pico_svg
 roxmltree = "0.19.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.15", features = ["js"] }
+web-time = { workspace = true }

--- a/examples/scenes/src/svg.rs
+++ b/examples/scenes/src/svg.rs
@@ -4,9 +4,12 @@
 use std::fs::read_dir;
 use std::path::{Path, PathBuf};
 
-use anyhow::Result;
-use instant::Instant;
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Instant;
+#[cfg(target_arch = "wasm32")]
+use web_time::Instant;
 
+use anyhow::Result;
 use vello::{
     kurbo::{Affine, Rect, Stroke, Vec2},
     peniko::{Color, Fill},

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -30,7 +30,6 @@ vello = { workspace = true, features = ["buffer_labels"] }
 scenes = { path = "../scenes" }
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
-instant = { workspace = true }
 pollster = { workspace = true }
 wgpu-profiler = { workspace = true, optional = true }
 
@@ -67,4 +66,5 @@ console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"
 wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.69", features = ["HtmlCollection", "Text"] }
+web-time = { workspace = true }
 getrandom = { version = "0.2.15", features = ["js"] }

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -1,10 +1,19 @@
 // Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use instant::Instant;
 use std::collections::HashSet;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Instant;
+#[cfg(target_arch = "wasm32")]
+use web_time::Instant;
+
+#[cfg(all(feature = "wgpu-profiler", not(target_arch = "wasm32")))]
+use std::time::Duration;
+#[cfg(all(feature = "wgpu-profiler", target_arch = "wasm32"))]
+use web_time::Duration;
 
 use clap::Parser;
 use scenes::{ImageCache, SceneParams, SceneSet, SimpleText};
@@ -457,7 +466,7 @@ fn run(
                                 .and_then(|it| it.profile_result.take())
                             {
                                 if profile_stored.is_none()
-                                    || profile_taken.elapsed() > instant::Duration::from_secs(1)
+                                    || profile_taken.elapsed() > Duration::from_secs(1)
                                 {
                                     profile_stored = Some(profiling_result);
                                     profile_taken = Instant::now();

--- a/examples/with_winit/src/stats.rs
+++ b/examples/with_winit/src/stats.rs
@@ -7,6 +7,11 @@ use vello::kurbo::{Affine, PathEl, Rect, Stroke};
 use vello::peniko::{Brush, Color, Fill};
 use vello::{AaConfig, BumpAllocators, Scene};
 
+#[cfg(all(feature = "wgpu-profiler", not(target_arch = "wasm32")))]
+use std::time::Duration;
+#[cfg(all(feature = "wgpu-profiler", target_arch = "wasm32"))]
+use web_time::Duration;
+
 const SLIDING_WINDOW_SIZE: usize = 100;
 
 #[derive(Debug)]
@@ -308,10 +313,7 @@ pub fn draw_gpu_profiling(
     let total_time = max - min;
     {
         let labels = [
-            format!(
-                "GPU Time: {:.2?}",
-                instant::Duration::from_secs_f64(total_time)
-            ),
+            format!("GPU Time: {:.2?}", Duration::from_secs_f64(total_time)),
             "Press P to save a trace".to_string(),
         ];
 
@@ -402,13 +404,13 @@ pub fn draw_gpu_profiling(
                     if this_time < 0.0 {
                         format!(
                             "-{:.2?}(!!) - {:.30}",
-                            instant::Duration::from_secs_f64(this_time.abs()),
+                            Duration::from_secs_f64(this_time.abs()),
                             profile.label
                         )
                     } else {
                         format!(
                             "{:.2?} - {:.30}",
-                            instant::Duration::from_secs_f64(this_time),
+                            Duration::from_secs_f64(this_time),
                             profile.label
                         )
                     }


### PR DESCRIPTION
Recently, `instant` has been marked as unmaintained by the maintainer. A suggested replacement is `web-time`, which is used by `winit` and is already in our dependency tree.