### PR TITLE
Narrow and document the `getrandom` `js` feature usage.

### DIFF
--- a/examples/scenes/Cargo.toml
+++ b/examples/scenes/Cargo.toml
@@ -20,5 +20,9 @@ rand = "0.8.5"
 roxmltree = "0.20.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.2.15", features = ["js"] }
 web-time = { workspace = true }
+
+[target.wasm32-unknown-unknown.dependencies]
+# We have a transitive dependency on getrandom and it does not automatically
+# support wasm32-unknown-unknown. We need to enable the js feature.
+getrandom = { version = "0.2.15", features = ["js"] }

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -69,6 +69,10 @@ console_log = "1.0.0"
 wasm-bindgen-futures = "0.4.43"
 web-sys = { version = "0.3.70", features = ["HtmlCollection", "Text"] }
 web-time = { workspace = true }
-getrandom = { version = "0.2.15", features = ["js"] }
 # If updating, also update in .github/workflows/web-demo.yml
 wasm-bindgen = "=0.2.95"
+
+[target.wasm32-unknown-unknown.dependencies]
+# We have a transitive dependency on getrandom and it does not automatically
+# support wasm32-unknown-unknown. We need to enable the js feature.
+getrandom = { version = "0.2.15", features = ["js"] }


### PR DESCRIPTION
As was pointed out in [velato#39](https://github.com/linebender/velato/pull/39) this `js` feature specification can be more narrow than all of `wasm32` and should also be documented.