### PR TITLE
Don't encode empty strokes

### DIFF
--- a/vello/src/scene.rs
+++ b/vello/src/scene.rs
@@ -227,6 +227,9 @@ impl Scene {
         brush_transform: Option<Affine>,
         shape: &impl Shape,
     ) {
+        // if style.width == 0 {
+        //     return;
+        // }
         // The setting for tolerance are a compromise. For most applications,
         // shape tolerance doesn't matter, as the input is likely Bézier paths,
         // which is exact. Note that shape tolerance is hard-coded as 0.1 in
@@ -243,9 +246,14 @@ impl Scene {
 
         const GPU_STROKES: bool = true; // Set this to `true` to enable GPU-side stroking
         if GPU_STROKES {
+            if style.width == 0. {
+                return;
+            }
+
             let t = Transform::from_kurbo(&transform);
             self.encoding.encode_transform(t);
-            self.encoding.encode_stroke_style(style);
+            let encoded_stroke = self.encoding.encode_stroke_style(style);
+            debug_assert!(encoded_stroke, "Stroke width is non-zero");
 
             // We currently don't support dashing on the GPU. If the style has a dash pattern, then
             // we convert it into stroked paths on the CPU and encode those as individual draw

--- a/vello/src/scene.rs
+++ b/vello/src/scene.rs
@@ -227,9 +227,6 @@ impl Scene {
         brush_transform: Option<Affine>,
         shape: &impl Shape,
     ) {
-        // if style.width == 0 {
-        //     return;
-        // }
         // The setting for tolerance are a compromise. For most applications,
         // shape tolerance doesn't matter, as the input is likely Bézier paths,
         // which is exact. Note that shape tolerance is hard-coded as 0.1 in

--- a/vello_encoding/src/encoding.rs
+++ b/vello_encoding/src/encoding.rs
@@ -184,8 +184,17 @@ impl Encoding {
     }
 
     /// Encodes a stroke style.
-    pub fn encode_stroke_style(&mut self, stroke: &Stroke) {
-        self.encode_style(Style::from_stroke(stroke));
+    ///
+    /// Returns false if the stroke had zero width and so couldn't be encoded.
+    #[must_use]
+    pub fn encode_stroke_style(&mut self, stroke: &Stroke) -> bool {
+        let style = Style::from_stroke(stroke);
+        if let Some(style) = style {
+            self.encode_style(style);
+            true
+        } else {
+            false
+        }
     }
 
     fn encode_style(&mut self, style: Style) {

--- a/vello_encoding/src/glyph_cache.rs
+++ b/vello_encoding/src/glyph_cache.rs
@@ -65,7 +65,7 @@ impl GlyphCache {
         // TODO: we're ignoring dashing for now
         let style_bits = match style {
             Style::Fill(fill) => super::path::Style::from_fill(*fill),
-            Style::Stroke(stroke) => super::path::Style::from_stroke(stroke),
+            Style::Stroke(stroke) => super::path::Style::from_stroke(stroke)?,
         };
         let style_bits: [u32; 2] = bytemuck::cast(style_bits);
         Some(GlyphCacheSession {
@@ -175,7 +175,8 @@ impl GlyphCacheSession<'_> {
                 true
             }
             Style::Stroke(stroke) => {
-                encoding_ptr.encode_stroke_style(stroke);
+                let encoded_stroke = encoding_ptr.encode_stroke_style(stroke);
+                debug_assert!(encoded_stroke, "Stroke width is non-zero");
                 false
             }
         };

--- a/vello_tests/snapshots/stroke_width_zero.png
+++ b/vello_tests/snapshots/stroke_width_zero.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ad14a9d40ff106ee8a6476b7a4a524473489a49059cefb377454e83d1dbcab4
+size 648

--- a/vello_tests/snapshots/stroke_width_zero.png
+++ b/vello_tests/snapshots/stroke_width_zero.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d8a5e0d1651be0701ddaab297a10c521d22ecde05cd71b5b11a63c6cf51d0b13
-size 329
+oid sha256:3ff82360a2b7fdc3f7d803c62a73bbdb8f16b141eeed52e438e3486f542db558
+size 70

--- a/vello_tests/snapshots/stroke_width_zero.png
+++ b/vello_tests/snapshots/stroke_width_zero.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9ad14a9d40ff106ee8a6476b7a4a524473489a49059cefb377454e83d1dbcab4
-size 648
+oid sha256:d8a5e0d1651be0701ddaab297a10c521d22ecde05cd71b5b11a63c6cf51d0b13
+size 329

--- a/vello_tests/snapshots/text_stroke_width_zero.png
+++ b/vello_tests/snapshots/text_stroke_width_zero.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7474bb570272423a058fb16fa59e7ebab22fd949a59142c5fc6394dfbc008bcf
+size 1738

--- a/vello_tests/snapshots/text_stroke_width_zero.png
+++ b/vello_tests/snapshots/text_stroke_width_zero.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7474bb570272423a058fb16fa59e7ebab22fd949a59142c5fc6394dfbc008bcf
-size 1738
+oid sha256:b296fa047cf0e2d913f328945bf146daa2d2e7b4eea5fc509af2a9292439c737
+size 192

--- a/vello_tests/snapshots/text_stroke_width_zero.png
+++ b/vello_tests/snapshots/text_stroke_width_zero.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b296fa047cf0e2d913f328945bf146daa2d2e7b4eea5fc509af2a9292439c737
-size 192
+oid sha256:5c55b36a187e551170e375a72791878ea321ec1edb7c1a6bf69d6ca403f1ccc4
+size 68

--- a/vello_tests/tests/regression.rs
+++ b/vello_tests/tests/regression.rs
@@ -6,7 +6,7 @@
 use scenes::ImageCache;
 use vello::{
     AaConfig, Scene,
-    kurbo::{Affine, RoundedRect, Stroke},
+    kurbo::{Affine, Rect, RoundedRect, Stroke},
     peniko::{Extend, ImageQuality, color::palette},
 };
 use vello_tests::{TestParams, smoke_snapshot_test_sync, snapshot_test_sync};
@@ -42,6 +42,23 @@ fn test_data_image_roundtrip_extend_pad() {
     let mut params = TestParams::new("data_image_roundtrip", image.width, image.height);
     params.anti_aliasing = AaConfig::Area;
     smoke_snapshot_test_sync(scene, &params)
+        .unwrap()
+        .assert_mean_less_than(0.001);
+}
+
+/// Test created from <https://github.com/linebender/vello/issues/662>
+#[test]
+#[cfg_attr(skip_gpu_tests, ignore)]
+fn stroke_width_zero() {
+    let mut scene = Scene::new();
+    let stroke = Stroke::new(0.0);
+    let rect = Rect::new(10.0, 10.0, 40.0, 40.0);
+    let rect_stroke_color = palette::css::PEACH_PUFF;
+    scene.stroke(&stroke, Affine::IDENTITY, rect_stroke_color, None, &rect);
+    let mut params = TestParams::new("stroke_width_zero", 50, 50);
+    params.anti_aliasing = AaConfig::Msaa16;
+    // params.use_cpu = true;
+    snapshot_test_sync(scene, &params)
         .unwrap()
         .assert_mean_less_than(0.001);
 }

--- a/vello_tests/tests/regression.rs
+++ b/vello_tests/tests/regression.rs
@@ -4,6 +4,7 @@
 //! Tests to ensure that certain issues which don't deserve a test scene don't regress
 
 use scenes::ImageCache;
+use scenes::SimpleText;
 use vello::{
     AaConfig, Scene,
     kurbo::{Affine, Rect, RoundedRect, Stroke},
@@ -57,6 +58,33 @@ fn stroke_width_zero() {
     scene.stroke(&stroke, Affine::IDENTITY, rect_stroke_color, None, &rect);
     let mut params = TestParams::new("stroke_width_zero", 50, 50);
     params.anti_aliasing = AaConfig::Msaa16;
+    snapshot_test_sync(scene, &params)
+        .unwrap()
+        .assert_mean_less_than(0.001);
+}
+
+#[test]
+#[cfg_attr(skip_gpu_tests, ignore)]
+#[expect(clippy::cast_possible_truncation, reason = "Test code")]
+fn text_stroke_width_zero() {
+    let font_size = 12.;
+    let mut scene = Scene::new();
+    let mut simple_text = SimpleText::new();
+    simple_text.add_run(
+        &mut scene,
+        None,
+        font_size,
+        palette::css::WHITE,
+        Affine::translate((0., f64::from(font_size))),
+        None,
+        &Stroke::new(0.),
+        "Testing text",
+    );
+    let params = TestParams::new(
+        "text_stroke_width_zero",
+        (font_size * 6.) as _,
+        (font_size * 1.25).ceil() as _,
+    );
     snapshot_test_sync(scene, &params)
         .unwrap()
         .assert_mean_less_than(0.001);

--- a/vello_tests/tests/regression.rs
+++ b/vello_tests/tests/regression.rs
@@ -57,7 +57,6 @@ fn stroke_width_zero() {
     scene.stroke(&stroke, Affine::IDENTITY, rect_stroke_color, None, &rect);
     let mut params = TestParams::new("stroke_width_zero", 50, 50);
     params.anti_aliasing = AaConfig::Msaa16;
-    // params.use_cpu = true;
     snapshot_test_sync(scene, &params)
         .unwrap()
         .assert_mean_less_than(0.001);


### PR DESCRIPTION
Fixes https://github.com/linebender/vello/issues/662

I was unable to isolate why this bug originally occurs (making the stroke expansion conditional on the width being non-zero appeared to work, but artificially increasing the offset didn't change anything), as I failed to find the condition mentioned in https://github.com/linebender/vello/issues/662#issuecomment-2289723432.

However, I was able to make the fix suggested by Chad in https://github.com/linebender/vello/issues/662#issuecomment-2283730287.

This fix wouldn't apply to manually created (or GPU encoded scenes), but that's pretty much fine, as we don't really support those.