### PR TITLE
Add minimal infrastructure for overriding an `Image`

### DIFF
--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -89,7 +89,7 @@ mod shaders;
 mod wgpu_engine;
 
 #[cfg(feature = "wgpu")]
-use std::num::NonZeroUsize;
+use std::{num::NonZeroUsize, sync::Arc};
 
 /// Styling and composition primitives.
 pub use peniko;
@@ -334,9 +334,9 @@ impl Renderer {
     /// If texture is `None`, removes the override.
     pub fn override_image(
         &mut self,
-        image: peniko::Image,
-        texture: Option<wgpu::ImageCopyTextureBase<wgpu::Texture>>,
-    ) -> Option<wgpu::ImageCopyTextureBase<wgpu::Texture>> {
+        image: &peniko::Image,
+        texture: Option<Arc<wgpu::ImageCopyTextureBase<wgpu::Texture>>>,
+    ) -> Option<Arc<wgpu::ImageCopyTextureBase<wgpu::Texture>>> {
         match texture {
             Some(texture) => self.engine.image_overrides.insert(image.data.id(), texture),
             None => self.engine.image_overrides.remove(&image.data.id()),

--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -329,6 +329,20 @@ impl Renderer {
         })
     }
 
+    /// Overwrite the `Image` with the `Texture` texture.
+    ///
+    /// If texture is `None`, removes the override.
+    pub fn override_image(
+        &mut self,
+        image: peniko::Image,
+        texture: Option<wgpu::ImageCopyTextureBase<wgpu::Texture>>,
+    ) -> Option<wgpu::ImageCopyTextureBase<wgpu::Texture>> {
+        match texture {
+            Some(texture) => self.engine.image_overrides.insert(image.data.id(), texture),
+            None => self.engine.image_overrides.remove(&image.data.id()),
+        }
+    }
+
     /// Renders a scene to the target texture.
     ///
     /// The texture is assumed to be of the specified dimensions and have been created with

--- a/vello/src/recording.rs
+++ b/vello/src/recording.rs
@@ -4,6 +4,8 @@
 use std::num::NonZeroU64;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use peniko::Image;
+
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct ShaderId(pub usize);
 
@@ -61,7 +63,7 @@ pub enum Command {
     UploadUniform(BufferProxy, Vec<u8>),
     /// Commands the data to be uploaded to the given image.
     UploadImage(ImageProxy, Vec<u8>),
-    WriteImage(ImageProxy, [u32; 4], Vec<u8>),
+    WriteImage(ImageProxy, [u32; 2], Image),
     // Discussion question: third argument is vec of resources?
     // Maybe use tricks to make more ergonomic?
     // Alternative: provide bufs & images as separate sequences
@@ -133,17 +135,8 @@ impl Recording {
         image_proxy
     }
 
-    pub fn write_image(
-        &mut self,
-        image: ImageProxy,
-        x: u32,
-        y: u32,
-        width: u32,
-        height: u32,
-        data: impl Into<Vec<u8>>,
-    ) {
-        let data = data.into();
-        self.push(Command::WriteImage(image, [x, y, width, height], data));
+    pub fn write_image(&mut self, proxy: ImageProxy, x: u32, y: u32, image: Image) {
+        self.push(Command::WriteImage(proxy, [x, y], image));
     }
 
     pub fn dispatch<R>(&mut self, shader: ShaderId, wg_size: (u32, u32, u32), resources: R)

--- a/vello/src/render.rs
+++ b/vello/src/render.rs
@@ -113,14 +113,7 @@ impl Render {
             ImageProxy::new(images.width, images.height, ImageFormat::Rgba8)
         };
         for image in images.images {
-            recording.write_image(
-                image_atlas,
-                image.1,
-                image.2,
-                image.0.width,
-                image.0.height,
-                image.0.data.data(),
-            );
+            recording.write_image(image_atlas, image.1, image.2, image.0.clone());
         }
         let cpu_config =
             RenderConfig::new(&layout, params.width, params.height, &params.base_color);

--- a/vello/src/wgpu_engine.rs
+++ b/vello/src/wgpu_engine.rs
@@ -8,7 +8,6 @@ use std::collections::{HashMap, HashSet};
 
 use vello_shaders::cpu::CpuBinding;
 
-use wgpu::naga::Override;
 use wgpu::{
     BindGroup, BindGroupLayout, Buffer, BufferUsages, CommandEncoder, CommandEncoderDescriptor,
     ComputePipeline, Device, PipelineCompilationOptions, Queue, Texture, TextureAspect,

--- a/vello/src/wgpu_engine.rs
+++ b/vello/src/wgpu_engine.rs
@@ -5,6 +5,7 @@ use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use vello_shaders::cpu::CpuBinding;
 
@@ -39,7 +40,7 @@ pub struct WgpuEngine {
     /// Overrides from a specific `Image`'s [`id`](peniko::Image::id) to a wgpu `Texture`.
     ///
     /// The `Texture` should have the same size as the `Image`.
-    pub(crate) image_overrides: HashMap<u64, wgpu::ImageCopyTextureBase<Texture>>,
+    pub(crate) image_overrides: HashMap<u64, Arc<wgpu::ImageCopyTextureBase<Texture>>>,
 }
 
 struct WgpuShader {


### PR DESCRIPTION
This is related to https://github.com/linebender/xilem/issues/395

See also [#gpu > vello adding wgpu texture buffers to scene](https://xi.zulipchat.com/#narrow/stream/197075-gpu/topic/vello.20adding.20wgpu.20texture.20buffers.20to.20scene)

This is a targeted hack working within our current API.