### PR TITLE
Free the `blend_spill` buffer

### DIFF
--- a/vello/src/render.rs
+++ b/vello/src/render.rs
@@ -566,6 +566,7 @@ impl Render {
         recording.free_resource(fine.gradient_image);
         recording.free_resource(fine.image_atlas);
         recording.free_resource(fine.info_bin_data_buf);
+        recording.free_resource(fine.blend_spill_buf);
         // TODO: make mask buf persistent
         if let Some(mask_buf) = self.mask_buf.take() {
             recording.free_resource(mask_buf);


### PR DESCRIPTION
This was missed in #657

I have been running into consistent issues with freeing things incorrectly; I think we need to develop better tools for this.

This will be a consideration for the planned API changes.