### PR TITLE
Update Peniko to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,7 +128,6 @@ This release has an [MSRV][] of 1.75.
 [#635]: https://github.com/linebender/vello/pull/635
 [#641]: https://github.com/linebender/vello/pull/641
 [#657]: https://github.com/linebender/vello/pull/657
-[#693]: https://github.com/linebender/vello/pull/693
 
 <!-- Note that this still comparing against 0.2.0, because 0.2.1 is a cherry-picked patch -->
 [Unreleased]: https://github.com/linebender/vello/compare/v0.2.0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ This release has an [MSRV][] of 1.75.
 
 ### Fixed
 
-## Removed
+### Removed
 
 - Breaking: `Pipelines` API from `vello_shaders` ([#612] by [@DJMcNab])
 
@@ -128,6 +128,7 @@ This release has an [MSRV][] of 1.75.
 [#635]: https://github.com/linebender/vello/pull/635
 [#641]: https://github.com/linebender/vello/pull/641
 [#657]: https://github.com/linebender/vello/pull/657
+[#693]: https://github.com/linebender/vello/pull/693
 
 <!-- Note that this still comparing against 0.2.0, because 0.2.1 is a cherry-picked patch -->
 [Unreleased]: https://github.com/linebender/vello/compare/v0.2.0...HEAD

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,9 +178,9 @@ checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "as-raw-xcb-connection"
@@ -1146,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "kurbo"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e5aa9f0f96a938266bdb12928a67169e8d22c6a786fda8ed984b85e6ba93c3c"
+checksum = "89234b2cc610a7dd927ebde6b41dd1a5d4214cffaef4cf1fb2195d592f92518f"
 dependencies = [
  "arrayvec",
  "smallvec",
@@ -1687,9 +1687,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "peniko"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c28d7294093837856bb80ad191cc46a2fcec8a30b43b7a3b0285325f0a917a9"
+checksum = "0a648c93f502a0bef0a9cb47fa1335994958a2744667d3f82defe513f276741a"
 dependencies = [
  "kurbo",
  "smallvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ vello_encoding = { version = "0.2.0", path = "vello_encoding" }
 vello_shaders = { version = "0.2.0", path = "vello_shaders" }
 bytemuck = { version = "1.16.0", features = ["derive"] }
 skrifa = "0.19.3"
-peniko = "0.1.1"
+peniko = "0.2.0"
 futures-intrusive = "0.5.0"
 raw-window-handle = "0.6.2"
 smallvec = "1.13.2"

--- a/vello/src/scene.rs
+++ b/vello/src/scene.rs
@@ -574,6 +574,7 @@ impl<'a> DrawGlyphs<'a> {
                             )
                         }
                     };
+                    let image = image.multiply_alpha(self.brush_alpha);
                     // Split into multiple statements because rustfmt breaks
                     let transform =
                         run_transform.then_translate(Vec2::new(glyph.x.into(), glyph.y.into()));

--- a/vello_encoding/src/encoding.rs
+++ b/vello_encoding/src/encoding.rs
@@ -264,14 +264,13 @@ impl Encoding {
     }
 
     /// Encodes a brush with an optional alpha modifier.
-    #[allow(unused_variables)]
     pub fn encode_brush<'b>(&mut self, brush: impl Into<BrushRef<'b>>, alpha: f32) {
         #[cfg(feature = "full")]
         use super::math::point_to_f32;
         match brush.into() {
             BrushRef::Solid(color) => {
                 let color = if alpha != 1.0 {
-                    color.with_alpha_factor(alpha)
+                    color.multiply_alpha(alpha)
                 } else {
                     color
                 };
@@ -500,7 +499,7 @@ impl Encoding {
         if alpha != 1.0 {
             self.resources
                 .color_stops
-                .extend(color_stops.map(|stop| stop.with_alpha_factor(alpha)));
+                .extend(color_stops.map(|stop| stop.multiply_alpha(alpha)));
         } else {
             self.resources.color_stops.extend(color_stops);
         }

--- a/vello_encoding/src/encoding.rs
+++ b/vello_encoding/src/encoding.rs
@@ -417,9 +417,11 @@ impl Encoding {
 
     /// Encodes an image brush.
     #[cfg(feature = "full")]
-    pub fn encode_image(&mut self, image: &Image, _alpha: f32) {
+    pub fn encode_image(&mut self, image: &Image, alpha: f32) {
+        let _alpha = alpha * f32::from(image.alpha);
         // TODO: feed the alpha multiplier through the full pipeline for consistency
         // with other brushes?
+        // Tracked in https://github.com/linebender/vello/issues/692
         self.resources.patches.push(Patch::Image {
             image: image.clone(),
             draw_data_offset: self.draw_data.len(),

--- a/vello_tests/snapshots/stroke_styles.png
+++ b/vello_tests/snapshots/stroke_styles.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:172954534a5496a6e2e2883d644c6c073541e0302a216e689ae63cddc799dfae
-size 94334
+oid sha256:144176c89e644116dcc211e0e4341ed99bc72ff21732a9af40cb9f7a0b32e7b5
+size 96014

--- a/vello_tests/snapshots/stroke_styles_non_uniform.png
+++ b/vello_tests/snapshots/stroke_styles_non_uniform.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:73da696256f7ed8c94a76dc0dfc915a8aca38da9de68c86610c70a3e3e0da18b
-size 88607
+oid sha256:17d592ab5fed53f2916e85f5d62d7ec7ff8b12ad8c4184b8ed7f09c6dc813068
+size 89907

--- a/vello_tests/snapshots/stroke_styles_skew.png
+++ b/vello_tests/snapshots/stroke_styles_skew.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:66591bfd8cea31bbd39f657afd2f25cf30b8b19f8ff4775be416c97e2035572a
-size 97701
+oid sha256:ebf82e0c7414f4f455eaa7e623b84beb05ba4abd377283b303461326c549af4a
+size 100039


### PR DESCRIPTION
This updates Peniko to [0.2.0](https://github.com/linebender/peniko/releases/tag/v0.2.0).

The main impact this would have on users is being able to set `alpha` on images, but that is currently broken because of #692.

This also updates to Kurbo [0.11.1](https://github.com/linebender/kurbo/releases/tag/v0.11.1), which of note includes https://github.com/linebender/kurbo/pull/353