### PR TITLE
Test `DrawColor` endianness and premultiplication

### DIFF
--- a/vello_encoding/src/draw.rs
+++ b/vello_encoding/src/draw.rs
@@ -240,3 +240,26 @@ impl Monoid for DrawMonoid {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use peniko::Color;
+
+    use super::DrawColor;
+
+    #[test]
+    fn draw_color_endianness() {
+        // `DrawColor` should be packed little-endian with red the least significant byte.
+        let c = Color::from_rgba8(0x00, 0xca, 0xfe, 0xff);
+        assert_eq!(
+            bytemuck::bytes_of(&DrawColor::from(c)),
+            [0x00, 0xca, 0xfe, 0xff]
+        );
+    }
+
+    #[test]
+    fn draw_color_premultiplied() {
+        let c = Color::from_rgba8(0x00, 0xca, 0xfe, 0x00);
+        assert_eq!(DrawColor::from(c).rgba, 0);
+    }
+}

--- a/vello_encoding/src/draw.rs
+++ b/vello_encoding/src/draw.rs
@@ -250,6 +250,8 @@ mod tests {
     #[test]
     fn draw_color_endianness() {
         // `DrawColor` should be packed little-endian with red the least significant byte.
+        //
+        // If this changes intentionally, the `DrawColor` docs also need updating.
         let c = Color::from_rgba8(0x00, 0xca, 0xfe, 0xff);
         assert_eq!(
             bytemuck::bytes_of(&DrawColor::from(c)),
@@ -259,6 +261,7 @@ mod tests {
 
     #[test]
     fn draw_color_premultiplied() {
+        // If this changes intentionally, the `DrawColor` docs also need updating.
         let c = Color::from_rgba8(0x00, 0xca, 0xfe, 0x00);
         assert_eq!(DrawColor::from(c).rgba, 0);
     }


### PR DESCRIPTION
`DrawColor` docs got out of sync (see https://github.com/linebender/vello/pull/796), and could get out of sync again: the code doing the packing and the code reading it do not live in this file.

Test whether it is premultiplied for good measure.