### PR TITLE
Change path_data's type to store values as f32

### DIFF
--- a/vello_encoding/src/encoding.rs
+++ b/vello_encoding/src/encoding.rs
@@ -518,7 +518,7 @@ impl Encoding {
                 return false;
             }
         }
-        return true;
+        true
     }
 }
 

--- a/vello_encoding/src/encoding.rs
+++ b/vello_encoding/src/encoding.rs
@@ -22,7 +22,7 @@ pub struct Encoding {
     /// The path tag stream.
     pub path_tags: Vec<PathTag>,
     /// The path data stream.
-    pub path_data: Vec<u8>,
+    pub path_data: Vec<f32>,
     /// The draw tag stream.
     pub draw_tags: Vec<DrawTag>,
     /// The draw data stream.
@@ -509,6 +509,16 @@ impl Encoding {
                 RampStops::Many
             }
         }
+    }
+
+    /// Return false if the path has any NaN values.
+    pub fn validate_path_data(&self) -> bool {
+        for value in &self.path_data {
+            if value.is_nan() {
+                return false;
+            }
+        }
+        return true;
     }
 }
 

--- a/vello_encoding/src/path.rs
+++ b/vello_encoding/src/path.rs
@@ -622,7 +622,7 @@ impl<'a> PathEncoder<'a> {
             // can't happen
             return;
         }
-        if &self.path_data[len - 2..len] != &self.first_point {
+        if self.path_data[len - 2..len] != self.first_point {
             self.path_data.extend_from_slice(&self.first_point);
             self.tags.push(PathTag::LINE_TO_F32);
             self.n_encoded_segments += 1;


### PR DESCRIPTION
This is useful on its own for simplicity, but it's also useful to more easily validate data.

Add `validate_path_data` as an example, though down the line we'd probably want a more holistic validation method that includes unbalanced tags, NaNs in transforms, infinite values, etc.