### PR TITLE
Correct example code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,11 @@ While drawing in a Vello scene is easy, actually rendering that scene to a surfa
 To use Vello as the renderer for your PDF reader / GUI toolkit / etc, your code will have to look roughly like this:
 
 ```rust
-use std::num::NonZeroUsize;
-use vello::{ Renderer, RendererOptions, AaConfig };
-use vello::peniko::{ Fill, Color };
-use vello::kurbo::{ Affine, Circle };
+use vello::{
+    kurbo::{Affine, Circle},
+    peniko::{Color, Fill},
+    *,
+};
 
 // Initialize wgpu and get handles
 let (width, height) = ...;
@@ -82,13 +83,13 @@ let mut renderer = Renderer::new(
    RendererOptions {
       surface_format: Some(texture_format),
       use_cpu: false,
-      antialiasing_support: vello::AaSupport::all(),
+      antialiasing_support: AaSupport::all(),
       num_init_threads: NonZeroUsize::new(1),
    },
 ).expect("Failed to create renderer");
 
 // Create scene and draw stuff in it
-let mut scene = vello::Scene::new();
+let mut scene = Scene::new();
 scene.fill(
    Fill::NonZero,
    Affine::IDENTITY,
@@ -112,7 +113,7 @@ renderer
       &queue,
       &scene,
       &surface_texture,
-      &vello::RenderParams {
+      &RenderParams {
          base_color: Color::BLACK, // Background color
          width,
          height,

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ While drawing in a Vello scene is easy, actually rendering that scene to a surfa
 To use Vello as the renderer for your PDF reader / GUI toolkit / etc, your code will have to look roughly like this:
 
 ```rust
+use std::num::NonZeroUsize;
+use vello::{ Renderer, RendererOptions, AaConfig };
+use vello::peniko::{ Fill, Color };
+use vello::kurbo::{ Affine, Circle };
+
 // Initialize wgpu and get handles
 let (width, height) = ...;
 let device: wgpu::Device = ...;
@@ -85,11 +90,11 @@ let mut renderer = Renderer::new(
 // Create scene and draw stuff in it
 let mut scene = vello::Scene::new();
 scene.fill(
-   vello::peniko::Fill::NonZero,
-   vello::Affine::IDENTITY,
-   vello::Color::rgb8(242, 140, 168),
+   Fill::NonZero,
+   Affine::IDENTITY,
+   Color::rgb8(242, 140, 168),
    None,
-   &vello::Circle::new((420.0, 200.0), 120.0),
+   &Circle::new((420.0, 200.0), 120.0),
 );
 
 // Draw more stuff


### PR DESCRIPTION
Corrected some incorrect parts of the example code in README.md file(i.e. using `vello::peniko::Color`, `vello::kurbo::Circle` as `vello::Color`, `vello::Circle`) and added `use`s.