### PR TITLE
[vello_shaders] Bring back the Bazel build hack

### DIFF
--- a/vello_shaders/src/compile/mod.rs
+++ b/vello_shaders/src/compile/mod.rs
@@ -274,5 +274,24 @@ fn postprocess(wgsl: &str) -> String {
 // NOTE: Embedding build environment info into the code makes reproducible builds trickier.
 pub fn shader_dir() -> &'static PathBuf {
     static SHADER_DIR: OnceLock<PathBuf> = OnceLock::new();
-    SHADER_DIR.get_or_init(|| Path::new(env!("CARGO_MANIFEST_DIR")).join("shader"))
+    SHADER_DIR.get_or_init(|| manifest_dir().join("shader"))
+}
+
+// In a regular cargo build the manifest directory is simply given by CARGO_MANIFEST_DIR.
+//
+// Skia, an external consumer of this crate, uses Bazel rules to compile Rust code. Due to
+// limitations in Bazel's rust support, Skia maintains its own build definitions
+// (https://source.chromium.org/chromium/chromium/src/+/main:third_party/skia/bazel/external/vello/BUILD.bazel).
+//
+// Because of the current setup, Bazel sets CARGO_MANIFEST_DIR to the workspace root instead of the
+// actual crate being built. This could be improved but until then, we work around this by allowing
+// the absolute path to the vello_shader crate's manifest to be specified using the
+// `BAZEL_CRATE_MANIFEST_PATH` build script environment variable. This should never be set when
+// using cargo.
+fn manifest_dir() -> PathBuf {
+    use std::env;
+    env::var_os("BAZEL_CRATE_MANIFEST_PATH")
+        .and_then(|p| Path::new(&p).parent().map(|p| p.to_owned()))
+        .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")))
+        .to_path_buf()
 }

--- a/vello_shaders/src/compile/mod.rs
+++ b/vello_shaders/src/compile/mod.rs
@@ -286,11 +286,12 @@ pub fn shader_dir() -> &'static PathBuf {
 // Because of the current setup, Bazel sets CARGO_MANIFEST_DIR to the workspace root instead of the
 // actual crate being built. This could be improved but until then, we work around this by allowing
 // the absolute path to the vello_shader crate's manifest to be specified using the
-// `BAZEL_CRATE_MANIFEST_PATH` build script environment variable. This should never be set when
-// using cargo.
+// `UNSTABLE_BAZEL_VELLO_SHADERS_CRATE_MANIFEST_PATH` build script environment variable.
+//
+// This should never be set when using cargo.
 fn manifest_dir() -> PathBuf {
     use std::env;
-    env::var_os("BAZEL_CRATE_MANIFEST_PATH")
+    env::var_os("UNSTABLE_BAZEL_VELLO_SHADERS_CRATE_MANIFEST_PATH")
         .and_then(|p| Path::new(&p).parent().map(|p| p.to_owned()))
         .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")))
         .to_path_buf()


### PR DESCRIPTION
Skia, an external consumer of this crate, uses [Bazel rules](https://source.chromium.org/chromium/chromium/src/+/main:third_party/skia/bazel/external/vello/BUILD.bazel) to compile Rust code. Due to limitations in Bazel's rust support, the CARGO_MANIFEST_DIR environment variable doesn't get set properly for nested crates since Bazel seems to assign the workspace root instead (as the [BUILD](https://source.chromium.org/chromium/chromium/src/+/main:third_party/skia/bazel/external/vello/BUILD.bazel) file needs to be specified relative to the external repository root).

Until we figure out a better way to manage the bazel integration, this PR reintroduces a recently removed hack to work around this by allowing the crate manifest path to be assigned explicitly, using a new environment variable called `BAZEL_CRATE_MANIFEST_PATH`. This is intended to be the absolute path to `vello_shaders/Cargo.toml` within the bazel sandbox file system.