### PR TITLE
Fix inference conflict with `serde_json` through `schemars` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3380,6 +3380,7 @@ dependencies = [
  "pollster",
  "profiling",
  "scenes",
+ "schemars",
  "tracing",
  "tracing-subscriber",
  "tracing_android_trace",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,6 +632,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+
+[[package]]
 name = "env_filter"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1145,6 +1151,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89234b2cc610a7dd927ebde6b41dd1a5d4214cffaef4cf1fb2195d592f92518f"
 dependencies = [
  "arrayvec",
+ "schemars",
  "smallvec",
 ]
 
@@ -2011,6 +2018,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+ "smallvec",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.85",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2080,6 +2112,17 @@ name = "serde_derive"
 version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3331,6 +3374,7 @@ dependencies = [
  "console_log",
  "env_logger",
  "getrandom",
+ "kurbo",
  "log",
  "notify-debouncer-mini",
  "pollster",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3380,7 +3380,6 @@ dependencies = [
  "pollster",
  "profiling",
  "scenes",
- "schemars",
  "tracing",
  "tracing-subscriber",
  "tracing_android_trace",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,10 @@ vello_encoding = { version = "0.3.0", path = "vello_encoding" }
 vello_shaders = { version = "0.3.0", path = "vello_shaders" }
 bytemuck = { version = "1.18.0", features = ["derive"] }
 skrifa = "0.22.3"
+# The version of kurbo used below should be kept in sync
+# with the version of kurbo used by peniko.
 peniko = "0.2.0"
+# FIXME: This can be removed once peniko supports the schemars feature.
 kurbo = "0.11.1"
 futures-intrusive = "0.5.0"
 raw-window-handle = "0.6.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ vello_shaders = { version = "0.3.0", path = "vello_shaders" }
 bytemuck = { version = "1.18.0", features = ["derive"] }
 skrifa = "0.22.3"
 peniko = "0.2.0"
+kurbo = "0.11.1"
 futures-intrusive = "0.5.0"
 raw-window-handle = "0.6.2"
 smallvec = "1.13.2"

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -16,6 +16,8 @@ default = ["wgpu-profiler"]
 # Enable the use of wgpu-profiler. This is an optional feature for times when we use a git dependency on
 # wgpu (which means the dependency used in wgpu-profiler would be incompatible)
 wgpu-profiler = ["dep:wgpu-profiler", "vello/wgpu-profiler"]
+# Test for dependencies which implement std traits in ways that cause type inference issues.
+_ci_dep_features_to_test = ["dep:kurbo", "kurbo/schemars"]
 
 [lints]
 workspace = true
@@ -41,6 +43,8 @@ log = { workspace = true }
 # We're still using env-logger, but we want to use tracing spans to allow using
 # tracing_android_trace
 tracing = { version = "0.1.40", features = ["log-always"] }
+# For _ci_dep_features_to_test feature tests.
+kurbo = { workspace = true, optional = true }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
 # We use android_logger on Android

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -17,7 +17,7 @@ default = ["wgpu-profiler"]
 # wgpu (which means the dependency used in wgpu-profiler would be incompatible)
 wgpu-profiler = ["dep:wgpu-profiler", "vello/wgpu-profiler"]
 # Test for dependencies which implement std traits in ways that cause type inference issues.
-_ci_dep_features_to_test = ["dep:kurbo", "kurbo/schemars", "dep:schemars"]
+_ci_dep_features_to_test = ["dep:kurbo", "kurbo/schemars"]
 
 [lints]
 workspace = true
@@ -45,8 +45,6 @@ log = { workspace = true }
 tracing = { version = "0.1.40", features = ["log-always"] }
 # For _ci_dep_features_to_test feature tests.
 kurbo = { workspace = true, optional = true }
-# For _ci_dep_features_to_test feature tests.
-schemars = { version = "0.8.21", optional = true }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
 # We use android_logger on Android

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -17,7 +17,7 @@ default = ["wgpu-profiler"]
 # wgpu (which means the dependency used in wgpu-profiler would be incompatible)
 wgpu-profiler = ["dep:wgpu-profiler", "vello/wgpu-profiler"]
 # Test for dependencies which implement std traits in ways that cause type inference issues.
-_ci_dep_features_to_test = ["dep:kurbo", "kurbo/schemars"]
+_ci_dep_features_to_test = ["dep:kurbo", "kurbo/schemars", "dep:schemars"]
 
 [lints]
 workspace = true
@@ -45,6 +45,8 @@ log = { workspace = true }
 tracing = { version = "0.1.40", features = ["log-always"] }
 # For _ci_dep_features_to_test feature tests.
 kurbo = { workspace = true, optional = true }
+# For _ci_dep_features_to_test feature tests.
+schemars = { version = "0.8.21", optional = true }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
 # We use android_logger on Android

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -951,7 +951,5 @@ fn android_main(app: AndroidApp) {
 // This just tests that the "kurbo" dependency we enable schemars for
 // aligns to the same version that vello's peniko dependency resolves to.
 fn test_kurbo_schemars_with_peniko() {
-    use schemars::schema_for;
-    let s = schema_for!(vello::peniko::kurbo::Rect);
-    println!("{:?}", s);
+    let _: PhantomData<kurbo::Rect> = PhantomData::<peniko::kurbo::Rect>;
 }

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -951,5 +951,6 @@ fn android_main(app: AndroidApp) {
 // This just tests that the "kurbo" dependency we enable schemars for
 // aligns to the same version that vello's peniko dependency resolves to.
 fn test_kurbo_schemars_with_peniko() {
-    let _: PhantomData<kurbo::Rect> = PhantomData::<peniko::kurbo::Rect>;
+    use std::marker::PhantomData;
+    let _: PhantomData<kurbo::Rect> = PhantomData::<vello::peniko::kurbo::Rect>;
 }

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -945,3 +945,13 @@ fn android_main(app: AndroidApp) {
 
     run(event_loop, args, scenes, render_cx);
 }
+
+#[cfg(all(feature = "_ci_dep_features_to_test", test))]
+#[test]
+// This just tests that the "kurbo" dependency we enable schemars for
+// aligns to the same version that vello's peniko dependency resolves to.
+fn test_kurbo_schemars_with_peniko() {
+    use schemars::schema_for;
+    let s = schema_for!(vello::peniko::kurbo::Rect);
+    println!("{:?}", s);
+}

--- a/vello/src/scene.rs
+++ b/vello/src/scene.rs
@@ -537,8 +537,7 @@ impl<'a> DrawGlyphs<'a> {
                     let image = match bitmap.data {
                         bitmap::BitmapData::Bgra(data) => {
                             if bitmap.width * bitmap.height * 4
-                                != <usize as std::convert::TryInto<u32>>::try_into(data.len())
-                                    .unwrap()
+                                != u32::try_from(data.len()).unwrap()
                             {
                                 // TODO: Error once?
                                 log::error!("Invalid font");

--- a/vello/src/scene.rs
+++ b/vello/src/scene.rs
@@ -536,7 +536,7 @@ impl<'a> DrawGlyphs<'a> {
                 EmojiLikeGlyph::Bitmap(bitmap) => {
                     let image = match bitmap.data {
                         bitmap::BitmapData::Bgra(data) => {
-                            if bitmap.width * bitmap.height * 4 != data.len().try_into().unwrap() {
+                            if bitmap.width * bitmap.height * 4 != <usize as std::convert::TryInto<u32>>::try_into(data.len()).unwrap() {
                                 // TODO: Error once?
                                 log::error!("Invalid font");
                                 continue;

--- a/vello/src/scene.rs
+++ b/vello/src/scene.rs
@@ -536,7 +536,10 @@ impl<'a> DrawGlyphs<'a> {
                 EmojiLikeGlyph::Bitmap(bitmap) => {
                     let image = match bitmap.data {
                         bitmap::BitmapData::Bgra(data) => {
-                            if bitmap.width * bitmap.height * 4 != <usize as std::convert::TryInto<u32>>::try_into(data.len()).unwrap() {
+                            if bitmap.width * bitmap.height * 4
+                                != <usize as std::convert::TryInto<u32>>::try_into(data.len())
+                                    .unwrap()
+                            {
                                 // TODO: Error once?
                                 log::error!("Invalid font");
                                 continue;


### PR DESCRIPTION
Initially marking as a draft, because this currently just fiddles with Cargo.toml to ensure that CI tests the feature.
this shouldn't actually require any changes to our CI scripts to trigger, and as Daniel suggested, this uses a feature on with_winit rather than vello itself.

Will follow up with the actual fix once I've confirmed CI fails.