### PR TITLE
Remove `r8` permutations of shaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This is the first step towards providing richer color functionality, better hand
 - Breaking: Updated `wgpu` to 23.0.1 ([#735][], [#743][] by [@waywardmonkeys])
 - Breaking: Updated to new `peniko` and `color` is now used for all colors ([#742][] by [@waywardmonkeys])
 - Breaking: The `full` feature is no longer present as the full pipeline is now always built ([#754][] by [@waywardmonkeys])
+- The `r8` permutation of the shaders is no longer available ([#756][] by [@waywardmonkeys])
 
 ### Fixed
 
@@ -212,6 +213,7 @@ This release has an [MSRV][] of 1.75.
 [#742]: https://github.com/linebender/vello/pull/742
 [#743]: https://github.com/linebender/vello/pull/743
 [#754]: https://github.com/linebender/vello/pull/754
+[#756]: https://github.com/linebender/vello/pull/756
 
 [Unreleased]: https://github.com/linebender/vello/compare/v0.3.0...HEAD
 <!-- Note that this still comparing against 0.2.0, because 0.2.1 is a cherry-picked patch -->

--- a/vello_shaders/shader/fine.wgsl
+++ b/vello_shaders/shader/fine.wgsl
@@ -6,12 +6,6 @@
 // To enable multisampled rendering, turn on both the msaa ifdef and one of msaa8
 // or msaa16.
 
-#ifdef r8
-// The R8 variant is only available via an internal extension in Dawn native
-// (see https://dawn.googlesource.com/dawn/+/refs/heads/main/docs/tint/extensions/chromium_internal_graphite.md).
-#enable chromium_internal_graphite;
-#endif
-
 struct Tile {
     backdrop: i32,
     segments: u32,
@@ -41,11 +35,7 @@ var<storage> info: array<u32>;
 var<storage, read_write> blend_spill: array<u32>;
 
 @group(0) @binding(5)
-#ifdef r8
-var output: texture_storage_2d<r8unorm, write>;
-#else
 var output: texture_storage_2d<rgba8unorm, write>;
-#endif
 
 @group(0) @binding(6)
 var gradients: texture_2d<f32>;

--- a/vello_shaders/shader/permutations
+++ b/vello_shaders/shader/permutations
@@ -5,6 +5,3 @@ fine
 + fine_area
 + fine_msaa8: msaa msaa8
 + fine_msaa16: msaa msaa16
-+ fine_area_r8: r8
-+ fine_msaa8_r8: msaa msaa8 r8
-+ fine_msaa16_r8: msaa msaa16 r8


### PR DESCRIPTION
These aren't used and it was discussed in #755 to remove them.

Fixes #755.