### PR TITLE
Add regression test for watertightness

### DIFF
--- a/vello_tests/snapshots/rounded_rectangle_watertight.png
+++ b/vello_tests/snapshots/rounded_rectangle_watertight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c8d031525fa9a146c43eb0b51bedf5aa7ed69af6dcb6acdef3e28e020b41c23
+size 821

--- a/vello_tests/tests/regression.rs
+++ b/vello_tests/tests/regression.rs
@@ -1,3 +1,6 @@
+// Copyright 2024 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use vello::{
     kurbo::{Affine, RoundedRect, Stroke},
     peniko::Color,

--- a/vello_tests/tests/regression.rs
+++ b/vello_tests/tests/regression.rs
@@ -1,0 +1,20 @@
+use vello::{
+    kurbo::{Affine, RoundedRect, Stroke},
+    peniko::Color,
+    AaConfig, Scene,
+};
+use vello_tests::{snapshot_test_sync, TestParams};
+
+#[test]
+#[cfg_attr(skip_gpu_tests, ignore)]
+fn rounded_rectangle_watertight() {
+    let mut scene = Scene::new();
+    let rect = RoundedRect::new(60.0, 10.0, 80.0, 30.0, 10.0);
+    let stroke = Stroke::new(2.0);
+    scene.stroke(&stroke, Affine::IDENTITY, Color::WHITE, None, &rect);
+    let mut params = TestParams::new("rounded_rectangle_watertight", 70, 30);
+    params.anti_aliasing = AaConfig::Msaa16;
+    snapshot_test_sync(scene, &params)
+        .unwrap()
+        .assert_mean_less_than(0.001);
+}


### PR DESCRIPTION
This is a test created from https://github.com/linebender/vello/issues/616#issuecomment-2181960739.

This was fixed in #695.

The version which fails looked like:
![half circle with an intruding line.](https://github.com/user-attachments/assets/9b567912-2ad3-4d11-96cd-6db43dd64b09)
