### PR TITLE
Use an array texture for the image atlas

### DIFF
--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -523,12 +523,14 @@ impl Renderer {
         let target_proxy = ImageProxy::new(
             width,
             height,
+            1,
             ImageFormat::from_wgpu(target.format)
                 .expect("`TargetTexture` always has a supported texture format"),
         );
         let surface_proxy = ImageProxy::new(
             width,
             height,
+            1,
             ImageFormat::from_wgpu(surface.texture.format())
                 .ok_or(Error::UnsupportedSurfaceFormat)?,
         );
@@ -792,12 +794,14 @@ impl Renderer {
         let target_proxy = ImageProxy::new(
             width,
             height,
+            1,
             ImageFormat::from_wgpu(target.format)
                 .expect("`TargetTexture` always has a supported texture format"),
         );
         let surface_proxy = ImageProxy::new(
             width,
             height,
+            1,
             ImageFormat::from_wgpu(surface.texture.format())
                 .ok_or(Error::UnsupportedSurfaceFormat)?,
         );

--- a/vello/src/recording.rs
+++ b/vello/src/recording.rs
@@ -99,6 +99,8 @@ pub enum BindType {
     Image(ImageFormat),
     /// A storage image with read only access.
     ImageRead(ImageFormat),
+    /// A storage array texture with read only access.
+    ImageArrayRead(ImageFormat),
     // TODO: Uniform, Sampler, maybe others
 }
 

--- a/vello/src/render.rs
+++ b/vello/src/render.rs
@@ -136,7 +136,7 @@ impl Render {
 
         let (layout, ramps, images) = resolver.resolve(encoding, &mut packed);
         let gradient_image = if ramps.height == 0 {
-            ResourceProxy::new_image(1, 1, ImageFormat::Rgba8)
+            ResourceProxy::new_image(1, 1, 1, ImageFormat::Rgba8)
         } else {
             let data: &[u8] = bytemuck::cast_slice(ramps.data);
             ResourceProxy::Image(recording.upload_image(
@@ -147,12 +147,17 @@ impl Render {
             ))
         };
         let image_atlas = if images.images.is_empty() {
-            ImageProxy::new(1, 1, ImageFormat::Rgba8)
+            ImageProxy::new(1, 1, 1, ImageFormat::Rgba8)
         } else {
-            ImageProxy::new(images.width, images.height, ImageFormat::Rgba8)
+            ImageProxy::new(
+                images.width,
+                images.height,
+                images.layers,
+                ImageFormat::Rgba8,
+            )
         };
-        for image in images.images {
-            recording.write_image(image_atlas, image.1, image.2, image.0.clone());
+        for (image, x, y, layer) in images.images {
+            recording.write_image(image_atlas, *x, *y, *layer, image.clone());
         }
         let cpu_config =
             RenderConfig::new(&layout, params.width, params.height, &params.base_color);
@@ -459,7 +464,7 @@ impl Render {
         recording.free_resource(draw_monoid_buf);
         recording.free_resource(bin_header_buf);
         recording.free_resource(path_buf);
-        let out_image = ImageProxy::new(params.width, params.height, ImageFormat::Rgba8);
+        let out_image = ImageProxy::new(params.width, params.height, 1, ImageFormat::Rgba8);
         let blend_spill_buf = BufferProxy::new(
             buffer_sizes.blend_spill.size_in_bytes().into(),
             "vello.blend_spill",

--- a/vello/src/render.rs
+++ b/vello/src/render.rs
@@ -147,7 +147,7 @@ impl Render {
             ))
         };
         let image_atlas = if images.images.is_empty() {
-            ImageProxy::new(1, 1, 1, ImageFormat::Rgba8)
+            ImageProxy::new(1, 1, 2, ImageFormat::Rgba8)
         } else {
             ImageProxy::new(
                 images.width,

--- a/vello/src/shaders.rs
+++ b/vello/src/shaders.rs
@@ -214,7 +214,7 @@ pub(crate) fn full_shaders(
         Buffer,
         Image(ImageFormat::Rgba8),
         ImageRead(ImageFormat::Rgba8),
-        ImageRead(ImageFormat::Rgba8),
+        ImageArrayRead(ImageFormat::Rgba8),
         // Mask LUT buffer, used only when MSAA is enabled.
         BufReadOnly,
     ];

--- a/vello/src/wgpu_engine.rs
+++ b/vello/src/wgpu_engine.rs
@@ -465,7 +465,7 @@ impl WgpuEngine {
                     self.bind_map
                         .insert_image(image_proxy.id, texture, texture_view);
                 }
-                Command::WriteImage(proxy, [x, y], image) => {
+                Command::WriteImage(proxy, [x, y, layer], image) => {
                     let (texture, _) = self.bind_map.get_or_create_image(*proxy, device);
                     let format = proxy.format.to_wgpu();
                     let block_size = format
@@ -482,7 +482,11 @@ impl WgpuEngine {
                             wgpu::ImageCopyTexture {
                                 texture,
                                 mip_level: 0,
-                                origin: wgpu::Origin3d { x: *x, y: *y, z: 0 },
+                                origin: wgpu::Origin3d {
+                                    x: *x,
+                                    y: *y,
+                                    z: *layer,
+                                },
                                 aspect: TextureAspect::All,
                             },
                             wgpu::Extent3d {
@@ -496,7 +500,11 @@ impl WgpuEngine {
                             wgpu::ImageCopyTexture {
                                 texture,
                                 mip_level: 0,
-                                origin: wgpu::Origin3d { x: *x, y: *y, z: 0 },
+                                origin: wgpu::Origin3d {
+                                    x: *x,
+                                    y: *y,
+                                    z: *layer,
+                                },
                                 aspect: TextureAspect::All,
                             },
                             image.data.data(),
@@ -899,7 +907,7 @@ impl BindMap {
                     size: wgpu::Extent3d {
                         width: proxy.width,
                         height: proxy.height,
-                        depth_or_array_layers: 1,
+                        depth_or_array_layers: proxy.layers,
                     },
                     mip_level_count: 1,
                     sample_count: 1,

--- a/vello_encoding/src/image_cache.rs
+++ b/vello_encoding/src/image_cache.rs
@@ -6,22 +6,27 @@ use peniko::Image;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 
-const DEFAULT_ATLAS_SIZE: i32 = 1024;
-const MAX_ATLAS_SIZE: i32 = 8192;
+const ATLAS_SIZE: i32 = 2048;
+const MAX_ATLAS_LAYERS: u32 = 255;
 
 #[derive(Default)]
 pub struct Images<'a> {
     pub width: u32,
     pub height: u32,
-    pub images: &'a [(Image, u32, u32)],
+    pub layers: u32,
+    pub images: &'a [(Image, u32, u32, u32)],
 }
 
 pub(crate) struct ImageCache {
     atlas: AtlasAllocator,
     /// Map from image blob id to atlas location.
-    map: HashMap<u64, (u32, u32)>,
+    map: HashMap<u64, (u32, u32, u32)>,
     /// List of all allocated images with associated atlas location.
-    images: Vec<(Image, u32, u32)>,
+    images: Vec<(Image, u32, u32, u32)>,
+    /// The current layer we're resolving for
+    layer: u32,
+    /// The number of layers we use.
+    layers: u32,
 }
 
 impl Default for ImageCache {
@@ -33,9 +38,11 @@ impl Default for ImageCache {
 impl ImageCache {
     pub(crate) fn new() -> Self {
         Self {
-            atlas: AtlasAllocator::new(size2(DEFAULT_ATLAS_SIZE, DEFAULT_ATLAS_SIZE)),
+            atlas: AtlasAllocator::new(size2(ATLAS_SIZE, ATLAS_SIZE)),
+            layer: 0,
             map: Default::default(),
             images: Default::default(),
+            layers: 4,
         }
     }
 
@@ -44,37 +51,54 @@ impl ImageCache {
             width: self.atlas.size().width as u32,
             height: self.atlas.size().height as u32,
             images: &self.images,
+            layers: self.layers,
         }
-    }
-
-    pub(crate) fn bump_size(&mut self) -> bool {
-        let new_size = self.atlas.size().width * 2;
-        if new_size > MAX_ATLAS_SIZE {
-            return false;
-        }
-        self.atlas = AtlasAllocator::new(size2(new_size, new_size));
-        self.map.clear();
-        self.images.clear();
-        true
     }
 
     pub(crate) fn clear(&mut self) {
         self.atlas.clear();
         self.map.clear();
         self.images.clear();
+        self.layer = 0;
     }
 
-    pub(crate) fn get_or_insert(&mut self, image: &Image) -> Option<(u32, u32)> {
+    pub(crate) fn get_or_insert(&mut self, image: &Image) -> Option<(u32, u32, u32)> {
         match self.map.entry(image.data.id()) {
             Entry::Occupied(occupied) => Some(*occupied.get()),
             Entry::Vacant(vacant) => {
+                if image.width > ATLAS_SIZE as u32 || image.height > ATLAS_SIZE as u32 {
+                    // We currently cannot support images larger than 2048 in any axis.
+                    // We should probably still support that, but I think the fallback
+                    // might end up being a second "atlas"
+                    // We choose not to re-size the atlas in that case, because it
+                    // would add a large amount of unused data.
+                    return None;
+                }
                 let alloc = self
                     .atlas
-                    .allocate(size2(image.width as _, image.height as _))?;
+                    .allocate(size2(image.width as _, image.height as _));
+                let alloc = match alloc {
+                    Some(alloc) => alloc,
+                    None => {
+                        if self.layer >= MAX_ATLAS_LAYERS {
+                            return None;
+                        }
+                        // We implement a greedy system for layers; if we ever get an image that won't fit.
+                        self.layer += 1;
+                        if self.layer >= self.layers {
+                            self.layers = (self.layers * 2).min(MAX_ATLAS_LAYERS);
+                            debug_assert!(self.layer < self.layers);
+                        }
+                        self.atlas.clear();
+                        // This should never fail, as it's a fresh atlas
+                        self.atlas
+                            .allocate(size2(image.width as _, image.height as _))?
+                    }
+                };
                 let x = alloc.rectangle.min.x as u32;
                 let y = alloc.rectangle.min.y as u32;
-                self.images.push((image.clone(), x, y));
-                Some(*vacant.insert((x, y)))
+                self.images.push((image.clone(), x, y, self.layer));
+                Some(*vacant.insert((x, y, self.layer)))
             }
         }
     }

--- a/vello_shaders/shader/fine.wgsl
+++ b/vello_shaders/shader/fine.wgsl
@@ -45,7 +45,7 @@ var output: texture_storage_2d<rgba8unorm, write>;
 var gradients: texture_2d<f32>;
 
 @group(0) @binding(7)
-var image_atlas: texture_2d<f32>;
+var image_atlas: texture_2d_array<f32>;
 
 // MSAA-only bindings and utilities
 #ifdef msaa
@@ -1170,7 +1170,7 @@ fn main(
                                 // TODO: If the image couldn't be added to the atlas (i.e. was too big), this isn't robust
                                 let atlas_uv_clamped = clamp(atlas_uv, image.atlas_offset, atlas_max);
                                 // Nearest neighbor sampling
-                                let fg_rgba = premul_alpha(textureLoad(image_atlas, vec2<i32>(atlas_uv_clamped), image.index));
+                                let fg_rgba = premul_alpha(textureLoad(image_atlas, vec2<i32>(atlas_uv_clamped), image.index, 0));
                                 let fg_i = fg_rgba * area[i] * image.alpha;
                                 rgba[i] = rgba[i] * (1.0 - fg_i.a) + fg_i;
                             }
@@ -1192,10 +1192,10 @@ fn main(
                                 // atlas_offset are integers
                                 let uv_quad = vec4(floor(atlas_uv_clamped), ceil(atlas_uv_clamped));
                                 let uv_frac = fract(atlas_uv);
-                                let a = premul_alpha(textureLoad(image_atlas, vec2<i32>(uv_quad.xy), image.index));
-                                let b = premul_alpha(textureLoad(image_atlas, vec2<i32>(uv_quad.xw), image.index));
-                                let c = premul_alpha(textureLoad(image_atlas, vec2<i32>(uv_quad.zy), image.index));
-                                let d = premul_alpha(textureLoad(image_atlas, vec2<i32>(uv_quad.zw), image.index));
+                                let a = premul_alpha(textureLoad(image_atlas, vec2<i32>(uv_quad.xy), image.index, 0));
+                                let b = premul_alpha(textureLoad(image_atlas, vec2<i32>(uv_quad.xw), image.index, 0));
+                                let c = premul_alpha(textureLoad(image_atlas, vec2<i32>(uv_quad.zy), image.index, 0));
+                                let d = premul_alpha(textureLoad(image_atlas, vec2<i32>(uv_quad.zw), image.index, 0));
                                 // Bilinear sampling
                                 let fg_rgba = mix(mix(a, b, uv_frac.y), mix(c, d, uv_frac.y), uv_frac.x);
                                 let fg_i = fg_rgba * area[i] * image.alpha;

--- a/vello_shaders/shader/shared/ptcl.wgsl
+++ b/vello_shaders/shader/shared/ptcl.wgsl
@@ -96,6 +96,7 @@ struct CmdImage {
     matrx: vec4<f32>,
     xlat: vec2<f32>,
     atlas_offset: vec2<f32>,
+    index: i32,
     extents: vec2<f32>,
     x_extend_mode: u32,
     y_extend_mode: u32,


### PR DESCRIPTION
This has a few tradeoffs, and should probably be treated as a proof of concept only:
1) Massively increases the number of images we can support (untested...)
2) Simplifies atlas allocation complexity, as we don't need to restart to increase the allocation
3) Doesn't allow any images larger than 2048x2048 to be included (currently).
    This is not a fundamental limitation
4) Shouldn't impact compatibility, as 256 layers are supported even in `downlevel_webgl2_defaults`
5) Reduces the memory efficiency of our atlases (as we just abandon partially-filled layers)
6) The Recording level code for this is very janky. We've previously discussed wanting to significantly clean up the recording as not-fit-for-purpose.

cc @nicoburns, have you run into issues with there being too many images?

This is a potential precursor to bindless, as:
1) Bindless can potentially contain atlas allocated (although they would then need to be non-array) textures