### PR TITLE
Remove `buffer_labels` feature, no longer optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This is the first step towards providing richer color functionality, better hand
 - Breaking: Updated to new `peniko` and `color` is now used for all colors ([#742][] by [@waywardmonkeys])
 - Breaking: The `full` feature is no longer present as the full pipeline is now always built ([#754][] by [@waywardmonkeys])
 - The `r8` permutation of the shaders is no longer available ([#756][] by [@waywardmonkeys])
+- Breaking: The `buffer_labels` feature is no longer present as the labels are always configured ([#757][] by [@waywardmonkeys])
 
 ### Fixed
 

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -29,7 +29,7 @@ path = "src/main.rs"
 
 
 [dependencies]
-vello = { workspace = true, features = ["buffer_labels", "debug_layers"] }
+vello = { workspace = true, features = ["debug_layers"] }
 scenes = { workspace = true }
 
 anyhow = { workspace = true }

--- a/vello/Cargo.toml
+++ b/vello/Cargo.toml
@@ -22,9 +22,6 @@ default = ["wgpu"]
 # bump-allocated GPU memory.
 # TODO: Turn this into a runtime option used at resolve time and remove the feature.
 bump_estimate = ["vello_encoding/bump_estimate"]
-# Adds labels to buffers created by Vello.
-# May improve debugability at the cost of slightly higher memory usage (TODO: We should just not make these optional).
-buffer_labels = []
 wgpu = ["dep:wgpu", "dep:vello_shaders", "dep:futures-intrusive"]
 
 # Development only features

--- a/vello/src/wgpu_engine.rs
+++ b/vello/src/wgpu_engine.rs
@@ -101,13 +101,6 @@ enum MaterializedBuffer {
 
 struct BindMapBuffer {
     buffer: MaterializedBuffer,
-    #[cfg_attr(
-        not(feature = "buffer_labels"),
-        expect(
-            unused,
-            reason = "Useful for debugging; simplifies upstream to always provide this"
-        )
-    )]
     label: &'static str,
 }
 
@@ -122,7 +115,6 @@ struct BindMap {
 struct BufferProperties {
     size: u64,
     usages: BufferUsages,
-    #[cfg(feature = "buffer_labels")]
     name: &'static str,
 }
 
@@ -730,7 +722,6 @@ impl WgpuEngine {
                     let props = BufferProperties {
                         size: gpu_buf.size(),
                         usages: gpu_buf.usage(),
-                        #[cfg(feature = "buffer_labels")]
                         name: buf.label,
                     };
                     self.pool.bufs.entry(props).or_default().push(gpu_buf);
@@ -940,13 +931,6 @@ impl ResourcePool {
     fn get_buf(
         &mut self,
         size: u64,
-        #[cfg_attr(
-            not(feature = "buffer_labels"),
-            expect(
-                unused,
-                reason = "Debugging argument always present but only consumed when debugging feature enabled"
-            )
-        )]
         name: &'static str,
         usage: BufferUsages,
         device: &Device,
@@ -955,7 +939,6 @@ impl ResourcePool {
         let props = BufferProperties {
             size: rounded_size,
             usages: usage,
-            #[cfg(feature = "buffer_labels")]
             name,
         };
         if let Some(buf_vec) = self.bufs.get_mut(&props) {
@@ -964,10 +947,7 @@ impl ResourcePool {
             }
         }
         device.create_buffer(&wgpu::BufferDescriptor {
-            #[cfg(feature = "buffer_labels")]
             label: Some(name),
-            #[cfg(not(feature = "buffer_labels"))]
-            label: None,
             size: rounded_size,
             usage,
             mapped_at_creation: false,


### PR DESCRIPTION
This extra memory usage from this is tiny in comparison to even a simple use of Vello, so simplify things by removing the feature that made it optional.