### PR TITLE
Update package-level badges.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ smallvec = "1.13.2"
 static_assertions = "1.1.0"
 thiserror = "1.0.61"
 
-# NOTE: Make sure to keep this in sync with the version badge in README.md
+# NOTE: Make sure to keep this in sync with the version badge in README.md and vello/README.md
 wgpu = { version = "0.20.0" }
 log = "0.4.21"
 

--- a/vello/README.md
+++ b/vello/README.md
@@ -4,14 +4,14 @@
 
 **An experimental GPU compute-centric 2D renderer**
 
-[![Linebender Zulip](https://img.shields.io/badge/Linebender-%23gpu-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/stream/197075-gpu)
-[![dependency status](https://deps.rs/repo/github/linebender/vello/status.svg)](https://deps.rs/repo/github/linebender/vello)
-[![MIT/Apache 2.0](https://img.shields.io/badge/license-MIT%2FApache-blue.svg)](#license)
-[![wgpu version](https://img.shields.io/badge/wgpu-v0.20.0-orange.svg)](https://crates.io/crates/wgpu)
-
-[![Crates.io](https://img.shields.io/crates/v/vello.svg)](https://crates.io/crates/vello)
-[![Docs](https://docs.rs/vello/badge.svg)](https://docs.rs/vello)
-[![Build status](https://github.com/linebender/vello/workflows/CI/badge.svg)](https://github.com/linebender/vello/actions)
+[![Latest published version.](https://img.shields.io/crates/v/vello.svg)](https://crates.io/crates/vello)
+[![Documentation build status.](https://img.shields.io/docsrs/vello.svg)](https://docs.rs/vello)
+[![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
+[![Required wgpu version.](https://img.shields.io/badge/wgpu-v0.20.0-orange.svg)](https://crates.io/crates/wgpu)
+\
+[![Linebender Zulip chat.](https://img.shields.io/badge/Linebender-%23gpu-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/stream/197075-gpu)
+[![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/linebender/vello/ci.yml?logo=github&label=CI)](https://github.com/linebender/vello/actions)
+[![Dependency staleness status.](https://deps.rs/crate/vello/latest/status.svg)](https://deps.rs/crate/vello)
 
 </div>
 

--- a/vello_encoding/README.md
+++ b/vello_encoding/README.md
@@ -1,4 +1,18 @@
+<div align="center">
+
 # Vello Encoding
+
+**Types that represent data that [Vello] can render**
+
+[![Latest published version.](https://img.shields.io/crates/v/vello_encoding.svg)](https://crates.io/crates/vello_encoding)
+[![Documentation build status.](https://img.shields.io/docsrs/vello_encoding.svg)](https://docs.rs/vello_encoding)
+[![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
+\
+[![Linebender Zulip chat.](https://img.shields.io/badge/Linebender-%23gpu-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/stream/197075-gpu)
+[![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/linebender/vello/ci.yml?logo=github&label=CI)](https://github.com/linebender/vello/actions)
+[![Dependency staleness status.](https://deps.rs/crate/vello_encoding/latest/status.svg)](https://deps.rs/crate/vello_encoding)
+
+</div>
 
 This package contains types that represent data that [Vello] can render.
 

--- a/vello_shaders/README.md
+++ b/vello_shaders/README.md
@@ -1,4 +1,18 @@
+<div align="center">
+
 # Vello Shaders
+
+**Integrate [Vello] shaders into any renderer project**
+
+[![Latest published version.](https://img.shields.io/crates/v/vello_shaders.svg)](https://crates.io/crates/vello_shaders)
+[![Documentation build status.](https://img.shields.io/docsrs/vello_shaders.svg)](https://docs.rs/vello_shaders)
+[![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
+\
+[![Linebender Zulip chat.](https://img.shields.io/badge/Linebender-%23gpu-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/stream/197075-gpu)
+[![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/linebender/vello/ci.yml?logo=github&label=CI)](https://github.com/linebender/vello/actions)
+[![Dependency staleness status.](https://deps.rs/crate/vello_shaders/latest/status.svg)](https://deps.rs/crate/vello_shaders)
+
+</div>
 
 This is a utility library to help integrate the [Vello] shader modules into any renderer project.
 It provides the necessary metadata to construct the individual compute pipelines on any GPU API while leaving the responsibility of all API interactions (such as resource management and command encoding) up to the client.


### PR DESCRIPTION
The three publishable packages get the new [standard set of badges](https://xi.zulipchat.com/#narrow/stream/419691-linebender/topic/Bikeshedding.20badges).

The repo level readme will eventually be updated too, pending further discussion in [the Zulip thread](https://xi.zulipchat.com/#narrow/stream/419691-linebender/topic/Bikeshedding.20badges).