### PR TITLE
Update typos, fix typo, improve config.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,4 +302,4 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: check typos
-        uses: crate-ci/typos@v1.22.9
+        uses: crate-ci/typos@v1.23.2

--- a/.typos.toml
+++ b/.typos.toml
@@ -6,9 +6,13 @@
 # word is treated as always correct. If the value is an empty string, the word
 # is treated as always incorrect.
 
+# Match Identifier - Case Sensitive
+[default.extend-identifiers]
+thm = "thm"
+wdth = "wdth"
+
 # Match Inside a Word - Case Insensitive
 [default.extend-words]
-thm = "thm"
 
 [files]
 # Include .github, .cargo, etc.

--- a/vello_tests/src/compare.rs
+++ b/vello_tests/src/compare.rs
@@ -21,7 +21,7 @@ fn comparison_dir() -> PathBuf {
 }
 
 #[must_use = "A snapshot test doesn't do anything unless an assertion method is called on it"]
-/// A scene rendered on the CPU and the same scene rendered on the GPU, and information about their diffences.
+/// A scene rendered on the CPU and the same scene rendered on the GPU, and information about their differences.
 ///
 /// Use an assertion method or access `statistics` to make a determination based on the result of this test.
 pub struct GpuCpuComparison {


### PR DESCRIPTION
Instead of matching anywhere in a word, we can match the exact identifier. This will help reduce not finding typos.