### PR TITLE
Fix panic caused by improperly aligned read

### DIFF
--- a/vello_encoding/src/path.rs
+++ b/vello_encoding/src/path.rs
@@ -723,8 +723,10 @@ impl<'a> PathEncoder<'a> {
         if len < 8 {
             return None;
         }
-        let pts: &[f32; 2] = bytemuck::from_bytes(&self.data[len - 8..len]);
-        Some((pts[0], pts[1]))
+        Some((
+            bytemuck::pod_read_unaligned::<f32>(&self.data[len - 8..len - 4]),
+            bytemuck::pod_read_unaligned::<f32>(&self.data[len - 4..len]),
+        ))
     }
 
     fn is_zero_length_segment(


### PR DESCRIPTION
Under certain circumstances, Vello could attempt an improperly aligned read, which would cause bytemuck to panic.

This uses `bytemuck::pod_read_unaligned` instead of `bytemuck::from_bytes` to achieve the same thing without the possibility of a panic.