### PR TITLE
Add `draw_blurred_rounded_rect_in` (intended for box shadows)

### DIFF
--- a/examples/scenes/src/test_scenes.rs
+++ b/examples/scenes/src/test_scenes.rs
@@ -87,6 +87,7 @@ mod impls {
     use std::f64::consts::PI;
 
     use crate::SceneParams;
+    use kurbo::RoundedRect;
     use rand::Rng;
     use rand::{rngs::StdRng, SeedableRng};
     use vello::kurbo::{
@@ -1719,15 +1720,6 @@ mod impls {
             params.time.sin() * 50.0 + 50.0,
         );
 
-        // Stretch affine transformation.
-        scene.draw_blurred_rounded_rect(
-            Affine::translate((600.0, 600.0)) * Affine::scale_non_uniform(2.2, 0.9),
-            rect,
-            Color::BLACK,
-            radius,
-            params.time.sin() * 50.0 + 50.0,
-        );
-
         // Circle.
         scene.draw_blurred_rounded_rect(
             Affine::IDENTITY,
@@ -1744,6 +1736,29 @@ mod impls {
             Color::BLACK,
             150.0,
             params.time.sin() * 50.0 + 50.0,
+        );
+
+        // An enulated box shadow, to demonstrate the use of `draw_blurred_rounded_rect_in`.
+        let std_dev = params.time.sin() * 50.0 + 50.0;
+        let kernel_size = 2.5 * std_dev;
+
+        // TODO: Add utils to Kurbo for ad-hoc composed shapes
+        let shape = BezPath::from_iter(
+            rect.inflate(kernel_size, kernel_size)
+                .path_elements(0.1)
+                .chain(
+                    RoundedRect::from_rect(rect, radius)
+                        .to_path(0.1)
+                        .reverse_subpaths(),
+                ),
+        );
+        scene.draw_blurred_rounded_rect_in(
+            &shape,
+            Affine::translate((600.0, 600.0)) * Affine::scale_non_uniform(2.2, 0.9),
+            rect,
+            Color::BLACK,
+            radius,
+            std_dev,
         );
     }
 }

--- a/examples/scenes/src/test_scenes.rs
+++ b/examples/scenes/src/test_scenes.rs
@@ -1738,7 +1738,7 @@ mod impls {
             params.time.sin() * 50.0 + 50.0,
         );
 
-        // An enulated box shadow, to demonstrate the use of `draw_blurred_rounded_rect_in`.
+        // An emulated box shadow, to demonstrate the use of `draw_blurred_rounded_rect_in`.
         let std_dev = params.time.sin() * 50.0 + 50.0;
         let kernel_size = 2.5 * std_dev;
 

--- a/vello/src/scene.rs
+++ b/vello/src/scene.rs
@@ -135,7 +135,9 @@ impl Scene {
     /// `std_dev` away from the edges of `rect` (as any such points will not be perceptably painted to,
     /// but calculations will still be performed for them).
     ///
-    /// This method is a more advanced version of [`Self::draw_blurred_rounded_rect`].
+    /// This method effectively draws the blurred rounded rectangle clipped to the given shape. 
+    /// If just the blurred rounded rectangle is desired without clipping,
+    /// use the simpler [`Self::draw_blurred_rounded_rect`].
     /// For many users, that method will be easier to use.
     pub fn draw_blurred_rounded_rect_in(
         &mut self,

--- a/vello/src/scene.rs
+++ b/vello/src/scene.rs
@@ -135,7 +135,7 @@ impl Scene {
     /// `std_dev` away from the edges of `rect` (as any such points will not be perceptably painted to,
     /// but calculations will still be performed for them).
     ///
-    /// This method effectively draws the blurred rounded rectangle clipped to the given shape. 
+    /// This method effectively draws the blurred rounded rectangle clipped to the given shape.
     /// If just the blurred rounded rectangle is desired without clipping,
     /// use the simpler [`Self::draw_blurred_rounded_rect`].
     /// For many users, that method will be easier to use.

--- a/vello/src/scene.rs
+++ b/vello/src/scene.rs
@@ -6,7 +6,7 @@ mod bitmap;
 use std::sync::Arc;
 
 use peniko::{
-    kurbo::{Affine, BezPath, Point, Rect, RoundedRect, Shape, Stroke, Vec2},
+    kurbo::{Affine, BezPath, Point, Rect, Shape, Stroke, Vec2},
     BlendMode, Blob, Brush, BrushRef, Color, ColorStop, ColorStops, ColorStopsSource, Compose,
     Extend, Fill, Font, Gradient, Image, Mix, StyleRef,
 };
@@ -129,44 +129,14 @@ impl Scene {
         self.draw_blurred_rounded_rect_in(&shape, transform, rect, brush, radius, std_dev);
     }
 
-    /// Draw a box shadow based on Gaussian filter box filter.
-    ///
-    /// This method is a thin wrapper around [`Self::draw_blurred_rounded_rect_in`], and is
-    pub fn draw_rounded_rect_box_shadow(
-        &mut self,
-        transform: Affine,
-        rect: Rect,
-        brush: Color,
-        radius: f64,
-        std_dev: f64,
-    ) {
-        // The impulse response of a gaussian filter is infinite.
-        // For performance reason we cut off the filter at some extent where the response is close to zero.
-        let kernel_size = 2.5 * std_dev;
-
-        // TODO: Add utils for ad-hoc composed shapes
-        let shape = BezPath::from_iter(
-            rect.inflate(kernel_size, kernel_size)
-                .path_elements(0.1)
-                .chain(
-                    RoundedRect::from_rect(rect, radius)
-                        .to_path(0.1)
-                        .reverse_subpaths(),
-                ),
-        );
-        // self.fill(Fill::NonZero, transform, brush, None, &shape);
-        self.draw_blurred_rounded_rect_in(&shape, transform, rect, brush, radius, std_dev);
-    }
-
     /// Draw a rounded rectangle blurred with a gaussian filter in `shape`.
     ///
-    /// `shape` should will be in the same with the top-left corner of the rectangle
-    /// (before corner radius and blurring is applied).
     /// For performance reasons, `shape` should not extend more than approximately 2.5 times
-    /// `std_dev` away from points in rect (as all such points will not be perceptably painted to,
+    /// `std_dev` away from the edges of `rect` (as any such points will not be perceptably painted to,
     /// but calculations will still be performed for them).
     ///
-    /// This is useful for shadows which are not used as the background for a shape but will be used for the.
+    /// This method is a more advanced version of [`Self::draw_blurred_rounded_rect`].
+    /// For many users, that method will be easier to use.
     pub fn draw_blurred_rounded_rect_in(
         &mut self,
         shape: &impl Shape,

--- a/vello_tests/snapshots/blurred_rounded_rect.png
+++ b/vello_tests/snapshots/blurred_rounded_rect.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:31045b3af3ada20e0a0763f453a69c9f6e9a6963a024c11603490ad6e036e68a
-size 766382
+oid sha256:700b4e27b371c609d7cc47c7dad623248d57cb2eac9eb3f90548adec59fc6f66
+size 121632

--- a/vello_tests/tests/snapshot_test_scenes.rs
+++ b/vello_tests/tests/snapshot_test_scenes.rs
@@ -94,6 +94,6 @@ fn snapshot_many_clips() {
 #[cfg_attr(skip_gpu_tests, ignore)]
 fn snapshot_blurred_rounded_rect() {
     let test_scene = test_scenes::blurred_rounded_rect();
-    let params = TestParams::new("blurred_rounded_rect", 1200, 1200);
+    let params = TestParams::new("blurred_rounded_rect", 400, 400);
     snapshot_test_scene(test_scene, params);
 }


### PR DESCRIPTION
This avoids needing a clip layer for a rounded rectangle which doesn't need to draw the inner parts (e.g. a transparent background with a box shadow).

The previous test image was oversized, so this also fixes that (and makes any future such image fail the tests as expected). I imagine that the author of that test manually copied the value into the place, not realising the size of the image.