### PR TITLE
Update to Rust 1.83

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ env:
   # version like 1.70. Note that we only specify MAJOR.MINOR and not PATCH so that bugfixes still
   # come automatically. If the version specified here is no longer the latest stable version,
   # then please feel free to submit a PR that adjusts it along with the potential clippy fixes.
-  RUST_STABLE_VER: "1.82" # In quotes because otherwise (e.g.) 1.70 would be interpreted as 1.7
+  RUST_STABLE_VER: "1.83" # In quotes because otherwise (e.g.) 1.70 would be interpreted as 1.7
   # The purpose of checking with the minimum supported Rust toolchain is to detect its staleness.
   # If the compilation fails, then the version specified here needs to be bumped up to reality.
   # Be sure to also update the rust-version property in the workspace Cargo.toml file,

--- a/vello_encoding/src/config.rs
+++ b/vello_encoding/src/config.rs
@@ -242,12 +242,12 @@ impl WorkgroupCounts {
         } else {
             path_tag_wgs
         };
-        let draw_object_wgs = (n_draw_objects + PATH_BBOX_WG - 1) / PATH_BBOX_WG;
+        let draw_object_wgs = n_draw_objects.div_ceil(PATH_BBOX_WG);
         let draw_monoid_wgs = draw_object_wgs.min(PATH_BBOX_WG);
-        let flatten_wgs = (n_path_tags + FLATTEN_WG - 1) / FLATTEN_WG;
+        let flatten_wgs = n_path_tags.div_ceil(FLATTEN_WG);
         let clip_reduce_wgs = n_clips.saturating_sub(1) / CLIP_REDUCE_WG;
-        let clip_wgs = (n_clips + CLIP_REDUCE_WG - 1) / CLIP_REDUCE_WG;
-        let path_wgs = (n_paths + PATH_BBOX_WG - 1) / PATH_BBOX_WG;
+        let clip_wgs = n_clips.div_ceil(CLIP_REDUCE_WG);
+        let path_wgs = n_paths.div_ceil(PATH_BBOX_WG);
         let width_in_bins = (width_in_tiles + 15) / 16;
         let height_in_bins = (height_in_tiles + 15) / 16;
         Self {

--- a/vello_encoding/src/glyph_cache.rs
+++ b/vello_encoding/src/glyph_cache.rs
@@ -148,7 +148,7 @@ pub(crate) struct GlyphCacheSession<'a> {
     cached_count: &'a mut usize,
 }
 
