### PR TITLE
Update color byte packing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ dependencies = [
 [[package]]
 name = "color"
 version = "0.1.0"
-source = "git+https://github.com/linebender/color.git?rev=bccd4050607eba830cfba3b2f39616a27500288a#bccd4050607eba830cfba3b2f39616a27500288a"
+source = "git+https://github.com/linebender/color.git?rev=a4fa61aff6c3f292b729dc409e7832e5f0166e4a#a4fa61aff6c3f292b729dc409e7832e5f0166e4a"
 dependencies = [
  "serde",
 ]
@@ -1656,7 +1656,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 [[package]]
 name = "peniko"
 version = "0.2.0"
-source = "git+https://github.com/linebender/peniko.git?rev=cb75a00#cb75a00f1915b46e65a47cbef69f693934b27629"
+source = "git+https://github.com/linebender/peniko.git?rev=d114c62#d114c6292dbcfb03e7360692198be423168a0edd"
 dependencies = [
  "color",
  "kurbo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ skrifa = "0.26.0"
 # The version of kurbo used below should be kept in sync
 # with the version of kurbo used by peniko.
 # peniko = "0.2.0"
-peniko = { version = "0.2.0", git = "https://github.com/linebender/peniko.git", rev = "cb75a00" }
+peniko = { version = "0.2.0", git = "https://github.com/linebender/peniko.git", rev = "d114c62" }
 # FIXME: This can be removed once peniko supports the schemars feature.
 kurbo = "0.11.1"
 futures-intrusive = "0.5.0"

--- a/examples/scenes/src/test_scenes.rs
+++ b/examples/scenes/src/test_scenes.rs
@@ -1796,12 +1796,7 @@ mod impls {
         ]
         .iter()
         .for_each(|c| {
-            // FIXME(color): Get rid of the to_u32 and just use the PremulRgba8
-            let b = c.premultiply().to_rgba8().to_u32().to_ne_bytes();
-            blob.push(b[3]);
-            blob.push(b[2]);
-            blob.push(b[1]);
-            blob.push(b[0]);
+            blob.extend(c.premultiply().to_rgba8().to_u8_array());
         });
         let data = Blob::new(Arc::new(blob));
         let image = Image::new(data, Format::Rgba8, 2, 2);
@@ -1844,12 +1839,7 @@ mod impls {
         ]
         .iter()
         .for_each(|c| {
-            // FIXME(color): Get rid of the to_u32 and just use the PremulRgba8
-            let b = c.premultiply().to_rgba8().to_u32().to_ne_bytes();
-            blob.push(b[3]);
-            blob.push(b[2]);
-            blob.push(b[1]);
-            blob.push(b[0]);
+            blob.extend(c.premultiply().to_rgba8().to_u8_array());
         });
         let data = Blob::new(Arc::new(blob));
         let image = Image::new(data, Format::Rgba8, 2, 2);

--- a/vello_shaders/shader/fine.wgsl
+++ b/vello_shaders/shader/fine.wgsl
@@ -921,7 +921,7 @@ fn main(
     let local_xy = vec2(f32(local_id.x * PIXELS_PER_THREAD), f32(local_id.y));
     var rgba: array<vec4<f32>, PIXELS_PER_THREAD>;
     for (var i = 0u; i < PIXELS_PER_THREAD; i += 1u) {
-        rgba[i] = unpack4x8unorm(config.base_color).wzyx;
+        rgba[i] = unpack4x8unorm(config.base_color);
     }
     var blend_stack: array<array<u32, PIXELS_PER_THREAD>, BLEND_STACK_SPLIT>;
     var clip_depth = 0u;
@@ -953,7 +953,7 @@ fn main(
             }
             case CMD_COLOR: {
                 let color = read_color(cmd_ix);
-                let fg = unpack4x8unorm(color.rgba_color).wzyx;
+                let fg = unpack4x8unorm(color.rgba_color);
                 for (var i = 0u; i < PIXELS_PER_THREAD; i += 1u) {
                     let fg_i = fg * area[i];
                     rgba[i] = rgba[i] * (1.0 - fg_i.a) + fg_i;
@@ -1044,7 +1044,7 @@ fn main(
                     let d = d_pos + d_neg - r1;
                     let alpha = scale * (erf7(inv_std_dev * (min_edge + d)) - erf7(inv_std_dev * d));
 
-                    let fg_rgba = unpack4x8unorm(blur.rgba_color).wzyx * alpha;
+                    let fg_rgba = unpack4x8unorm(blur.rgba_color) * alpha;
                     let fg_i = fg_rgba * area[i];
                     rgba[i] = rgba[i] * (1.0 - fg_i.a) + fg_i;
                 }


### PR DESCRIPTION
Colors are now packed in little-endian u32s rather than big-endian which lets us get rid of some swizzling within the shaders.

We also get to take advantage of the new `to_u8_array` functions to simplify the image creation for some tests.