### PR TITLE
Simplify MSRV Wasm testing configuration in CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ env:
   # List of packages that will be checked with the minimum supported Rust version.
   # This should be limited to packages that are intended for publishing.
   RUST_MIN_VER_PKGS: "-p vello -p vello_encoding -p vello_shaders"
-  # List of packages that can not target wasm.
-  # `vello_tests` uses `nv-flip`, which doesn't support wasm.
+  # List of packages that can not target Wasm.
+  # `vello_tests` uses `nv-flip`, which doesn't support Wasm.
   NO_WASM_PKGS: "--exclude vello_tests --exclude simple_sdl2"
 
 
@@ -349,9 +349,7 @@ jobs:
           tool: cargo-hack
 
       - name: cargo check
-        # We don't include ${{ env.NO_WASM_PKGS }} here, because `-p foo --exclude foo` doesn't work
-        # and none of our `NO_WASM_PKGS` have an MSRV.
-        run: cargo hack check ${{ env.RUST_MIN_VER_PKGS }} --locked --target wasm32-unknown-unknown --optional-deps --each-feature
+        run: cargo hack check ${{ env.RUST_MIN_VER_PKGS }} ${{ env.NO_WASM_PKGS }} --locked --target wasm32-unknown-unknown --optional-deps --each-feature
 
   doc:
     name: cargo doc


### PR DESCRIPTION
`cargo-hack` has gained the ability to use `--exclude` along with `-p` in [cargo-hack#258](https://github.com/taiki-e/cargo-hack/pull/258).
This allows us to simplify our CI configuration.