### PR TITLE
Retained/Fine Granular Mode (Beta)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,7 +1170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.5",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 # NOTE: When bumping this, remember to also bump the aforementioned other packages'
 #       version in the dependencies section at the bottom of this file.
 #       Additionally, bump the Vello dependency version in the 'simple' example.
-version = "0.2.1"
+version = "0.2.0"
 
 edition = "2021"
 # Keep in sync with RUST_MIN_VER in .github/workflows/ci.yml, with the relevant README.md files
@@ -37,9 +37,9 @@ clippy.semicolon_if_nothing_returned = "warn"
 # rust.unreachable_pub = "warn"
 
 [workspace.dependencies]
-vello = { version = "0.2.1", path = "vello" }
-vello_encoding = { version = "0.2.1", path = "vello_encoding" }
-vello_shaders = { version = "0.2.1", path = "vello_shaders" }
+vello = { version = "0.2.0", path = "vello" }
+vello_encoding = { version = "0.2.0", path = "vello_encoding" }
+vello_shaders = { version = "0.2.0", path = "vello_shaders" }
 bytemuck = { version = "1.16.0", features = ["derive"] }
 skrifa = "0.19.3"
 peniko = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 # NOTE: When bumping this, remember to also bump the aforementioned other packages'
 #       version in the dependencies section at the bottom of this file.
 #       Additionally, bump the Vello dependency version in the 'simple' example.
-version = "0.2.0"
+version = "0.2.1"
 
 edition = "2021"
 # Keep in sync with RUST_MIN_VER in .github/workflows/ci.yml, with the relevant README.md files
@@ -37,9 +37,9 @@ clippy.semicolon_if_nothing_returned = "warn"
 # rust.unreachable_pub = "warn"
 
 [workspace.dependencies]
-vello = { version = "0.2.0", path = "vello" }
-vello_encoding = { version = "0.2.0", path = "vello_encoding" }
-vello_shaders = { version = "0.2.0", path = "vello_shaders" }
+vello = { version = "0.2.1", path = "vello" }
+vello_encoding = { version = "0.2.1", path = "vello_encoding" }
+vello_shaders = { version = "0.2.1", path = "vello_shaders" }
 bytemuck = { version = "1.16.0", features = ["derive"] }
 skrifa = "0.19.3"
 peniko = "0.1.1"

--- a/vello/src/glyph.rs
+++ b/vello/src/glyph.rs
@@ -11,7 +11,7 @@ use skrifa::outline::OutlinePen;
 use skrifa::raw::FontRef;
 use skrifa::setting::Setting;
 use skrifa::{GlyphId, OutlineGlyphCollection};
-use vello_encoding::Encoding;
+use vello_encoding::{Encoding, Index};
 
 use peniko::kurbo::Shape;
 pub use skrifa;
@@ -94,7 +94,7 @@ impl<'a> GlyphProvider<'a> {
             Style::Fill(fill) => *fill,
             Style::Stroke(_) => Fill::NonZero,
         };
-        encoding.encode_fill_style(fill);
+        encoding.encode_fill_style(&mut Index::default(), fill);
         let mut path = encoding.encode_path(true);
         let outline = self.outlines.get(GlyphId::new(gid))?;
         let draw_settings = DrawSettings::unhinted(self.size, self.coords);

