### PR TITLE
Change type of image override resources

### DIFF
--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -365,8 +365,8 @@ impl Renderer {
     pub fn override_image(
         &mut self,
         image: &peniko::Image,
-        texture: Option<Arc<wgpu::ImageCopyTextureBase<wgpu::Texture>>>,
-    ) -> Option<Arc<wgpu::ImageCopyTextureBase<wgpu::Texture>>> {
+        texture: Option<wgpu::ImageCopyTextureBase<Arc<wgpu::Texture>>>,
+    ) -> Option<wgpu::ImageCopyTextureBase<Arc<wgpu::Texture>>> {
         match texture {
             Some(texture) => self.engine.image_overrides.insert(image.data.id(), texture),
             None => self.engine.image_overrides.remove(&image.data.id()),

--- a/vello/src/wgpu_engine.rs
+++ b/vello/src/wgpu_engine.rs
@@ -40,7 +40,7 @@ pub(crate) struct WgpuEngine {
     /// Overrides from a specific `Image`'s [`id`](peniko::Image::id) to a wgpu `Texture`.
     ///
     /// The `Texture` should have the same size as the `Image`.
-    pub(crate) image_overrides: HashMap<u64, Arc<wgpu::ImageCopyTextureBase<Texture>>>,
+    pub(crate) image_overrides: HashMap<u64, wgpu::ImageCopyTextureBase<Arc<Texture>>>,
 }
 
 enum PipelineState {


### PR DESCRIPTION
This is related to this discussion on [zulip](https://xi.zulipchat.com/#narrow/stream/197075-gpu/topic/vello.20adding.20wgpu.20texture.20buffers.20to.20scene/near/456478943) and a followup to https://github.com/linebender/vello/pull/636