### PR TITLE
Add the required `--lib` when using `cargo apk`

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ There is also a web demo [available here](https://linebender.github.io/vello) on
 The [`with_winit`](#winit) example supports running on Android, using [cargo apk](https://crates.io/crates/cargo-apk).
 
 ```shell
-cargo apk run -p with_winit
+cargo apk run -p with_winit --lib
 ```
 
 > [!TIP]

--- a/vello/README.md
+++ b/vello/README.md
@@ -186,7 +186,7 @@ There is also a web demo [available here](https://linebender.github.io/vello) on
 The [`with_winit`](#winit) example supports running on Android, using [cargo apk](https://crates.io/crates/cargo-apk).
 
 ```shell
-cargo apk run -p with_winit
+cargo apk run -p with_winit --lib
 ```
 
 > 💡 TIP


### PR DESCRIPTION
Pointed out in https://github.com/linebender/vello/issues/723