### PR TITLE
Add transparency support to render_to_surface.

### DIFF
--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -152,6 +152,7 @@ impl ApplicationHandler for SimpleVelloApp<'_> {
                             height,
                             antialiasing_method: AaConfig::Msaa16,
                         },
+                        true,
                     )
                     .expect("failed to render to surface");
 

--- a/examples/simple_sdl2/src/main.rs
+++ b/examples/simple_sdl2/src/main.rs
@@ -86,6 +86,7 @@ fn main() {
                     height,
                     antialiasing_method: AaConfig::Msaa16,
                 },
+                true,
             )
             .expect("failed to render to surface");
 

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -573,6 +573,7 @@ impl ApplicationHandler<UserEvent> for VelloApp<'_> {
                                 &surface_texture,
                                 &render_params,
                                 self.debug,
+                                true,
                             ),
                     )
                     .expect("failed to render to surface");
@@ -586,6 +587,7 @@ impl ApplicationHandler<UserEvent> for VelloApp<'_> {
                             &self.scene,
                             &surface_texture,
                             &render_params,
+                            true,
                         )
                         .expect("failed to render to surface");
                 }

--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -502,6 +502,7 @@ impl Renderer {
         scene: &Scene,
         surface: &SurfaceTexture,
         params: &RenderParams,
+        clear: bool,
     ) -> Result<()> {
         let width = params.width;
         let height = params.height;
@@ -539,7 +540,10 @@ impl Renderer {
             vertex_buffer: None,
             resources: vec![ResourceProxy::Image(target_proxy)],
             target: surface_proxy,
-            clear_color: Some([0., 0., 0., 0.]),
+            clear_color: match clear {
+                true => Some([0., 0., 0., 0.]),
+                false => None,
+            },
         });
 
         let surface_view = surface
@@ -759,6 +763,7 @@ impl Renderer {
         surface: &SurfaceTexture,
         params: &RenderParams,
         debug_layers: DebugLayers,
+        clear: bool,
     ) -> Result<Option<BumpAllocators>> {
         if cfg!(not(feature = "debug_layers")) && !debug_layers.is_empty() {
             static HAS_WARNED: AtomicBool = AtomicBool::new(false);
@@ -808,7 +813,10 @@ impl Renderer {
             vertex_buffer: None,
             resources: vec![ResourceProxy::Image(target_proxy)],
             target: surface_proxy,
-            clear_color: Some([0., 0., 0., 0.]),
+            clear_color: match clear {
+                true => Some([0., 0., 0., 0.]),
+                false => None,
+            },
         });
 
         #[cfg(feature = "debug_layers")]
@@ -955,7 +963,7 @@ impl BlitPipeline {
             wgpu::PrimitiveTopology::TriangleList,
             wgpu::ColorTargetState {
                 format,
-                blend: None,
+                blend: Some(wgpu::BlendState::ALPHA_BLENDING),
                 write_mask: wgpu::ColorWrites::ALL,
             },
             None,


### PR DESCRIPTION
This tiny PR adds the feature suggested in #549.

It adds transparency support for `render_to_surface`, with the addition of being able to render scenes on top of already rendered stuff with this function by giving you the option to choose if you want to clear the screen before drawing via an extra argument called "clear". If the check is true, it clears the screen before drawing the scene; if it is false, it doesn't.