### PR TITLE
Add Linebender lint set v2.

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,1 +1,12 @@
+# LINEBENDER LINT SET - .clippy.toml - v1
+# See https://linebender.org/wiki/canonical-lints/
+
+# The default Clippy value is capped at 8 bytes, which was chosen to improve performance on 32-bit.
+# Given that we are building for the future and even low-end mobile phones have 64-bit CPUs,
+# it makes sense to optimize for 64-bit and accept the performance hits on 32-bit.
+# 16 bytes is the number of bytes that fits into two 64-bit CPU registers.
+trivial-copy-size-limit = 16
+
+# END LINEBENDER LINT SET
+
 doc-valid-idents = ["MotionMark", "WebGPU", "PostScript", ".."]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2445,7 +2445,6 @@ dependencies = [
  "log",
  "peniko",
  "png",
- "raw-window-handle",
  "skrifa",
  "static_assertions",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,11 @@ members = [
     "vello_tests",
 
     "examples/headless",
-    "examples/with_winit",
     "examples/run_wasm",
     "examples/scenes",
     "examples/simple",
     "examples/simple_sdl2",
+    "examples/with_winit",
 ]
 
 [workspace.package]
@@ -32,11 +32,64 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/linebender/vello"
 
 [workspace.lints]
+# LINEBENDER LINT SET - Cargo.toml - v2
+# See https://linebender.org/wiki/canonical-lints/
+rust.keyword_idents_2024 = "forbid"
+rust.non_ascii_idents = "forbid"
+rust.non_local_definitions = "forbid"
+rust.unsafe_op_in_unsafe_fn = "forbid"
+
+rust.elided_lifetimes_in_paths = "warn"
+rust.let_underscore_drop = "warn"
+rust.missing_debug_implementations = "warn"
+rust.missing_docs = "warn"
+rust.single_use_lifetimes = "warn"
+rust.trivial_numeric_casts = "warn"
+rust.unexpected_cfgs = "warn"
+rust.unit_bindings = "warn"
+rust.unnameable_types = "warn"
+rust.unreachable_pub = "warn"
+rust.unused_import_braces = "warn"
+rust.unused_lifetimes = "warn"
+rust.unused_macro_rules = "warn"
+rust.unused_qualifications = "warn"
+rust.variant_size_differences = "warn"
+
+clippy.allow_attributes = "warn"
+clippy.allow_attributes_without_reason = "warn"
+clippy.cast_possible_truncation = "warn"
+clippy.collection_is_never_read = "warn"
+clippy.dbg_macro = "warn"
+clippy.debug_assert_with_mut_call = "warn"
 clippy.doc_markdown = "warn"
+clippy.exhaustive_enums = "warn"
+clippy.fn_to_numeric_cast_any = "warn" # Can't be forbid due to 'scenes' requiring an exception.
+clippy.infinite_loop = "warn"
+clippy.large_include_file = "warn"
+clippy.large_stack_arrays = "warn"
+clippy.match_same_arms = "warn"
+clippy.mismatching_type_param_order = "warn"
+clippy.missing_assert_message = "warn"
+clippy.missing_errors_doc = "warn"
+clippy.missing_fields_in_debug = "warn"
+clippy.missing_panics_doc = "warn"
+clippy.partial_pub_fields = "warn"
+clippy.return_self_not_must_use = "warn"
+clippy.same_functions_in_if_condition = "warn"
 clippy.semicolon_if_nothing_returned = "warn"
-# We use a modified version of `unreachable_pub`, where we mark associated functions of pub(crate) items as pub.
-# This policy was implemented as it could gain begrudging consensus - there is no lint for this.
-# rust.unreachable_pub = "warn"
+clippy.shadow_unrelated = "warn"
+clippy.should_panic_without_expect = "warn"
+clippy.todo = "warn"
+clippy.trivially_copy_pass_by_ref = "warn"
+clippy.unseparated_literal_suffix = "warn"
+clippy.use_self = "warn"
+clippy.wildcard_imports = "warn"
+
+clippy.cargo_common_metadata = "warn"
+clippy.negative_feature_names = "warn"
+clippy.redundant_feature_names = "warn"
+clippy.wildcard_dependencies = "warn"
+# END LINEBENDER LINT SET
 
 [workspace.dependencies]
 vello = { version = "0.3.0", path = "vello" }
@@ -50,7 +103,6 @@ peniko = "0.2.0"
 # FIXME: This can be removed once peniko supports the schemars feature.
 kurbo = "0.11.1"
 futures-intrusive = "0.5.0"
-raw-window-handle = "0.6.2"
 smallvec = "1.13.2"
 static_assertions = "1.1.0"
 thiserror = "1.0.64"

--- a/examples/headless/src/main.rs
+++ b/examples/headless/src/main.rs
@@ -1,6 +1,16 @@
 // Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+//! Headless
+
+// The following lints are part of the Linebender standard set,
+// but resolving them has been deferred for now.
+// Feel free to send a PR that solves one or more of these.
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::allow_attributes_without_reason
+)]
+
 use std::fs::File;
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
@@ -206,10 +216,10 @@ async fn render(mut scenes: SceneSet, index: usize, args: &Args) -> Result<()> {
         .join(&example_scene.config.name)
         .with_extension("png");
     let mut file = File::create(&out_path)?;
-    let mut encoder = png::Encoder::new(&mut file, width, height);
-    encoder.set_color(png::ColorType::Rgba);
-    encoder.set_depth(png::BitDepth::Eight);
-    let mut writer = encoder.write_header()?;
+    let mut png_encoder = png::Encoder::new(&mut file, width, height);
+    png_encoder.set_color(png::ColorType::Rgba);
+    png_encoder.set_depth(png::BitDepth::Eight);
+    let mut writer = png_encoder.write_header()?;
     writer.write_image_data(&result_unpadded)?;
     writer.finish()?;
     println!("Wrote result ({width}x{height}) to {out_path:?}");

--- a/examples/run_wasm/src/main.rs
+++ b/examples/run_wasm/src/main.rs
@@ -1,6 +1,8 @@
 // Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+//! Wasm
+
 /// Use [cargo-run-wasm](https://github.com/rukai/cargo-run-wasm) to build an example for web
 ///
 /// Usage:

--- a/examples/scenes/src/lib.rs
+++ b/examples/scenes/src/lib.rs
@@ -1,8 +1,30 @@
 // Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// This is not a published crate, so we don't need to understand our public API
-#![allow(unreachable_pub)]
+//! Scenes
+
+// The following lints are part of the Linebender standard set,
+// but resolving them has been deferred for now.
+// Feel free to send a PR that solves one or more of these.
+#![allow(
+    missing_debug_implementations,
+    elided_lifetimes_in_paths,
+    single_use_lifetimes,
+    unreachable_pub,
+    missing_docs,
+    clippy::wildcard_imports,
+    clippy::unseparated_literal_suffix,
+    clippy::cast_possible_truncation,
+    clippy::shadow_unrelated,
+    clippy::missing_panics_doc,
+    clippy::missing_errors_doc,
+    clippy::partial_pub_fields,
+    clippy::use_self,
+    clippy::match_same_arms,
+    clippy::allow_attributes_without_reason,
+    clippy::allow_attributes,
+    clippy::fn_to_numeric_cast_any
+)]
 
 mod images;
 mod mmark;
@@ -32,7 +54,7 @@ pub struct SceneParams<'a> {
     pub text: &'a mut SimpleText,
     pub images: &'a mut ImageCache,
     pub resolution: Option<Vec2>,
-    pub base_color: Option<vello::peniko::Color>,
+    pub base_color: Option<Color>,
     pub complexity: usize,
 }
 

