### PR TITLE
vello_shaders: Rename use of `gen`

### DIFF
--- a/vello_shaders/build.rs
+++ b/vello_shaders/build.rs
@@ -65,7 +65,7 @@ fn write_shaders(
     buf: &mut String,
     shaders: &[(String, ShaderInfo)],
 ) -> Result<(), std::fmt::Error> {
-    writeln!(buf, "mod gen {{")?;
+    writeln!(buf, "mod generated {{")?;
     writeln!(buf, "    use super::*;")?;
     writeln!(buf, "    use BindType::*;")?;
     writeln!(buf, "    pub const SHADERS: Shaders<'static> = Shaders {{")?;

--- a/vello_shaders/src/lib.rs
+++ b/vello_shaders/src/lib.rs
@@ -125,4 +125,4 @@ pub trait PipelineHost {
 
 include!(concat!(env!("OUT_DIR"), "/shaders.rs"));
 
-pub use gen::SHADERS;
+pub use generated::SHADERS;


### PR DESCRIPTION
This becomes a reserved word in the 2024 edition.