### PR TITLE
Make segments and seg_counts use the same buffer size.

### DIFF
--- a/vello_shaders/build.rs
+++ b/vello_shaders/build.rs
@@ -24,7 +24,10 @@ fn main() {
     let mut shaders = match compile::ShaderInfo::from_default() {
         Ok(s) => s,
         Err(err) => {
-            eprintln!("{err}");
+            let formatted = err.to_string();
+            for line in formatted.lines() {
+                println!("cargo:warning={line}");
+            }
             return;
         }
     };

--- a/vello_shaders/shader/coarse.wgsl
+++ b/vello_shaders/shader/coarse.wgsl
@@ -164,7 +164,7 @@ fn main(
     // we still want to know this workgroup's memory requirement.   
     if local_id.x == 0u {
         var failed = atomicLoad(&bump.failed) & (STAGE_BINNING | STAGE_TILE_ALLOC | STAGE_FLATTEN);
-        if atomicLoad(&bump.seg_counts) > config.seg_counts_size {
+        if atomicLoad(&bump.seg_counts) > config.segments_size {
             failed |= STAGE_PATH_COUNT;
         }
         // Reuse sh_part_count to hold failed flag, shmem is tight

--- a/vello_shaders/shader/path_count.wgsl
+++ b/vello_shaders/shader/path_count.wgsl
@@ -191,7 +191,7 @@ fn main(
             let counts = (seg_within_slice << 16u) | subix;
             let seg_count = SegmentCount(line_ix, counts);
             let seg_ix = seg_base + i - imin;
-            if seg_ix < config.seg_counts_size {
+            if seg_ix < config.segments_size {
                 seg_counts[seg_ix] = seg_count;
             }
             // Note: since we're iterating, we have a reliable value for

--- a/vello_shaders/shader/shared/config.wgsl
+++ b/vello_shaders/shader/shared/config.wgsl
@@ -36,7 +36,6 @@ struct Config {
     lines_size: u32,
     binning_size: u32,
     tiles_size: u32,
-    seg_counts_size: u32,
     segments_size: u32,
     blend_size: u32,
     ptcl_size: u32,


### PR DESCRIPTION
Supercedes #673. See also [#gpu > Segments and seg_counts buffer sizes](https://xi.zulipchat.com/#narrow/stream/197075-gpu/topic/Segments.20and.20seg_counts.20buffer.20sizes).

The motivation for this change is as discussed in the linked thread, but essentially the main advantage is that once we have a solution to #366, this should be able to avoid some of the issues with cascading allocation failures.