--- a/examples/scenes/src/mmark.rs
+++ b/examples/scenes/src/mmark.rs
@@ -69,7 +69,7 @@ impl MMark {
 }
 
 impl TestScene for MMark {
-    fn render(&mut self, scene: &mut Scene, params: &mut SceneParams) {
+    fn render(&mut self, scene: &mut Scene, params: &mut SceneParams<'_>) {
         let c = params.complexity;
         let n = if c < 10 {
             (c + 1) * 1000
@@ -101,7 +101,7 @@ impl TestScene for MMark {
                 );
                 path.truncate(0); // Should have clear method, to avoid allocations.
             }
-            if rng.gen::<f32>() > 0.995 {
+            if rng.r#gen::<f32>() > 0.995 {
                 element.is_split ^= true;
             }
         }
@@ -161,8 +161,8 @@ impl Element {
             )
         };
         let color = *COLORS.choose(&mut rng).unwrap();
-        let width = rng.gen::<f64>().powi(5) * 20.0 + 1.0;
-        let is_split = rng.gen();
+        let width = rng.r#gen::<f64>().powi(5) * 20.0 + 1.0;
+        let is_split = rng.r#gen();
         Element {
             seg,
             color,
@@ -191,7 +191,7 @@ impl GridPoint {
         GridPoint(x, y)
     }
 
-    fn coordinate(&self) -> Point {
+    fn coordinate(self) -> Point {
         let scale_x = WIDTH as f64 / ((GRID_WIDTH + 1) as f64);
         let scale_y = HEIGHT as f64 / ((GRID_HEIGHT + 1) as f64);
         Point::new(

--- a/examples/scenes/src/pico_svg.rs
+++ b/examples/scenes/src/pico_svg.rs
@@ -133,7 +133,7 @@ impl Parser {
 
     fn rec_parse(
         &mut self,
-        node: Node,
+        node: Node<'_, '_>,
         properties: &RecursiveProperties,
         items: &mut Vec<Item>,
     ) -> Result<(), Box<dyn std::error::Error>> {
@@ -274,7 +274,7 @@ fn parse_color(color: &str) -> Color {
     }
 }
 
-fn modify_opacity(mut color: Color, attr_name: &str, node: Node) -> Color {
+fn modify_opacity(mut color: Color, attr_name: &str, node: Node<'_, '_>) -> Color {
     if let Some(opacity) = node.attribute(attr_name) {
         let alpha: f64 = if let Some(o) = opacity.strip_suffix('%') {
             let pctg = o.parse().unwrap_or(100.0);

--- a/examples/scenes/src/svg.rs
+++ b/examples/scenes/src/svg.rs
@@ -185,7 +185,7 @@ pub fn svg_function_of<R: AsRef<str>>(
                     None,
                     48.,
                     None,
-                    vello::kurbo::Affine::translate((110.0, 600.0)),
+                    Affine::translate((110.0, 600.0)),
                     &format!("Loading {name}"),
                 ),
                 Err(RecvTimeoutError::Disconnected) => {

--- a/examples/scenes/src/test_scenes.rs
+++ b/examples/scenes/src/test_scenes.rs
@@ -735,7 +735,7 @@ mod impls {
             Affine::IDENTITY,
             &Brush::Solid(Color::rgb8(128, 0, 0)),
             None,
-            &[PathEl::MoveTo(center), PathEl::LineTo(p1)],
+            &[MoveTo(center), LineTo(p1)],
         );
         scene.fill(
             Fill::NonZero,
@@ -1128,7 +1128,7 @@ mod impls {
                     scene.push_layer(Mix::Clip, 1.0, translate * rot, &base_tri);
                 }
                 let rot = Affine::rotate(rng.gen_range(0.0..PI));
-                let color = Color::rgb(rng.gen(), rng.gen(), rng.gen());
+                let color = Color::rgb(rng.r#gen(), rng.r#gen(), rng.r#gen());
                 scene.fill(Fill::NonZero, translate * rot, color, None, &base_tri);
                 for _ in 0..CLIPS_PER_FILL {
                     scene.pop_layer();
@@ -1141,7 +1141,7 @@ mod impls {
 
     pub(super) fn render_cardioid(scene: &mut Scene) {
         let n = 601;
-        let dth = std::f64::consts::PI * 2.0 / (n as f64);
+        let dth = PI * 2.0 / (n as f64);
         let center = Point::new(1024.0, 768.0);
         let r = 750.0;
         let mut path = BezPath::new();
@@ -1571,21 +1571,21 @@ mod impls {
         }
         scene.pop_layer();
 
-        let large_background_rect = kurbo::Rect::new(-1000.0, -1000.0, 2000.0, 2000.0);
-        let inside_clip_rect = kurbo::Rect::new(11.0, 13.399999999999999, 59.0, 56.6);
-        let outside_clip_rect = kurbo::Rect::new(
+        let large_background_rect = Rect::new(-1000.0, -1000.0, 2000.0, 2000.0);
+        let inside_clip_rect = Rect::new(11.0, 13.399999999999999, 59.0, 56.6);
+        let outside_clip_rect = Rect::new(
             12.599999999999998,
             12.599999999999998,
             57.400000000000006,
             57.400000000000006,
         );
-        let clip_rect = kurbo::Rect::new(0.0, 0.0, 74.4, 339.20000000000005);
+        let clip_rect = Rect::new(0.0, 0.0, 74.4, 339.20000000000005);
         let scale = 2.0;
 
         scene.push_layer(
             BlendMode {
-                mix: peniko::Mix::Normal,
-                compose: peniko::Compose::SrcOver,
+                mix: Mix::Normal,
+                compose: Compose::SrcOver,
             },
             1.0,
             Affine::new([scale, 0.0, 0.0, scale, 27.07470703125, 176.40660533027858]),
@@ -1593,15 +1593,15 @@ mod impls {
         );
 
         scene.fill(
-            peniko::Fill::NonZero,
-            kurbo::Affine::new([scale, 0.0, 0.0, scale, 27.07470703125, 176.40660533027858]),
-            peniko::Color::rgb8(0, 0, 255),
+            Fill::NonZero,
+            Affine::new([scale, 0.0, 0.0, scale, 27.07470703125, 176.40660533027858]),
+            Color::rgb8(0, 0, 255),
             None,
             &large_background_rect,
         );
         scene.fill(
-            peniko::Fill::NonZero,
-            kurbo::Affine::new([
+            Fill::NonZero,
+            Affine::new([
                 scale,
                 0.0,
                 0.0,
@@ -1609,13 +1609,13 @@ mod impls {
                 29.027636718750003,
                 182.9755506427786,
             ]),
-            peniko::Color::rgb8(0, 255, 0),
+            Color::rgb8(0, 255, 0),
             None,
             &inside_clip_rect,
         );
         scene.fill(
-            peniko::Fill::NonZero,
-            kurbo::Affine::new([
+            Fill::NonZero,
+            Affine::new([
                 scale,
                 0.0,
                 0.0,
@@ -1623,7 +1623,7 @@ mod impls {
                 29.027636718750003,
                 scale * 559.3583631427786,
             ]),
-            peniko::Color::rgb8(255, 0, 0),
+            Color::rgb8(255, 0, 0),
             None,
             &outside_clip_rect,
         );
@@ -1778,8 +1778,8 @@ mod impls {
                 blob.push(b[1]);
                 blob.push(b[0]);
             });
-        let data = vello::peniko::Blob::new(Arc::new(blob));
-        let image = vello::peniko::Image::new(data, vello::peniko::Format::Rgba8, 2, 2);
+        let data = Blob::new(Arc::new(blob));
+        let image = Image::new(data, Format::Rgba8, 2, 2);
 
         scene.draw_image(
             &image,
@@ -1820,8 +1820,8 @@ mod impls {
                 blob.push(b[1]);
                 blob.push(b[0]);
             });
-        let data = vello::peniko::Blob::new(Arc::new(blob));
-        let image = vello::peniko::Image::new(data, vello::peniko::Format::Rgba8, 2, 2);
+        let data = Blob::new(Arc::new(blob));
+        let image = Image::new(data, Format::Rgba8, 2, 2);
         let image = image.with_extend(Extend::Pad);
         // Pad extend mode
         scene.fill(

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -1,6 +1,8 @@
 // Copyright 2024 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+//! Simple example.
+
 use anyhow::Result;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
@@ -10,12 +12,13 @@ use vello::util::{RenderContext, RenderSurface};
 use vello::{AaConfig, Renderer, RendererOptions, Scene};
 use winit::application::ApplicationHandler;
 use winit::dpi::LogicalSize;
-use winit::event::*;
+use winit::event::WindowEvent;
 use winit::event_loop::{ActiveEventLoop, EventLoop};
 use winit::window::Window;
 
 use vello::wgpu;
-// Simple struct to hold the state of the renderer
+/// Simple struct to hold the state of the renderer
+#[derive(Debug)]
 pub struct ActiveRenderState<'s> {
     // The fields MUST be in this order, so that the surface is dropped before the window
     surface: RenderSurface<'s>,
@@ -45,7 +48,7 @@ struct SimpleVelloApp<'s> {
     scene: Scene,
 }
 
-impl<'s> ApplicationHandler for SimpleVelloApp<'s> {
+impl ApplicationHandler for SimpleVelloApp<'_> {
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
         let RenderState::Suspended(cached_window) = &mut self.state else {
             return;
@@ -188,7 +191,7 @@ fn create_winit_window(event_loop: &ActiveEventLoop) -> Arc<Window> {
 }
 
 /// Helper function that creates a vello `Renderer` for a given `RenderContext` and `RenderSurface`
-fn create_vello_renderer(render_cx: &RenderContext, surface: &RenderSurface) -> Renderer {
+fn create_vello_renderer(render_cx: &RenderContext, surface: &RenderSurface<'_>) -> Renderer {
     Renderer::new(
         &render_cx.devices[surface.dev_id].device,
         RendererOptions {

--- a/examples/simple_sdl2/src/main.rs
+++ b/examples/simple_sdl2/src/main.rs
@@ -20,7 +20,7 @@ use vello::{AaConfig, Renderer, RendererOptions, Scene};
 
 use vello::wgpu;
 
-pub fn main() {
+fn main() {
     let sdl_context = sdl2::init().unwrap();
     let video_subsystem = sdl_context.video().unwrap();
 
@@ -103,7 +103,7 @@ pub fn main() {
     }
 }
 
-fn create_vello_renderer(render_cx: &RenderContext, surface: &RenderSurface) -> Renderer {
+fn create_vello_renderer(render_cx: &RenderContext, surface: &RenderSurface<'_>) -> Renderer {
     Renderer::new(
         &render_cx.devices[surface.dev_id].device,
         RendererOptions {

--- a/examples/with_winit/src/hot_reload.rs
+++ b/examples/with_winit/src/hot_reload.rs
@@ -4,7 +4,7 @@
 use std::time::Duration;
 
 use anyhow::Result;
-use notify_debouncer_mini::notify::*;
+use notify_debouncer_mini::notify::RecursiveMode;
 use notify_debouncer_mini::{new_debouncer, DebounceEventResult};
 
 pub fn hot_reload(mut f: impl FnMut() -> Option<()> + Send + 'static) -> Result<impl Sized> {

--- a/examples/with_winit/src/main.rs
+++ b/examples/with_winit/src/main.rs
@@ -1,6 +1,8 @@
 // Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+//! Winit example.
+
 use anyhow::Result;
 
 fn main() -> Result<()> {

--- a/examples/with_winit/src/stats.rs
+++ b/examples/with_winit/src/stats.rs
@@ -3,6 +3,8 @@
 
 use scenes::SimpleText;
 use std::collections::VecDeque;
+#[cfg(feature = "wgpu-profiler")]
+use vello::kurbo::Line;
 use vello::kurbo::{Affine, PathEl, Rect, Stroke};
 use vello::peniko::{Brush, Color, Fill};
 use vello::{low_level::BumpAllocators, AaConfig, Scene};
@@ -195,8 +197,8 @@ pub struct Stats {
 }
 
 impl Stats {
-    pub fn new() -> Stats {
-        Stats {
+    pub fn new() -> Self {
+        Self {
             count: 0,
             sum: 0,
             min: u64::MAX,
@@ -452,7 +454,7 @@ pub fn draw_gpu_profiling(
                         offset,
                         &Brush::Solid(color),
                         None,
-                        &vello::kurbo::Line::new(
+                        &Line::new(
                             (x + depth_size, (end_normalised + start_normalised) / 2.),
                             (width * 0.31, cur_text_y - text_size as f64 * 0.35),
                         ),

--- a/vello/Cargo.toml
+++ b/vello/Cargo.toml
@@ -25,7 +25,7 @@ bump_estimate = ["vello_encoding/bump_estimate"]
 # Adds labels to buffers created by Vello.
 # May improve debugability at the cost of slightly higher memory usage (TODO: We should just not make these optional).
 buffer_labels = []
-wgpu = ["dep:wgpu"]
+wgpu = ["dep:wgpu", "dep:vello_shaders", "dep:futures-intrusive"]
 
 # Development only features
 
@@ -46,15 +46,14 @@ workspace = true
 
 [dependencies]
 vello_encoding = { workspace = true }
-vello_shaders = { workspace = true }
+vello_shaders = { workspace = true, optional = true }
 bytemuck = { workspace = true }
 skrifa = { workspace = true }
 peniko = { workspace = true }
 wgpu = { workspace = true, optional = true }
 log = { workspace = true }
-raw-window-handle = { workspace = true }
 static_assertions = { workspace = true }
-futures-intrusive = { workspace = true }
+futures-intrusive = { workspace = true, optional = true }
 wgpu-profiler = { workspace = true, optional = true }
 thiserror = { workspace = true }
 # TODO: Add feature for built-in bitmap emoji support?

--- a/vello/src/debug/renderer.rs
+++ b/vello/src/debug/renderer.rs
@@ -1,6 +1,10 @@
 // Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+// size_of is not part of the prelude until Rust 1.80 and our MSRV is below that
+#[allow(unused_imports)]
+use core::mem::size_of;
+
 use super::DebugLayers;
 use crate::{
     debug::validate::{validate_line_soup, LineEndpoint},

--- a/vello/src/debug/renderer.rs
+++ b/vello/src/debug/renderer.rs
@@ -72,7 +72,7 @@ impl DebugRenderer {
             },
             // This mirrors the layout of the PathBbox structure.
             Some(wgpu::VertexBufferLayout {
-                array_stride: std::mem::size_of::<PathBbox>() as u64,
+                array_stride: size_of::<PathBbox>() as u64,
                 step_mode: wgpu::VertexStepMode::Instance,
                 attributes: &[
                     wgpu::VertexAttribute {
@@ -103,7 +103,7 @@ impl DebugRenderer {
             },
             // This mirrors the layout of the LineSoup structure.
             Some(wgpu::VertexBufferLayout {
-                array_stride: std::mem::size_of::<LineSoup>() as u64,
+                array_stride: size_of::<LineSoup>() as u64,
                 step_mode: wgpu::VertexStepMode::Instance,
                 attributes: &[
                     wgpu::VertexAttribute {
@@ -144,7 +144,7 @@ impl DebugRenderer {
             // render all points. All unpaired points alone get drawn by the `unpaired_points`
             // pipeline, so no point should get missed.
             Some(wgpu::VertexBufferLayout {
-                array_stride: std::mem::size_of::<LineSoup>() as u64,
+                array_stride: size_of::<LineSoup>() as u64,
                 step_mode: wgpu::VertexStepMode::Instance,
                 attributes: &[wgpu::VertexAttribute {
                     format: wgpu::VertexFormat::Float32x2,
@@ -181,7 +181,7 @@ impl DebugRenderer {
             },
             // This mirrors the layout of the LineSoup structure.
             Some(wgpu::VertexBufferLayout {
-                array_stride: std::mem::size_of::<LineEndpoint>() as u64,
+                array_stride: size_of::<LineEndpoint>() as u64,
                 step_mode: wgpu::VertexStepMode::Instance,
                 attributes: &[wgpu::VertexAttribute {
                     format: wgpu::VertexFormat::Float32x2,
@@ -301,7 +301,7 @@ impl DebugRenderer {
                     ResourceProxy::BufferRange {
                         proxy: linepoints_uniforms_buf,
                         offset: 0,
-                        size: std::mem::size_of::<LinepointsUniforms>() as u64,
+                        size: size_of::<LinepointsUniforms>() as u64,
                     },
                 ],
                 target,
@@ -318,8 +318,8 @@ impl DebugRenderer {
                     uniforms_buf,
                     ResourceProxy::BufferRange {
                         proxy: linepoints_uniforms_buf,
-                        offset: std::mem::size_of::<LinepointsUniforms>() as u64,
-                        size: std::mem::size_of::<LinepointsUniforms>() as u64,
+                        offset: size_of::<LinepointsUniforms>() as u64,
+                        size: size_of::<LinepointsUniforms>() as u64,
                     },
                 ],
                 target,

--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -113,6 +113,10 @@
     clippy::match_same_arms
 )]
 
+// size_of is not part of the prelude until Rust 1.80 and our MSRV is below that
+#[allow(unused_imports)]
+use core::mem::size_of;
+
 mod debug;
 mod recording;
 mod render;

--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -81,7 +81,37 @@
 //!
 //! See the [`examples/`](https://github.com/linebender/vello/tree/main/examples) folder to see how that code integrates with frameworks like winit.
 
+// LINEBENDER LINT SET - lib.rs - v1
+// See https://linebender.org/wiki/canonical-lints/
+// These lints aren't included in Cargo.toml because they
+// shouldn't apply to examples and tests
+#![warn(unused_crate_dependencies)]
+#![warn(clippy::print_stdout, clippy::print_stderr)]
+// END LINEBENDER LINT SET
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+// The following lints are part of the Linebender standard set,
+// but resolving them has been deferred for now.
+// Feel free to send a PR that solves one or more of these.
+#![allow(
+    missing_debug_implementations,
+    elided_lifetimes_in_paths,
+    single_use_lifetimes,
+    unnameable_types,
+    unreachable_pub,
+    missing_docs,
+    clippy::return_self_not_must_use,
+    clippy::cast_possible_truncation,
+    clippy::missing_assert_message,
+    clippy::shadow_unrelated,
+    clippy::missing_panics_doc,
+    clippy::missing_errors_doc,
+    clippy::exhaustive_enums,
+    clippy::todo,
+    clippy::print_stderr,
+    clippy::partial_pub_fields,
+    clippy::use_self,
+    clippy::match_same_arms
+)]
 
 mod debug;
 mod recording;
@@ -121,7 +151,12 @@ pub use wgpu;
 pub use scene::{DrawGlyphs, Scene};
 pub use vello_encoding::Glyph;
 
-use low_level::*;
+use low_level::ShaderId;
+#[cfg(feature = "wgpu")]
+use low_level::{
+    BindType, BumpAllocators, FullShaders, ImageFormat, ImageProxy, Recording, Render,
+    ResourceProxy,
+};
 use thiserror::Error;
 
 #[cfg(feature = "wgpu")]
@@ -815,13 +850,13 @@ struct TargetTexture {
     view: TextureView,
     width: u32,
     height: u32,
-    format: wgpu::TextureFormat,
+    format: TextureFormat,
 }
 
 #[cfg(feature = "wgpu")]
 impl TargetTexture {
     fn new(device: &Device, width: u32, height: u32) -> Self {
-        let format = wgpu::TextureFormat::Rgba8Unorm;
+        let format = TextureFormat::Rgba8Unorm;
         let texture = device.create_texture(&wgpu::TextureDescriptor {
             label: None,
             size: wgpu::Extent3d {
@@ -925,7 +960,7 @@ impl<'a> DebugDownloads<'a> {
             return Err(Error::DownloadError("linesoup"));
         };
 
-        let lines = lines_buf.slice(..bump.lines as u64 * std::mem::size_of::<LineSoup>() as u64);
+        let lines = lines_buf.slice(..bump.lines as u64 * size_of::<LineSoup>() as u64);
         let (sender, receiver) = futures_intrusive::channel::shared::oneshot_channel();
         lines.map_async(wgpu::MapMode::Read, move |v| sender.send(v).unwrap());
         receiver.receive().await.expect("channel was closed")?;

--- a/vello/src/render.rs
+++ b/vello/src/render.rs
@@ -3,8 +3,6 @@
 
 //! Take an encoded scene and create a graph to render it
 
-use std::mem::size_of;
-
 use crate::recording::{BufferProxy, ImageFormat, ImageProxy, Recording, ResourceProxy};
 use crate::shaders::FullShaders;
 use crate::{AaConfig, RenderParams};

--- a/vello/src/render.rs
+++ b/vello/src/render.rs
@@ -3,6 +3,10 @@
 
 //! Take an encoded scene and create a graph to render it
 
+// size_of is not part of the prelude until Rust 1.80 and our MSRV is below that
+#[allow(unused_imports)]
+use core::mem::size_of;
+
 use crate::recording::{BufferProxy, ImageFormat, ImageProxy, Recording, ResourceProxy};
 use crate::shaders::FullShaders;
 use crate::{AaConfig, RenderParams};

--- a/vello/src/shaders.rs
+++ b/vello/src/shaders.rs
@@ -207,16 +207,16 @@ pub(crate) fn full_shaders(
         ]
     );
     let fine_resources = [
-        BindType::Uniform,
-        BindType::BufReadOnly,
-        BindType::BufReadOnly,
-        BindType::BufReadOnly,
-        BindType::Buffer,
-        BindType::Image(ImageFormat::Rgba8),
-        BindType::ImageRead(ImageFormat::Rgba8),
-        BindType::ImageRead(ImageFormat::Rgba8),
+        Uniform,
+        BufReadOnly,
+        BufReadOnly,
+        BufReadOnly,
+        Buffer,
+        Image(ImageFormat::Rgba8),
+        ImageRead(ImageFormat::Rgba8),
+        ImageRead(ImageFormat::Rgba8),
         // Mask LUT buffer, used only when MSAA is enabled.
-        BindType::BufReadOnly,
+        BufReadOnly,
     ];
 
     let aa_support = &options.antialiasing_support;

--- a/vello/src/util.rs
+++ b/vello/src/util.rs
@@ -76,7 +76,7 @@ impl RenderContext {
             .find(|it| matches!(it, TextureFormat::Rgba8Unorm | TextureFormat::Bgra8Unorm))
             .ok_or(Error::UnsupportedSurfaceFormat)?;
 
-        let config = wgpu::SurfaceConfiguration {
+        let config = SurfaceConfiguration {
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
             format,
             width,

--- a/vello/src/wgpu_engine.rs
+++ b/vello/src/wgpu_engine.rs
@@ -786,14 +786,14 @@ impl WgpuEngine {
                         ty: if bind_type == BindType::ImageRead(format) {
                             wgpu::BindingType::Texture {
                                 sample_type: wgpu::TextureSampleType::Float { filterable: true },
-                                view_dimension: wgpu::TextureViewDimension::D2,
+                                view_dimension: TextureViewDimension::D2,
                                 multisampled: false,
                             }
                         } else {
                             wgpu::BindingType::StorageTexture {
                                 access: wgpu::StorageTextureAccess::WriteOnly,
                                 format: format.to_wgpu(),
-                                view_dimension: wgpu::TextureViewDimension::D2,
+                                view_dimension: TextureViewDimension::D2,
                             }
                         },
                         count: None,

--- a/vello_encoding/Cargo.toml
+++ b/vello_encoding/Cargo.toml
@@ -2,6 +2,8 @@
 name = "vello_encoding"
 version.workspace = true # We mimic Vello's version
 description = "Vello types that represent the data that needs to be rendered."
+categories = ["rendering", "graphics"]
+keywords = ["2d", "vector-graphics"]
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -18,7 +20,7 @@ default = ["full"]
 
 # Enables support for the full pipeline including late-bound
 # resources (gradients, images and glyph runs)
-full = ["dep:skrifa", "dep:guillotiere"]
+full = ["dep:skrifa", "dep:guillotiere", "dep:smallvec"]
 
 # Enables an optional GPU memory usage estimation utility. This can be used to
 # perform additional computations in order to estimate the minimum required allocations
@@ -33,4 +35,4 @@ bytemuck = { workspace = true }
 skrifa = { workspace = true, optional = true }
 peniko = { workspace = true }
 guillotiere = { version = "0.6.2", optional = true }
-smallvec = { workspace = true }
+smallvec = { workspace = true, optional = true }

--- a/vello_encoding/src/clip.rs
+++ b/vello_encoding/src/clip.rs
@@ -22,6 +22,7 @@ pub struct ClipBic {
 /// Clip element.
 #[derive(Copy, Clone, Pod, Zeroable, Debug, Default)]
 #[repr(C)]
+#[allow(clippy::partial_pub_fields)]
 pub struct ClipElement {
     pub parent_ix: u32,
     _padding: [u8; 12],
@@ -35,7 +36,7 @@ pub struct ClipElement {
 #[derive(Copy, Clone, Pod, Zeroable, Debug, Default)]
 #[repr(C)]
 pub struct Clip {
-    // Index of the draw object.
+    /// Index of the draw object.
     pub ix: u32,
     /// This is a packed encoding of an enum with the sign bit as the tag. If positive,
     /// this entry is a `BeginClip` and contains the associated path index. If negative,
@@ -52,7 +53,7 @@ pub struct ClipBbox {
 
 impl ClipBic {
     pub fn new(a: u32, b: u32) -> Self {
-        ClipBic { a, b }
+        Self { a, b }
     }
 
     /// The bicyclic semigroup operation.
@@ -61,8 +62,8 @@ impl ClipBic {
     /// operation, it represents doing the pops of `self`, the pushes of
     /// `self`, the pops of `other`, and the pushes of `other`. The middle
     /// two can cancel each other out.
-    pub fn combine(self, other: ClipBic) -> Self {
+    pub fn combine(self, other: Self) -> Self {
         let m = self.b.min(other.a);
-        ClipBic::new(self.a + other.a - m, self.b + other.b - m)
+        Self::new(self.a + other.a - m, self.b + other.b - m)
     }
 }

--- a/vello_encoding/src/config.rs
+++ b/vello_encoding/src/config.rs
@@ -8,7 +8,6 @@ use super::{
     PathBbox, PathMonoid, PathSegment, Tile,
 };
 use bytemuck::{Pod, Zeroable};
-use std::mem;
 
 const TILE_WIDTH: u32 = 16;
 const TILE_HEIGHT: u32 = 16;
@@ -297,7 +296,7 @@ impl<T: Sized> BufferSize<T> {
 
     /// Creates a new buffer size from size in bytes.
     pub const fn from_size_in_bytes(size: u32) -> Self {
-        Self::new(size / mem::size_of::<T>() as u32)
+        Self::new(size / size_of::<T>() as u32)
     }
 
     /// Returns the number of elements.
@@ -308,7 +307,7 @@ impl<T: Sized> BufferSize<T> {
 
     /// Returns the size in bytes.
     pub const fn size_in_bytes(self) -> u32 {
-        mem::size_of::<T>() as u32 * self.len
+        size_of::<T>() as u32 * self.len
     }
 
     /// Returns the size in bytes aligned up to the given value.

--- a/vello_encoding/src/config.rs
+++ b/vello_encoding/src/config.rs
@@ -1,6 +1,10 @@
 // Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+// size_of is not part of the prelude until Rust 1.80 and our MSRV is below that
+#[allow(unused_imports)]
+use core::mem::size_of;
+
 use crate::SegmentCount;
 
 use super::{

--- a/vello_encoding/src/estimate.rs
+++ b/vello_encoding/src/estimate.rs
@@ -272,7 +272,7 @@ impl LineSoup {
         (self.curves as f64 * scale.sqrt()).ceil() as u32
     }
 
-    fn add(&mut self, other: &LineSoup, scale: f64) {
+    fn add(&mut self, other: &Self, scale: f64) {
         self.linetos += other.linetos;
         self.curves += other.scaled_curve_line_count(scale);
         self.curve_count += other.curve_count;
@@ -363,7 +363,7 @@ fn count_segments_for_line_length(scaled_width: f64) -> u32 {
 /// over the continuous change in the number of flattened segments, with an error expressed in terms
 /// of curvature and infinitesimal arclength).
 mod wang {
-    use super::*;
+    use super::{transform, Transform, Vec2};
 
     // The curve degree term sqrt(n * (n - 1) / 8) specialized for cubics:
     //
@@ -377,19 +377,26 @@ mod wang {
     //
     const SQRT_OF_DEGREE_TERM_QUAD: f64 = 0.5;
 
-    pub fn quadratic(rsqrt_of_tol: f64, p0: Vec2, p1: Vec2, p2: Vec2, t: &Transform) -> f64 {
+    pub(crate) fn quadratic(rsqrt_of_tol: f64, p0: Vec2, p1: Vec2, p2: Vec2, t: &Transform) -> f64 {
         let v = -2. * p1 + p0 + p2;
         let v = transform(t, v); // transform is distributive
         let m = v.length();
-        (SQRT_OF_DEGREE_TERM_QUAD * m.sqrt() * rsqrt_of_tol).ceil() as f64
+        (SQRT_OF_DEGREE_TERM_QUAD * m.sqrt() * rsqrt_of_tol).ceil()
     }
 
-    pub fn cubic(rsqrt_of_tol: f64, p0: Vec2, p1: Vec2, p2: Vec2, p3: Vec2, t: &Transform) -> f64 {
+    pub(crate) fn cubic(
+        rsqrt_of_tol: f64,
+        p0: Vec2,
+        p1: Vec2,
+        p2: Vec2,
+        p3: Vec2,
+        t: &Transform,
+    ) -> f64 {
         let v1 = -2. * p1 + p0 + p2;
         let v2 = -2. * p2 + p1 + p3;
         let v1 = transform(t, v1);
         let v2 = transform(t, v2);
-        let m = v1.length().max(v2.length()) as f64;
-        (SQRT_OF_DEGREE_TERM_CUBIC * m.sqrt() * rsqrt_of_tol).ceil() as f64
+        let m = v1.length().max(v2.length());
+        (SQRT_OF_DEGREE_TERM_CUBIC * m.sqrt() * rsqrt_of_tol).ceil()
     }
 }

--- a/vello_encoding/src/glyph_cache.rs
+++ b/vello_encoding/src/glyph_cache.rs
@@ -23,7 +23,7 @@ pub(crate) struct GlyphCache {
 }
 
 impl GlyphCache {
-    pub fn session<'a>(
+    pub(crate) fn session<'a>(
         &'a mut self,
         font: &'a Font,
         coords: &'a [NormalizedCoord],
@@ -85,7 +85,7 @@ impl GlyphCache {
         })
     }
 
-    pub fn maintain(&mut self) {
+    pub(crate) fn maintain(&mut self) {
         // Maximum number of resolve phases where we'll retain an unused glyph
         const MAX_ENTRY_AGE: u64 = 64;
         // Maximum number of resolve phases before we force a prune
@@ -149,7 +149,10 @@ pub(crate) struct GlyphCacheSession<'a> {
 }
 
 impl<'a> GlyphCacheSession<'a> {
-    pub fn get_or_insert(&mut self, glyph_id: u32) -> Option<(Arc<Encoding>, StreamOffsets)> {
+    pub(crate) fn get_or_insert(
+        &mut self,
+        glyph_id: u32,
+    ) -> Option<(Arc<Encoding>, StreamOffsets)> {
         let key = GlyphKey {
             font_id: self.font_id,
             font_index: self.font_index,
@@ -270,7 +273,7 @@ struct HintCache {
 }
 
 impl HintCache {
-    fn get(&mut self, key: &HintKey) -> Option<&HintingInstance> {
+    fn get(&mut self, key: &HintKey<'_>) -> Option<&HintingInstance> {
         let entries = match key.outlines.format()? {
             OutlineGlyphFormat::Glyf => &mut self.glyf_entries,
             OutlineGlyphFormat::Cff | OutlineGlyphFormat::Cff2 => &mut self.cff_entries,
@@ -298,7 +301,7 @@ struct HintEntry {
     serial: u64,
 }
 
-fn find_hint_entry(entries: &mut Vec<HintEntry>, key: &HintKey) -> Option<(usize, bool)> {
+fn find_hint_entry(entries: &mut Vec<HintEntry>, key: &HintKey<'_>) -> Option<(usize, bool)> {
     let mut found_serial = u64::MAX;
     let mut found_index = 0;
     for (ix, entry) in entries.iter().enumerate() {

--- a/vello_encoding/src/image_cache.rs
+++ b/vello_encoding/src/image_cache.rs
@@ -31,7 +31,7 @@ impl Default for ImageCache {
 }
 
 impl ImageCache {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             atlas: AtlasAllocator::new(size2(DEFAULT_ATLAS_SIZE, DEFAULT_ATLAS_SIZE)),
             map: Default::default(),
@@ -39,7 +39,7 @@ impl ImageCache {
         }
     }
 
-    pub fn images(&self) -> Images {
+    pub(crate) fn images(&self) -> Images<'_> {
         Images {
             width: self.atlas.size().width as u32,
             height: self.atlas.size().height as u32,
@@ -47,7 +47,7 @@ impl ImageCache {
         }
     }
 
-    pub fn bump_size(&mut self) -> bool {
+    pub(crate) fn bump_size(&mut self) -> bool {
         let new_size = self.atlas.size().width * 2;
         if new_size > MAX_ATLAS_SIZE {
             return false;
@@ -58,13 +58,13 @@ impl ImageCache {
         true
     }
 
-    pub fn clear(&mut self) {
+    pub(crate) fn clear(&mut self) {
         self.atlas.clear();
         self.map.clear();
         self.images.clear();
     }
 
-    pub fn get_or_insert(&mut self, image: &Image) -> Option<(u32, u32)> {
+    pub(crate) fn get_or_insert(&mut self, image: &Image) -> Option<(u32, u32)> {
         match self.map.entry(image.data.id()) {
             Entry::Occupied(occupied) => Some(*occupied.get()),
             Entry::Vacant(vacant) => {

--- a/vello_encoding/src/lib.rs
+++ b/vello_encoding/src/lib.rs
@@ -3,7 +3,32 @@
 
 //! Raw scene encoding.
 
+// LINEBENDER LINT SET - lib.rs - v1
+// See https://linebender.org/wiki/canonical-lints/
+// These lints aren't included in Cargo.toml because they
+// shouldn't apply to examples and tests
+#![warn(unused_crate_dependencies)]
+#![warn(clippy::print_stdout, clippy::print_stderr)]
+// END LINEBENDER LINT SET
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+// The following lints are part of the Linebender standard set,
+// but resolving them has been deferred for now.
+// Feel free to send a PR that solves one or more of these.
+#![allow(
+    missing_debug_implementations,
+    elided_lifetimes_in_paths,
+    single_use_lifetimes,
+    unnameable_types,
+    missing_docs,
+    variant_size_differences,
+    clippy::return_self_not_must_use,
+    clippy::unseparated_literal_suffix,
+    clippy::cast_possible_truncation,
+    clippy::missing_assert_message,
+    clippy::shadow_unrelated,
+    clippy::missing_panics_doc,
+    clippy::exhaustive_enums
+)]
 
 mod binning;
 mod clip;

--- a/vello_encoding/src/path.rs
+++ b/vello_encoding/src/path.rs
@@ -1,6 +1,10 @@
 // Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+// size_of is not part of the prelude until Rust 1.80 and our MSRV is below that
+#[allow(unused_imports)]
+use core::mem::size_of;
+
 use bytemuck::{Pod, Zeroable};
 use peniko::kurbo::{Cap, Join, Shape, Stroke};
 use peniko::Fill;

--- a/vello_encoding/src/path.rs
+++ b/vello_encoding/src/path.rs
@@ -103,7 +103,7 @@ impl Style {
     }
 
     #[cfg(test)]
-    fn fill(&self) -> Option<Fill> {
+    fn fill(self) -> Option<Fill> {
         if self.is_fill() {
             Some(
                 if (self.flags_and_miter_limit & Self::FLAGS_FILL_BIT) == 0 {
@@ -118,7 +118,7 @@ impl Style {
     }
 
     #[cfg(test)]
-    fn stroke_width(&self) -> Option<f64> {
+    fn stroke_width(self) -> Option<f64> {
         if self.is_fill() {
             return None;
         }
@@ -126,7 +126,7 @@ impl Style {
     }
 
     #[cfg(test)]
-    fn stroke_join(&self) -> Option<Join> {
+    fn stroke_join(self) -> Option<Join> {
         if self.is_fill() {
             return None;
         }
@@ -140,7 +140,7 @@ impl Style {
     }
 
     #[cfg(test)]
-    fn stroke_start_cap(&self) -> Option<Cap> {
+    fn stroke_start_cap(self) -> Option<Cap> {
         if self.is_fill() {
             return None;
         }
@@ -154,7 +154,7 @@ impl Style {
     }
 
     #[cfg(test)]
-    fn stroke_end_cap(&self) -> Option<Cap> {
+    fn stroke_end_cap(self) -> Option<Cap> {
         if self.is_fill() {
             return None;
         }
@@ -168,7 +168,7 @@ impl Style {
     }
 
     #[cfg(test)]
-    fn stroke_miter_limit(&self) -> Option<u16> {
+    fn stroke_miter_limit(self) -> Option<u16> {
         if self.is_fill() {
             return None;
         }
@@ -176,7 +176,7 @@ impl Style {
     }
 
     #[cfg(test)]
-    fn is_fill(&self) -> bool {
+    fn is_fill(self) -> bool {
         (self.flags_and_miter_limit & Self::FLAGS_STYLE_BIT) == 0
     }
 }
@@ -339,7 +339,7 @@ impl Monoid for PathMonoid {
         a += a >> 16;
         c.pathseg_offset = a & 0xff;
         c.path_ix = (tag_word & (PathTag::PATH.0 as u32 * 0x1010101)).count_ones();
-        let style_size = (std::mem::size_of::<Style>() / std::mem::size_of::<u32>()) as u32;
+        let style_size = (size_of::<Style>() / size_of::<u32>()) as u32;
         c.style_ix = (tag_word & (PathTag::STYLE.0 as u32 * 0x1010101)).count_ones() * style_size;
         c
     }
@@ -390,6 +390,7 @@ pub struct PathBbox {
 /// Tiled path object.
 #[derive(Copy, Clone, Pod, Zeroable, Debug, Default)]
 #[repr(C)]
+#[allow(clippy::partial_pub_fields)]
 pub struct Path {
     /// Bounding box in tiles.
     pub bbox: [u32; 4],

--- a/vello_encoding/src/ramp_cache.rs
+++ b/vello_encoding/src/ramp_cache.rs
@@ -24,7 +24,7 @@ pub(crate) struct RampCache {
 }
 
 impl RampCache {
-    pub fn maintain(&mut self) {
+    pub(crate) fn maintain(&mut self) {
         self.epoch += 1;
         if self.map.len() > RETAINED_COUNT {
             self.map
@@ -33,7 +33,7 @@ impl RampCache {
         }
     }
 
-    pub fn add(&mut self, stops: &[ColorStop]) -> u32 {
+    pub(crate) fn add(&mut self, stops: &[ColorStop]) -> u32 {
         if let Some(entry) = self.map.get_mut(stops) {
             entry.1 = self.epoch;
             entry.0
@@ -70,7 +70,7 @@ impl RampCache {
         }
     }
 
-    pub fn ramps(&self) -> Ramps {
+    pub(crate) fn ramps(&self) -> Ramps {
         Ramps {
             data: &self.data,
             width: N_SAMPLES as u32,

--- a/vello_encoding/src/resolve.rs
+++ b/vello_encoding/src/resolve.rs
@@ -601,11 +601,11 @@ impl SceneBufferSizes {
 }
 
 fn slice_size_in_bytes<T: Sized>(slice: &[T], extra: usize) -> usize {
-    (slice.len() + extra) * std::mem::size_of::<T>()
+    (slice.len() + extra) * size_of::<T>()
 }
 
 fn size_to_words(byte_size: usize) -> u32 {
-    (byte_size / std::mem::size_of::<u32>()) as u32
+    (byte_size / size_of::<u32>()) as u32
 }
 
 fn align_up(len: usize, alignment: u32) -> usize {

--- a/vello_encoding/src/resolve.rs
+++ b/vello_encoding/src/resolve.rs
@@ -1,6 +1,10 @@
 // Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+// size_of is not part of the prelude until Rust 1.80 and our MSRV is below that
+#[allow(unused_imports)]
+use core::mem::size_of;
+
 use bytemuck::{Pod, Zeroable};
 
 use super::{DrawTag, Encoding, PathTag, StreamOffsets, Style, Transform};

--- a/vello_shaders/Cargo.toml
+++ b/vello_shaders/Cargo.toml
@@ -2,6 +2,8 @@
 name = "vello_shaders"
 version.workspace = true # We mimic Vello's version
 description = "Vello infrastructure to preprocess and cross-compile shaders at compile time."
+categories = ["rendering", "graphics"]
+keywords = ["2d", "vector-graphics"]
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/vello_shaders/build.rs
+++ b/vello_shaders/build.rs
@@ -1,6 +1,8 @@
 // Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+//! Build step.
+
 // These modules are also included in the main crate, where the items are reachable
 #[allow(unreachable_pub, unused)]
 #[path = "src/compile/mod.rs"]
@@ -21,7 +23,7 @@ fn main() {
 
     println!("cargo:rerun-if-changed={}", compile::shader_dir().display());
 
-    let mut shaders = match compile::ShaderInfo::from_default() {
+    let mut shaders = match ShaderInfo::from_default() {
         Ok(s) => s,
         Err(err) => {
             let formatted = err.to_string();
@@ -55,6 +57,7 @@ fn write_shaders(
     shaders: &[(String, ShaderInfo)],
 ) -> Result<(), std::fmt::Error> {
     writeln!(buf, "mod generated {{")?;
+    writeln!(buf, "    #[allow(clippy::wildcard_imports)]")?;
     writeln!(buf, "    use super::*;")?;
     writeln!(buf, "    use BindType::*;")?;
     writeln!(buf, "    pub const SHADERS: Shaders<'static> = Shaders {{")?;

--- a/vello_shaders/src/compile/permutations.rs
+++ b/vello_shaders/src/compile/permutations.rs
@@ -20,7 +20,7 @@ pub fn parse(source: &str) -> HashMap<String, Vec<Permutation>> {
             continue;
         }
         if let Some(line) = line.strip_prefix('+') {
-            if let Some(source) = &current_source {
+            if let Some(current_source) = &current_source {
                 let mut parts = line.split(':').map(|s| s.trim());
                 let Some(name) = parts.next() else {
                     continue;
@@ -29,7 +29,7 @@ pub fn parse(source: &str) -> HashMap<String, Vec<Permutation>> {
                 if let Some(define_list) = parts.next() {
                     defines.extend(define_list.split(' ').map(|s| s.trim().to_string()));
                 }
-                map.entry(source.to_string())
+                map.entry(current_source.to_string())
                     .or_default()
                     .push(Permutation {
                         name: name.to_string(),

--- a/vello_shaders/src/cpu/coarse.rs
+++ b/vello_shaders/src/cpu/coarse.rs
@@ -35,10 +35,10 @@ struct TileState {
 }
 
 impl TileState {
-    fn new(tile_ix: u32) -> TileState {
+    fn new(tile_ix: u32) -> Self {
         let cmd_offset = tile_ix * PTCL_INITIAL_ALLOC;
         let cmd_limit = cmd_offset + (PTCL_INITIAL_ALLOC - PTCL_HEADROOM);
-        TileState {
+        Self {
             cmd_offset,
             cmd_limit,
         }

--- a/vello_shaders/src/cpu/flatten.rs
+++ b/vello_shaders/src/cpu/flatten.rs
@@ -524,7 +524,7 @@ struct IntBbox {
 
 impl Default for IntBbox {
     fn default() -> Self {
-        IntBbox {
+        Self {
             x0: 0x7fff_ffff,
             y0: 0x7fff_ffff,
             x1: -0x8000_0000,
@@ -560,9 +560,7 @@ fn compute_tag_monoid(ix: usize, pathtags: &[u32], tag_monoids: &[PathMonoid]) -
     // We wrap here because these values will return to positive values later
     // (when we add style_base)
     tm.trans_ix = tm.trans_ix.wrapping_sub(1);
-    tm.style_ix = tm
-        .style_ix
-        .wrapping_sub(core::mem::size_of::<Style>() as u32 / 4);
+    tm.style_ix = tm.style_ix.wrapping_sub(size_of::<Style>() as u32 / 4);
     PathTagData {
         tag_byte,
         monoid: tm,

--- a/vello_shaders/src/cpu/flatten.rs
+++ b/vello_shaders/src/cpu/flatten.rs
@@ -1,6 +1,10 @@
 // Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
 
+// size_of is not part of the prelude until Rust 1.80 and our MSRV is below that
+#[allow(unused_imports)]
+use core::mem::size_of;
+
 use std::f32::consts::FRAC_1_SQRT_2;
 
 use super::{

--- a/vello_shaders/src/cpu/util.rs
+++ b/vello_shaders/src/cpu/util.rs
@@ -14,10 +14,10 @@ pub struct Vec2 {
 }
 
 impl std::ops::Add for Vec2 {
-    type Output = Vec2;
+    type Output = Self;
 
     fn add(self, rhs: Self) -> Self {
-        Vec2 {
+        Self {
             x: self.x + rhs.x,
             y: self.y + rhs.y,
         }
@@ -25,21 +25,21 @@ impl std::ops::Add for Vec2 {
 }
 
 impl std::ops::Sub for Vec2 {
-    type Output = Vec2;
+    type Output = Self;
 
     fn sub(self, rhs: Self) -> Self {
-        Vec2 {
+        Self {
             x: self.x - rhs.x,
             y: self.y - rhs.y,
         }
     }
 }
 
-impl std::ops::Mul<f32> for Vec2 {
-    type Output = Vec2;
+impl Mul<f32> for Vec2 {
+    type Output = Self;
 
     fn mul(self, rhs: f32) -> Self {
-        Vec2 {
+        Self {
             x: self.x * rhs,
             y: self.y * rhs,
         }
@@ -47,17 +47,17 @@ impl std::ops::Mul<f32> for Vec2 {
 }
 
 impl std::ops::Div<f32> for Vec2 {
-    type Output = Vec2;
+    type Output = Self;
 
     fn div(self, rhs: f32) -> Self {
-        Vec2 {
+        Self {
             x: self.x / rhs,
             y: self.y / rhs,
         }
     }
 }
 
-impl std::ops::Mul<Vec2> for f32 {
+impl Mul<Vec2> for f32 {
     type Output = Vec2;
 
     fn mul(self, rhs: Vec2) -> Self::Output {
@@ -66,23 +66,23 @@ impl std::ops::Mul<Vec2> for f32 {
 }
 
 impl std::ops::Neg for Vec2 {
-    type Output = Vec2;
+    type Output = Self;
 
     fn neg(self) -> Self::Output {
-        Vec2::new(-self.x, -self.y)
+        Self::new(-self.x, -self.y)
     }
 }
 
 impl Vec2 {
     pub fn new(x: f32, y: f32) -> Self {
-        Vec2 { x, y }
+        Self { x, y }
     }
 
-    pub fn dot(self, other: Vec2) -> f32 {
+    pub fn dot(self, other: Self) -> f32 {
         self.x * other.x + self.y * other.y
     }
 
-    pub fn cross(self, other: Vec2) -> f32 {
+    pub fn cross(self, other: Self) -> f32 {
         (self.x * other.y) - (self.y * other.x)
     }
 
@@ -94,7 +94,7 @@ impl Vec2 {
         self.dot(self)
     }
 
-    pub fn distance(self, other: Vec2) -> f32 {
+    pub fn distance(self, other: Self) -> f32 {
         (self - other).length()
     }
 
@@ -103,16 +103,16 @@ impl Vec2 {
     }
 
     pub fn from_array(a: [f32; 2]) -> Self {
-        Vec2 { x: a[0], y: a[1] }
+        Self { x: a[0], y: a[1] }
     }
 
-    pub fn mix(self, other: Vec2, t: f32) -> Self {
+    pub fn mix(self, other: Self, t: f32) -> Self {
         let x = self.x + (other.x - self.x) * t;
         let y = self.y + (other.y - self.y) * t;
-        Vec2 { x, y }
+        Self { x, y }
     }
 
-    pub fn normalize(self) -> Vec2 {
+    pub fn normalize(self) -> Self {
         self / self.length()
     }
 
@@ -120,16 +120,16 @@ impl Vec2 {
         self.y.atan2(self.x)
     }
 
-    pub fn is_nan(&self) -> bool {
+    pub fn is_nan(self) -> bool {
         self.x.is_nan() || self.y.is_nan()
     }
 
-    pub fn min(&self, other: Vec2) -> Vec2 {
-        Vec2::new(self.x.min(other.x), self.y.min(other.y))
+    pub fn min(self, other: Self) -> Self {
+        Self::new(self.x.min(other.x), self.y.min(other.y))
     }
 
-    pub fn max(&self, other: Vec2) -> Vec2 {
-        Vec2::new(self.x.max(other.x), self.y.max(other.y))
+    pub fn max(self, other: Self) -> Self {
+        Self::new(self.x.max(other.x), self.y.max(other.y))
     }
 }
 
@@ -137,18 +137,18 @@ impl Vec2 {
 pub(crate) struct Transform(pub(crate) [f32; 6]);
 
 impl Transform {
-    pub fn identity() -> Self {
+    pub(crate) fn identity() -> Self {
         Self([1., 0., 0., 1., 0., 0.])
     }
 
-    pub fn apply(&self, p: Vec2) -> Vec2 {
+    pub(crate) fn apply(&self, p: Vec2) -> Vec2 {
         let z = self.0;
         let x = z[0] * p.x + z[2] * p.y + z[4];
         let y = z[1] * p.x + z[3] * p.y + z[5];
         Vec2 { x, y }
     }
 
-    pub fn inverse(&self) -> Transform {
+    pub(crate) fn inverse(&self) -> Self {
         let z = self.0;
         let inv_det = (z[0] * z[3] - z[1] * z[2]).recip();
         let inv_mat = [
@@ -167,13 +167,13 @@ impl Transform {
         ])
     }
 
-    pub fn read(transform_base: u32, ix: u32, data: &[u32]) -> Transform {
+    pub(crate) fn read(transform_base: u32, ix: u32, data: &[u32]) -> Self {
         let mut z = [0.0; 6];
         let base = (transform_base + ix * 6) as usize;
         for i in 0..6 {
             z[i] = f32::from_bits(data[base + i]);
         }
-        Transform(z)
+        Self(z)
     }
 }
 

--- a/vello_shaders/src/lib.rs
+++ b/vello_shaders/src/lib.rs
@@ -17,7 +17,32 @@
 //!
 //! [Vello]: https://github.com/linebender/vello
 
+// LINEBENDER LINT SET - lib.rs - v1
+// See https://linebender.org/wiki/canonical-lints/
+// These lints aren't included in Cargo.toml because they
+// shouldn't apply to examples and tests
+#![warn(unused_crate_dependencies)]
+#![warn(clippy::print_stdout, clippy::print_stderr)]
+// END LINEBENDER LINT SET
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+// The following lints are part of the Linebender standard set,
+// but resolving them has been deferred for now.
+// Feel free to send a PR that solves one or more of these.
+#![allow(
+    missing_debug_implementations,
+    elided_lifetimes_in_paths,
+    single_use_lifetimes,
+    unnameable_types,
+    missing_docs,
+    clippy::unseparated_literal_suffix,
+    clippy::cast_possible_truncation,
+    clippy::missing_assert_message,
+    clippy::shadow_unrelated,
+    clippy::missing_panics_doc,
+    clippy::exhaustive_enums,
+    clippy::todo,
+    clippy::print_stderr
+)]
 
 mod types;
 

--- a/vello_shaders/src/types.rs
+++ b/vello_shaders/src/types.rs
@@ -3,6 +3,11 @@
 
 //! Types that are shared between the main crate and build.
 
+// The following lints are part of the Linebender standard set,
+// but resolving them has been deferred for now.
+// Feel free to send a PR that solves one or more of these.
+#![allow(elided_lifetimes_in_paths)]
+
 /// The type of resource that will be bound to a slot in a shader.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum BindType {

--- a/vello_tests/Cargo.toml
+++ b/vello_tests/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "vello_tests"
 description = "Integration tests for Vello."
+categories = ["rendering", "graphics"]
+keywords = ["2d", "vector-graphics"]
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/vello_tests/build.rs
+++ b/vello_tests/build.rs
@@ -1,6 +1,8 @@
 // Copyright 2024 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+//! Build step.
+
 use std::env;
 
 fn main() {

--- a/vello_tests/src/compare.rs
+++ b/vello_tests/src/compare.rs
@@ -138,7 +138,7 @@ pub async fn compare_gpu_cpu(scene: Scene, mut params: TestParams) -> Result<Gpu
 
     let error_map = nv_flip::flip(cpu_flip, gpu_flip, nv_flip::DEFAULT_PIXELS_PER_DEGREE);
 
-    let pool = nv_flip::FlipPool::from_image(&error_map);
+    let pool = FlipPool::from_image(&error_map);
 
     Ok(GpuCpuComparison {
         statistics: Some(pool),

--- a/vello_tests/src/lib.rs
+++ b/vello_tests/src/lib.rs
@@ -1,6 +1,35 @@
 // Copyright 2024 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+//! Vello tests.
+
+// LINEBENDER LINT SET - lib.rs - v1
+// See https://linebender.org/wiki/canonical-lints/
+// These lints aren't included in Cargo.toml because they
+// shouldn't apply to examples and tests
+#![warn(unused_crate_dependencies)]
+#![warn(clippy::print_stdout, clippy::print_stderr)]
+// END LINEBENDER LINT SET
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+// The following lints are part of the Linebender standard set,
+// but resolving them has been deferred for now.
+// Feel free to send a PR that solves one or more of these.
+#![allow(
+    missing_debug_implementations,
+    elided_lifetimes_in_paths,
+    unreachable_pub,
+    missing_docs,
+    clippy::missing_assert_message,
+    clippy::shadow_unrelated,
+    clippy::missing_panics_doc,
+    clippy::missing_errors_doc,
+    clippy::exhaustive_enums,
+    clippy::use_self,
+    clippy::print_stderr,
+    clippy::print_stdout,
+    clippy::allow_attributes_without_reason
+)]
+
 use std::env;
 use std::fs::File;
 use std::io::ErrorKind;
@@ -165,7 +194,7 @@ pub async fn get_scene_image(params: &TestParams, scene: &Scene) -> Result<Image
 
 pub fn write_png_to_file(
     params: &TestParams,
-    out_path: &std::path::Path,
+    out_path: &Path,
     image: &Image,
     max_size_in_bytes: Option<u64>,
 ) -> Result<(), anyhow::Error> {

--- a/vello_tests/src/snapshot.rs
+++ b/vello_tests/src/snapshot.rs
@@ -4,7 +4,7 @@
 use core::fmt;
 use std::{
     env,
-    io::{self, ErrorKind},
+    io::ErrorKind,
     path::{Path, PathBuf},
 };
 
@@ -198,7 +198,7 @@ pub fn snapshot_test_image(
 
             contents.into_rgb8()
         }
-        Err(ImageError::IoError(e)) if e.kind() == io::ErrorKind::NotFound => {
+        Err(ImageError::IoError(e)) if e.kind() == ErrorKind::NotFound => {
             if env_var_relates_to("VELLO_TEST_CREATE", &params.name, params.use_cpu) {
                 if !params.use_cpu {
                     write_png_to_file(
@@ -306,7 +306,7 @@ pub fn snapshot_test_image(
 
     let error_map = nv_flip::flip(expected, rendered, nv_flip::DEFAULT_PIXELS_PER_DEGREE);
 
-    let pool = nv_flip::FlipPool::from_image(&error_map);
+    let pool = FlipPool::from_image(&error_map);
 
     Ok(Snapshot {
         statistics: Some(pool),

--- a/vello_tests/tests/emoji.rs
+++ b/vello_tests/tests/emoji.rs
@@ -3,6 +3,14 @@
 
 //! Snapshot tests for Emoji [`scenes`].
 
+// The following lints are part of the Linebender standard set,
+// but resolving them has been deferred for now.
+// Feel free to send a PR that solves one or more of these.
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::allow_attributes_without_reason
+)]
+
 use scenes::SimpleText;
 use vello::{kurbo::Affine, peniko::Fill, Scene};
 use vello_tests::{snapshot_test_sync, TestParams};

--- a/vello_tests/tests/known_issues.rs
+++ b/vello_tests/tests/known_issues.rs
@@ -3,6 +3,15 @@
 
 //! Reproductions for known bugs, to allow test driven development
 
+// The following lints are part of the Linebender standard set,
+// but resolving them has been deferred for now.
+// Feel free to send a PR that solves one or more of these.
+#![allow(
+    clippy::missing_assert_message,
+    clippy::should_panic_without_expect,
+    clippy::allow_attributes_without_reason
+)]
+
 use vello::{
     kurbo::{Affine, Rect},
     peniko::{Color, Format},

--- a/vello_tests/tests/property.rs
+++ b/vello_tests/tests/property.rs
@@ -1,6 +1,14 @@
 // Copyright 2024 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+// The following lints are part of the Linebender standard set,
+// but resolving them has been deferred for now.
+// Feel free to send a PR that solves one or more of these.
+#![allow(
+    clippy::missing_assert_message,
+    clippy::allow_attributes_without_reason
+)]
+
 use vello::kurbo::{Affine, Rect};
 use vello::peniko::{Brush, Color, Format};
 use vello::Scene;

--- a/vello_tests/tests/smoke_snapshots.rs
+++ b/vello_tests/tests/smoke_snapshots.rs
@@ -14,7 +14,7 @@ use vello_tests::{smoke_snapshot_test_sync, TestParams};
 fn filled_square(use_cpu: bool) {
     let mut scene = Scene::new();
     scene.fill(
-        vello::peniko::Fill::NonZero,
+        Fill::NonZero,
         Affine::IDENTITY,
         &Brush::Solid(Color::BLUE),
         None,
@@ -32,7 +32,7 @@ fn filled_square(use_cpu: bool) {
 fn filled_circle(use_cpu: bool) {
     let mut scene = Scene::new();
     scene.fill(
-        vello::peniko::Fill::NonZero,
+        Fill::NonZero,
         Affine::IDENTITY,
         &Brush::Solid(Color::BLUE),
         None,


### PR DESCRIPTION
Actually satisfying a good chunk of these lints is deferred and they are in various `allow` blocks.

I deleted the `clone_style_ref` function because `StyleRef` implements `Copy`.

The `rand` method `gen` has to be a raw `r#gen` until they publish a new version. They have that method renamed in [`master`](https://github.com/rust-random/rand).

Other lint based changes should be straightforward to understand.