### PR TITLE
Allow access to adapter

### DIFF
--- a/vello/src/util.rs
+++ b/vello/src/util.rs
@@ -148,6 +148,13 @@ impl RenderContext {
     }
 }
 
+impl DeviceHandle {
+    /// Returns the adapter associated with the device.
+    pub fn adapter(&self) -> &Adapter {
+        &self.adapter
+    }
+}
+
 /// Combination of surface and its configuration.
 #[derive(Debug)]
 pub struct RenderSurface<'s> {


### PR DESCRIPTION
Currently there is no way to access the adapter outside of Vello, which prevents users of Vello from doing things like checking surface capabilities. This pull request exposes the adapter.