### PR TITLE
Hack around unsupported glyphs

### DIFF
--- a/vello_encoding/src/resolve.rs
+++ b/vello_encoding/src/resolve.rs
@@ -438,9 +438,14 @@ impl Resolver {
                     };
                     let glyph_start = self.glyphs.len();
                     for glyph in glyphs {
-                        let Some((encoding, stream_sizes)) = session.get_or_insert(glyph.id) else {
-                            continue;
-                        };
+                        let (encoding, stream_sizes) =
+                            session.get_or_insert(glyph.id).unwrap_or_else(|| {
+                                // HACK: We pretend that the encoding was empty.
+                                // In theory, we should be able to skip this glyph, but there is also
+                                // a corresponding entry in `resources`, which means that we would
+                                // need to make the patching process skip this glyph.
+                                (Arc::new(Encoding::new()), StreamOffsets::default())
+                            });
                         run_sizes.add(&stream_sizes);
                         self.glyphs.push(encoding);
                     }


### PR DESCRIPTION
Currently, if we get a glyph which the current font "doesn't support" (such as if that font only supports bitmap images, which we don't), then the entire transforms stream gets misaligned. That leads to some funny rendering, such as 
![Screenshot of the mason example, with misaligned text, some upside down characters and incorrect looking layout.](https://github.com/linebender/vello/assets/36049421/87e84446-7959-48db-9744-f3eac5dad3ff)

This PR works around this, by instead of skipping these glyphs, inserting an empty encoding into their location.