### PR TITLE
Add fn encoding_mut() to Scene.

### DIFF
--- a/vello/src/scene.rs
+++ b/vello/src/scene.rs
@@ -65,6 +65,11 @@ impl Scene {
         &self.encoding
     }
 
+    /// Returns a mutable reference to the underlying raw encoding.
+    pub fn encoding_mut(&mut self) -> &mut Encoding {
+        &mut self.encoding
+    }
+
     /// Pushes a new layer clipped by the specified shape and composed with
     /// previous layers using the specified blend mode.
     ///

--- a/vello/src/scene.rs
+++ b/vello/src/scene.rs
@@ -66,6 +66,8 @@ impl Scene {
     }
 
     /// Returns a mutable reference to the underlying raw encoding.
+    ///
+    /// This can be used to more easily create invalid scenes, and so should be used with care.
     pub fn encoding_mut(&mut self) -> &mut Encoding {
         &mut self.encoding
     }


### PR DESCRIPTION
This is a useful escape hatch to implement things not supported by the standard API.