### PR TITLE
Remove the `Pipelines` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ You can find its changes [documented below](#020---2024-06-08).
 
 ### Fixed
 
+## Removed
+
+- Breaking: `Pipelines` API from `vello_shaders` ([#612] by [@DJMcNab])
+
 ## [0.2.0] - 2024-06-08
 
 ### Added
@@ -91,6 +95,7 @@ You can find its changes [documented below](#020---2024-06-08).
 [#573]: https://github.com/linebender/vello/pull/573
 [#575]: https://github.com/linebender/vello/pull/575
 [#589]: https://github.com/linebender/vello/pull/589
+[#612]: https://github.com/linebender/vello/pull/612
 
 [Unreleased]: https://github.com/linebender/vello/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/linebender/vello/compare/v0.1.0...v0.2.0

--- a/vello_shaders/build.rs
+++ b/vello_shaders/build.rs
@@ -41,23 +41,6 @@ fn write_types(buf: &mut String, shaders: &[(String, ShaderInfo)]) -> Result<(),
         writeln!(buf, "    pub {name}: ComputeShader<'a>,")?;
     }
     writeln!(buf, "}}")?;
-    writeln!(buf, "pub struct Pipelines<T> {{")?;
-    for (name, _) in shaders {
-        writeln!(buf, "    pub {name}: T,")?;
-    }
-    writeln!(buf, "}}")?;
-    writeln!(buf, "impl<T> Pipelines<T> {{")?;
-    writeln!(buf, "    pub fn from_shaders<H: PipelineHost<ComputePipeline = T>>(shaders: &Shaders, device: &H::Device, host: &mut H) -> Result<Self, H::Error> {{")?;
-    writeln!(buf, "        Ok(Self {{")?;
-    for (name, _) in shaders {
-        writeln!(
-            buf,
-            "            {name}: host.new_compute_pipeline(device, &shaders.{name})?,"
-        )?;
-    }
-    writeln!(buf, "        }})")?;
-    writeln!(buf, "    }}")?;
-    writeln!(buf, "}}")?;
     Ok(())
 }
 

--- a/vello_shaders/src/lib.rs
+++ b/vello_shaders/src/lib.rs
@@ -111,18 +111,6 @@ pub struct MslSource<'a> {
     pub binding_indices: Cow<'a, [msl::BindingIndex]>,
 }
 
-pub trait PipelineHost {
-    type Device;
-    type ComputePipeline;
-    type Error;
-
-    fn new_compute_pipeline(
-        &mut self,
-        device: &Self::Device,
-        shader: &ComputeShader,
-    ) -> Result<Self::ComputePipeline, Self::Error>;
-}
-
 include!(concat!(env!("OUT_DIR"), "/shaders.rs"));
 
 pub use generated::SHADERS;


### PR DESCRIPTION
This has a few issues:
- Pipelines cannot be optional, and so all pipelines will be compiled even if unused. This includes all 6 variants of `fine`
- It cannot support multi-threaded initialisation
- It has, as far as I can tell, never been used (based on a search of all of GitHub, including [google/skia](https://github.com/google/skia/))