### PR TITLE
Fix some warnings in examples

### DIFF
--- a/examples/scenes/src/simple_text.rs
+++ b/examples/scenes/src/simple_text.rs
@@ -160,7 +160,7 @@ impl SimpleText {
         transform: Affine,
         text: &str,
     ) {
-        use vello::peniko::{Color, Fill};
+        use vello::peniko::Fill;
         let brush = brush.unwrap_or(&Brush::Solid(Color::WHITE));
         self.add_run(
             scene,

--- a/examples/scenes/src/test_scenes.rs
+++ b/examples/scenes/src/test_scenes.rs
@@ -608,7 +608,6 @@ mod impls {
     }
 
     pub(super) fn longpathdash(cap: Cap) -> impl FnMut(&mut Scene, &mut SceneParams) {
-        use std::f64::consts::PI;
         use PathEl::*;
         move |scene, _| {
             let mut path = BezPath::new();


### PR DESCRIPTION
Fixs the following warnings.
```rust
   Compiling scenes v0.0.0 (C:\Users\tannal\tannalwork\projects\vello\examples\scenes)
warning: the item `Color` is imported redundantly
   --> examples\scenes\src\simple_text.rs:163:29
    |
8   | use vello::peniko::{Blob, Brush, BrushRef, Color, Font, StyleRef};
    |                                            ----- the item `Color` is already imported here
...
163 |         use vello::peniko::{Color, Fill};
    |                             ^^^^^
    |
    = note: `#[warn(unused_imports)]` on by default

warning: the item `PI` is imported redundantly
   --> examples\scenes\src\test_scenes.rs:611:13
    |
86  |     use std::f64::consts::PI;
    |         -------------------- the item `PI` is already imported here
...
611 |         use std::f64::consts::PI;
    |             ^^^^^^^^^^^^^^^^^^^^

   Compiling vello_tests v0.0.0 (C:\Users\tannal\tannalwork\projects\vello\vello_tests)
warning: `scenes` (lib) generated 2 warnings (2 duplicates)
   Compiling with_winit v0.0.0 (C:\Users\tannal\tannalwork\projects\vello\examples\with_winit) 
   Compiling headless v0.0.0 (C:\Users\tannal\tannalwork\projects\vello\examples\headless)     
warning: `scenes` (lib test) generated 2 warnings
```