### PR TITLE
Encode `path_data` and `draw_data` directly as `u32`

### DIFF
--- a/vello_encoding/src/encoding.rs
+++ b/vello_encoding/src/encoding.rs
@@ -22,9 +22,8 @@ pub struct Encoding {
     /// The path tag stream.
     pub path_tags: Vec<PathTag>,
     /// The path data stream.
-    ///
     /// Stores all coordinates on paths.
-    /// Stored as u32 as all comparisons are performed bitwise.
+    /// Stored as `u32` as all comparisons are performed bitwise.
     pub path_data: Vec<u32>,
     /// The draw tag stream.
     pub draw_tags: Vec<DrawTag>,

--- a/vello_encoding/src/encoding.rs
+++ b/vello_encoding/src/encoding.rs
@@ -22,11 +22,14 @@ pub struct Encoding {
     /// The path tag stream.
     pub path_tags: Vec<PathTag>,
     /// The path data stream.
-    pub path_data: Vec<u8>,
+    ///
+    /// Stores all coordinates on paths.
+    /// Stored as u32 as all comparisons are performed bitwise.
+    pub path_data: Vec<u32>,
     /// The draw tag stream.
     pub draw_tags: Vec<DrawTag>,
     /// The draw data stream.
-    pub draw_data: Vec<u8>,
+    pub draw_data: Vec<u32>,
     /// The transform stream.
     pub transforms: Vec<Transform>,
     /// The style stream
@@ -331,7 +334,8 @@ impl Encoding {
     pub fn encode_color(&mut self, color: impl Into<DrawColor>) {
         let color = color.into();
         self.draw_tags.push(DrawTag::COLOR);
-        self.draw_data.extend_from_slice(bytemuck::bytes_of(&color));
+        let DrawColor { rgba } = color;
+        self.draw_data.push(rgba);
     }
 
     /// Encodes a linear gradient brush.
@@ -350,7 +354,7 @@ impl Encoding {
             RampStops::Many => {
                 self.draw_tags.push(DrawTag::LINEAR_GRADIENT);
                 self.draw_data
-                    .extend_from_slice(bytemuck::bytes_of(&gradient));
+                    .extend_from_slice(bytemuck::cast_slice(bytemuck::bytes_of(&gradient)));
             }
         }
     }
@@ -375,7 +379,7 @@ impl Encoding {
             RampStops::Many => {
                 self.draw_tags.push(DrawTag::RADIAL_GRADIENT);
                 self.draw_data
-                    .extend_from_slice(bytemuck::bytes_of(&gradient));
+                    .extend_from_slice(bytemuck::cast_slice(bytemuck::bytes_of(&gradient)));
             }
         }
     }
@@ -399,7 +403,7 @@ impl Encoding {
             RampStops::Many => {
                 self.draw_tags.push(DrawTag::SWEEP_GRADIENT);
                 self.draw_data
-                    .extend_from_slice(bytemuck::bytes_of(&gradient));
+                    .extend_from_slice(bytemuck::cast_slice(bytemuck::bytes_of(&gradient)));
             }
         }
     }
@@ -416,14 +420,14 @@ impl Encoding {
         });
         self.draw_tags.push(DrawTag::IMAGE);
         self.draw_data
-            .extend_from_slice(bytemuck::bytes_of(&DrawImage {
+            .extend_from_slice(bytemuck::cast_slice(bytemuck::bytes_of(&DrawImage {
                 xy: 0,
                 width_height: (image.width << 16) | (image.height & 0xFFFF),
                 sample_alpha: ((image.quality as u32) << 12)
                     | ((image.x_extend as u32) << 10)
                     | ((image.y_extend as u32) << 8)
                     | alpha as u32,
-            }));
+            })));
     }
 
     // Encodes a blurred rounded rectangle brush.
