### PR TITLE
Remove "experimental" verbiage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For now, prefer updating the package-level readmes, e.g. vello/README.md.
 
 # Vello
 
-**An experimental GPU compute-centric 2D renderer**
+**A GPU compute-centric 2D renderer**
 
 [![Linebender Zulip](https://img.shields.io/badge/Linebender-%23gpu-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/stream/197075-gpu)
 [![dependency status](https://deps.rs/repo/github/linebender/vello/status.svg)](https://deps.rs/repo/github/linebender/vello)
@@ -24,7 +24,7 @@ For now, prefer updating the package-level readmes, e.g. vello/README.md.
 
 </div>
 
-Vello is an experimental 2D graphics rendering engine written in Rust, with a focus on GPU compute.
+Vello is a 2D graphics rendering engine written in Rust, with a focus on GPU compute.
 It can draw large 2D scenes with interactive or near-interactive performance, using [`wgpu`] for GPU access.
 
 Quickstart to run an example program:

--- a/vello/Cargo.toml
+++ b/vello/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vello"
 version.workspace = true
-description = "An experimental GPU compute-centric 2D renderer."
+description = "A GPU compute-centric 2D renderer."
 categories = ["rendering", "graphics"]
 keywords = ["2d", "vector-graphics"]
 edition.workspace = true

--- a/vello/README.md
+++ b/vello/README.md
@@ -2,7 +2,7 @@
 
 # Vello
 
-**An experimental GPU compute-centric 2D renderer**
+**A GPU compute-centric 2D renderer**
 
 [![Latest published version.](https://img.shields.io/crates/v/vello.svg)](https://crates.io/crates/vello)
 [![Documentation build status.](https://img.shields.io/docsrs/vello.svg)](https://docs.rs/vello)
@@ -15,7 +15,7 @@
 
 </div>
 
-Vello is an experimental 2D graphics rendering engine written in Rust, with a focus on GPU compute.
+Vello is a 2D graphics rendering engine written in Rust, with a focus on GPU compute.
 It can draw large 2D scenes with interactive or near-interactive performance, using [`wgpu`] for GPU access.
 
 Quickstart to run an example program:

--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-//! Vello is an experimental 2d graphics rendering engine written in Rust, using [`wgpu`].
+//! Vello is a 2d graphics rendering engine written in Rust, using [`wgpu`].
 //! It efficiently draws large 2d scenes with interactive or near-interactive performance.
 //!
 //! ![image](https://github.com/linebender/vello/assets/8573618/cc2b742e-2135-4b70-8051-c49aeddb5d19)


### PR DESCRIPTION
Vello is in use by others and we're actively encouraging such use.

While Vello has some current shortcomings and issues, that's different from being "experimental".