### PR TITLE
feat: derives for `AaSupport`

### DIFF
--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -134,15 +134,25 @@ use wgpu::{Device, Queue, SurfaceTexture, TextureFormat, TextureView};
 use wgpu_profiler::{GpuProfiler, GpuProfilerSettings};
 
 /// Represents the antialiasing method to use during a render pass.
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum AaConfig {
     Area,
     Msaa8,
     Msaa16,
 }
 
+impl From<AaConfig> for AaSupport {
+    fn from(value: AaConfig) -> Self {
+        Self {
+            area: value == AaConfig::Area,
+            msaa8: value == AaConfig::Msaa8,
+            msaa16: value == AaConfig::Msaa16,
+        }
+    }
+}
+
 /// Represents the set of antialiasing configurations to enable during pipeline creation.
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct AaSupport {
     pub area: bool,
     pub msaa8: bool,

--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -142,6 +142,7 @@ pub enum AaConfig {
 }
 
 /// Represents the set of antialiasing configurations to enable during pipeline creation.
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct AaSupport {
     pub area: bool,
     pub msaa8: bool,

--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -141,16 +141,6 @@ pub enum AaConfig {
     Msaa16,
 }
 
-impl From<AaConfig> for AaSupport {
-    fn from(value: AaConfig) -> Self {
-        Self {
-            area: value == AaConfig::Area,
-            msaa8: value == AaConfig::Msaa8,
-            msaa16: value == AaConfig::Msaa16,
-        }
-    }
-}
-
 /// Represents the set of antialiasing configurations to enable during pipeline creation.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct AaSupport {


### PR DESCRIPTION
Doesn't play well with bevy_vello since I can't interoperate these types or clone, etc.