--- a/vello_encoding/src/encoding.rs
+++ b/vello_encoding/src/encoding.rs
@@ -213,7 +213,6 @@ impl Encoding {
     }
 
     fn encode_style(&mut self, index: &mut Index, style: Style) {
-
         self.path_tags.push(PathTag::STYLE);
         self.styles.push(style);
         self.flags &= !Self::FORCE_NEXT_STYLE;
@@ -226,7 +225,6 @@ impl Encoding {
     /// If the given transform is different from the current one, encodes it and
     /// returns true. Otherwise, encodes nothing and returns false.
     pub fn encode_transform(&mut self, index: &mut Index, transform: Transform) -> bool {
-
         self.path_tags.push(PathTag::TRANSFORM);
         self.transforms.push(transform);
         self.flags &= !Self::FORCE_NEXT_TRANSFORM;
@@ -252,7 +250,6 @@ impl Encoding {
     /// Encodes a shape. If `is_fill` is true, all subpaths will be automatically closed.
     /// Returns true if a non-zero number of segments were encoded.
     pub fn encode_shape(&mut self, index: &mut Index, shape: &impl Shape, is_fill: bool) -> bool {
-
         index.path_data_in.0 = self.path_data.len() + 1;
 
         let mut encoder = self.encode_path(is_fill);
@@ -290,7 +287,12 @@ impl Encoding {
 
     /// Encodes a brush with an optional alpha modifier.
     #[allow(unused_variables)]
-    pub fn encode_brush<'b>(&mut self, index: &mut Index, brush: impl Into<BrushRef<'b>>, alpha: f32) {
+    pub fn encode_brush<'b>(
+        &mut self,
+        index: &mut Index,
+        brush: impl Into<BrushRef<'b>>,
+        alpha: f32,
+    ) {
         #[cfg(feature = "full")]
         use super::math::point_to_f32;
         match brush.into() {
@@ -305,7 +307,8 @@ impl Encoding {
             #[cfg(feature = "full")]
             BrushRef::Gradient(gradient) => match gradient.kind {
                 GradientKind::Linear { start, end } => {
-                    self.encode_linear_gradient(index,
+                    self.encode_linear_gradient(
+                        index,
                         DrawLinearGradient {
                             index: 0,
                             p0: point_to_f32(start),
@@ -322,7 +325,8 @@ impl Encoding {
                     end_center,
                     end_radius,
                 } => {
-                    self.encode_radial_gradient(index,
+                    self.encode_radial_gradient(
+                        index,
                         DrawRadialGradient {
                             index: 0,
                             p0: point_to_f32(start_center),
@@ -341,7 +345,8 @@ impl Encoding {
                     end_angle,
                 } => {
                     use core::f32::consts::TAU;
-                    self.encode_sweep_gradient(index,
+                    self.encode_sweep_gradient(
+                        index,
                         DrawSweepGradient {
                             index: 0,
                             p0: point_to_f32(center),
@@ -366,7 +371,12 @@ impl Encoding {
 
     /// Modifies a brush with an optional alpha modifier.
     #[allow(unused_variables)]
-    pub fn modify_brush<'b>(&mut self, index: &mut Index, brush: impl Into<BrushRef<'b>>, alpha: f32) {
+    pub fn modify_brush<'b>(
+        &mut self,
+        index: &mut Index,
+        brush: impl Into<BrushRef<'b>>,
+        alpha: f32,
+    ) {
         #[cfg(feature = "full")]
         match brush.into() {
             BrushRef::Solid(color) => {
@@ -376,14 +386,13 @@ impl Encoding {
                     color
                 };
                 self.modify_color(index, DrawColor::new(color));
-            },
-            _ => todo!()
+            }
+            _ => todo!(),
         }
     }
 
     /// Encodes a solid color brush.
     pub fn encode_color(&mut self, index: &mut Index, color: DrawColor) {
-
         self.draw_tags.push(DrawTag::COLOR);
         index.draw_tag_in = self.draw_tags.len();
 
@@ -396,7 +405,6 @@ impl Encoding {
 
     /// Modifies a solid color brush.
     pub fn modify_color(&mut self, index: &mut Index, color: DrawColor) {
-
         if index.draw_tag_in == 0 || index.draw_data_in.0 == 0 || index.draw_data_in.1 == 0 {
             return;
         }

--- a/vello_encoding/src/encoding.rs
+++ b/vello_encoding/src/encoding.rs
@@ -4,7 +4,7 @@
 use super::{DrawColor, DrawTag, PathEncoder, PathTag, Style, Transform};
 
 use peniko::kurbo::{Shape, Stroke};
-use peniko::{BlendMode, Brush, BrushRef, Fill};
+use peniko::{BlendMode, BrushRef, Fill};
 
 #[cfg(feature = "full")]
 use {
@@ -29,7 +29,7 @@ pub struct Index {
 
 impl Index {
     pub fn is_empty(&self) -> bool {
-        return self.transform_in == 0 && self.style_in == 0;
+        self.transform_in == 0 && self.style_in == 0
     }
 }
 
@@ -213,13 +213,12 @@ impl Encoding {
     }
 
     fn encode_style(&mut self, index: &mut Index, style: Style) {
-        // if self.flags & Self::FORCE_NEXT_STYLE != 0 || self.styles.last() != Some(&style) {
-            self.path_tags.push(PathTag::STYLE);
-            self.styles.push(style);
-            self.flags &= !Self::FORCE_NEXT_STYLE;
 
-            index.style_in = self.styles.len();
-        // }
+        self.path_tags.push(PathTag::STYLE);
+        self.styles.push(style);
+        self.flags &= !Self::FORCE_NEXT_STYLE;
+
+        index.style_in = self.styles.len();
     }
 
     /// Encodes a transform.
@@ -227,20 +226,15 @@ impl Encoding {
     /// If the given transform is different from the current one, encodes it and
     /// returns true. Otherwise, encodes nothing and returns false.
     pub fn encode_transform(&mut self, index: &mut Index, transform: Transform) -> bool {
-        // if self.flags & Self::FORCE_NEXT_TRANSFORM != 0
-        //     || self.transforms.last() != Some(&transform)
-        // {
-            self.path_tags.push(PathTag::TRANSFORM);
-            self.transforms.push(transform);
-            self.flags &= !Self::FORCE_NEXT_TRANSFORM;
 
-            index.path_tags_in.0 = self.path_tags.len();
-            index.transform_in = self.transforms.len();
+        self.path_tags.push(PathTag::TRANSFORM);
+        self.transforms.push(transform);
+        self.flags &= !Self::FORCE_NEXT_TRANSFORM;
 
-            true
-        // } else {
-        //     false
-        // }
+        index.path_tags_in.0 = self.path_tags.len();
+        index.transform_in = self.transforms.len();
+
+        true
     }
 
     /// Returns an encoder for encoding a path. If `is_fill` is true, all subpaths will
@@ -268,7 +262,7 @@ impl Encoding {
         index.path_tags_in.1 = self.path_tags.len();
         index.path_data_in.1 = self.path_data.len();
 
-        return final_res;
+        final_res
     }
 
     /// Encode an empty path.
@@ -374,7 +368,6 @@ impl Encoding {
     #[allow(unused_variables)]
     pub fn modify_brush<'b>(&mut self, index: &mut Index, brush: impl Into<BrushRef<'b>>, alpha: f32) {
         #[cfg(feature = "full")]
-        use super::math::point_to_f32;
         match brush.into() {
             BrushRef::Solid(color) => {
                 let color = if alpha != 1.0 {
@@ -415,9 +408,7 @@ impl Encoding {
         let begin = index.draw_data_in.0 - 1;
         let end = index.draw_data_in.1 - 1;
 
-        for i in begin..end {
-            self.draw_data[i] = bytes[i - begin];
-        }
+        self.draw_data[begin..end].copy_from_slice(&bytes[..(end - begin)]);
     }
 
     /// Encodes a linear gradient brush.

--- a/vello_encoding/src/glyph_cache.rs
+++ b/vello_encoding/src/glyph_cache.rs
@@ -4,7 +4,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use super::{Encoding, StreamOffsets};
+use super::{Encoding, Index, StreamOffsets};
 
 use peniko::{Font, Style};
 use skrifa::instance::{NormalizedCoord, Size};
@@ -168,11 +168,11 @@ impl<'a> GlyphCacheSession<'a> {
         encoding_ptr.reset();
         let is_fill = match &self.style {
             Style::Fill(fill) => {
-                encoding_ptr.encode_fill_style(*fill);
+                encoding_ptr.encode_fill_style(&mut Index::default(), *fill);
                 true
             }
             Style::Stroke(stroke) => {
-                encoding_ptr.encode_stroke_style(stroke);
+                encoding_ptr.encode_stroke_style(&mut Index::default(), stroke);
                 false
             }
         };

--- a/vello_encoding/src/lib.rs
+++ b/vello_encoding/src/lib.rs
@@ -34,7 +34,7 @@ pub use draw::{
     DrawBbox, DrawBeginClip, DrawColor, DrawImage, DrawLinearGradient, DrawMonoid,
     DrawRadialGradient, DrawSweepGradient, DrawTag, DRAW_INFO_FLAGS_FILL_RULE_BIT,
 };
-pub use encoding::{Encoding, StreamOffsets};
+pub use encoding::{Encoding, Index, StreamOffsets};
 pub use mask::{make_mask_lut, make_mask_lut_16};
 pub use math::Transform;
 pub use monoid::Monoid;


### PR DESCRIPTION
This is something that i've been working in [#gpu > (Showcase) Vello Retained/Fine Granular Mode WIP](https://xi.zulipchat.com/#narrow/stream/197075-gpu/topic/.28Showcase.29.20Vello.20Retained.2FFine.20Granular.20Mode.20WIP). But i'll explain in short sentences what is it, what does it do, what doesn't do yet, and why.

# What is it?

The Retained/Fine Granular Mode is a system that allows you to modify already existing shapes without having to reset the entire scene, allowing you to:
- Run complex dynamic/static/hybrid scenes overall.
- Have a huge performance gain.
- More control over shapes, allowing you to handle specific edge-use cases if you stumble upon them.

# What does it do?

This mode allows for `fill()` and `stroke()` to return what's called an `Index`, which is a struct that contains information about where your shape is in the encoder.

Then you can use this information to modify its transform, its style, its brush, etc. via:

```rs
scene.modify_transform(&index, ...);
scene.modify_style(&index, ...);
scene.modify_brush(&index, ...);
```

Without having to reset the scene.

# Does having this mode requires to modify examples or already existing code powered by Vello?

Nope! You can still run and use Vello like you usually do. In fact, you can switch between Normal and Retained Mode at any time without any compromises! There's no need for you to write Retained Mode code if you don't want to.

# What doesn't do yet?

- You can't modify shapes.
- You can't modify gradient brushes, only solids.
- You can't use other stuff that aren't `fill()` or `stroke()` in Retained Mode.
- You can't *really* modify a brush transform (not fully tested yet).

To make these 4 items happen, it will require more investigation in the encoder, and a proposal that i'm working on.

# Why?

Well, for two reasons:
- I stumbled upon a huge roadblock in a scene with 10.000 shapes, and started to run out of CPU usage extremely quickly. This *may* seen like a lot, but if you want to make a fully vector game, and you start adding detail, as an artist, 10k shapes is a number that you'll eventually hit. And that's my biggest fear: **This becoming a huge problem mid-developement**.
- I believe Vello should have more low-level control/tools of the API if anyone hits scenarios like this.