-impl<'a> GlyphCacheSession<'a> {
+impl GlyphCacheSession<'_> {
     pub(crate) fn get_or_insert(
         &mut self,
         glyph_id: u32,
@@ -246,7 +246,7 @@ pub(crate) struct HintKey<'a> {
     coords: &'a [NormalizedCoord],
 }
 
-impl<'a> HintKey<'a> {
+impl HintKey<'_> {
     fn instance(&self) -> Option<HintingInstance> {
         HintingInstance::new(self.outlines, self.size, self.coords, HINTING_OPTIONS).ok()
     }

--- a/vello_shaders/src/cpu.rs
+++ b/vello_shaders/src/cpu.rs
@@ -71,7 +71,7 @@ pub enum TypedBufGuardMut<'a, T: ?Sized> {
     Interior(RefMut<'a, T>),
 }
 
-impl<'a, T: ?Sized> Deref for TypedBufGuard<'a, T> {
+impl<T: ?Sized> Deref for TypedBufGuard<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -82,7 +82,7 @@ impl<'a, T: ?Sized> Deref for TypedBufGuard<'a, T> {
     }
 }
 
-impl<'a, T: ?Sized> Deref for TypedBufGuardMut<'a, T> {
+impl<T: ?Sized> Deref for TypedBufGuardMut<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -93,7 +93,7 @@ impl<'a, T: ?Sized> Deref for TypedBufGuardMut<'a, T> {
     }
 }
 
-impl<'a, T: ?Sized> DerefMut for TypedBufGuardMut<'a, T> {
+impl<T: ?Sized> DerefMut for TypedBufGuardMut<'_, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         match self {
             TypedBufGuardMut::Slice(s) => s,
@@ -102,7 +102,7 @@ impl<'a, T: ?Sized> DerefMut for TypedBufGuardMut<'a, T> {
     }
 }
 
-impl<'a> CpuBinding<'a> {
+impl CpuBinding<'_> {
     pub fn as_typed<T: Pod>(&self) -> TypedBufGuard<T> {
         match self {
             CpuBinding::Buffer(b) => TypedBufGuard::Slice(bytemuck::from_bytes(b)),

--- a/vello_shaders/src/cpu/binning.rs
+++ b/vello_shaders/src/cpu/binning.rs
@@ -36,10 +36,8 @@ fn binning_main(
     for wg in 0..n_wg as usize {
         let mut counts = [0; WG_SIZE];
         let mut bboxes = [[0, 0, 0, 0]; WG_SIZE];
-        let width_in_bins =
-            ((config.width_in_tiles + N_TILE_X as u32 - 1) / N_TILE_X as u32) as i32;
-        let height_in_bins =
-            ((config.height_in_tiles + N_TILE_Y as u32 - 1) / N_TILE_Y as u32) as i32;
+        let width_in_bins = config.width_in_tiles.div_ceil(N_TILE_X as u32) as i32;
+        let height_in_bins = config.height_in_tiles.div_ceil(N_TILE_Y as u32) as i32;
         for local_ix in 0..WG_SIZE {
             let element_ix = wg * WG_SIZE + local_ix;
             let mut x0 = 0;

--- a/vello_shaders/src/cpu/coarse.rs
+++ b/vello_shaders/src/cpu/coarse.rs
@@ -193,13 +193,13 @@ fn coarse_main(
 ) {
     let width_in_tiles = config.width_in_tiles;
     let height_in_tiles = config.height_in_tiles;
-    let width_in_bins = (width_in_tiles + N_TILE_X as u32 - 1) / N_TILE_X as u32;
-    let height_in_bins = (height_in_tiles + N_TILE_Y as u32 - 1) / N_TILE_Y as u32;
+    let width_in_bins = width_in_tiles.div_ceil(N_TILE_X as u32);
+    let height_in_bins = height_in_tiles.div_ceil(N_TILE_Y as u32);
     let n_bins = width_in_bins * height_in_bins;
     let bin_data_start = config.layout.bin_data_start;
     let drawtag_base = config.layout.draw_tag_base;
     let mut compacted = vec![vec![]; N_TILE];
-    let n_partitions = (config.layout.n_draw_objects + N_TILE as u32 - 1) / N_TILE as u32;
+    let n_partitions = config.layout.n_draw_objects.div_ceil(N_TILE as u32);
     for bin in 0..n_bins {
         for v in &mut compacted {
             v.clear();

--- a/vello_shaders/src/cpu/draw_leaf.rs
+++ b/vello_shaders/src/cpu/draw_leaf.rs
@@ -21,7 +21,7 @@ fn draw_leaf_main(
     info: &mut [u32],
     clip_inp: &mut [Clip],
 ) {
-    let num_blocks_total = (config.layout.n_draw_objects as usize + (WG_SIZE - 1)) / WG_SIZE;
+    let num_blocks_total = (config.layout.n_draw_objects as usize).div_ceil(WG_SIZE);
     let n_blocks_base = num_blocks_total / WG_SIZE;
     let remainder = num_blocks_total % WG_SIZE;
     let mut prefix = DrawMonoid::default();

--- a/vello_shaders/src/cpu/draw_reduce.rs
+++ b/vello_shaders/src/cpu/draw_reduce.rs
@@ -8,7 +8,7 @@ use super::{util::read_draw_tag_from_scene, CpuBinding};
 const WG_SIZE: usize = 256;
 
 fn draw_reduce_main(n_wg: u32, config: &ConfigUniform, scene: &[u32], reduced: &mut [DrawMonoid]) {
-    let num_blocks_total = (config.layout.n_draw_objects as usize + (WG_SIZE - 1)) / WG_SIZE;
+    let num_blocks_total = (config.layout.n_draw_objects as usize).div_ceil(WG_SIZE);
     let n_blocks_base = num_blocks_total / WG_SIZE;
     let remainder = num_blocks_total % WG_SIZE;
     for i in 0..n_wg as usize {

--- a/vello_shaders/src/cpu/path_count_setup.rs
+++ b/vello_shaders/src/cpu/path_count_setup.rs
@@ -9,7 +9,7 @@ const WG_SIZE: usize = 256;
 
 fn path_count_setup_main(bump: &BumpAllocators, indirect: &mut IndirectCount) {
     let lines = bump.lines;
-    indirect.count_x = (lines + (WG_SIZE as u32 - 1)) / WG_SIZE as u32;
+    indirect.count_x = lines.div_ceil(WG_SIZE as u32);
     indirect.count_y = 1;
     indirect.count_z = 1;
 }

--- a/vello_shaders/src/cpu/path_tiling_setup.rs
+++ b/vello_shaders/src/cpu/path_tiling_setup.rs
@@ -9,7 +9,7 @@ const WG_SIZE: usize = 256;
 
 fn path_tiling_setup_main(bump: &BumpAllocators, indirect: &mut IndirectCount) {
     let segments = bump.seg_counts;
-    indirect.count_x = (segments + (WG_SIZE as u32 - 1)) / WG_SIZE as u32;
+    indirect.count_x = segments.div_ceil(WG_SIZE as u32);
     indirect.count_y = 1;
     indirect.count_z = 1;
 }

--- a/vello_tests/tests/property.rs
+++ b/vello_tests/tests/property.rs
@@ -1,6 +1,8 @@
 // Copyright 2024 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+//! Simple property tests of rendered Vello scenes.
+
 // The following lints are part of the Linebender standard set,
 // but resolving them has been deferred for now.
 // Feel free to send a PR that solves one or more of these.

--- a/vello_tests/tests/regression.rs
+++ b/vello_tests/tests/regression.rs
@@ -1,6 +1,8 @@
 // Copyright 2024 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+//! Tests to ensure that certain issues which don't deserve a test scene don't regress
+
 use vello::{
     kurbo::{Affine, RoundedRect, Stroke},
     peniko::color::palette,
@@ -8,6 +10,7 @@ use vello::{
 };
 use vello_tests::{snapshot_test_sync, TestParams};
 
+/// Test created from <https://github.com/linebender/vello/issues/616>
 #[test]
 #[cfg_attr(skip_gpu_tests, ignore)]
 fn rounded_rectangle_watertight() {


### PR DESCRIPTION
Major changes are some new clippy lints and updates to existing lints.

We don't really use const, which are the other main changes from this release.