### PR TITLE
Hoist base and blur color unpack4x8unorm from loop

### DIFF
--- a/vello_shaders/shader/fine.wgsl
+++ b/vello_shaders/shader/fine.wgsl
@@ -920,8 +920,9 @@ fn main(
     let xy = vec2(f32(global_id.x * PIXELS_PER_THREAD), f32(global_id.y));
     let local_xy = vec2(f32(local_id.x * PIXELS_PER_THREAD), f32(local_id.y));
     var rgba: array<vec4<f32>, PIXELS_PER_THREAD>;
+    let base_color = unpack4x8unorm(config.base_color);
     for (var i = 0u; i < PIXELS_PER_THREAD; i += 1u) {
-        rgba[i] = unpack4x8unorm(config.base_color);
+        rgba[i] = base_color;
     }
     var blend_stack: array<array<u32, PIXELS_PER_THREAD>, BLEND_STACK_SPLIT>;
     var clip_depth = 0u;
@@ -1026,6 +1027,8 @@ fn main(
 
                 let scale = 0.5 * erf7(inv_std_dev * 0.5 * (max(width, height) - 0.5 * blur.radius));
 
+                let blur_rgba = unpack4x8unorm(blur.rgba_color);
+
                 for (var i = 0u; i < PIXELS_PER_THREAD; i += 1u) {
                     // Transform fragment location to local 'uv' space of the rounded rectangle.
                     let my_xy = vec2(xy.x + f32(i), xy.y);
@@ -1044,7 +1047,7 @@ fn main(
                     let d = d_pos + d_neg - r1;
                     let alpha = scale * (erf7(inv_std_dev * (min_edge + d)) - erf7(inv_std_dev * d));
 
-                    let fg_rgba = unpack4x8unorm(blur.rgba_color) * alpha;
+                    let fg_rgba = blur_rgba * alpha;
                     let fg_i = fg_rgba * area[i];
                     rgba[i] = rgba[i] * (1.0 - fg_i.a) + fg_i;
                 }


### PR DESCRIPTION
The calls to unpack the base color for clearing a tile and the blur color for blurred box code don't need to happen within the loop and we can hoist them out to ensure that they're treated more optimally.