### PR TITLE
deps: Update dev dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-run-wasm"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1e37cf14ef470ed74ec2a8b95e51b8623bcf6f76d24f233ebaeb209f766230"
+checksum = "fa9c33bbfab116bda01ec67729b988895b34167a1e9cf034343099092421ed43"
 dependencies = [
  "devserver_lib",
  "pico-args",
@@ -1363,11 +1363,12 @@ dependencies = [
 
 [[package]]
 name = "notify-debouncer-mini"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55ee272914f4563a2f8b8553eb6811f3c0caea81c756346bad15b7e3ef969f0"
+checksum = "5d40b221972a1fc5ef4d858a2f671fb34c75983eb385463dff3780eeff6a9d43"
 dependencies = [
  "crossbeam-channel",
+ "log",
  "notify",
 ]
 
@@ -1782,9 +1783,9 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "roxmltree"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd14fd5e3b777a7422cca79358c57a8f6e3a703d9ac187448d0daf220c2407f"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "run_wasm"

--- a/examples/run_wasm/Cargo.toml
+++ b/examples/run_wasm/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 workspace = true
 
 [dependencies]
-cargo-run-wasm = "0.3.2"
+cargo-run-wasm = "0.4.0"

--- a/examples/run_wasm/src/main.rs
+++ b/examples/run_wasm/src/main.rs
@@ -13,5 +13,5 @@
 /// ```
 
 fn main() {
-    cargo_run_wasm::run_wasm_with_css("body { margin: 0px; }");
+    cargo_run_wasm::run_wasm_cli_with_css("body { margin: 0px; }");
 }

--- a/examples/scenes/Cargo.toml
+++ b/examples/scenes/Cargo.toml
@@ -17,7 +17,7 @@ image = { version = "0.25.1", default-features = false, features = ["jpeg"] }
 rand = "0.8.5"
 
 # for pico_svg
-roxmltree = "0.19.0"
+roxmltree = "0.20.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.15", features = ["js"] }

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -47,7 +47,7 @@ env_logger = "0.11.3"
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]
 vello = { workspace = true, features = ["hot_reload"] }
 vello_shaders = { workspace = true, features = ["compile"] }
-notify-debouncer-mini = "0.3.0"
+notify-debouncer-mini = "0.4.1"
 
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/examples/with_winit/src/hot_reload.rs
+++ b/examples/with_winit/src/hot_reload.rs
@@ -10,10 +10,9 @@ use notify_debouncer_mini::{new_debouncer, DebounceEventResult};
 pub(crate) fn hot_reload(mut f: impl FnMut() -> Option<()> + Send + 'static) -> Result<impl Sized> {
     let mut debouncer = new_debouncer(
         Duration::from_millis(500),
-        None,
         move |res: DebounceEventResult| match res {
             Ok(_) => f().unwrap(),
-            Err(errors) => errors.iter().for_each(|e| println!("Error {:?}", e)),
+            Err(e) => println!("Hot reloading file watching failed: {e:?}"),
         },
     )?;
 


### PR DESCRIPTION
Update to current `roxmltree`, `notify-debouncer-mini`, and `cargo-run-wasm`.