### PR TITLE
Fix `Cargo.lock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3410,11 +3410,3 @@ checksum = "ec866b44a2a1fd6133d363f073ca1b179f438f99e7e5bfb1e33f7181facfe448"
 dependencies = [
  "zune-core",
 ]
-
-[[patch.unused]]
-name = "bevy"
-version = "0.15.0-dev"
-
-[[patch.unused]]
-name = "bevy_vello"
-version = "0.5.1"


### PR DESCRIPTION
This picked up some `[patch.unused]` sections that want to be removed.

This was introduced in #671 / 5a7c34e2672c50b41ad5011c7bf626f13c766ff3.