### PR TITLE
examples: Use `clamp`

### DIFF
--- a/examples/scenes/src/pico_svg.rs
+++ b/examples/scenes/src/pico_svg.rs
@@ -272,7 +272,7 @@ fn modify_opacity(mut color: Color, attr_name: &str, node: Node) -> Color {
         } else {
             opacity.parse().unwrap_or(1.0)
         };
-        color.a = (alpha.min(1.0).max(0.0) * 255.0).round() as u8;
+        color.a = (alpha.clamp(0.0, 1.0) * 255.0).round() as u8;
         color
     } else {
         color

--- a/examples/with_winit/src/stats.rs
+++ b/examples/with_winit/src/stats.rs
@@ -37,7 +37,7 @@ impl Snapshot {
     ) where
         T: Iterator<Item = &'a u64>,
     {
-        let width = (viewport_width * 0.4).max(200.).min(600.);
+        let width = (viewport_width * 0.4).clamp(200., 600.);
         let height = width * 0.7;
         let x_offset = viewport_width - width;
         let y_offset = viewport_height - height;


### PR DESCRIPTION
This satisfies a clippy lint that is newly enabled in 1.79.