### PR TITLE
Update `CHANGELOG.md` in preparation for v0.2.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 # Changelog
 
-The latest published Vello release is [0.2.0](#020---2024-06-07) which was released on 2024-06-07.
-You can find its changes [documented below](#020---2024-06-07).
+The latest published Vello release is [0.2.0](#020---2024-06-08) which was released on 2024-06-08.
+You can find its changes [documented below](#020---2024-06-08).
 
 ## [Unreleased]
 
@@ -19,7 +19,7 @@ You can find its changes [documented below](#020---2024-06-07).
 
 ### Fixed
 
-## [0.2.0] - 2024-06-07
+## [0.2.0] - 2024-06-08
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 # Changelog
 
-The latest published Vello release is [0.2.0](#020---2024-06-06) which was released on 2024-06-06.
-You can find its changes [documented below](#020---2024-06-06).
+The latest published Vello release is [0.2.0](#020---2024-06-07) which was released on 2024-06-07.
+You can find its changes [documented below](#020---2024-06-07).
 
 ## [Unreleased]
 
@@ -19,7 +19,7 @@ You can find its changes [documented below](#020---2024-06-06).
 
 ### Fixed
 
-## [0.2.0] - 2024-06-06
+## [0.2.0] - 2024-06-07
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,21 +23,22 @@ You can find its changes [documented below](#020---2024-06-06).
 
 ### Added
 
+- Euler spiral based stroke expansion. ([#496] by [@raphlinus])
 - Sweep gradients. ([#435] by [@dfrg])
 - Bump allocation estimation. ([#436], [#454], [#522] by [@armansito])
-- Make `wgpu-profiler` completely optional. ([#502] by [@DJMcNab])
 - Impl `From<Encoding>` for `Scene`. ([#538] by [@waywardmonkeys])
-- Restore glyph hinting support. ([#544] by [@dfrg])
+- Glyph hinting support. ([#544] by [@dfrg])
 - Better glyph caching. ([#555] by [@dfrg])
-- Use `vello_shaders` crate to load and preprocess WGSL. ([#563] by [@armansito])
+- `vello_shaders` crate to load and preprocess WGSL. ([#563] by [@armansito])
 - Coverage-mask specialization. ([#540] by [@armansito])
 - Support for the `#enable` post-process directive. ([#550] by [@armansito])
+- `wgpu-profiler` feature. ([#502] by [@DJMcNab])
 
 ### Changed
 
 - Better error types. ([#516] by [@DasLixou])
 - `RenderContext::new()` no longer returns a `Result`. ([#547] by [@waywardmonkeys])
-- Update to `wgpu` 0.20. ([#560] by [@waywardmonkeys])
+- Updated `wgpu` to 0.20. ([#560] by [@waywardmonkeys])
 
 ### Removed
 
@@ -45,11 +46,10 @@ You can find its changes [documented below](#020---2024-06-06).
 
 ### Fixed
 
-- Performance optimizations for stroke-heavy scenes. ([#496] by [@raphlinus])
-- Increase robustness of cubic params. ([#521] by [@raphlinus])
-- Increases ~64k draw object limit. ([#526] by [@raphlinus])
-- Make `draw_leaf` pass uniformity analysis. ([#535] by [@raphlinus])
-- Increase robustness of GPU shaders. ([#537] by [@raphlinus])
+- 64k draw object limit. ([#526] by [@raphlinus])
+- Increased robustness of cubic params. ([#521] by [@raphlinus])
+- Increased robustness of GPU shaders. ([#537] by [@raphlinus])
+- `draw_leaf` uniformity. ([#535] by [@raphlinus])
 - Bug in join estimates in `vello_encoding`. ([#573] by [@armansito])
 - Incorrect use of numerical operators on atomics in binning. ([#539] by [@armansito])
 - `path_reduced_scan` buffer size. ([#551] by [@armansito])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@ You can find its changes [documented below](#020---2024-06-08).
 - `vello_shaders` crate to load and preprocess WGSL. ([#563] by [@armansito])
 - Coverage-mask specialization. ([#540] by [@armansito])
 - Support for the `#enable` post-process directive. ([#550] by [@armansito])
-- `wgpu-profiler` feature. ([#502] by [@DJMcNab])
 
 ### Changed
 
@@ -72,7 +71,6 @@ You can find its changes [documented below](#020---2024-06-08).
 [#436]: https://github.com/linebender/vello/pull/436
 [#454]: https://github.com/linebender/vello/pull/454
 [#496]: https://github.com/linebender/vello/pull/496
-[#502]: https://github.com/linebender/vello/pull/502
 [#516]: https://github.com/linebender/vello/pull/516
 [#521]: https://github.com/linebender/vello/pull/521
 [#522]: https://github.com/linebender/vello/pull/522

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,37 +1,99 @@
-# Changelog
-
 <!-- Instructions
 
-This changelog follows the patterns described here: <https://keepachangelog.com/en/1.0.0/>.
+This changelog follows the patterns described here: <https://keepachangelog.com/en/>.
 
 Subheadings to categorize changes are `added, changed, deprecated, removed, fixed, security`.
 
 -->
 
-## Unreleased
+# Changelog
+
+The latest published Vello release is [0.2.0](#020---2024-06-06) which was released on 2024-06-06.
+You can find its changes [documented below](#020---2024-06-06).
+
+## [Unreleased]
 
 ### Added
 
-- [#435](https://github.com/linebender/vello/pull/435) - Sweep gradients by [@dfrg](https://github.com/drfg)
-- [#538](https://github.com/linebender/vello/pull/538) - Impl `From<Encoding>` for `Scene` by [@waywardmonkeys](https://github.com/waywardmonkeys)
-- [#544](https://github.com/linebender/vello/pull/544) - Restore glyph hinting support by [@dfrg](https://github.com/drfg)
-- [#555](https://github.com/linebender/vello/pull/555) - Better glyph caching by [@dfrg](https://github.com/drfg)
-- [#563](https://github.com/linebender/vello/pull/563) - Use `vello_shaders` crate to load and preprocess WGSL by [@armansito](https://github.com/armansito)
-
 ### Changed
-
-- [#516](https://github.com/linebender/vello/pull/516) - Better error types by [@DasLixou](https://github.com/DasLixou)
-- [#547](https://github.com/linebender/vello/pull/547) - `RenderContext::new()` no longer returns a `Result` by [@waywardmonkeys](https://github.com/waywardmonkeys)
-- [#560](https://github.com/linebender/vello/pull/560) - Update to `wgpu` 0.20 by [@waywardmonkeys](https://github.com/waywardmonkeys)
 
 ### Fixed
 
-- [#496](https://github.com/linebender/vello/pull/496) - Performance optimizations for stroke-heavy scenes by [@raphlinus](https://github.com/raphlinus)
-- [#521](https://github.com/linebender/vello/pull/521) - Increase robustness of cubic params by [@raphlinus](https://github.com/raphlinus)
-- [#526](https://github.com/linebender/vello/pull/526) - Increases ~64k draw object limit by [@raphlinus](https://github.com/raphlinus)
-- [#537](https://github.com/linebender/vello/pull/537) - Increase robustness of GPU shaders by [@raphlinus](https://github.com/raphlinus)
-- [#573](https://github.com/linebender/vello/pull/573) - Fix bug in join estimates in `vello_encoding`  by [@armansito](https://github.com/armansito)
+## [0.2.0] - 2024-06-06
 
-## 0.1.0 (2024-03-04)
+### Added
+
+- Sweep gradients. ([#435] by [@dfrg])
+- Bump allocation estimation. ([#436], [#454], [#522] by [@armansito])
+- Make `wgpu-profiler` completely optional. ([#502] by [@DJMcNab])
+- Impl `From<Encoding>` for `Scene`. ([#538] by [@waywardmonkeys])
+- Restore glyph hinting support. ([#544] by [@dfrg])
+- Better glyph caching. ([#555] by [@dfrg])
+- Use `vello_shaders` crate to load and preprocess WGSL. ([#563] by [@armansito])
+- Coverage-mask specialization. ([#540] by [@armansito])
+- Support for the `#enable` post-process directive. ([#550] by [@armansito])
+
+### Changed
+
+- Better error types. ([#516] by [@DasLixou])
+- `RenderContext::new()` no longer returns a `Result`. ([#547] by [@waywardmonkeys])
+- Update to `wgpu` 0.20. ([#560] by [@waywardmonkeys])
+
+### Removed
+
+- `force_rw_storage` feature. ([#540] by [@armansito])
+
+### Fixed
+
+- Performance optimizations for stroke-heavy scenes. ([#496] by [@raphlinus])
+- Increase robustness of cubic params. ([#521] by [@raphlinus])
+- Increases ~64k draw object limit. ([#526] by [@raphlinus])
+- Make `draw_leaf` pass uniformity analysis. ([#535] by [@raphlinus])
+- Increase robustness of GPU shaders. ([#537] by [@raphlinus])
+- Bug in join estimates in `vello_encoding`. ([#573] by [@armansito])
+- Incorrect use of numerical operators on atomics in binning. ([#539] by [@armansito])
+- `path_reduced_scan` buffer size. ([#551] by [@armansito])
+- Handling of upstream pipeline failure. ([#553] by [@armansito])
+- Very slow shader compilation. ([#575] by [@DJMcNab], [@waywardmonkeys])
+- Full system hang on Apple systems. ([#589] by [@raphlinus])
+
+## [0.1.0] - 2024-03-04
 
 - Initial release
+
+[@raphlinus]: https://github.com/raphlinus
+[@armansito]: https://github.com/armansito
+[@DJMcNab]: https://github.com/DJMcNab
+[@dfrg]: https://github.com/drfg
+[@waywardmonkeys]: https://github.com/waywardmonkeys
+[@DasLixou]: https://github.com/DasLixou
+
+[#435]: https://github.com/linebender/vello/pull/435
+[#436]: https://github.com/linebender/vello/pull/436
+[#454]: https://github.com/linebender/vello/pull/454
+[#496]: https://github.com/linebender/vello/pull/496
+[#502]: https://github.com/linebender/vello/pull/502
+[#516]: https://github.com/linebender/vello/pull/516
+[#521]: https://github.com/linebender/vello/pull/521
+[#522]: https://github.com/linebender/vello/pull/522
+[#526]: https://github.com/linebender/vello/pull/526
+[#535]: https://github.com/linebender/vello/pull/535
+[#537]: https://github.com/linebender/vello/pull/537
+[#538]: https://github.com/linebender/vello/pull/538
+[#539]: https://github.com/linebender/vello/pull/539
+[#540]: https://github.com/linebender/vello/pull/540
+[#544]: https://github.com/linebender/vello/pull/544
+[#547]: https://github.com/linebender/vello/pull/547
+[#550]: https://github.com/linebender/vello/pull/550
+[#551]: https://github.com/linebender/vello/pull/551
+[#553]: https://github.com/linebender/vello/pull/553
+[#555]: https://github.com/linebender/vello/pull/555
+[#560]: https://github.com/linebender/vello/pull/560
+[#563]: https://github.com/linebender/vello/pull/563
+[#573]: https://github.com/linebender/vello/pull/573
+[#575]: https://github.com/linebender/vello/pull/575
+[#589]: https://github.com/linebender/vello/pull/589
+
+[Unreleased]: https://github.com/linebender/vello/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/linebender/vello/compare/v0.1.0...v0.2.0
+[0.0.1]: https://github.com/linebender/vello/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,4 +96,4 @@ You can find its changes [documented below](#020---2024-06-06).
 
 [Unreleased]: https://github.com/linebender/vello/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/linebender/vello/compare/v0.1.0...v0.2.0
-[0.0.1]: https://github.com/linebender/vello/releases/tag/v0.1.0
+[0.1.0]: https://github.com/linebender/vello/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ renderer
 surface_texture.present();
 ```
 
-See the [`examples`](https://github.com/linebender/vello/tree/main/examples) directory for code that integrates with frameworks like winit and bevy.
+See the [`examples`](https://github.com/linebender/vello/tree/main/examples) directory for code that integrates with frameworks like winit.
 
 ## Performance
 
@@ -128,11 +128,15 @@ More formal benchmarks are on their way.
 
 ### SVG
 
-A separate Linebender integration for rendering SVG files is available through the [`vello_svg`](https://github.com/linebender/vello_svg) crate.
+A separate Linebender integration for rendering SVG files is available through [`vello_svg`](https://github.com/linebender/vello_svg).
 
 ### Lottie
 
-A separate Linebender integration for playing Lottie animations is available through the [`velato`](https://github.com/linebender/velato) crate.
+A separate Linebender integration for playing Lottie animations is available through [`velato`](https://github.com/linebender/velato).
+
+### Bevy
+
+A separate Linebender integration for rendering raw scenes or Lottie and SVG files in [Bevy] through [`bevy_vello`](https://github.com/linebender/bevy_vello).
 
 ## Examples
 
@@ -152,10 +156,6 @@ cargo run -p with_winit
 ```
 
 <!-- ### Headless -->
-
-### Bevy
-
-There is a separate community integration for rendering raw scenes or Lottie and SVG files in [Bevy] through [`bevy_vello`](https://github.com/linebender/bevy_vello).
 
 ## Platforms
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ It is used as the rendering backend for [Xilem], a Rust GUI toolkit.
 > - [GPU memory allocation strategy](https://github.com/linebender/vello/issues/366)
 > - [Glyph caching](https://github.com/linebender/vello/issues/204)
 
+Significant changes are documented in [the changelog].
+
 ## Motivation
 
 Vello is meant to fill the same place in the graphics stack as other vector graphics renderers like [Skia](https://skia.org/), [Cairo](https://www.cairographics.org/), and its predecessor project [Piet](https://github.com/linebender/piet).
@@ -300,3 +302,4 @@ The files in subdirectories of the [`examples/assets`](https://github.com/linebe
 [winit]: https://github.com/rust-windowing/winit
 [Bevy]: https://bevyengine.org/
 [Requiem for piet-gpu-hal]: https://raphlinus.github.io/rust/gpu/2023/01/07/requiem-piet-gpu-hal.html
+[the changelog]: https://github.com/linebender/vello/tree/main/CHANGELOG.md

--- a/vello/README.md
+++ b/vello/README.md
@@ -37,6 +37,8 @@ It is used as the rendering backend for [Xilem], a Rust GUI toolkit.
 > - [GPU memory allocation strategy](https://github.com/linebender/vello/issues/366)
 > - [Glyph caching](https://github.com/linebender/vello/issues/204)
 
+Significant changes are documented in [the changelog].
+
 ## Motivation
 
 Vello is meant to fill the same place in the graphics stack as other vector graphics renderers like [Skia](https://skia.org/), [Cairo](https://www.cairographics.org/), and its predecessor project [Piet](https://github.com/linebender/piet).
@@ -287,3 +289,4 @@ at your option.
 [winit]: https://github.com/rust-windowing/winit
 [Bevy]: https://bevyengine.org/
 [Requiem for piet-gpu-hal]: https://raphlinus.github.io/rust/gpu/2023/01/07/requiem-piet-gpu-hal.html
+[the changelog]: https://github.com/linebender/vello/tree/main/CHANGELOG.md

--- a/vello/README.md
+++ b/vello/README.md
@@ -108,7 +108,7 @@ renderer
 surface_texture.present();
 ```
 
-See the repository's [`examples`](https://github.com/linebender/vello/tree/main/examples) directory for code that integrates with frameworks like winit and bevy.
+See the repository's [`examples`](https://github.com/linebender/vello/tree/main/examples) directory for code that integrates with frameworks like winit.
 
 ## Performance
 
@@ -120,11 +120,15 @@ More formal benchmarks are on their way.
 
 ### SVG
 
-A separate Linebender integration for rendering SVG files is available through the [`vello_svg`](https://github.com/linebender/vello_svg) crate.
+A separate Linebender integration for rendering SVG files is available through [`vello_svg`](https://github.com/linebender/vello_svg).
 
 ### Lottie
 
-A separate Linebender integration for playing Lottie animations is available through the [`velato`](https://github.com/linebender/velato) crate.
+A separate Linebender integration for playing Lottie animations is available through [`velato`](https://github.com/linebender/velato).
+
+### Bevy
+
+A separate Linebender integration for rendering raw scenes or Lottie and SVG files in [Bevy] through [`bevy_vello`](https://github.com/linebender/bevy_vello).
 
 ## Examples
 
@@ -144,10 +148,6 @@ cargo run -p with_winit
 ```
 
 <!-- ### Headless -->
-
-### Bevy
-
-There is a separate community integration for rendering raw scenes or Lottie and SVG files in [Bevy] through [`bevy_vello`](https://github.com/linebender/bevy_vello).
 
 ## Platforms
 

--- a/vello_encoding/README.md
+++ b/vello_encoding/README.md
@@ -16,6 +16,8 @@
 
 This package contains types that represent data that [Vello] can render.
 
+Significant changes are documented in [the changelog].
+
 ## Minimum supported Rust Version (MSRV)
 
 This version of Vello Encoding has been verified to compile with **Rust 1.75** and later.
@@ -54,3 +56,4 @@ at your option.
 
 [Rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct
 [Vello]: https://github.com/linebender/vello
+[the changelog]: https://github.com/linebender/vello/tree/main/CHANGELOG.md

--- a/vello_shaders/README.md
+++ b/vello_shaders/README.md
@@ -20,6 +20,8 @@ It provides the necessary metadata to construct the individual compute pipelines
 The shaders can be pre-compiled to any target shading language at build time based on feature flags.
 Currently only WGSL and Metal Shading Language are supported.
 
+Significant changes are documented in [the changelog].
+
 ## Minimum supported Rust Version (MSRV)
 
 This version of Vello Shaders has been verified to compile with **Rust 1.75** and later.
@@ -62,3 +64,4 @@ The intent is for this research to be used in as broad a context as possible.
 
 [Rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct
 [Vello]: https://github.com/linebender/vello
+[the changelog]: https://github.com/linebender/vello/tree/main/CHANGELOG.md


### PR DESCRIPTION
I quickly went over the commits and added some things that are of some relevance to consumers of Vello.

I also switched to the more compact markdown format that we used in [Druid](https://raw.githubusercontent.com/linebender/druid/master/CHANGELOG.md).