### PR TITLE
Robust memory allocation handling

### DIFF
--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -83,6 +83,7 @@
 
 mod recording;
 mod render;
+mod robust;
 mod scene;
 mod shaders;
 #[cfg(feature = "wgpu")]

--- a/vello/src/render.rs
+++ b/vello/src/render.rs
@@ -143,6 +143,10 @@ impl Render {
             buffer_sizes.path_reduced.size_in_bytes().into(),
             "reduced_buf",
         );
+        let bump_buf = BufferProxy::new(buffer_sizes.bump_alloc.size_in_bytes().into(), "bump_buf");
+        recording.clear_all(bump_buf);
+        let bump_buf = ResourceProxy::Buffer(bump_buf);
+        recording.dispatch(shaders.prepare, (1, 1, 1), [config_buf, bump_buf]);
         // TODO: really only need pathtag_wgs - 1
         recording.dispatch(
             shaders.pathtag_reduce,
@@ -203,9 +207,6 @@ impl Render {
             wg_counts.bbox_clear,
             [config_buf, path_bbox_buf],
         );
-        let bump_buf = BufferProxy::new(buffer_sizes.bump_alloc.size_in_bytes().into(), "bump_buf");
-        recording.clear_all(bump_buf);
-        let bump_buf = ResourceProxy::Buffer(bump_buf);
         let lines_buf =
             ResourceProxy::new_buf(buffer_sizes.lines.size_in_bytes().into(), "lines_buf");
         recording.dispatch(

--- a/vello/src/render.rs
+++ b/vello/src/render.rs
@@ -417,7 +417,6 @@ impl Render {
         if robust {
             recording.download(*bump_buf.as_buf().unwrap());
         }
-        recording.free_resource(bump_buf);
         recording
     }
 

--- a/vello/src/robust.rs
+++ b/vello/src/robust.rs
@@ -1,0 +1,12 @@
+//! A discussion of Vello's robust dynamic memory support
+//!
+//! When running the Vello pipeline, there are several buffers which:
+//! 1) Need to be large enough to store
+//! 2) Have a size which is non-trivial to calculate before running the pipeline
+//!
+//! When using wgpu (and most GPU apis), it is not possible for the GPU to synchronously
+//! request a larger buffer, so we have to provide a best-effort buffer for this purpose.
+//!
+//! ## Handling failures
+//!
+//! If the buffer which was provided was too small, we have an issue.

--- a/vello/src/shaders.rs
+++ b/vello/src/shaders.rs
@@ -17,6 +17,7 @@ use crate::{
 
 // Shaders for the full pipeline
 pub struct FullShaders {
+    pub prepare: ShaderId,
     pub pathtag_reduce: ShaderId,
     pub pathtag_reduce2: ShaderId,
     pub pathtag_scan1: ShaderId,
@@ -101,6 +102,7 @@ pub fn full_shaders(
         };
     }
 
+    let prepare = add_shader!(prepare, [Buffer, Buffer], CpuShaderType::Skipped);
     let pathtag_reduce = add_shader!(pathtag_reduce, [Uniform, BufReadOnly, Buffer]);
     let pathtag_reduce2 = add_shader!(
         pathtag_reduce2,
@@ -248,6 +250,7 @@ pub fn full_shaders(
     };
 
     Ok(FullShaders {
+        prepare,
         pathtag_reduce,
         pathtag_reduce2,
         pathtag_scan,

--- a/vello/src/wgpu_engine.rs
+++ b/vello/src/wgpu_engine.rs
@@ -374,7 +374,9 @@ impl WgpuEngine {
                     transient_map
                         .bufs
                         .insert(buf_proxy.id, TransientBuf::Cpu(bytes));
-                    let usage = BufferUsages::UNIFORM | BufferUsages::COPY_DST;
+                    // TODO: More principled way of working out usages
+                    let usage =
+                        BufferUsages::UNIFORM | BufferUsages::COPY_DST | BufferUsages::STORAGE;
                     // Same consideration as above
                     let buf = self
                         .pool

--- a/vello_encoding/src/config.rs
+++ b/vello_encoding/src/config.rs
@@ -137,6 +137,10 @@ pub struct ConfigUniform {
     pub base_color: u32,
     /// Layout of packed scene data.
     pub layout: Layout,
+    /// Whether this stage has been cancelled at startup due to a predicted
+    ///
+    /// Will be set by the `prepare` stage, and so should always be 0 on CPU.
+    pub cancelled: u32,
     /// Size of line soup buffer allocation (in [`LineSoup`]s)
     pub lines_size: u32,
     /// Size of binning buffer allocation (in `u32`s).
@@ -175,6 +179,7 @@ impl RenderConfig {
         Self {
             gpu: ConfigUniform {
                 width_in_tiles,
+                cancelled: false.into(),
                 height_in_tiles,
                 target_width: width,
                 target_height: height,

--- a/vello_shaders/build.rs
+++ b/vello_shaders/build.rs
@@ -21,7 +21,10 @@ fn main() {
     let mut shaders = match compile::ShaderInfo::from_default() {
         Ok(s) => s,
         Err(err) => {
-            eprintln!("{err}");
+            let formatted = err.to_string();
+            for line in formatted.lines() {
+                println!("cargo:warning={line}");
+            }
             return;
         }
     };

--- a/vello_shaders/shader/backdrop.wgsl
+++ b/vello_shaders/shader/backdrop.wgsl
@@ -26,6 +26,9 @@ fn main(
     @builtin(local_invocation_id) local_id: vec3<u32>,
     @builtin(workgroup_id) wg_id: vec3<u32>,
 ) {
+    if config.cancelled != 0u {
+        return;
+    }
     let width_in_tiles = config.width_in_tiles;
     let ix = wg_id.x * width_in_tiles + local_id.x;
     var backdrop = 0;

--- a/vello_shaders/shader/bbox_clear.wgsl
+++ b/vello_shaders/shader/bbox_clear.wgsl
@@ -14,6 +14,9 @@ var<storage, read_write> path_bboxes: array<PathBbox>;
 fn main(
     @builtin(global_invocation_id) global_id: vec3<u32>,
 ) {
+    if config.cancelled != 0u {
+        return;
+    }
     let ix = global_id.x;
     if ix < config.n_path {
         path_bboxes[ix].x0 = 0x7fffffff;

--- a/vello_shaders/shader/clip_leaf.wgsl
+++ b/vello_shaders/shader/clip_leaf.wgsl
@@ -83,6 +83,9 @@ fn main(
     @builtin(local_invocation_id) local_id: vec3<u32>,
     @builtin(workgroup_id) wg_id: vec3<u32>,
 ) {
+    if config.cancelled != 0u {
+        return;
+    }
     var bic: Bic;
     if local_id.x < wg_id.x {
         bic = reduced[local_id.x];

--- a/vello_shaders/shader/clip_reduce.wgsl
+++ b/vello_shaders/shader/clip_reduce.wgsl
@@ -27,6 +27,7 @@ fn main(
     @builtin(local_invocation_id) local_id: vec3<u32>,
     @builtin(workgroup_id) wg_id: vec3<u32>,
 ) {
+    // TODO: Cancel if this entire run has been cancelled?
     let inp = clip_inp[global_id.x].path_ix;
     let is_push = inp >= 0;
     var bic = Bic(1u - u32(is_push), u32(is_push));

--- a/vello_shaders/shader/coarse.wgsl
+++ b/vello_shaders/shader/coarse.wgsl
@@ -155,7 +155,7 @@ fn main(
     // We need to check only prior stages, as if this stage has failed in another workgroup, 
     // we still want to know this workgroup's memory requirement.   
     if local_id.x == 0u {
-        var failed = atomicLoad(&bump.failed) & (STAGE_BINNING | STAGE_TILE_ALLOC | STAGE_FLATTEN);
+        var failed = atomicLoad(&bump.failed) & (STAGE_BINNING | STAGE_TILE_ALLOC | STAGE_FLATTEN | PREVIOUS_RUN);
         if atomicLoad(&bump.seg_counts) > config.seg_counts_size {
             failed |= STAGE_PATH_COUNT;
         }

--- a/vello_shaders/shader/draw_leaf.wgsl
+++ b/vello_shaders/shader/draw_leaf.wgsl
@@ -54,6 +54,9 @@ fn main(
     @builtin(local_invocation_id) local_id: vec3<u32>,
     @builtin(workgroup_id) wg_id: vec3<u32>,
 ) {
+    if config.cancelled != 0u {
+        return;
+    }
     // Reduce prefix of workgroups up to this one
     var agg = draw_monoid_identity();
     if local_id.x < wg_id.x {
@@ -108,10 +111,7 @@ fn main(
         }
         let dd = config.drawdata_base + m.scene_offset;
         let di = m.info_offset;
-        if tag_word == DRAWTAG_FILL_COLOR || tag_word == DRAWTAG_FILL_LIN_GRADIENT ||
-            tag_word == DRAWTAG_FILL_RAD_GRADIENT || tag_word == DRAWTAG_FILL_SWEEP_GRADIENT ||
-            tag_word == DRAWTAG_FILL_IMAGE || tag_word == DRAWTAG_BEGIN_CLIP
-        {
+        if tag_word == DRAWTAG_FILL_COLOR || tag_word == DRAWTAG_FILL_LIN_GRADIENT || tag_word == DRAWTAG_FILL_RAD_GRADIENT || tag_word == DRAWTAG_FILL_SWEEP_GRADIENT || tag_word == DRAWTAG_FILL_IMAGE || tag_word == DRAWTAG_BEGIN_CLIP {
             let bbox = path_bbox[m.path_ix];
             // TODO: bbox is mostly yagni here, sort that out. Maybe clips?
             // let x0 = f32(bbox.x0);
@@ -121,9 +121,7 @@ fn main(
             // let bbox_f = vec4(x0, y0, x1, y1);
             var transform = Transform();
             let draw_flags = bbox.draw_flags;
-            if tag_word == DRAWTAG_FILL_LIN_GRADIENT || tag_word == DRAWTAG_FILL_RAD_GRADIENT ||
-                tag_word == DRAWTAG_FILL_SWEEP_GRADIENT || tag_word == DRAWTAG_FILL_IMAGE
-            {
+            if tag_word == DRAWTAG_FILL_LIN_GRADIENT || tag_word == DRAWTAG_FILL_RAD_GRADIENT || tag_word == DRAWTAG_FILL_SWEEP_GRADIENT || tag_word == DRAWTAG_FILL_IMAGE {
                 transform = read_transform(config.transform_base, bbox.trans_ix);
             }
             switch tag_word {

--- a/vello_shaders/shader/draw_reduce.wgsl
+++ b/vello_shaders/shader/draw_reduce.wgsl
@@ -24,6 +24,9 @@ fn main(
     @builtin(local_invocation_id) local_id: vec3<u32>,
     @builtin(workgroup_id) wg_id: vec3<u32>,
 ) {
+    if config.cancelled != 0u {
+        return;
+    }
     let num_blocks_total = (config.n_drawobj + (WG_SIZE - 1u)) / WG_SIZE;
     // When the number of blocks exceeds the workgroup size, divide
     // the work evenly so each workgroup handles n_blocks / wg, with

--- a/vello_shaders/shader/flatten.wgsl
+++ b/vello_shaders/shader/flatten.wgsl
@@ -359,8 +359,7 @@ fn flatten_euler(
 
         transform = local_to_device;
         let mat = transform.mat;
-        scale = 0.5 * length(vec2(mat.x + mat.w, mat.y - mat.z)) +
-                length(vec2(mat.x - mat.w, mat.y + mat.z));
+        scale = 0.5 * length(vec2(mat.x + mat.w, mat.y - mat.z)) + length(vec2(mat.x - mat.w, mat.y + mat.z));
     }
 
     // Drop zero length lines. This is an exact equality test because dropping very short
@@ -811,6 +810,9 @@ fn main(
     @builtin(global_invocation_id) global_id: vec3<u32>,
     @builtin(local_invocation_id) local_id: vec3<u32>,
 ) {
+    if config.cancelled != 0u {
+        return;
+    }
     let ix = global_id.x;
     pathdata_base = config.pathdata_base;
     bbox = vec4(1e31, 1e31, -1e31, -1e31);
@@ -848,7 +850,7 @@ fn main(
                     let offset_tangent = offset * normalize(tangent);
                     let n = offset_tangent.yx * vec2f(-1., 1.);
                     draw_cap(path_ix, (style_flags & STYLE_FLAGS_START_CAP_MASK) >> 2u,
-                             pts.p0, pts.p0 - n, pts.p0 + n, -offset_tangent, transform);
+                        pts.p0, pts.p0 - n, pts.p0 + n, -offset_tangent, transform);
                 } else {
                     // Don't draw anything if the path is closed.
                 }
@@ -878,11 +880,11 @@ fn main(
 
                 if neighbor.do_join {
                     draw_join(path_ix, style_flags, pts.p3, tan_prev, tan_next,
-                              n_prev, n_next, transform);
+                        n_prev, n_next, transform);
                 } else {
                     // Draw end cap.
                     draw_cap(path_ix, (style_flags & STYLE_FLAGS_END_CAP_MASK),
-                             pts.p3, pts.p3 + n_prev, pts.p3 - n_prev, offset_tangent, transform);
+                        pts.p3, pts.p3 + n_prev, pts.p3 - n_prev, offset_tangent, transform);
                 }
             }
         } else {

--- a/vello_shaders/shader/path_count.wgsl
+++ b/vello_shaders/shader/path_count.wgsl
@@ -52,6 +52,7 @@ let ROBUST_EPSILON: f32 = 2e-7;
 fn main(
     @builtin(global_invocation_id) global_id: vec3<u32>,
 ) {
+    // If the pipeline is cancelled, `path_count_setup` will not allocate any threads
     let n_lines = atomicLoad(&bump.lines);
     var count = 0u;
     if global_id.x < n_lines {

--- a/vello_shaders/shader/path_tiling.wgsl
+++ b/vello_shaders/shader/path_tiling.wgsl
@@ -40,6 +40,7 @@ let ROBUST_EPSILON: f32 = 2e-7;
 fn main(
     @builtin(global_invocation_id) global_id: vec3<u32>,
 ) {
+    // If the pipeline is cancelled, `path_tiling_setup` will not allocate any threads
     let n_segments = atomicLoad(&bump.seg_counts);
     if global_id.x < n_segments {
         let seg_count = seg_counts[global_id.x];

--- a/vello_shaders/shader/pathtag_reduce.wgsl
+++ b/vello_shaders/shader/pathtag_reduce.wgsl
@@ -23,6 +23,9 @@ fn main(
     @builtin(global_invocation_id) global_id: vec3<u32>,
     @builtin(local_invocation_id) local_id: vec3<u32>,
 ) {
+    if config.cancelled != 0u {
+        return;
+    }
     let ix = global_id.x;
     let tag_word = scene[config.pathtag_base + ix];
     var agg = reduce_tag(tag_word);

--- a/vello_shaders/shader/pathtag_reduce2.wgsl
+++ b/vello_shaders/shader/pathtag_reduce2.wgsl
@@ -23,6 +23,7 @@ fn main(
     @builtin(global_invocation_id) global_id: vec3<u32>,
     @builtin(local_invocation_id) local_id: vec3<u32>,
 ) {
+    // TODO: Cancel if needed?
     let ix = global_id.x;
     var agg = reduced_in[ix];
     sh_scratch[local_id.x] = agg;

--- a/vello_shaders/shader/pathtag_scan.wgsl
+++ b/vello_shaders/shader/pathtag_scan.wgsl
@@ -31,6 +31,9 @@ fn main(
     @builtin(local_invocation_id) local_id: vec3<u32>,
     @builtin(workgroup_id) wg_id: vec3<u32>,
 ) {
+    if config.cancelled != 0u {
+        return;
+    }
 #ifdef small
     var agg = tag_monoid_identity();
     if local_id.x < wg_id.x {

--- a/vello_shaders/shader/pathtag_scan1.wgsl
+++ b/vello_shaders/shader/pathtag_scan1.wgsl
@@ -29,6 +29,7 @@ fn main(
     @builtin(local_invocation_id) local_id: vec3<u32>,
     @builtin(workgroup_id) wg_id: vec3<u32>,
 ) {
+    // TODO: Cancel if needed
     var agg = tag_monoid_identity();
     if local_id.x < wg_id.x {
         agg = reduced2[local_id.x];

--- a/vello_shaders/shader/prepare.wgsl
+++ b/vello_shaders/shader/prepare.wgsl
@@ -1,0 +1,70 @@
+// Copyright 2022 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
+
+// Determine whether the Vello pipeline is likely to fail during this run
+// and therefore whether all later stages should be cancelled.
+
+#import config
+#import bump
+
+@group(0) @binding(0)
+var<storage, read_write> config: Config;
+
+@group(0) @binding(1)
+// TODO: Use a non-atomic version of BumpAllocators?
+var<storage, read_write> bump: BumpAllocators;
+
+@compute @workgroup_size(1)
+fn main() {
+    var should_cancel = false;
+    let previous_failure = atomicLoad(&bump.failed);
+    if previous_failure == PREVIOUS_RUN {
+        // Don't early-exit from multiple frames in a row
+        // The CPU should be blocking on the frame which failed anyway, so this
+        // case should never be reached, but if the CPU side isn't doing that
+        // properly, we can try again.
+        // (Note that this check is simply an early-exit for this case, as all the 
+        // bump values would have been reset to 0 anyway)
+        atomicStore(&bump.failed, 0u);
+    } else if previous_failure != 0u {
+        // If the previous frame failed (for another reason)
+
+        // And we don't have enough memory to have run that previous frame
+        if config.lines_size < atomicLoad(&bump.lines) {
+            should_cancel = true;
+        }
+        if config.binning_size < atomicLoad(&bump.binning) {
+            should_cancel = true;
+        }
+        if config.ptcl_size < atomicLoad(&bump.ptcl) {
+            should_cancel = true;
+        }
+        if config.tiles_size < atomicLoad(&bump.tile) {
+            should_cancel = true;
+        }
+        if config.seg_counts_size < atomicLoad(&bump.seg_counts) {
+            should_cancel = true;
+        }
+        if config.segments_size < atomicLoad(&bump.segments) {
+            should_cancel = true;
+        }
+        if config.lines_size < atomicLoad(&bump.lines) {
+            should_cancel = true;
+        }
+        // config.blend_size < atomicLoad(&bump.blend)
+        if should_cancel {
+            // Then don't run this frame
+            config.cancelled = 1u;
+            atomicStore(&bump.failed, PREVIOUS_RUN);
+        } else {
+            atomicStore(&bump.failed, 0u);
+        }
+    }
+    atomicStore(&bump.binning, 0u);
+    atomicStore(&bump.ptcl, 0u);
+    atomicStore(&bump.tile, 0u);
+    atomicStore(&bump.seg_counts, 0u);
+    atomicStore(&bump.segments, 0u);
+    atomicStore(&bump.blend, 0u);
+    atomicStore(&bump.lines, 0u);
+}

--- a/vello_shaders/shader/shared/bump.wgsl
+++ b/vello_shaders/shader/shared/bump.wgsl
@@ -7,6 +7,7 @@ let STAGE_TILE_ALLOC: u32 = 0x2u;
 let STAGE_FLATTEN: u32 = 0x4u;
 let STAGE_PATH_COUNT: u32 = 0x8u;
 let STAGE_COARSE: u32 = 0x10u;
+let PREVIOUS_RUN: u32 = 0x20u;
 
 // This must be kept in sync with the struct in config.rs in the encoding crate.
 struct BumpAllocators {

--- a/vello_shaders/shader/shared/config.wgsl
+++ b/vello_shaders/shader/shared/config.wgsl
@@ -32,6 +32,9 @@ struct Config {
     transform_base: u32,
     style_base: u32,
 
+    // Whether this stage has been cancelled at startup. 0 means uncancelled.
+    cancelled: u32,
+
     // Sizes of bump allocated buffers (in element size units)
     lines_size: u32,
     binning_size: u32,

--- a/vello_shaders/shader/tile_alloc.wgsl
+++ b/vello_shaders/shader/tile_alloc.wgsl
@@ -41,7 +41,7 @@ fn main(
     // We need to check only prior stages, as if this stage has failed in another workgroup, 
     // we still want to know this workgroup's memory requirement.
     if local_id.x == 0u {
-        let failed = (atomicLoad(&bump.failed) & (STAGE_BINNING | STAGE_FLATTEN)) != 0u;
+        let failed = (atomicLoad(&bump.failed) & (STAGE_BINNING | STAGE_FLATTEN | PREVIOUS_RUN)) != 0u;
         sh_previous_failed = u32(failed);
     }
     let failed = workgroupUniformLoad(&sh_previous_failed);


### PR DESCRIPTION
Fixes #366 

This is work in progress:

- [x] Cancel the pipeline if a failure *would* likely occur
- [ ] Readback the bump buffer (of two frames ago) before starting rendering a frame
- [ ] Reallocate based on those buffers

Some potential followup:
- Move rendering to its own thread; this would enable our use of [`Device::poll`](https://docs.rs/wgpu/latest/wgpu/struct.Device.html#method.poll) to not block the main thread.
  - This likely interacts poorly with resizing, if not done carefully.