### PR TITLE
Custom Shading System & Vune Shading Language (v0.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2136,6 +2136,7 @@ dependencies = [
 [[package]]
 name = "rune"
 version = "0.14.0"
+source = "git+https://github.com/TheNachoBIT/rune?branch=optional-static-typing#d42f14750278f2c0d3eca359641a2764baf12048"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -2160,6 +2161,7 @@ dependencies = [
 [[package]]
 name = "rune-alloc"
 version = "0.14.0"
+source = "git+https://github.com/TheNachoBIT/rune?branch=optional-static-typing#d42f14750278f2c0d3eca359641a2764baf12048"
 dependencies = [
  "ahash",
  "pin-project",
@@ -2170,6 +2172,7 @@ dependencies = [
 [[package]]
 name = "rune-alloc-macros"
 version = "0.14.0"
+source = "git+https://github.com/TheNachoBIT/rune?branch=optional-static-typing#d42f14750278f2c0d3eca359641a2764baf12048"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2179,6 +2182,7 @@ dependencies = [
 [[package]]
 name = "rune-core"
 version = "0.14.0"
+source = "git+https://github.com/TheNachoBIT/rune?branch=optional-static-typing#d42f14750278f2c0d3eca359641a2764baf12048"
 dependencies = [
  "musli",
  "rune-alloc",
@@ -2189,6 +2193,7 @@ dependencies = [
 [[package]]
 name = "rune-macros"
 version = "0.14.0"
+source = "git+https://github.com/TheNachoBIT/rune?branch=optional-static-typing#d42f14750278f2c0d3eca359641a2764baf12048"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2199,6 +2204,7 @@ dependencies = [
 [[package]]
 name = "rune-tracing"
 version = "0.14.0"
+source = "git+https://github.com/TheNachoBIT/rune?branch=optional-static-typing#d42f14750278f2c0d3eca359641a2764baf12048"
 dependencies = [
  "rune-tracing-macros",
 ]
@@ -2206,6 +2212,7 @@ dependencies = [
 [[package]]
 name = "rune-tracing-macros"
 version = "0.14.0"
+source = "git+https://github.com/TheNachoBIT/rune?branch=optional-static-typing#d42f14750278f2c0d3eca359641a2764baf12048"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,6 +525,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,6 +756,37 @@ dependencies = [
  "futures-core",
  "lock_api",
  "parking_lot",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+]
+
+[[package]]
+name = "generator"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bd114ceda131d3b1d665eba35788690ad37f5916457286b32ab6fd3c438dd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows",
 ]
 
 [[package]]
@@ -1172,12 +1209,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -1230,6 +1289,38 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "musli"
+version = "0.0.124"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b310b280353d9e1c92861820321f8742b02666acaf984a29cd8946965444384"
+dependencies = [
+ "loom",
+ "musli-core",
+ "serde",
+ "simdutf8",
+]
+
+[[package]]
+name = "musli-core"
+version = "0.0.124"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00e227a374e92550ce2eb5002ae116e02a43926d7243c95997138406ae4e157"
+dependencies = [
+ "musli-macros",
+]
+
+[[package]]
+name = "musli-macros"
+version = "0.0.124"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7427c9aa85c882cd4dbe712d2fcdc511db05d595f7787e6747c90cd7d67efc4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1330,6 +1421,80 @@ name = "notify-types"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1596,6 +1761,10 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "orbclient"
@@ -1614,6 +1783,12 @@ checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owned_ttf_parser"
@@ -1703,6 +1878,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1741,6 +1922,12 @@ name = "pollster"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
+name = "portable-atomic"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
 name = "ppv-lite86"
@@ -1891,8 +2078,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -1903,8 +2099,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -1929,6 +2131,85 @@ name = "run_wasm"
 version = "0.0.0"
 dependencies = [
  "cargo-run-wasm",
+]
+
+[[package]]
+name = "rune"
+version = "0.14.0"
+dependencies = [
+ "anyhow",
+ "codespan-reporting",
+ "futures-core",
+ "futures-util",
+ "itoa",
+ "memchr",
+ "musli",
+ "num",
+ "once_cell",
+ "pin-project",
+ "rune-alloc",
+ "rune-core",
+ "rune-macros",
+ "rune-tracing",
+ "ryu",
+ "serde",
+ "syntree",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rune-alloc"
+version = "0.14.0"
+dependencies = [
+ "ahash",
+ "pin-project",
+ "rune-alloc-macros",
+ "serde",
+]
+
+[[package]]
+name = "rune-alloc-macros"
+version = "0.14.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "rune-core"
+version = "0.14.0"
+dependencies = [
+ "musli",
+ "rune-alloc",
+ "serde",
+ "twox-hash",
+]
+
+[[package]]
+name = "rune-macros"
+version = "0.14.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rune-core",
+ "syn",
+]
+
+[[package]]
+name = "rune-tracing"
+version = "0.14.0"
+dependencies = [
+ "rune-tracing-macros",
+]
+
+[[package]]
+name = "rune-tracing-macros"
+version = "0.14.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2139,6 +2420,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "simple"
 version = "0.0.0"
 dependencies = [
@@ -2298,6 +2585,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntree"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00c99c9cda412afe293a6b962af651b4594161ba88c1affe7ef66459ea040a06"
+
+[[package]]
 name = "tempfile"
 version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2446,15 +2739,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2476,6 +2786,12 @@ name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
+name = "twox-hash"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7b17f197b3050ba473acf9181f7b1d3b66d1cf7356c6cc57886662276e65908"
 
 [[package]]
 name = "unicode-ident"
@@ -2527,6 +2843,7 @@ dependencies = [
  "thiserror 2.0.11",
  "vello_encoding",
  "vello_shaders",
+ "vune",
  "wgpu",
  "wgpu-profiler",
 ]
@@ -2577,6 +2894,13 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vune"
+version = "0.1.0"
+dependencies = [
+ "rune",
+]
 
 [[package]]
 name = "walkdir"
@@ -3057,6 +3381,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3064,6 +3404,12 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ clippy.wildcard_dependencies = "warn"
 vello = { version = "0.4.0", path = "vello" }
 vello_encoding = { version = "0.4.0", path = "vello_encoding" }
 vello_shaders = { version = "0.4.0", path = "vello_shaders" }
+vune = { path = "../vune/" }
 bytemuck = { version = "1.21.0", features = ["derive"] }
 skrifa = "0.26.4"
 # The version of kurbo used below should be kept in sync

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ clippy.wildcard_dependencies = "warn"
 vello = { version = "0.4.0", path = "vello" }
 vello_encoding = { version = "0.4.0", path = "vello_encoding" }
 vello_shaders = { version = "0.4.0", path = "vello_shaders" }
-vune = { path = "../vune/" }
+vune = { version = "0.1.0", path = "vune" }
 bytemuck = { version = "1.21.0", features = ["derive"] }
 skrifa = "0.26.4"
 # The version of kurbo used below should be kept in sync

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -152,6 +152,7 @@ impl ApplicationHandler for SimpleVelloApp<'_> {
                             height,
                             antialiasing_method: AaConfig::Msaa16,
                         },
+                        true,
                     )
                     .expect("failed to render to surface");
 

--- a/examples/simple_sdl2/src/main.rs
+++ b/examples/simple_sdl2/src/main.rs
@@ -86,6 +86,7 @@ fn main() {
                     height,
                     antialiasing_method: AaConfig::Msaa16,
                 },
+                true,
             )
             .expect("failed to render to surface");
 

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -570,6 +570,7 @@ impl ApplicationHandler<UserEvent> for VelloApp<'_> {
                                 &surface_texture,
                                 &render_params,
                                 self.debug,
+                                true,
                             ),
                     )
                     .expect("failed to render to surface");
@@ -583,6 +584,7 @@ impl ApplicationHandler<UserEvent> for VelloApp<'_> {
                             &self.scene,
                             &surface_texture,
                             &render_params,
+                            true,
                         )
                         .expect("failed to render to surface");
                 }

--- a/vello/Cargo.toml
+++ b/vello/Cargo.toml
@@ -44,6 +44,7 @@ workspace = true
 [dependencies]
 vello_encoding = { workspace = true }
 vello_shaders = { workspace = true, optional = true }
+vune = { workspace = true }
 bytemuck = { workspace = true }
 skrifa = { workspace = true }
 peniko = { workspace = true }

--- a/vello/src/scene.rs
+++ b/vello/src/scene.rs
@@ -24,6 +24,9 @@ use skrifa::{
 use vello_encoding::BumpAllocatorMemory;
 use vello_encoding::{Encoding, Glyph, GlyphRun, NormalizedCoord, Patch, Transform};
 
+use crate::ShaderId;
+use crate::render::WgpuVune;
+
 // TODO - Document invariants and edge cases (#470)
 // - What happens when we pass a transform matrix with NaN values to the Scene?
 // - What happens if a push_layer isn't matched by a pop_layer?
@@ -45,6 +48,7 @@ pub struct Scene {
     encoding: Encoding,
     #[cfg(feature = "bump_estimate")]
     estimator: vello_encoding::BumpEstimator,
+    pub flatten_shader: WgpuVune,
 }
 static_assertions::assert_impl_all!(Scene: Send, Sync);
 
@@ -326,6 +330,7 @@ impl From<Encoding> for Scene {
             encoding,
             #[cfg(feature = "bump_estimate")]
             estimator: vello_encoding::BumpEstimator::default(),
+            flatten_shader: WgpuVune::default(),
         }
     }
 }

--- a/vello/src/shaders.rs
+++ b/vello/src/shaders.rs
@@ -15,6 +15,8 @@ use crate::{
     Error, RendererOptions,
 };
 
+pub use vune::VuneShader;
+
 // Shaders for the full pipeline
 pub struct FullShaders {
     pub pathtag_reduce: ShaderId,
@@ -127,6 +129,16 @@ pub(crate) fn full_shaders(
         flatten,
         [Uniform, BufReadOnly, BufReadOnly, Buffer, Buffer, Buffer]
     );
+
+    // CUSTOM FLATTEN
+    // let flatten = engine.add_compute_shader(
+    //     device,
+    //     "vello.flatten",
+    //     std::borrow::Cow::Owned(flatten_shader.content()),
+    //     &[Uniform, BufReadOnly, BufReadOnly, Buffer, Buffer, Buffer],
+    //     CpuShaderType::Missing,
+    // );
+
     let draw_reduce = add_shader!(draw_reduce, [Uniform, BufReadOnly, Buffer]);
     let draw_leaf = add_shader!(
         draw_leaf,

--- a/vello_encoding/src/encoding.rs
+++ b/vello_encoding/src/encoding.rs
@@ -199,16 +199,9 @@ impl Encoding {
     /// If the given transform is different from the current one, encodes it and
     /// returns true. Otherwise, encodes nothing and returns false.
     pub fn encode_transform(&mut self, transform: Transform) -> bool {
-        if self.flags & Self::FORCE_NEXT_TRANSFORM != 0
-            || self.transforms.last() != Some(&transform)
-        {
-            self.path_tags.push(PathTag::TRANSFORM);
-            self.transforms.push(transform);
-            self.flags &= !Self::FORCE_NEXT_TRANSFORM;
-            true
-        } else {
-            false
-        }
+        self.path_tags.push(PathTag::TRANSFORM);
+        self.transforms.push(transform);
+        true
     }
 
     /// Returns an encoder for encoding a path. If `is_fill` is true, all subpaths will

--- a/vune/Cargo.toml
+++ b/vune/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "vune"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rune = { git = "https://github.com/TheNachoBIT/rune", branch = "optional-static-typing" }

--- a/vune/base_shaders/flatten.wgsl
+++ b/vune/base_shaders/flatten.wgsl
@@ -602,7 +602,7 @@ const ESPC_ROBUST_LOW_DIST = 2;
 // segments, and then computes a near-optimal flattening of the parallel curves of
 // the Euler spiral segments.
 fn flatten_euler(
-    cubic: CubicPoints,
+    cubic: core_points_CubicPoints,
     path_ix: u32,
     local_to_device: core_transform_Transform,
     offset: f32,
@@ -954,14 +954,7 @@ fn compute_tag_monoid(ix: u32) -> PathTagData {
     return PathTagData(tag_byte, tm);
 }
 
-struct CubicPoints {
-    p0: vec2f,
-    p1: vec2f,
-    p2: vec2f,
-    p3: vec2f,
-}
-
-fn read_path_segment(tag: PathTagData, is_stroke: bool) -> CubicPoints {
+fn read_path_segment(tag: PathTagData, is_stroke: bool) -> core_points_CubicPoints {
     var p0: vec2f;
     var p1: vec2f;
     var p2: vec2f;
@@ -1016,7 +1009,7 @@ fn read_path_segment(tag: PathTagData, is_stroke: bool) -> CubicPoints {
         p1 = p1 + (1.0 / 3.0) * (p0 - p1);
     }
 
-    return CubicPoints(p0, p1, p2, p3);
+    return core_points_CubicPoints(p0, p1, p2, p3);
 }
 
 // Writes a line into a the `lines` buffer at a pre-allocated location designated by `line_ix`.
@@ -1112,7 +1105,9 @@ fn main(
 
         transform = flat_main(transform);
 
-        let pts = read_path_segment(tag, is_stroke);
+        var pts = read_path_segment(tag, is_stroke);
+
+        pts = flap_main(pts);
 
         if is_stroke {
             let linewidth = bitcast<f32>(scene[config.style_base + style_ix + 1u]);

--- a/vune/base_shaders/flatten.wgsl
+++ b/vune/base_shaders/flatten.wgsl
@@ -1,0 +1,1180 @@
+// Copyright 2022 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
+
+// Flatten curves to lines
+
+// Copyright 2022 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
+
+// This must be kept in sync with `ConfigUniform` in `vello_encoding/src/config.rs`
+struct Config {
+    width_in_tiles: u32,
+    height_in_tiles: u32,
+
+    target_width: u32,
+    target_height: u32,
+
+    // The initial color applied to the pixels in a tile during the fine stage.
+    // The format is packed RGBA8 in MSB order.
+    base_color: u32,
+
+    n_drawobj: u32,
+    n_path: u32,
+    n_clip: u32,
+
+    // To reduce the number of bindings, info and bin data are combined
+    // into one buffer.
+    bin_data_start: u32,
+
+    // offsets within scene buffer (in u32 units)
+    pathtag_base: u32,
+    pathdata_base: u32,
+
+    drawtag_base: u32,
+    drawdata_base: u32,
+
+    transform_base: u32,
+    style_base: u32,
+
+    // Sizes of bump allocated buffers (in element size units)
+    lines_size: u32,
+    binning_size: u32,
+    tiles_size: u32,
+    seg_counts_size: u32,
+    segments_size: u32,
+    blend_size: u32,
+    ptcl_size: u32,
+}
+
+// Geometry of tiles and bins
+
+const TILE_WIDTH = 16u;
+const TILE_HEIGHT = 16u;
+// Number of tiles per bin
+const N_TILE_X = 16u;
+const N_TILE_Y = 16u;
+const N_TILE = N_TILE_X * N_TILE_Y;
+
+// Not currently supporting non-square tiles
+const TILE_SCALE = 0.0625;
+
+// The "split" point between using local memory in fine for the blend stack and spilling to the blend_spill buffer.
+// A higher value will increase vgpr ("register") pressure in fine, but decrease required dynamic memory allocation.
+// If changing, also change in vello_shaders/src/cpu/coarse.rs.
+const BLEND_STACK_SPLIT = 4u;
+
+// The following are computed in draw_leaf from the generic gradient parameters
+// encoded in the scene, and stored in the gradient's info struct, for
+// consumption during fine rasterization.
+
+// Radial gradient kinds
+const RAD_GRAD_KIND_CIRCULAR = 1u;
+const RAD_GRAD_KIND_STRIP = 2u;
+const RAD_GRAD_KIND_FOCAL_ON_CIRCLE = 3u;
+const RAD_GRAD_KIND_CONE = 4u;
+
+// Radial gradient flags
+const RAD_GRAD_SWAPPED = 1u;
+
+// Copyright 2022 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
+
+// The DrawMonoid is computed as a prefix sum to aid in decoding
+// the variable-length encoding of draw objects.
+struct DrawMonoid {
+    // The number of paths preceding this draw object.
+    path_ix: u32,
+    // The number of clip operations preceding this draw object.
+    clip_ix: u32,
+    // The offset of the encoded draw object in the scene (u32s).
+    scene_offset: u32,
+    // The offset of the associated info.
+    info_offset: u32,
+}
+
+// Each draw object has a 32-bit draw tag, which is a bit-packed
+// version of the draw monoid.
+const DRAWTAG_NOP = 0u;
+const DRAWTAG_FILL_COLOR = 0x44u;
+const DRAWTAG_FILL_LIN_GRADIENT = 0x114u;
+const DRAWTAG_FILL_RAD_GRADIENT = 0x29cu;
+const DRAWTAG_FILL_SWEEP_GRADIENT = 0x254u;
+const DRAWTAG_FILL_IMAGE = 0x28Cu;
+const DRAWTAG_BLURRED_ROUNDED_RECT = 0x2d4u;
+const DRAWTAG_BEGIN_CLIP = 0x9u;
+const DRAWTAG_END_CLIP = 0x21u;
+
+/// The first word of each draw info stream entry contains the flags. This is not a part of the
+/// draw object stream but get used after the draw objects have been reduced on the GPU.
+/// 0 represents a non-zero fill. 1 represents an even-odd fill.
+const DRAW_INFO_FLAGS_FILL_RULE_BIT = 1u;
+
+fn draw_monoid_identity() -> DrawMonoid {
+    return DrawMonoid();
+}
+
+fn combine_draw_monoid(a: DrawMonoid, b: DrawMonoid) -> DrawMonoid {
+    var c: DrawMonoid;
+    c.path_ix = a.path_ix + b.path_ix;
+    c.clip_ix = a.clip_ix + b.clip_ix;
+    c.scene_offset = a.scene_offset + b.scene_offset;
+    c.info_offset = a.info_offset + b.info_offset;
+    return c;
+}
+
+fn map_draw_tag(tag_word: u32) -> DrawMonoid {
+    var c: DrawMonoid;
+    c.path_ix = u32(tag_word != DRAWTAG_NOP);
+    c.clip_ix = tag_word & 1u;
+    c.scene_offset = (tag_word >> 2u) & 0x07u;
+    c.info_offset = (tag_word >> 6u) & 0x0fu;
+    return c;
+}
+
+// Copyright 2022 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
+
+struct TagMonoid {
+    trans_ix: u32,
+    // TODO: I don't think pathseg_ix is used.
+    pathseg_ix: u32,
+    pathseg_offset: u32,
+    style_ix: u32,
+    path_ix: u32,
+}
+
+const PATH_TAG_SEG_TYPE = 3u;
+const PATH_TAG_LINETO = 1u;
+const PATH_TAG_QUADTO = 2u;
+const PATH_TAG_CUBICTO = 3u;
+const PATH_TAG_F32 = 8u;
+const PATH_TAG_TRANSFORM = 0x20u;
+const PATH_TAG_PATH = 0x10u;
+const PATH_TAG_STYLE = 0x40u;
+const PATH_TAG_SUBPATH_END = 4u;
+
+// Size of the `Style` data structure in words
+const STYLE_SIZE_IN_WORDS: u32 = 2u;
+
+const STYLE_FLAGS_STYLE: u32 = 0x80000000u;
+const STYLE_FLAGS_FILL: u32 = 0x40000000u;
+const STYLE_MITER_LIMIT_MASK: u32 = 0xFFFFu;
+
+const STYLE_FLAGS_START_CAP_MASK: u32 = 0x0C000000u;
+const STYLE_FLAGS_END_CAP_MASK: u32 = 0x03000000u;
+
+const STYLE_FLAGS_CAP_BUTT: u32 = 0u;
+const STYLE_FLAGS_CAP_SQUARE: u32 = 0x01000000u;
+const STYLE_FLAGS_CAP_ROUND: u32 = 0x02000000u;
+
+const STYLE_FLAGS_JOIN_MASK: u32 = 0x30000000u;
+const STYLE_FLAGS_JOIN_BEVEL: u32 = 0u;
+const STYLE_FLAGS_JOIN_MITER: u32 = 0x10000000u;
+const STYLE_FLAGS_JOIN_ROUND: u32 = 0x20000000u;
+
+// TODO: Declare the remaining STYLE flags here.
+
+fn tag_monoid_identity() -> TagMonoid {
+    return TagMonoid();
+}
+
+fn combine_tag_monoid(a: TagMonoid, b: TagMonoid) -> TagMonoid {
+    var c: TagMonoid;
+    c.trans_ix = a.trans_ix + b.trans_ix;
+    c.pathseg_ix = a.pathseg_ix + b.pathseg_ix;
+    c.pathseg_offset = a.pathseg_offset + b.pathseg_offset;
+    c.style_ix = a.style_ix + b.style_ix;
+    c.path_ix = a.path_ix + b.path_ix;
+    return c;
+}
+
+fn reduce_tag(tag_word: u32) -> TagMonoid {
+    var c: TagMonoid;
+    let point_count = tag_word & 0x3030303u;
+    c.pathseg_ix = countOneBits((point_count * 7u) & 0x4040404u);
+    c.trans_ix = countOneBits(tag_word & (PATH_TAG_TRANSFORM * 0x1010101u));
+    let n_points = point_count + ((tag_word >> 2u) & 0x1010101u);
+    var a = n_points + (n_points & (((tag_word >> 3u) & 0x1010101u) * 15u));
+    a += a >> 8u;
+    a += a >> 16u;
+    c.pathseg_offset = a & 0xffu;
+    c.path_ix = countOneBits(tag_word & (PATH_TAG_PATH * 0x1010101u));
+    c.style_ix = countOneBits(tag_word & (PATH_TAG_STYLE * 0x1010101u)) * STYLE_SIZE_IN_WORDS;
+    return c;
+}
+
+// Copyright 2022 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
+
+// Segments laid out for contiguous storage
+struct Segment {
+    // Points are relative to tile origin
+    point0: vec2<f32>,
+    point1: vec2<f32>,
+    y_edge: f32,
+}
+
+// A line segment produced by flattening and ready for rasterization.
+//
+// The name is perhaps too playful, but reflects the fact that these
+// lines are completely unordered. They will flow through coarse path
+// rasterization, then the per-tile segments will be scatter-written into
+// segment storage so that each (tile, path) tuple gets a contiguous
+// slice of segments.
+struct LineSoup {
+    path_ix: u32,
+    // Note: this creates an alignment gap. Don't worry about
+    // this now, but maybe move to scalars.
+    p0: vec2<f32>,
+    p1: vec2<f32>,
+}
+
+// An intermediate data structure for sorting tile segments.
+struct SegmentCount {
+    // Reference to element of LineSoup array
+    line_ix: u32,
+    // Two count values packed into a single u32
+    // Lower 16 bits: index of segment within line
+    // Upper 16 bits: index of segment within segment slice
+    counts: u32,
+}
+
+// Copyright 2022 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
+
+struct Cubic {
+    p0: vec2<f32>,
+    p1: vec2<f32>,
+    p2: vec2<f32>,
+    p3: vec2<f32>,
+    stroke: vec2<f32>,
+    path_ix: u32,
+    flags: u32,
+}
+
+const CUBIC_IS_STROKE = 1u;
+
+// Copyright 2022 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT OR Unlicense
+
+// Bitflags for each stage that can fail allocation.
+const STAGE_BINNING: u32 = 0x1u;
+const STAGE_TILE_ALLOC: u32 = 0x2u;
+const STAGE_FLATTEN: u32 = 0x4u;
+const STAGE_PATH_COUNT: u32 = 0x8u;
+const STAGE_COARSE: u32 = 0x10u;
+
+// This must be kept in sync with the struct in config.rs in the encoding crate.
+struct BumpAllocators {
+    // Bitmask of stages that have failed allocation.
+    failed: atomic<u32>,
+    binning: atomic<u32>,
+    ptcl: atomic<u32>,
+    tile: atomic<u32>,
+    seg_counts: atomic<u32>,
+    segments: atomic<u32>,
+    blend: atomic<u32>,
+    lines: atomic<u32>,
+}
+
+struct IndirectCount {
+    count_x: u32,
+    count_y: u32,
+    count_z: u32,
+}
+
+
+// =========================== REAL CODE ===========================
+
+@group(0) @binding(0)
+var<uniform> config: Config;
+
+@group(0) @binding(1)
+var<storage> scene: array<u32>;
+
+@group(0) @binding(2)
+var<storage> tag_monoids: array<TagMonoid>;
+
+struct AtomicPathBbox {
+    x0: atomic<i32>,
+    y0: atomic<i32>,
+    x1: atomic<i32>,
+    y1: atomic<i32>,
+    draw_flags: u32,
+    trans_ix: u32,
+}
+
+@group(0) @binding(3)
+var<storage, read_write> path_bboxes: array<AtomicPathBbox>;
+
+@group(0) @binding(4)
+var<storage, read_write> bump: BumpAllocators;
+
+@group(0) @binding(5)
+var<storage, read_write> lines: array<LineSoup>;
+
+struct SubdivResult {
+    val: f32,
+    a0: f32,
+    a2: f32,
+}
+
+const D = 0.67;
+fn approx_parabola_integral(x: f32) -> f32 {
+    return x * inverseSqrt(sqrt(1.0 - D + (D * D * D * D + 0.25 * x * x)));
+}
+
+const B = 0.39;
+fn approx_parabola_inv_integral(x: f32) -> f32 {
+    return x * sqrt(1.0 - B + (B * B + 0.5 * x * x));
+}
+
+// Functions for Euler spirals
+
+struct CubicParams {
+    th0: f32,
+    th1: f32,
+    chord_len: f32,
+    err: f32,
+}
+
+struct EulerParams {
+    th0: f32,
+    // th1 need not be explicitly stored, as it can be derived from k0 - th0
+    k0: f32,
+    k1: f32,
+    ch: f32,
+}
+
+struct EulerSeg {
+    p0: vec2f,
+    p1: vec2f,
+    params: EulerParams,
+}
+
+// Threshold below which a derivative is considered too small.
+const DERIV_THRESH: f32 = 1e-6;
+const DERIV_THRESH_SQUARED: f32 = DERIV_THRESH * DERIV_THRESH;
+// Amount to nudge t when derivative is near-zero.
+const DERIV_EPS: f32 = 1e-6;
+// Limit for subdivision of cubic Béziers.
+const SUBDIV_LIMIT: f32 = 1.0 / 65536.0;
+// Robust ESPC computation: below this value, treat curve as circular arc
+const K1_THRESH: f32 = 1e-3;
+// Robust ESPC: below this value, evaluate ES rather than parallel curve
+const DIST_THRESH: f32 = 1e-3;
+// Threshold for tangents to be considered near zero length
+const TANGENT_THRESH: f32 = 1e-6;
+
+/// Compute cubic parameters from endpoints and derivatives.
+fn cubic_from_points_derivs(p0: vec2f, p1: vec2f, q0: vec2f, q1: vec2f, dt: f32) -> CubicParams {
+    let chord = p1 - p0;
+    let chord_squared = dot(chord, chord);
+    let chord_len = sqrt(chord_squared);
+    if chord_squared < DERIV_THRESH_SQUARED {
+        let chord_err = sqrt((9. / 32.0) * (dot(q0, q0) + dot(q1, q1))) * dt;
+        return CubicParams(0.0, 0.0, DERIV_THRESH, chord_err);
+    }
+    let scale = dt / chord_squared;
+    let h0 = vec2(q0.x * chord.x + q0.y * chord.y, q0.y * chord.x - q0.x * chord.y);
+    let th0 = atan2(h0.y, h0.x);
+    let d0 = length(h0) * scale;
+    let h1 = vec2(q1.x * chord.x + q1.y * chord.y, q1.x * chord.y - q1.y * chord.x);
+    let th1 = atan2(h1.y, h1.x);
+    let d1 = length(h1) * scale;
+
+    // Estimate error of geometric Hermite interpolation to Euler spiral.
+    let cth0 = cos(th0);
+    let cth1 = cos(th1);
+    var err = 2.0;
+    if cth0 * cth1 >= 0.0 {
+        let e0 = (2. / 3.) / max(1.0 + cth0, 1e-9);
+        let e1 = (2. / 3.) / max(1.0 + cth1, 1e-9);
+        let s0 = sin(th0);
+        let s1 = sin(th1);
+        let s01 = cth0 * s1 + cth1 * s0;
+        let amin = 0.15 * (2. * e0 * s0 + 2. * e1 * s1 - e0 * e1 * s01);
+        let a = 0.15 * (2. * d0 * s0 + 2. * d1 * s1 - d0 * d1 * s01);
+        let aerr = abs(a - amin);
+        let symm = abs(th0 + th1);
+        let asymm = abs(th0 - th1);
+        let dist = length(vec2(d0 - e0, d1 - e1));
+        let symm2 = symm * symm;
+        let ctr = (4.625e-6 * symm * symm2 + 7.5e-3 * asymm) * symm2;
+        let halo = (5e-3 * symm + 7e-2 * asymm) * dist;
+        err = ctr + 1.55 * aerr + halo;
+    }
+    err *= chord_len;
+    return CubicParams(th0, th1, chord_len, err);
+}
+
+fn es_params_from_angles(th0: f32, th1: f32) -> EulerParams {
+    let k0 = th0 + th1;
+    let dth = th1 - th0;
+    let d2 = dth * dth;
+    let k2 = k0 * k0;
+    var a = 6.0;
+    a -= d2 * (1. / 70.);
+    a -= (d2 * d2) * (1. / 10780.);
+    a += (d2 * d2 * d2) * 2.769178184818219e-07;
+    let b = -0.1 + d2 * (1. / 4200.) + d2 * d2 * 1.6959677820260655e-05;
+    let c = -1. / 1400. + d2 * 6.84915970574303e-05 - k2 * 7.936475029053326e-06;
+    a += (b + c * k2) * k2;
+    let k1 = dth * a;
+
+    // calculation of chord
+    var ch = 1.0;
+    ch -= d2 * (1. / 40.);
+    ch += (d2 * d2) * 0.00034226190482569864;
+    ch -= (d2 * d2 * d2) * 1.9349474568904524e-06;
+    let b_ = -1. / 24. + d2 * 0.0024702380951963226 - d2 * d2 * 3.7297408997537985e-05;
+    let c_ = 1. / 1920. - d2 * 4.87350869747975e-05 - k2 * 3.1001936068463107e-06;
+    ch += (b_ + c_ * k2) * k2;
+    return EulerParams(th0, k0, k1, ch);
+}
+
+fn es_params_eval_th(params: EulerParams, t: f32) -> f32 {
+    return (params.k0 + 0.5 * params.k1 * (t - 1.0)) * t - params.th0;
+}
+
+// Integrate Euler spiral.
+fn integ_euler_10(k0: f32, k1: f32) -> vec2f {
+    let t1_1 = k0;
+    let t1_2 = 0.5 * k1;
+    let t2_2 = t1_1 * t1_1;
+    let t2_3 = 2. * (t1_1 * t1_2);
+    let t2_4 = t1_2 * t1_2;
+    let t3_4 = t2_2 * t1_2 + t2_3 * t1_1;
+    let t3_6 = t2_4 * t1_2;
+    let t4_4 = t2_2 * t2_2;
+    let t4_5 = 2. * (t2_2 * t2_3);
+    let t4_6 = 2. * (t2_2 * t2_4) + t2_3 * t2_3;
+    let t4_7 = 2. * (t2_3 * t2_4);
+    let t4_8 = t2_4 * t2_4;
+    let t5_6 = t4_4 * t1_2 + t4_5 * t1_1;
+    let t5_8 = t4_6 * t1_2 + t4_7 * t1_1;
+    let t6_6 = t4_4 * t2_2;
+    let t6_7 = t4_4 * t2_3 + t4_5 * t2_2;
+    let t6_8 = t4_4 * t2_4 + t4_5 * t2_3 + t4_6 * t2_2;
+    let t7_8 = t6_6 * t1_2 + t6_7 * t1_1;
+    let t8_8 = t6_6 * t2_2;
+    var u = 1.;
+    u -= (1. / 24.) * t2_2 + (1. / 160.) * t2_4;
+    u += (1. / 1920.) * t4_4 + (1. / 10752.) * t4_6 + (1. / 55296.) * t4_8;
+    u -= (1. / 322560.) * t6_6 + (1. / 1658880.) * t6_8;
+    u += (1. / 92897280.) * t8_8;
+    var v = (1. / 12.) * t1_2;
+    v -= (1. / 480.) * t3_4 + (1. / 2688.) * t3_6;
+    v += (1. / 53760.) * t5_6 + (1. / 276480.) * t5_8;
+    v -= (1. / 11612160.) * t7_8;
+    return vec2(u, v);
+}
+
+fn es_params_eval(params: EulerParams, t: f32) -> vec2f {
+    let thm = es_params_eval_th(params, t * 0.5);
+    let k0 = params.k0;
+    let k1 = params.k1;
+    let uv = integ_euler_10((k0 + k1 * (0.5 * t - 0.5)) * t, k1 * t * t);
+    let scale = t / params.ch;
+    let s = scale * sin(thm);
+    let c = scale * cos(thm);
+    let x = uv.x * c - uv.y * s;
+    let y = -uv.y * c - uv.x * s;
+    return vec2(x, y);
+}
+
+fn es_params_eval_with_offset(params: EulerParams, t: f32, offset: f32) -> vec2f {
+    let th = es_params_eval_th(params, t);
+    let v = offset * vec2f(sin(th), cos(th));
+    return es_params_eval(params, t) + v;
+}
+
+fn es_seg_from_params(p0: vec2f, p1: vec2f, params: EulerParams) -> EulerSeg {
+    return EulerSeg(p0, p1, params);
+}
+
+// Note: offset provided is scaled so that 1 = chord length
+fn es_seg_eval_with_offset(es: EulerSeg, t: f32, normalized_offset: f32) -> vec2f {
+    let chord = es.p1 - es.p0;
+    let xy = es_params_eval_with_offset(es.params, t, normalized_offset);
+    return es.p0 + vec2f(chord.x * xy.x - chord.y * xy.y, chord.x * xy.y + chord.y * xy.x);
+}
+
+fn pow_1_5_signed(x: f32) -> f32 {
+    return x * sqrt(abs(x));
+}
+
+const BREAK1: f32 = 0.8;
+const BREAK2: f32 = 1.25;
+const BREAK3: f32 = 2.1;
+const SIN_SCALE: f32 = 1.0976991822760038;
+const QUAD_A1: f32 = 0.6406;
+const QUAD_B1: f32 = -0.81;
+const QUAD_C1: f32 = 0.9148117935952064;
+const QUAD_A2: f32 = 0.5;
+const QUAD_B2: f32 = -0.156;
+const QUAD_C2: f32 = 0.16145779359520596;
+const QUAD_W1: f32 = 0.5 * QUAD_B1 / QUAD_A1;
+const QUAD_V1: f32 = 1.0 / QUAD_A1;
+const QUAD_U1: f32 = QUAD_W1 * QUAD_W1 - QUAD_C1 / QUAD_A1;
+const QUAD_W2: f32 = 0.5 * QUAD_B2 / QUAD_A2;
+const QUAD_V2: f32 = 1.0 / QUAD_A2;
+const QUAD_U2: f32 = QUAD_W2 * QUAD_W2 - QUAD_C2 / QUAD_A2;
+const FRAC_PI_4: f32 = 0.7853981633974483;
+const CBRT_9_8: f32 = 1.040041911525952;
+
+fn espc_int_approx(x: f32) -> f32 {
+    let y = abs(x);
+    var a: f32;
+    if y < BREAK1 {
+        a = sin(SIN_SCALE * y) * (1.0 / SIN_SCALE);
+    } else if y < BREAK2 {
+        a = (sqrt(8.0) / 3.0) * pow_1_5_signed(y - 1.0) + FRAC_PI_4;
+    } else {
+        let abc = select(vec3(QUAD_A2, QUAD_B2, QUAD_C2), vec3(QUAD_A1, QUAD_B1, QUAD_C1), y < BREAK3);
+        a = (abc.x * y + abc.y) * y + abc.z;
+    };
+    return a * sign(x);
+}
+
+fn espc_int_inv_approx(x: f32) -> f32 {
+    let y = abs(x);
+    var a: f32;
+    if y < 0.7010707591262915 {
+        a = asin(y * SIN_SCALE) * (1.0 / SIN_SCALE);
+    } else if y < 0.903249293595206 {
+        let b = y - FRAC_PI_4;
+        let u = pow(abs(b), 2. / 3.) * sign(b);
+        a = u * CBRT_9_8 + 1.0;
+    } else {
+        let uvw = select(vec3(QUAD_U2, QUAD_V2, QUAD_W2), vec3(QUAD_U1, QUAD_V1, QUAD_W1), y < 2.038857793595206);
+        a = sqrt(uvw.x + uvw.y * y) - uvw.z;
+    }
+    return a * sign(x);
+}
+
+struct PointDeriv {
+    point: vec2f,
+    deriv: vec2f,
+}
+
+fn eval_cubic_and_deriv(p0: vec2f, p1: vec2f, p2: vec2f, p3: vec2f, t: f32) -> PointDeriv {
+    let m = 1.0 - t;
+    let mm = m * m;
+    let mt = m * t;
+    let tt = t * t;
+    let p = p0 * (mm * m) + (p1 * (3.0 * mm) + p2 * (3.0 * mt) + p3 * tt) * t;
+    let q = (p1 - p0) * mm + (p2 - p1) * (2.0 * mt) + (p3 - p2) * tt;
+    return PointDeriv(p, q);
+}
+
+fn cubic_start_tangent(p0: vec2f, p1: vec2f, p2: vec2f, p3: vec2f) -> vec2f {
+    let EPS = 1e-12;
+    let d01 = p1 - p0;
+    let d02 = p2 - p0;
+    let d03 = p3 - p0;
+    return select(select(d03, d02, dot(d02, d02) > EPS), d01, dot(d01, d01) > EPS);
+}
+
+fn cubic_end_tangent(p0: vec2f, p1: vec2f, p2: vec2f, p3: vec2f) -> vec2f {
+    let EPS = 1e-12;
+    let d23 = p3 - p2;
+    let d13 = p3 - p1;
+    let d03 = p3 - p0;
+    return select(select(d03, d13, dot(d13, d13) > EPS), d23, dot(d23, d23) > EPS);
+}
+
+fn cubic_start_normal(p0: vec2f, p1: vec2f, p2: vec2f, p3: vec2f) -> vec2f {
+    let tangent = normalize(cubic_start_tangent(p0, p1, p2, p3));
+    return vec2(-tangent.y, tangent.x);
+}
+
+fn cubic_end_normal(p0: vec2f, p1: vec2f, p2: vec2f, p3: vec2f) -> vec2f {
+    let tangent = normalize(cubic_end_tangent(p0, p1, p2, p3));
+    return vec2(-tangent.y, tangent.x);
+}
+
+const ESPC_ROBUST_NORMAL = 0;
+const ESPC_ROBUST_LOW_K1 = 1;
+const ESPC_ROBUST_LOW_DIST = 2;
+
+// This function flattens a cubic Bézier by first converting it into Euler spiral
+// segments, and then computes a near-optimal flattening of the parallel curves of
+// the Euler spiral segments.
+fn flatten_euler(
+    cubic: CubicPoints,
+    path_ix: u32,
+    local_to_device: core_transform_Transform,
+    offset: f32,
+    start_p: vec2f,
+    end_p: vec2f,
+) {
+    var p0: vec2f;
+    var p1: vec2f;
+    var p2: vec2f;
+    var p3: vec2f;
+    var scale: f32;
+    var transform: core_transform_Transform;
+    var t_start = start_p;
+    var t_end = end_p;
+    if offset == 0. {
+        let t = local_to_device;
+        p0 = transform_apply(t, cubic.p0);
+        p1 = transform_apply(t, cubic.p1);
+        p2 = transform_apply(t, cubic.p2);
+        p3 = transform_apply(t, cubic.p3);
+        scale = 1.;
+        transform = transform_identity();
+        t_start = p0;
+        t_end = p3;
+    } else {
+        p0 = cubic.p0;
+        p1 = cubic.p1;
+        p2 = cubic.p2;
+        p3 = cubic.p3;
+
+        transform = local_to_device;
+        let mat = transform.mat;
+        scale = 0.5 * length(vec2(mat.x + mat.w, mat.y - mat.z)) +
+                length(vec2(mat.x - mat.w, mat.y + mat.z));
+    }
+
+    // Drop zero length lines. This is an exact equality test because dropping very short
+    // line segments may result in loss of watertightness.
+    if all(p0 == p1) && all(p0 == p2) && all(p0 == p3) {
+        return;
+    }
+
+    let tol = 0.25;
+    var t0_u = 0u;
+    var dt = 1.0;
+    var last_p = p0;
+    var last_q = p1 - p0;
+    if dot(last_q, last_q) < DERIV_THRESH_SQUARED {
+        last_q = eval_cubic_and_deriv(p0, p1, p2, p3, DERIV_EPS).deriv;
+    }
+    var last_t = 0.0;
+    var lp0 = t_start;
+    loop {
+        let t0 = f32(t0_u) * dt;
+        if t0 == 1.0 {
+            break;
+        }
+        var t1 = t0 + dt;
+        let this_p0 = last_p;
+        let this_q0 = last_q;
+        var this_pq1 = eval_cubic_and_deriv(p0, p1, p2, p3, t1);
+        if dot(this_pq1.deriv, this_pq1.deriv) < DERIV_THRESH_SQUARED {
+            let new_pq1 = eval_cubic_and_deriv(p0, p1, p2, p3, t1 - DERIV_EPS);
+            this_pq1.deriv = new_pq1.deriv;
+            if t1 < 1.0 {
+                this_pq1.point = new_pq1.point;
+                t1 = t1 - DERIV_EPS;
+            }
+        }
+        let actual_dt = t1 - last_t;
+        let cubic_params = cubic_from_points_derivs(this_p0, this_pq1.point, this_q0, this_pq1.deriv, actual_dt);
+        if cubic_params.err * scale <= tol || dt <= SUBDIV_LIMIT {
+            let euler_params = es_params_from_angles(cubic_params.th0, cubic_params.th1);
+            let es = es_seg_from_params(this_p0, this_pq1.point, euler_params);
+            let k0 = es.params.k0 - 0.5 * es.params.k1;
+            let k1 = es.params.k1;
+            let normalized_offset = offset / cubic_params.chord_len;
+            let dist_scaled = normalized_offset * es.params.ch;
+            let scale_multiplier = sqrt(0.125 * scale * cubic_params.chord_len / (es.params.ch * tol));
+            var a = 0.0;
+            var b = 0.0;
+            var integral = 0.0;
+            var int0 = 0.0;
+            var n_frac: f32;
+            var robust = ESPC_ROBUST_NORMAL;
+            if abs(k1) < K1_THRESH {
+                let k = es.params.k0;
+                n_frac = sqrt(abs(k * (k * dist_scaled + 1.0)));
+                robust = ESPC_ROBUST_LOW_K1;
+            } else if abs(dist_scaled) < DIST_THRESH {
+                a = k1;
+                b = k0;
+                int0 = pow_1_5_signed(b);
+                let int1 = pow_1_5_signed(a + b);
+                integral = int1 - int0;
+                n_frac = (2. / 3.) * integral / a;
+                robust = ESPC_ROBUST_LOW_DIST;
+            } else {
+                a = -2.0 * dist_scaled * k1;
+                b = -1.0 - 2.0 * dist_scaled * k0;
+                int0 = espc_int_approx(b);
+                let int1 = espc_int_approx(a + b);
+                integral = int1 - int0;
+                let k_peak = k0 - k1 * b / a;
+                let integrand_peak = sqrt(abs(k_peak * (k_peak * dist_scaled + 1.0)));
+                n_frac = integral * integrand_peak / a;
+            }
+            // Bound number of subdivisions to a reasonable number when the scale is huge.
+            // This may give slightly incorrect rendering but avoids hangs.
+            // TODO: aggressively cull to viewport
+            let n = clamp(ceil(n_frac * scale_multiplier), 1.0, 100.0);
+            for (var i = 0u; i < u32(n); i++) {
+                var lp1: vec2f;
+                if i + 1u == u32(n) && t1 == 1.0 {
+                    lp1 = t_end;
+                } else {
+                    let t = f32(i + 1u) / n;
+                    var s = t;
+                    if robust != ESPC_ROBUST_LOW_K1 {
+                        let u = integral * t + int0;
+                        var inv: f32;
+                        if robust == ESPC_ROBUST_LOW_DIST {
+                            inv = pow(abs(u), 2. / 3.) * sign(u);
+                        } else {
+                            inv = espc_int_inv_approx(u);
+                        }
+                        s = (inv - b) / a;
+                    }
+                    lp1 = es_seg_eval_with_offset(es, s, normalized_offset);
+                }
+                let l0 = select(lp1, lp0, offset >= 0.);
+                let l1 = select(lp0, lp1, offset >= 0.);
+                output_line_with_core_transform_Transform(path_ix, l0, l1, transform);
+                lp0 = lp1;
+            }
+            last_p = this_pq1.point;
+            last_q = this_pq1.deriv;
+            last_t = t1;
+            t0_u += 1u;
+            let shift = countTrailingZeros(t0_u);
+            t0_u >>= shift;
+            dt *= f32(1u << shift);
+        } else {
+            t0_u = t0_u * 2u;
+            dt *= 0.5;
+        }
+    }
+}
+
+// Flattens the circular arc that subtends the angle begin-center-end. It is assumed that
+// ||begin - center|| == ||end - center||. `begin`, `end`, and `center` are defined in the path's
+// local coordinate space.
+//
+// The direction of the arc is always a counter-clockwise (Y-down) rotation starting from `begin`,
+// towards `end`, centered at `center`, and will be subtended by `angle` (which is assumed to be
+// positive). A line segment will always be drawn from the arc's terminus to `end`, regardless of
+// `angle`.
+//
+// `begin`, `end`, center`, and `angle` should be chosen carefully to ensure a smooth arc with the
+// correct winding.
+fn flatten_arc(
+    path_ix: u32, begin: vec2f, end: vec2f, center: vec2f, angle: f32, transform: core_transform_Transform
+) {
+    var p0 = transform_apply(transform, begin);
+    var r = begin - center;
+
+    let MIN_THETA = 0.0001;
+    let tol = 0.25;
+    let radius = max(tol, length(p0 - transform_apply(transform, center)));
+    let theta = max(MIN_THETA, 2. * acos(1. - tol / radius));
+
+    // Always output at least one line so that we always draw the chord.
+    let n_lines = max(1u, u32(ceil(angle / theta)));
+
+    let c = cos(theta);
+    let s = sin(theta);
+    let rot = mat2x2(c, -s, s, c);
+
+    let line_ix = atomicAdd(&bump.lines, n_lines);
+    for (var i = 0u; i < n_lines - 1u; i += 1u) {
+        r = rot * r;
+        let p1 = transform_apply(transform, center + r);
+        write_line(line_ix + i, path_ix, p0, p1);
+        p0 = p1;
+    }
+    let p1 = transform_apply(transform, end);
+    write_line(line_ix + n_lines - 1u, path_ix, p0, p1);
+}
+
+fn draw_cap(
+    path_ix: u32, cap_style: u32, point: vec2f,
+    cap0: vec2f, cap1: vec2f, offset_tangent: vec2f,
+    transform: core_transform_Transform,
+) {
+    if cap_style == STYLE_FLAGS_CAP_ROUND {
+        flatten_arc(path_ix, cap0, cap1, point, 3.1415927, transform);
+        return;
+    }
+
+    var start = cap0;
+    var end = cap1;
+    let is_square = (cap_style == STYLE_FLAGS_CAP_SQUARE);
+    let line_ix = atomicAdd(&bump.lines, select(1u, 3u, is_square));
+    if is_square {
+        let v = offset_tangent;
+        let p0 = start + v;
+        let p1 = end + v;
+        write_line_with_core_transform_Transform(line_ix + 1u, path_ix, start, p0, transform);
+        write_line_with_core_transform_Transform(line_ix + 2u, path_ix, p1, end, transform);
+        start = p0;
+        end = p1;
+    }
+    write_line_with_core_transform_Transform(line_ix, path_ix, start, end, transform);
+}
+
+fn draw_join(
+    path_ix: u32, style_flags: u32, p0: vec2f,
+    tan_prev: vec2f, tan_next: vec2f,
+    n_prev: vec2f, n_next: vec2f,
+    transform: core_transform_Transform,
+) {
+    var front0 = p0 + n_prev;
+    let front1 = p0 + n_next;
+    var back0 = p0 - n_next;
+    let back1 = p0 - n_prev;
+
+    let cr = tan_prev.x * tan_next.y - tan_prev.y * tan_next.x;
+    let d = dot(tan_prev, tan_next);
+
+    switch style_flags & STYLE_FLAGS_JOIN_MASK {
+        case STYLE_FLAGS_JOIN_BEVEL: {
+            output_two_lines_with_core_transform_Transform(path_ix, front0, front1, back0, back1, transform);
+        }
+        case STYLE_FLAGS_JOIN_MITER: {
+            let hypot = length(vec2f(cr, d));
+            let miter_limit = unpack2x16float(style_flags & STYLE_MITER_LIMIT_MASK)[0];
+
+            var line_ix: u32;
+            if 2. * hypot < (hypot + d) * miter_limit * miter_limit && cr != 0. {
+                let is_backside = cr > 0.;
+                let fp_last = select(front0, back1, is_backside);
+                let fp_this = select(front1, back0, is_backside);
+                let p = select(front0, back0, is_backside);
+
+                let v = fp_this - fp_last;
+                let h = (tan_prev.x * v.y - tan_prev.y * v.x) / cr;
+                let miter_pt = fp_this - tan_next * h;
+
+                line_ix = atomicAdd(&bump.lines, 3u);
+                write_line_with_core_transform_Transform(line_ix, path_ix, p, miter_pt, transform);
+                line_ix += 1u;
+
+                if is_backside {
+                    back0 = miter_pt;
+                } else {
+                    front0 = miter_pt;
+                }
+            } else {
+                line_ix = atomicAdd(&bump.lines, 2u);
+            }
+            write_line_with_core_transform_Transform(line_ix, path_ix, front0, front1, transform);
+            write_line_with_core_transform_Transform(line_ix + 1u, path_ix, back0, back1, transform);
+        }
+        case STYLE_FLAGS_JOIN_ROUND: {
+            var arc0: vec2f;
+            var arc1: vec2f;
+            var other0: vec2f;
+            var other1: vec2f;
+            if cr > 0. {
+                arc0 = back0;
+                arc1 = back1;
+                other0 = front0;
+                other1 = front1;
+            } else {
+                arc0 = front0;
+                arc1 = front1;
+                other0 = back0;
+                other1 = back1;
+            }
+            flatten_arc(path_ix, arc0, arc1, p0, abs(atan2(cr, d)), transform);
+            output_line_with_core_transform_Transform(path_ix, other0, other1, transform);
+        }
+        default: {}
+    }
+}
+
+fn read_f32_point(ix: u32) -> vec2f {
+    let x = bitcast<f32>(scene[pathdata_base + ix]);
+    let y = bitcast<f32>(scene[pathdata_base + ix + 1u]);
+    return vec2(x, y);
+}
+
+fn read_i16_point(ix: u32) -> vec2f {
+    let raw = scene[pathdata_base + ix];
+    let x = f32(i32(raw << 16u) >> 16u);
+    let y = f32(i32(raw) >> 16u);
+    return vec2(x, y);
+}
+
+fn transform_identity() -> core_transform_Transform {
+    return core_transform_Transform(vec4(1., 0., 0., 1.), vec2(0.));
+}
+
+fn read_core_transform_Transform(transform_base: u32, ix: u32) -> core_transform_Transform {
+    let base = transform_base + ix * 6u;
+    let c0 = bitcast<f32>(scene[base]);
+    let c1 = bitcast<f32>(scene[base + 1u]);
+    let c2 = bitcast<f32>(scene[base + 2u]);
+    let c3 = bitcast<f32>(scene[base + 3u]);
+    let c4 = bitcast<f32>(scene[base + 4u]);
+    let c5 = bitcast<f32>(scene[base + 5u]);
+    let mat = vec4(c0, c1, c2, c3);
+    let translate = vec2(c4, c5);
+    return core_transform_Transform(mat, translate);
+}
+
+fn transform_apply(transform: core_transform_Transform, p: vec2f) -> vec2f {
+    let px = fma(transform.mat.x, p.x, fma(transform.mat.z, p.y, transform.translate.x));
+    let py = fma(transform.mat.y, p.x, fma(transform.mat.w, p.y, transform.translate.y));
+    return vec2(px, py);
+}
+
+fn round_down(x: f32) -> i32 {
+    return i32(floor(x));
+}
+
+fn round_up(x: f32) -> i32 {
+    return i32(ceil(x));
+}
+
+struct PathTagData {
+    tag_byte: u32,
+    monoid: TagMonoid,
+}
+
+fn compute_tag_monoid(ix: u32) -> PathTagData {
+    let tag_word = scene[config.pathtag_base + (ix >> 2u)];
+    let shift = (ix & 3u) * 8u;
+    var tm = reduce_tag(tag_word & ((1u << shift) - 1u));
+    // TODO: this can be a read buf overflow. Conditionalize by tag byte?
+    tm = combine_tag_monoid(tag_monoids[ix >> 2u], tm);
+    var tag_byte = (tag_word >> shift) & 0xffu;
+    // We no longer encode an initial transform and style so these
+    // are off by one.
+    // Note: an alternative would be to adjust config.transform_base and
+    // config.style_base.
+    tm.trans_ix -= 1u;
+    tm.style_ix -= STYLE_SIZE_IN_WORDS;
+    return PathTagData(tag_byte, tm);
+}
+
+struct CubicPoints {
+    p0: vec2f,
+    p1: vec2f,
+    p2: vec2f,
+    p3: vec2f,
+}
+
+fn read_path_segment(tag: PathTagData, is_stroke: bool) -> CubicPoints {
+    var p0: vec2f;
+    var p1: vec2f;
+    var p2: vec2f;
+    var p3: vec2f;
+
+    var seg_type = tag.tag_byte & PATH_TAG_SEG_TYPE;
+    let pathseg_offset = tag.monoid.pathseg_offset;
+    let is_stroke_cap_marker = is_stroke && (tag.tag_byte & PATH_TAG_SUBPATH_END) != 0u;
+    let is_open = seg_type == PATH_TAG_QUADTO;
+
+    if (tag.tag_byte & PATH_TAG_F32) != 0u {
+        p0 = read_f32_point(pathseg_offset);
+        p1 = read_f32_point(pathseg_offset + 2u);
+        if seg_type >= PATH_TAG_QUADTO {
+            p2 = read_f32_point(pathseg_offset + 4u);
+            if seg_type == PATH_TAG_CUBICTO {
+                p3 = read_f32_point(pathseg_offset + 6u);
+            }
+        }
+    } else {
+        p0 = read_i16_point(pathseg_offset);
+        p1 = read_i16_point(pathseg_offset + 1u);
+        if seg_type >= PATH_TAG_QUADTO {
+            p2 = read_i16_point(pathseg_offset + 2u);
+            if seg_type == PATH_TAG_CUBICTO {
+                p3 = read_i16_point(pathseg_offset + 3u);
+            }
+        }
+    }
+
+    if is_stroke_cap_marker && is_open {
+        // The stroke cap marker for an open path is encoded as a quadto where the p1 and p2 store
+        // the start control point of the subpath and together with p2 forms the start tangent. p0
+        // is ignored.
+        //
+        // This is encoded this way because encoding this as a lineto would require adding a moveto,
+        // which would terminate the subpath too early (by setting the SUBPATH_END on the
+        // segment preceding the cap marker). This scheme is only used for strokes.
+        p0 = p1;
+        p1 = p2;
+        seg_type = PATH_TAG_LINETO;
+    }
+
+    // Degree-raise
+    if seg_type == PATH_TAG_LINETO {
+        p3 = p1;
+        p2 = p3 + (1.0 / 3.0) * (p0 - p3);
+        p1 = p0 + (1.0 / 3.0) * (p3 - p0);
+    } else if seg_type == PATH_TAG_QUADTO {
+        p3 = p2;
+        p2 = p1 + (1.0 / 3.0) * (p2 - p1);
+        p1 = p1 + (1.0 / 3.0) * (p0 - p1);
+    }
+
+    return CubicPoints(p0, p1, p2, p3);
+}
+
+// Writes a line into a the `lines` buffer at a pre-allocated location designated by `line_ix`.
+fn write_line(line_ix: u32, path_ix: u32, p0: vec2f, p1: vec2f) {
+    bbox = vec4(min(bbox.xy, min(p0, p1)), max(bbox.zw, max(p0, p1)));
+    if line_ix < config.lines_size {
+        lines[line_ix] = LineSoup(path_ix, p0, p1);
+    }
+}
+
+fn write_line_with_core_transform_Transform(line_ix: u32, path_ix: u32, p0: vec2f, p1: vec2f, t: core_transform_Transform) {
+    let tp0 = transform_apply(t, p0);
+    let tp1 = transform_apply(t, p1);
+    write_line(line_ix, path_ix, tp0, tp1);
+}
+
+fn output_line(path_ix: u32, p0: vec2f, p1: vec2f) {
+    let line_ix = atomicAdd(&bump.lines, 1u);
+    write_line(line_ix, path_ix, p0, p1);
+}
+
+fn output_line_with_core_transform_Transform(path_ix: u32, p0: vec2f, p1: vec2f, transform: core_transform_Transform) {
+    let line_ix = atomicAdd(&bump.lines, 1u);
+    write_line_with_core_transform_Transform(line_ix, path_ix, p0, p1, transform);
+}
+
+fn output_two_lines_with_core_transform_Transform(
+    path_ix: u32,
+    p00: vec2f, p01: vec2f,
+    p10: vec2f, p11: vec2f,
+    transform: core_transform_Transform
+) {
+    let line_ix = atomicAdd(&bump.lines, 2u);
+    write_line_with_core_transform_Transform(line_ix, path_ix, p00, p01, transform);
+    write_line_with_core_transform_Transform(line_ix + 1u, path_ix, p10, p11, transform);
+}
+
+struct NeighboringSegment {
+    do_join: bool,
+
+    // Device-space start tangent vector
+    tangent: vec2f,
+}
+
+fn read_neighboring_segment(ix: u32) -> NeighboringSegment {
+    let tag = compute_tag_monoid(ix);
+    let pts = read_path_segment(tag, true);
+
+    let is_closed = (tag.tag_byte & PATH_TAG_SEG_TYPE) == PATH_TAG_LINETO;
+    let is_stroke_cap_marker = (tag.tag_byte & PATH_TAG_SUBPATH_END) != 0u;
+    let do_join = !is_stroke_cap_marker || is_closed;
+    var tangent = pts.p3 - pts.p0;
+    if !is_stroke_cap_marker {
+        tangent = cubic_start_tangent(pts.p0, pts.p1, pts.p2, pts.p3);
+    }
+    return NeighboringSegment(do_join, tangent);
+}
+
+// `pathdata_base` is decoded once and reused by helpers above.
+var<private> pathdata_base: u32;
+
+// This is the bounding box of the shape flattened by a single shader invocation. It gets modified
+// during LineSoup generation.
+var<private> bbox: vec4f;
+
+@compute @workgroup_size(256)
+fn main(
+    @builtin(global_invocation_id) global_id: vec3<u32>,
+    @builtin(local_invocation_id) local_id: vec3<u32>,
+) {
+    let ix = global_id.x;
+    pathdata_base = config.pathdata_base;
+    bbox = vec4(1e31, 1e31, -1e31, -1e31);
+
+    let tag = compute_tag_monoid(ix);
+    let path_ix = tag.monoid.path_ix;
+    let style_ix = tag.monoid.style_ix;
+    let trans_ix = tag.monoid.trans_ix;
+
+    let out = &path_bboxes[path_ix];
+    let style_flags = scene[config.style_base + style_ix];
+    // The fill bit is always set to 0 for strokes which represents a non-zero fill.
+    let draw_flags = select(DRAW_INFO_FLAGS_FILL_RULE_BIT, 0u, (style_flags & STYLE_FLAGS_FILL) == 0u);
+    if (tag.tag_byte & PATH_TAG_PATH) != 0u {
+        (*out).draw_flags = draw_flags;
+        (*out).trans_ix = trans_ix;
+    }
+    // Decode path data
+    let seg_type = tag.tag_byte & PATH_TAG_SEG_TYPE;
+    if seg_type != 0u {
+        let is_stroke = (style_flags & STYLE_FLAGS_STYLE) != 0u;
+        var transform = read_core_transform_Transform(config.transform_base, trans_ix);
+
+        transform = flat_main(transform);
+
+        let pts = read_path_segment(tag, is_stroke);
+
+        if is_stroke {
+            let linewidth = bitcast<f32>(scene[config.style_base + style_ix + 1u]);
+            let offset = 0.5 * linewidth;
+
+            let is_open = (tag.tag_byte & PATH_TAG_SEG_TYPE) != PATH_TAG_LINETO;
+            let is_stroke_cap_marker = (tag.tag_byte & PATH_TAG_SUBPATH_END) != 0u;
+            if is_stroke_cap_marker {
+                if is_open {
+                    // Draw start cap
+                    let tangent = pts.p3 - pts.p0;
+                    let offset_tangent = offset * normalize(tangent);
+                    let n = offset_tangent.yx * vec2f(-1., 1.);
+                    draw_cap(path_ix, (style_flags & STYLE_FLAGS_START_CAP_MASK) >> 2u,
+                             pts.p0, pts.p0 - n, pts.p0 + n, -offset_tangent, transform);
+                } else {
+                    // Don't draw anything if the path is closed.
+                }
+            } else {
+                // Read the neighboring segment.
+                let neighbor = read_neighboring_segment(ix + 1u);
+                var tan_start = cubic_start_tangent(pts.p0, pts.p1, pts.p2, pts.p3);
+                if dot(tan_start, tan_start) < TANGENT_THRESH * TANGENT_THRESH {
+                    tan_start = vec2(TANGENT_THRESH, 0.);
+                }
+                var tan_prev = cubic_end_tangent(pts.p0, pts.p1, pts.p2, pts.p3);
+                if dot(tan_prev, tan_prev) < TANGENT_THRESH * TANGENT_THRESH {
+                    tan_prev = vec2(TANGENT_THRESH, 0.);
+                }
+                var tan_next = neighbor.tangent;
+                if dot(tan_next, tan_next) < TANGENT_THRESH * TANGENT_THRESH {
+                    tan_next = vec2(TANGENT_THRESH, 0.);
+                }
+                let n_start = offset * normalize(vec2(-tan_start.y, tan_start.x));
+                let offset_tangent = offset * normalize(tan_prev);
+                let n_prev = offset_tangent.yx * vec2f(-1., 1.);
+                let n_next = offset * normalize(tan_next).yx * vec2f(-1., 1.);
+
+                // Render offset curves
+                flatten_euler(pts, path_ix, transform, offset, pts.p0 + n_start, pts.p3 + n_prev);
+                flatten_euler(pts, path_ix, transform, -offset, pts.p0 - n_start, pts.p3 - n_prev);
+
+                if neighbor.do_join {
+                    draw_join(path_ix, style_flags, pts.p3, tan_prev, tan_next,
+                              n_prev, n_next, transform);
+                } else {
+                    // Draw end cap.
+                    draw_cap(path_ix, (style_flags & STYLE_FLAGS_END_CAP_MASK),
+                             pts.p3, pts.p3 + n_prev, pts.p3 - n_prev, offset_tangent, transform);
+                }
+            }
+        } else {
+            let offset = 0.;
+            flatten_euler(pts, path_ix, transform, offset, pts.p0, pts.p3);
+        }
+        // Update bounding box using atomics only. Computing a monoid is a
+        // potential future optimization.
+        if bbox.z > bbox.x || bbox.w > bbox.y {
+            atomicMin(&(*out).x0, round_down(bbox.x));
+            atomicMin(&(*out).y0, round_down(bbox.y));
+            atomicMax(&(*out).x1, round_up(bbox.z));
+            atomicMax(&(*out).y1, round_up(bbox.w));
+        }
+    }
+}

--- a/vune/core/points.vune
+++ b/vune/core/points.vune
@@ -1,0 +1,6 @@
+struct CubicPoints {
+	p0: vec2f,
+	p1: vec2f,
+	p2: vec2f,
+	p3: vec2f,
+}

--- a/vune/core/transform.vune
+++ b/vune/core/transform.vune
@@ -1,0 +1,28 @@
+struct Transform {
+	mat: vec4f,
+	translate: vec2f,
+}
+
+impl Transform {
+	pub fn scale(by: f32) -> Self {
+		return Transform(
+			vec4f(by, 0.0, 0.0, by), 
+			vec2f(0.0)
+		);
+	}
+
+	pub fn then_scale(tr: Transform, by: f32) -> Self {
+		return Transform(
+			vec4f(tr.mat.x * by, tr.mat.y, tr.mat.z, tr.mat.w * by),
+			tr.translate,
+		);
+	}
+
+	pub fn get_position(tr: Transform) -> vec2f {
+		return tr.translate;
+	}
+
+	pub fn identity() -> Self {
+		return Transform::scale(1.0);
+	}
+}

--- a/vune/src/lib.rs
+++ b/vune/src/lib.rs
@@ -1,0 +1,564 @@
+use rune::ast;
+use rune::ast::{
+    Ident,
+    ByteIndex,
+    Path,
+    Pat,
+    PatPath,
+    Span,
+    Stmt::{
+        Local,
+    },
+};
+use rune::SourceId;
+use rune::parse::Parser;
+use rune::alloc::Box;
+use rune::alloc::clone::TryClone;
+
+use std::collections::HashMap;
+
+pub struct CodeGen {
+    pub content: String,
+    pub vune_path: Option<String>,
+    pub ext_content: HashMap<String, String>,
+    pub full_names: HashMap<String, String>,
+    pub current_struct_name: String,
+}
+
+pub type RuneVec<T> = rune::alloc::Vec<T>;
+
+impl CodeGen {
+    pub fn new(content: &str, vune_path: &str) -> Self {
+        let mut ext_content = HashMap::new();
+
+        ext_content.insert("core::transform".to_string(), include_str!("../core/transform.vune").to_string());
+
+        Self {
+            content: content.to_string(),
+            vune_path: match vune_path != "" {
+                true => Some(vune_path.to_string()),
+                false => None,
+            },
+            ext_content,
+            full_names: HashMap::new(),
+            current_struct_name: String::new(),
+        }
+    }
+
+    pub fn codegen_stmt(&mut self, stmt: ast::Stmt) -> String {
+        match stmt {
+            ast::Stmt::Local(l) => self.codegen_local(l),
+            ast::Stmt::Expr(e) => self.codegen_expr(e),
+            ast::Stmt::Semi(s) => self.codegen_stmt_semi(s),
+            _ => { dbg!(stmt); todo!() },
+        }
+    }
+
+    pub fn codegen_stmt_semi(&mut self, semi: ast::StmtSemi) -> String {
+        self.codegen_expr(semi.expr) + ";"
+    }
+
+    pub fn codegen_expr(&mut self, expr: ast::Expr) -> String {
+        match expr {
+            ast::Expr::Lit(ast::ExprLit { lit, .. }) => self.codegen_lit(lit),
+            ast::Expr::Binary(b) => self.codegen_binary(b),
+            ast::Expr::Path(p) => self.codegen_path(p),
+            ast::Expr::Return(r) => self.codegen_return(r),
+            ast::Expr::Assign(a) => self.codegen_assign(a),
+            ast::Expr::FieldAccess(f) => self.codegen_field_access(f),
+            ast::Expr::Call(c) => self.codegen_call(c),
+            ast::Expr::Group(g) => self.codegen_group(g),
+            ast::Expr::Unary(u) => self.codegen_unary(u),
+            _ => { dbg!(expr); todo!() },
+        }
+    }
+
+    pub fn codegen_unary(&mut self, unary: ast::ExprUnary) -> String {
+        self.codegen_unop(unary.op) + &self.codegen_expr(Box::into_inner(unary.expr))
+    }
+
+    pub fn codegen_unop(&mut self, unop: ast::UnOp) -> String {
+        match unop {
+            ast::UnOp::Neg(_) => "-".to_string(),
+            _ => { dbg!(unop); todo!() },
+        }
+    }
+
+    pub fn codegen_group(&mut self, group: ast::ExprGroup) -> String {
+        "(".to_owned() + &self.codegen_expr(Box::into_inner(group.expr)) + ")"
+    }
+
+    pub fn codegen_call(&mut self, call: ast::ExprCall) -> String {
+        self.codegen_expr(Box::into_inner(call.expr)).replace("::", "_") + 
+        "(" +
+        &self.codegen_call_args(call.args) +
+        ")"
+    }
+
+    pub fn codegen_field_access(&mut self, field: ast::ExprFieldAccess) -> String {
+        let expr = self.codegen_expr(Box::into_inner(field.expr));
+        let field = self.codegen_expr_field(field.expr_field);
+
+        expr.to_string() + "." + &field
+    }
+
+    pub fn codegen_expr_field(&mut self, expr_field: ast::ExprField) -> String {
+        match expr_field {
+            ast::ExprField::Path(p) => self.codegen_path(p),
+            ast::ExprField::LitNumber(l) => self.codegen_lit_number(l),
+            _ => todo!(),
+        }
+    }
+
+    pub fn codegen_lit_number(&mut self, lit: ast::LitNumber) -> String {
+        // TODO: add NumberSource (source)
+        self.span_to_str(lit.span)
+    }
+
+    pub fn codegen_assign(&mut self, assign: ast::ExprAssign) -> String {
+        let lhs = self.codegen_expr(Box::into_inner(assign.lhs));
+        let rhs = self.codegen_expr(Box::into_inner(assign.rhs));
+
+        lhs.to_string() + " = " + &rhs
+    }
+
+    pub fn codegen_return(&mut self, ret: ast::ExprReturn) -> String {
+        "return ".to_owned() + &self.codegen_expr(Box::into_inner(ret.expr.unwrap()))
+    }
+
+    pub fn codegen_binary(&mut self, bin: ast::ExprBinary) -> String {
+        let lhs = self.codegen_expr(Box::into_inner(bin.lhs));
+        let rhs = self.codegen_expr(Box::into_inner(bin.rhs));
+        let op = self.codegen_binary_operator(bin.op);
+
+        lhs + " " + &op + " " + &rhs
+    }
+
+    pub fn codegen_binary_operator(&mut self, op: ast::BinOp) -> String {
+        match op {
+            ast::BinOp::Add(_) => "+".to_string(),
+            ast::BinOp::Sub(_) => "-".to_string(),
+            ast::BinOp::Mul(_) => "*".to_string(),
+            ast::BinOp::Div(_) => "/".to_string(),
+            ast::BinOp::AddAssign(_) => "+=".to_string(),
+            ast::BinOp::SubAssign(_) => "-=".to_string(),
+            ast::BinOp::MulAssign(_) => "*=".to_string(),
+            ast::BinOp::DivAssign(_) => "/=".to_string(),
+            _ => todo!(),
+        }
+    }
+
+    pub fn codegen_lit(&mut self, lit: ast::Lit) -> String {
+        match lit {
+            ast::Lit::Number(l) => self.codegen_lit_number(l),
+            _ => todo!(),
+        }
+    }
+    
+    pub fn codegen_local(&mut self, local: Box<ast::Local>) -> String {
+        let local_name = self.codegen_pat(local.pat.try_clone().unwrap());
+        let local_expr = self.codegen_expr(local.expr.try_clone().unwrap());
+
+        let final_local = if local.mut_token.is_some() {
+            "var "
+        }
+        else {
+            "let "
+        };
+
+        final_local.to_owned() + &local_name + " = " + &local_expr + ";"
+    }
+
+    pub fn codegen_pat(&mut self, pat: Pat) -> String {
+        match pat {
+            ast::Pat::Path(p) => self.get_first_name_from_path(p.path),
+            ast::Pat::Binding(b) => self.codegen_pat_binding(b),
+            _ => todo!(),
+        }
+    }
+
+    pub fn codegen_pat_binding(&mut self, pb: ast::PatBinding) -> String {
+        let key = self.codegen_object_key(pb.key);
+        let pat = self.codegen_pat(Box::into_inner(pb.pat));
+
+        key + ": " + &pat
+    }
+
+    pub fn codegen_object_key(&mut self, ok: ast::ObjectKey) -> String {
+        match ok {
+            ast::ObjectKey::Path(p) => self.codegen_path(p),
+            _ => todo!(),
+        }
+    }
+
+    pub fn get_first_name_from_pat(&mut self, pat: Pat) -> String {
+        match pat {
+            rune::ast::Pat::Path(p) => self.get_first_name_from_pat_path(p),
+            _ => todo!(),
+        }
+    }
+
+    pub fn get_first_name_from_pat_path(&mut self, pat: PatPath) -> String {
+        self.get_first_name_from_path(pat.path)
+    }
+
+    pub fn get_first_name_from_path(&mut self, p: Path) -> String {
+        match p.first {
+            rune::ast::PathSegment::Ident(id) => self.ident_to_str(id, true),
+            _ => todo!(),
+        }
+    }
+
+    pub fn ident_to_str(&mut self, id: ast::Ident, full_name: bool) -> String {
+        let mut result = self.span_to_str(id.span);
+        let mut final_result = String::new();
+
+        match full_name {
+            true => { 
+                match self.full_names.get(&result) {
+                    Some(r) => final_result = r.replace("::", "_"),
+                    None => final_result = result,
+                }
+
+                final_result
+            },
+            false => result,
+        }
+    }
+
+    pub fn codegen_function(&mut self, function: ast::ItemFn, impl_name: &Option<String>) -> String {
+        let mut function_name = match impl_name {
+            Some(im) => im.replace("::", "_") + "_" + &self.ident_to_str(function.name, true),
+            None => self.ident_to_str(function.name, true),
+        };
+
+        let block = self.codegen_block(function.body, 1);
+        let args = self.codegen_args(function.args);
+
+        let mut arrow_with_type = if function.output.is_some() {
+            "-> ".to_owned() + &self.codegen_type(function.output.unwrap().1)
+        }
+        else {
+            "".to_string()
+        };
+
+        "fn ".to_owned() + &function_name + "(" + &args + ") " + &arrow_with_type + " {\n"
+            + &block +
+        "}\n"
+    }
+
+    pub fn codegen_args(&mut self, args: ast::Parenthesized<ast::FnArg, ast::Comma>) -> String {
+        let mut result = String::new();
+        let length: isize = args.parenthesized.len() as isize;
+
+        let mut count = 0;
+        for i in args.parenthesized {
+            match i.0 {
+                ast::FnArg::Pat(p) => result += &self.codegen_pat(p),
+                _ => todo!(),
+            }
+
+            if count < length - 1 {
+                result += ", ";
+                count += 1;
+            }
+        }
+
+        result
+    }
+
+    pub fn codegen_call_args(&mut self, args: ast::Parenthesized<ast::Expr, ast::Comma>) -> String {
+        let mut result = String::new();
+        let length: isize = args.parenthesized.len() as isize;
+
+        let mut count = 0;
+        for i in args.parenthesized {
+            result += &self.codegen_expr(i.0);
+
+            if count < length - 1 {
+                result += ", ";
+                count += 1;
+            }
+        }
+
+        result
+    }
+
+    pub fn get_tabs(&mut self, tabs: usize) -> String {
+        let mut result = String::new();
+
+        for _i in 0..tabs {
+            result += "    ";
+        }
+
+        result
+    }
+
+    pub fn codegen_block(&mut self, block: ast::Block, tabs: usize) -> String {
+        let mut result = String::new();
+
+        for stmt in block.statements {
+            result += &(self.get_tabs(tabs) + &self.codegen_stmt(stmt) + "\n");
+        }
+
+        result
+    }
+
+    pub fn span_to_str(&mut self, span: Span) -> String {
+        self.content[span.start.into_usize()..span.end.into_usize()].to_string()
+    }
+
+    pub fn add_file(&mut self, filename: &str, input: &str) -> String {
+        self.add_str(&std::fs::read_to_string(filename).unwrap(), input)
+    }
+
+    pub fn add_str(&mut self, add: &str, to: &str) -> String {
+        let mut res = add.to_string();
+
+        res += "\n";
+        res += to;
+
+        res
+    }
+
+    pub fn codegen_use(&mut self, use_item: ast::ItemUse) -> String {
+        let mut item_path = self.codegen_item_use_path(use_item.path);
+
+        let cont = self.ext_content.get(&item_path);
+        let sh = VuneShader::new(&cont.unwrap(), &item_path);
+
+        self.full_names.extend(sh.full_names.clone());
+
+        sh.content()
+    }
+
+    pub fn codegen_item_use_path(&mut self, use_path: ast::ItemUsePath) -> String {
+        let mut result = self.codegen_item_use_segment(use_path.first);
+
+        for i in use_path.segments {
+            result += &("::".to_owned() + &self.codegen_item_use_segment(i.1));
+        }
+
+        result
+    }
+
+    pub fn codegen_item_use_segment(&mut self, ius: ast::ItemUseSegment) -> String {
+        match ius {
+            ast::ItemUseSegment::PathSegment(p) => self.codegen_path_segment(p),
+            _ => { dbg!(ius); todo!() },
+        }
+    }
+
+    pub fn codegen_path_segment(&mut self, path_seg: ast::PathSegment) -> String {
+        match path_seg {
+            ast::PathSegment::Ident(i) => self.ident_to_str(i, true),
+            ast::PathSegment::SelfType(s) => self.codegen_self(),
+            _ => { dbg!(path_seg); todo!() },
+        }
+    }
+
+    pub fn codegen_self(&mut self) -> String {
+        self.current_struct_name.clone()
+    }
+
+    pub fn codegen_file(&mut self, file: ast::File) -> String {
+        let mut result = String::new();
+
+        for i in file.items {
+            result += &(self.codegen_item(i.0) + "\n");
+        }
+
+        result
+    }
+
+    pub fn codegen_item(&mut self, item: ast::Item) -> String {
+        match item {
+            ast::Item::Fn(f) => self.codegen_function(f, &None),
+            ast::Item::Use(u) => self.codegen_use(u),
+            ast::Item::Impl(i) => self.codegen_impl(i),
+            ast::Item::Struct(s) => self.codegen_struct(s),
+            ast::Item::MacroCall(m) => self.codegen_macro(m),
+            _ => { dbg!(item); todo!() }
+        }
+    }
+
+    pub fn codegen_macro(&mut self, macro_call: ast::MacroCall) -> String {
+        let name: &str = &self.codegen_path(macro_call.path.try_clone().unwrap());
+
+        match name {
+            "uniform" => self.codegen_uniform(macro_call),
+            _ => { dbg!(macro_call); todo!() },
+        }
+    }
+
+    pub fn codegen_uniform(&mut self, macro_call: ast::MacroCall) -> String {
+        let input_vec: &RuneVec<ast::Token> = macro_call.input.vec();
+        let mut numb_vec: RuneVec<ast::Token> = RuneVec::new();
+        numb_vec.try_push(input_vec[0]);
+
+        let mut value_vec: RuneVec<ast::Token> = RuneVec::new();
+        value_vec.try_extend_from_slice(&input_vec[2..input_vec.len()]);
+
+        let numb_stream = rune::macros::TokenStream::from(numb_vec);
+        let mut numb_parser = Parser::from_token_stream(&numb_stream, macro_call.open.span);
+        let numb_ast = numb_parser.parse::<ast::LitNumber>().unwrap();
+        let numb_codegen = self.codegen_lit_number(numb_ast);
+
+        let value_stream = rune::macros::TokenStream::from(value_vec);
+        let mut value_parser = Parser::from_token_stream(&value_stream, macro_call.open.span);
+        let value_ast = value_parser.parse::<ast::Field>().unwrap();
+        let value_codegen = self.codegen_field(value_ast);
+
+        "@group(0) @binding(".to_owned() + &numb_codegen + ")\n" +
+        "var<uniform> " + &value_codegen + ";\n"
+    }
+
+    pub fn codegen_struct(&mut self, struct_item: ast::ItemStruct) -> String {
+        let name = self.ident_to_str(struct_item.ident, false);
+
+        let mut full_name = match &self.vune_path {
+            Some(p) => p.to_owned() + "::" + &self.ident_to_str(struct_item.ident, false),
+            None => self.ident_to_str(struct_item.ident, false),
+        };
+
+        self.full_names.insert(name, full_name.clone());
+
+        "struct ".to_owned() + &full_name.replace("::", "_") + " {\n" + &self.codegen_fields_body(struct_item.body) + "}\n"
+    }
+
+    pub fn codegen_fields_body(&mut self, fields: ast::Fields) -> String {
+        let mut result = String::new();
+
+        match fields {
+            ast::Fields::Named(b) => {
+                for i in b.braced {
+                    result += &(self.get_tabs(1) + &self.codegen_field(i.0));
+
+                    match i.1 {
+                        Some(_) => result += ",\n",
+                        None => result += "\n",
+                    }
+                }
+            },
+            _ => { dbg!(fields); todo!() },
+        }
+
+        result
+    }
+
+    pub fn codegen_field(&mut self, field: ast::Field) -> String {
+        let name = self.ident_to_str(field.name, false);
+        let field_type = match field.ty {
+            Some(ft) => ": ".to_owned() + &self.codegen_type(ft.1),
+            None => "".to_string(),
+        };
+
+        name + &field_type
+    }
+
+    pub fn codegen_type(&mut self, ast_type: ast::Type) -> String {
+        match ast_type {
+            ast::Type::Path(p) => self.codegen_path(p),
+            _ => { dbg!(ast_type); todo!() },
+        }
+    }
+
+    pub fn codegen_impl(&mut self, impl_ast: ast::ItemImpl) -> String {
+
+        let mut result = String::new();
+
+        let impl_path = self.codegen_path(impl_ast.path);
+
+        self.current_struct_name = impl_path.clone();
+
+        let option_impl = Some(impl_path);
+        for i in impl_ast.functions {
+            result += &self.codegen_function(i, &option_impl);
+        }
+
+        self.current_struct_name.clear();
+
+        result
+    }
+
+    pub fn codegen_path(&mut self, p: ast::Path) -> String {
+        let mut result = self.codegen_path_segment(p.first);
+
+        for i in p.rest {
+            result += &("::".to_owned() + &self.codegen_path_segment(i.1));
+        }
+
+        result
+    }
+}
+
+pub struct VuneShader {
+    content: String,
+    vune_path: Option<String>,
+    pub full_names: HashMap<String, String>,
+}
+
+fn parse_and_codegen(input: &str, codegen: &mut CodeGen) -> (String, HashMap<String, String>) {
+    let mut parser = Parser::new(input, SourceId::empty(), false);
+
+    let mut ast = parser.parse_all::<ast::File>().unwrap();
+
+    (codegen.codegen_file(ast), codegen.full_names.clone())
+}
+
+impl VuneShader {
+    pub fn new(input: &str, vune_path: &str) -> Self {
+        let mut codegen = CodeGen::new(&input, vune_path);
+        let result = parse_and_codegen(input, &mut codegen);
+
+        Self {
+            content: result.0,
+            vune_path: match vune_path != "" {
+                true => Some(vune_path.to_string()),
+                false => None,
+            },
+            full_names: result.1,
+        }
+    }
+
+    pub fn new_main(input: &str) -> Self {
+        let file = include_str!("../base_shaders/flatten.wgsl");
+
+        let mut vune = VuneShader::new(input, "");
+
+        let cont = vune.content_mut_ref();
+        *cont = file.to_string() + "\n" + cont;
+
+        vune
+    }
+
+    pub fn new_from_file(file: &str, vune_path: &str) -> Self {
+        VuneShader::new(&std::fs::read_to_string(file).unwrap(), vune_path)
+    }
+
+    pub fn new_main_from_file(file: &str) -> Self {
+        VuneShader::new_main(&std::fs::read_to_string(file).unwrap())
+    }
+
+    pub fn content(&self) -> String {
+        self.content.clone()
+    }
+
+    pub fn content_ref(&self) -> &String {
+        &self.content
+    }
+
+    pub fn content_mut_ref(&mut self) -> &mut String {
+        &mut self.content
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        println!("{}", VuneShader::new_main_from_file("test.vune").content());
+    }
+}

--- a/vune/src/lib.rs
+++ b/vune/src/lib.rs
@@ -32,6 +32,7 @@ impl CodeGen {
         let mut ext_content = HashMap::new();
 
         ext_content.insert("core::transform".to_string(), include_str!("../core/transform.vune").to_string());
+        ext_content.insert("core::points".to_string(), include_str!("../core/points.vune").to_string());
 
         Self {
             content: content.to_string(),

--- a/vune/test.vune
+++ b/vune/test.vune
@@ -1,0 +1,17 @@
+use core::transform;
+
+struct BellaConfig {
+	delta_time: f64,
+}
+
+uniform!(0, bella_config: BellaConfig);
+
+fn flat_main(input: Transform) -> Transform {
+
+	let mut final_input = input;
+
+	// Scale objects by 3.0
+	final_input = Transform::then_scale(final_input, 3.0);
+
+	return final_input;
+}


### PR DESCRIPTION
### WARNING: At the moment, this PR contains functionality from (#801), but it'll be replaced with (#803) once that PR is approved.

This PR is a month worth of work, so this probably will be a long read lol.

# Custom Shading System

This new Shading System allows Vello to have the power of OpenGL, Vulkan, Metal, etc. when it comes to shaders, by allowing you to run custom code on the GPU for graphical purposes, similar to how Vertex & Fragment Shaders work.

Since Custom Shading overall in a Tiling Renderer is kind of unknown territory, there's a lot of questions that have to be answered.

Three of the biggest ones are:
- **How should the stages & shaders be called?**
- **What shading language should i use for these?**
- **How should the custom shaders be designed syntax-wise?**

These questions come into mind, because Vello internally **is not a Traditional Raster Renderer, but a Tiling Renderer**. So, even if you can code a system that replicates the traditional Vertex & Fragment Shader system, that design can end up introducing limitations, or forcing a situation where the system has to translate something that works well in raster, into tiling, causing potential performance drops.

**However**, that doesn't mean that you cannot make something that is "equivalent to" or "similar to". So, to make things a bit easier to design, i decided to take this approach that answers the first question:

- If paths and transforms are treated in the "Flatten" stage of Vello's pipeline, the custom shaders will be called **"Flatten Shaders"**.
- If colors and gradients are treated in the "Fine" stage, the shaders are going to be called **"Fine Shaders"**.

And so on...

I'm going in this path so i don't have to follow any sort of standard/rules that aren't made by me, that could potentially put me in a situation where i have to ask myself constantly "Should i add 'x' feature or funcionality in the Fragment/Vertex Shader? Because Fragment/Vertex Shaders don't allow it."

So now, let's go to the second question.

# The Shading Language.

Here's another big and tricky design decision i had to make, which is deciding what shading language i'll have to use for this system.

At first, i tried with WGSL being the main language, then i tried Slang, and later on a bunch of other tests... But there's one big problem that i had with every shading language that i tried using.

## None of them know about the existence of Vello.

This was a big and constant problem, because in order to connect the shaders i was writing to Vello, the shader had to understand that it will be manipulated/executed in some way by Vello's pipeline. And to do that inside of the language of choice, you had three options.

1. **Deal with it and be forced to write convoluted code in some places in order to connect to Vello properly.**
2. **Make a preprocessor that reads the content of the shader file and make modifications.**
3. **Make a compiler that compiles from (insert shading language here) to Vello-compatible (insert shading language here).**

Eventually, as Vello's system grows in power, features and capabilities. Having only a preprocessor is not going to be enough, and eventually you'll have no choice but developing option 3 sooner or later.

But even if you choose one of the options, all of them have the same problem that question number one had, which is **having to follow standards/rules that aren't made by me**.

And don't forget about **CPU fallback**... yeah, that's another problem that gets added to the mix...

So, to fix these issues & more, ladies and gentlemen, allow me to introduce:

# The Vune Shading Language.

Vune is a version of [Rune](https://github.com/rune-rs/rune) that aims to compile Vello-compatible shaders at runtime.

Vune uses Rune's parser to create an AST that can be used for Code Generation. At the moment, its only target is WGSL, but the idea is that it could also compile to Rune so it can run shaders on the CPU. This could also help in the future with the problem of having to write the same shader twice.

Vune, because of Rune, has a syntax identical to Rust, so, to put it short, its **"Rust-GPU, but it's a Just In Time Compiler for Vello shading"**.

Once a Vune Shader finishes compiling, the Shading System will inject it inside of the pipeline by replacing the default shaders with custom ones.

Despite the execution being a bit primitive as you're probably going to see in the code, it allows the custom code to have zero performance penalties of any kind.

Now, what custom shaders can you make so far?

## The Flatten Shader.

Here's the only shader type that is able to do so far, which is the Flatten Shader. This shader is the one that allows you to handle paths and transforms, similar to the Vertex Shader.

This shader contains two functions that act as entry points.

- `flat_main`, which stands for "FLAtten Transform", is the function that allows you to handle the transforms.
- `flap_main`, which stands for "FLAtten Path", is the function that allows you to handle the individual paths (curves, lines, etc.).

So far, the only one that works is `flat_main`, but `flap_main` will be implemented soon in this PR.

Here's a tiny example of a Vune Flatten Shader in action:

https://github.com/user-attachments/assets/9610ebe0-e8c4-49fa-8432-eb16fec77d2c

Vune also allows you to send custom uniforms with any type of data that you want (as long as its bytemuck compatible). Here's another example where i'm sending the mouse's position & the window's resolution to the GPU:

https://github.com/user-attachments/assets/448c66e1-0efd-40da-9607-58afae5edc3d

Flatten Shader Code:

```rs
use core::transform;

struct MouseGPU {
	x: f32,
	y: f32,
	res_x: f32,
	res_y: f32,
}

uniform!(6, mouse: MouseGPU);

fn get_distance_between(a: vec2f, b: vec2f, div_by: vec2f) -> f32 {
	return 
		pow(sqrt(b.x - a.x), 2.0) / div_by.x + 
		pow(sqrt(b.y - a.y), 2.0) / div_by.y;
}

fn flat_main(input: Transform) -> Transform {

	let mut final_input = input;

	let mouse_vec = vec2f(mouse.x, mouse.y);
	let res_vec = vec2f(mouse.res_x, mouse.res_y);
	let distance = clamp(get_distance_between(Transform::get_position(final_input), mouse_vec, res_vec), -0.5, 0.5);

	final_input = Transform::then_scale(final_input, distance);

	return final_input;
}
```

The next video will demonstrate the amount of performance you get with this system: This is a stress test that contains 5000 shapes being scaled up and down individually the closer the mouse gets. Because the GPU takes care of the transformation instead of the CPU, this scene runs at 60+ fps on a GTX 1050 Ti (i still have to test with VSync off, that's why the "+").

https://github.com/user-attachments/assets/f1b115f1-5b8e-465b-85cc-163737a758c7

These are examples that are currently made in the [Bella Engine](https://github.com/bella-project/bella), but i'll make a port of these to pure Vello as "with_winit" scenes.

# Adding a Vune Shader.

*WARNING: This API design is subject to change.*

Adding a Vune Shader is pretty easy, first, you load & compile the shader you want by using the `Renderer`'s `add_vune_shader` function.

```rs
renderer.add_vune_shader("name", "path/to/shader.vune", WgpuVuneBindings::flatten(vec![
	/* Insert custom bindings here..., or send an empty vec if you don't want to send any. */
]));
```

If you're planning to send custom data, like a struct for example, you have to set its binding:

```rs
#[repr(C)]
#[derive(bytemuck::Zeroable, Copy, Clone, bytemuck::Pod)]
struct CustomStruct {
	a: f64,
	b: f64,
}

/* ... */

renderer.add_vune_shader("name", "path/to/shader.vune", WgpuVuneBindings::flatten(vec![
	BindType::Uniform
]));
```

Once that's done, you can get its reference via `get_vune_shader`.

```rs
let my_shader = renderer.get_vune_shader("name");
```

And add it to your scene:

```rs
scene.flatten_shader.set(my_shader);
```

If you want to send the `CustomStruct` that we've made earlier to the Flatten Shader, you can use `set_uniform`.

```rs
scene.flatten_shader.set_uniform::<CustomStruct>(0, CustomStruct { a: 1.0, b: 1.0 });
```

Aaaaand that's it! You've added a Vune shader to your scene successfully :D

Now you can draw the scene and let the shading system take care of the rest.

If you want different shader types in different scenes, at the moment, you'll have to split the scenes into two draw calls for that to take effect, but in the future, that's probably not going to be necessary.

# This is heavily WIP.

There's still **A TON** to do and add before this shading system can have a "full version" of it, but for this PR, i'll stop at adding the Flatten Shader and see what to do next, because the PR is getting insanely huge to review.

# To-Do (before setting it up for review):

- [x] Implement `flap_main` for the Flatten Shader.
- [x] Ask: Are automatic bindings a good idea?
      **EDIT:** Yes, in theory, but i still have to test a bit more.
- [ ] Implement transform & path buffers.
- [ ] Upload the examples to Bella Engine.
- [ ] Port the examples to "with_winit".
- [ ] Fix custom data indexing.
- [ ] Clean up `render_full`.
- [ ] See if i can add CPU fallback.
- [ ] Add error handling to Vune.
- [ ] Document everything.
- [ ] Fix issues found by clippy.

# Finally...

I want to thank @raphlinus , @DJMcNab , @waywardmonkeys and @xorgy for helping me by answering a ton of questions and giving support, i appreciate it a lot ❤️ 

Also, i would like to thank @udoprog for helping a ton with Rune related stuff ❤️ 

If there's any questions, or design choices that you want to discuss, feel free to do so! c:

Thank you for reading, and i hope y'all are having a good day/night, Cheers! :D