### PR TITLE
Better image sampling

### DIFF
--- a/examples/scenes/src/test_scenes.rs
+++ b/examples/scenes/src/test_scenes.rs
@@ -79,12 +79,14 @@ export_scenes!(
     mmark(crate::mmark::MMark::new(80_000), "mmark", false),
     many_draw_objects(many_draw_objects),
     blurred_rounded_rect(blurred_rounded_rect),
+    image_sampling(image_sampling),
 );
 
 /// Implementations for the test scenes.
 /// In a module because the exported [`ExampleScene`](crate::ExampleScene) creation functions use the same names.
 mod impls {
     use std::f64::consts::PI;
+    use std::sync::Arc;
 
     use crate::SceneParams;
     use kurbo::RoundedRect;
@@ -1759,6 +1761,27 @@ mod impls {
             Color::BLACK,
             radius,
             std_dev,
+        );
+    }
+
+    pub(super) fn image_sampling(scene: &mut Scene, params: &mut SceneParams) {
+        params.resolution = Some(Vec2::new(1200., 1200.));
+        params.base_color = Some(Color::WHITE);
+        let mut blob: Vec<u8> = Vec::new();
+        [Color::RED, Color::BLUE, Color::CYAN, Color::MAGENTA]
+            .iter()
+            .for_each(|c| {
+                let b = c.to_premul_u32().to_ne_bytes();
+                blob.push(b[3]);
+                blob.push(b[2]);
+                blob.push(b[1]);
+                blob.push(b[0]);
+            });
+        let data = vello::peniko::Blob::new(Arc::new(blob));
+        let image = vello::peniko::Image::new(data, vello::peniko::Format::Rgba8, 2, 2);
+        scene.draw_image(
+            &image,
+            Affine::scale(300.0).then_translate((100.0, 100.0).into()),
         );
     }
 }

--- a/vello_shaders/shader/fine.wgsl
+++ b/vello_shaders/shader/fine.wgsl
@@ -1161,12 +1161,13 @@ fn main(
             case CMD_IMAGE: {
                 let image = read_image(cmd_ix);
                 let atlas_extents = image.atlas_offset + image.extents;
+                let atlas_max = atlas_extents - vec2(1.0);
                 for (var i = 0u; i < PIXELS_PER_THREAD; i += 1u) {
                     let my_xy = vec2(xy.x + f32(i), xy.y);
-                    let atlas_uv = image.matrx.xy * my_xy.x + image.matrx.zw * my_xy.y + image.xlat + image.atlas_offset;
+                    let atlas_uv = image.matrx.xy * my_xy.x + image.matrx.zw * my_xy.y + image.xlat + image.atlas_offset - vec2(0.5);
                     // This currently clips to the image bounds. TODO: extend modes
                     if all(atlas_uv < atlas_extents) && area[i] != 0.0 {
-                        let uv_quad = vec4(max(floor(atlas_uv), image.atlas_offset), min(ceil(atlas_uv), atlas_extents));
+                        let uv_quad = vec4(max(floor(atlas_uv), image.atlas_offset), min(ceil(atlas_uv), atlas_max));
                         let uv_frac = fract(atlas_uv);
                         let a = premul_alpha(textureLoad(image_atlas, vec2<i32>(uv_quad.xy), 0));
                         let b = premul_alpha(textureLoad(image_atlas, vec2<i32>(uv_quad.xw), 0));


### PR DESCRIPTION
Constrains image sampling to the actual atlas region for a given image and adds a half pixel adjustment to sample from the pixel center.

Addresses #719 and maybe #656

Example 2x2 image with red, blue, cyan and magenta pixels:

<img width="387" alt="vello_image_sampling" src="https://github.com/user-attachments/assets/6bc02607-e9fa-4c79-83c9-241e76a42fb0">