@@ -437,13 +441,15 @@ impl Encoding {
     ) {
         self.draw_tags.push(DrawTag::BLUR_RECT);
         self.draw_data
-            .extend_from_slice(bytemuck::bytes_of(&DrawBlurRoundedRect {
-                color: color.into(),
-                width,
-                height,
-                radius,
-                std_dev,
-            }));
+            .extend_from_slice(bytemuck::cast_slice(bytemuck::bytes_of(
+                &DrawBlurRoundedRect {
+                    color: color.into(),
+                    width,
+                    height,
+                    radius,
+                    std_dev,
+                },
+            )));
     }
 
     /// Encodes a begin clip command.
@@ -451,7 +457,9 @@ impl Encoding {
         use super::DrawBeginClip;
         self.draw_tags.push(DrawTag::BEGIN_CLIP);
         self.draw_data
-            .extend_from_slice(bytemuck::bytes_of(&DrawBeginClip::new(blend_mode, alpha)));
+            .extend_from_slice(bytemuck::cast_slice(bytemuck::bytes_of(
+                &DrawBeginClip::new(blend_mode, alpha),
+            )));
         self.n_clips += 1;
         self.n_open_clips += 1;
     }

--- a/vello_encoding/src/resolve.rs
+++ b/vello_encoding/src/resolve.rs
@@ -270,7 +270,9 @@ impl Resolver {
                         extend,
                     } => {
                         if pos < *draw_data_offset {
-                            data.extend_from_slice(&encoding.draw_data[pos..*draw_data_offset]);
+                            data.extend_from_slice(bytemuck::cast_slice(
+                                &encoding.draw_data[pos..*draw_data_offset],
+                            ));
                         }
                         let index_mode = (ramp_id << 2) | *extend as u32;
                         data.extend_from_slice(bytemuck::bytes_of(&index_mode));
@@ -282,7 +284,9 @@ impl Resolver {
                         draw_data_offset,
                     } => {
                         if pos < *draw_data_offset {
-                            data.extend_from_slice(&encoding.draw_data[pos..*draw_data_offset]);
+                            data.extend_from_slice(bytemuck::cast_slice(
+                                &encoding.draw_data[pos..*draw_data_offset],
+                            ));
                         }
                         if let Some((x, y)) = self.pending_images[*index].xy {
                             let xy = (x << 16) | y;

--- a/vello_encoding/src/resolve.rs
+++ b/vello_encoding/src/resolve.rs
@@ -276,7 +276,7 @@ impl Resolver {
                         }
                         let index_mode = (ramp_id << 2) | *extend as u32;
                         data.extend_from_slice(bytemuck::bytes_of(&index_mode));
-                        pos = *draw_data_offset + 4;
+                        pos = *draw_data_offset + 1;
                     }
                     ResolvedPatch::GlyphRun { .. } => {}
                     ResolvedPatch::Image {
@@ -291,14 +291,14 @@ impl Resolver {
                         if let Some((x, y)) = self.pending_images[*index].xy {
                             let xy = (x << 16) | y;
                             data.extend_from_slice(bytemuck::bytes_of(&xy));
-                            pos = *draw_data_offset + 4;
+                            pos = *draw_data_offset + 1;
                         } else {
                             // If we get here, we failed to allocate a slot for this image in the atlas.
                             // In this case, let's zero out the dimensions so we don't attempt to render
                             // anything.
                             // TODO: a better strategy: texture array? downsample large images?
                             data.extend_from_slice(&[0_u8; 8]);
-                            pos = *draw_data_offset + 8;
+                            pos = *draw_data_offset + 2;
                         }
                     }
                 }


### PR DESCRIPTION
We already assume these are word-aligned, and so this would catch a failure of that assumption very early, if it came up.

A potential alternative is to store `path_data` as f32 instead, as all values stored are f32. I've not done that for pretty weak reasons, and it should be trivial to change.

A future change would be to encode the full scene encoding as `u32`. That would be useful for #810, as the current code has an alignment hazard.