### PR TITLE
Switch to macos-latest in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,14 +32,6 @@ env:
 # Using cargo-hack also allows us to more easily test the feature matrix of our packages.
 # We use --each-feature & --optional-deps which will run a separate check for every feature.
 #
-# We use macos-14 explicitly instead of macos-latest because:
-#   * macos-latest currently points to macos-12
-#   * macos-14 provides us with the GPU support we want for testing
-#   * macos-14 comes with the M1 CPU which compiles our code much faster than the older runners
-# This explicit dependency can be switched back to macos-latest once it points to macos-14,
-# which is expected to happen sometime in Q2 FY24 (April – June 2024).
-# https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/
-#
 # The MSRV jobs run only cargo check because different clippy versions can disagree on goals and
 # running tests introduces dev dependencies which may require a higher MSRV than the bare package.
 
@@ -78,7 +70,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, macos-14, ubuntu-latest]
+        os: [windows-latest, macos-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
 
@@ -138,11 +130,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, macos-14, ubuntu-latest]
+        os: [windows-latest, macos-latest, ubuntu-latest]
         include:
           - os: ubuntu-latest
             gpu: 'yes'
-          - os: macos-14
+          - os: macos-latest
             gpu: 'yes'
           - os: windows-latest
             # TODO: The windows runners theoretically have CPU fallback for GPUs, but
@@ -226,7 +218,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, macos-14, ubuntu-latest]
+        os: [windows-latest, macos-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/