### PR TITLE
Match CPU/GPU logic for start tangents

### DIFF
--- a/vello_encoding/src/path.rs
+++ b/vello_encoding/src/path.rs
@@ -769,7 +769,7 @@ impl<'a> PathEncoder<'a> {
         Some(pt)
     }
 
-    // Similar to `start_tangent_for_curve` but for a line.
+    /// Similar to [`Self::start_tangent_for_curve`] but for a line.
     fn start_tangent_for_line(&self, p1: (f32, f32)) -> Option<(f32, f32)> {
         let p0 = (self.first_point[0], self.first_point[1]);
         let pt = if (p1.0 - p0.0).abs() > EPSILON || (p1.1 - p0.1).abs() > EPSILON {

--- a/vello_shaders/shader/flatten.wgsl
+++ b/vello_shaders/shader/flatten.wgsl
@@ -649,7 +649,9 @@ fn read_transform(transform_base: u32, ix: u32) -> Transform {
 }
 
 fn transform_apply(transform: Transform, p: vec2f) -> vec2f {
-    return transform.mat.xy * p.x + transform.mat.zw * p.y + transform.translate;
+    let px = fma(transform.mat.x, p.x, fma(transform.mat.z, p.y, transform.translate.x));
+    let py = fma(transform.mat.y, p.x, fma(transform.mat.w, p.y, transform.translate.y));
+    return vec2(px, py);
 }
 
 fn round_down(x: f32) -> i32 {

--- a/vello_shaders/shader/flatten.wgsl
+++ b/vello_shaders/shader/flatten.wgsl
@@ -735,12 +735,12 @@ fn read_path_segment(tag: PathTagData, is_stroke: bool) -> CubicPoints {
     // Degree-raise
     if seg_type == PATH_TAG_LINETO {
         p3 = p1;
-        p2 = mix(p3, p0, 1.0 / 3.0);
-        p1 = mix(p0, p3, 1.0 / 3.0);
+        p2 = p3 + (1.0 / 3.0) * (p0 - p3);
+        p1 = p0 + (1.0 / 3.0) * (p3 - p0);
     } else if seg_type == PATH_TAG_QUADTO {
         p3 = p2;
-        p2 = mix(p1, p2, 1.0 / 3.0);
-        p1 = mix(p1, p0, 1.0 / 3.0);
+        p2 = p1 + (1.0 / 3.0) * (p2 - p1);
+        p1 = p1 + (1.0 / 3.0) * (p0 - p1);
     }
 
     return CubicPoints(p0, p1, p2, p3);

--- a/vello_tests/snapshots/longpathdash_butt.png
+++ b/vello_tests/snapshots/longpathdash_butt.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:93dc92000d81921fe6a45a862db066736592e1ffc008ee3c29794287a68b930b
-size 64883
+oid sha256:a1a23c2e7ab9018ff3517cbc96f64befe6fcf7836cca12c17ba6b9e612fda71f
+size 42426

--- a/vello_tests/snapshots/longpathdash_butt.png
+++ b/vello_tests/snapshots/longpathdash_butt.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f5f52e9cdd7670b3fedf708d5b6eb2e9f42eadba9b822c091ac57e171b178ab1
-size 91104
+oid sha256:93dc92000d81921fe6a45a862db066736592e1ffc008ee3c29794287a68b930b
+size 64883

--- a/vello_tests/snapshots/longpathdash_butt.png
+++ b/vello_tests/snapshots/longpathdash_butt.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5f52e9cdd7670b3fedf708d5b6eb2e9f42eadba9b822c091ac57e171b178ab1
+size 91104

--- a/vello_tests/tests/snapshot_test_scenes.rs
+++ b/vello_tests/tests/snapshot_test_scenes.rs
@@ -97,3 +97,11 @@ fn snapshot_blurred_rounded_rect() {
     let params = TestParams::new("blurred_rounded_rect", 400, 400);
     snapshot_test_scene(test_scene, params);
 }
+
+#[test]
+#[cfg_attr(skip_gpu_tests, ignore)]
+fn snapshot_longpathdash_butt() {
+    let test_scene = test_scenes::longpathdash_butt();
+    let params = TestParams::new("longpathdash_butt", 250, 250);
+    snapshot_test_scene(test_scene, params);
+}

--- a/vello_tests/tests/snapshot_test_scenes.rs
+++ b/vello_tests/tests/snapshot_test_scenes.rs
@@ -11,7 +11,7 @@ fn snapshot_test_scene(test_scene: ExampleScene, mut params: TestParams) {
     let scene = encode_test_scene(test_scene, &mut params);
     snapshot_test_sync(scene, &params)
         .unwrap()
-        .assert_mean_less_than(0.01);
+        .assert_mean_less_than(0.007);
 }
 
 #[test]
@@ -102,6 +102,6 @@ fn snapshot_blurred_rounded_rect() {
 #[cfg_attr(skip_gpu_tests, ignore)]
 fn snapshot_longpathdash_butt() {
     let test_scene = test_scenes::longpathdash_butt();
-    let params = TestParams::new("longpathdash_butt", 250, 250);
+    let params = TestParams::new("longpathdash_butt", 500, 100);
     snapshot_test_scene(test_scene, params);
 }

--- a/vello_tests/tests/snapshot_test_scenes.rs
+++ b/vello_tests/tests/snapshot_test_scenes.rs
@@ -11,7 +11,7 @@ fn snapshot_test_scene(test_scene: ExampleScene, mut params: TestParams) {
     let scene = encode_test_scene(test_scene, &mut params);
     snapshot_test_sync(scene, &params)
         .unwrap()
-        .assert_mean_less_than(0.007);
+        .assert_mean_less_than(0.0095);
 }
 
 #[test]
@@ -102,6 +102,6 @@ fn snapshot_blurred_rounded_rect() {
 #[cfg_attr(skip_gpu_tests, ignore)]
 fn snapshot_longpathdash_butt() {
     let test_scene = test_scenes::longpathdash_butt();
-    let params = TestParams::new("longpathdash_butt", 500, 100);
+    let params = TestParams::new("longpathdash_butt", 440, 80);
     snapshot_test_scene(test_scene, params);
 }


### PR DESCRIPTION
When encoding a start tangent for an end cap or closed segment, use logic designed to match the GPU computed tangent for the first segment.

Note: this changes the GPU calculation to write out the lerp calculation explicitly rather than use the mix intrinsic, so we can rely on the rounding behavior. In the presence of fastmath, the rounding behavior is not guaranteed, but it is verified to work on M1.

Fixes #704, unless we get bitten by fastmath.