### PR TITLE
Remove line packing from tiles, slightly improve tile culling

### DIFF
--- a/sparse_strips/vello_common/src/coarse.rs
+++ b/sparse_strips/vello_common/src/coarse.rs
@@ -154,7 +154,8 @@ impl Wide {
                 && next_strip.x >= 0
             {
                 x = x1;
-                let x2 = next_strip.x as u32;
+                let x2 =
+                    (next_strip.x as u32).min(self.width.next_multiple_of(WIDE_TILE_WIDTH) as u32);
                 let fxt0 = x1 as usize / WIDE_TILE_WIDTH;
                 let fxt1 = (x2 as usize).div_ceil(WIDE_TILE_WIDTH);
                 for tile_x in fxt0..fxt1 {

--- a/sparse_strips/vello_cpu/snapshots/eo_filling_missing_anti_aliasing.png
+++ b/sparse_strips/vello_cpu/snapshots/eo_filling_missing_anti_aliasing.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b79e38722c2ad12febaecdf8d4dcb57421ce01a132ce8bbd1dfebb1a79afd91e
-size 219
+oid sha256:18fa5af2e5279deb475be420e2772cd9a82e77dc025c108bd61f8bc569938501
+size 213

--- a/sparse_strips/vello_cpu/snapshots/filling_evenodd_rule.png
+++ b/sparse_strips/vello_cpu/snapshots/filling_evenodd_rule.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b6c3921c0acad8dca99d955aeb0564422df1c3d18bd366d556f9d55951e27b23
-size 832
+oid sha256:c30cefd5e417136aa65bfdc90cc841514e2bafce765914991c3f5d4cac2c0439
+size 840

--- a/sparse_strips/vello_cpu/snapshots/filling_nonzero_rule.png
+++ b/sparse_strips/vello_cpu/snapshots/filling_nonzero_rule.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f1440086e64002849d92e51292e22a6b78c91b970082cec7a7784c9aafec1386
-size 717
+oid sha256:33e8a40b36dc176dac9a7aa6b7ed86c2cf4e72f15223ea56e6bc8021d23551ec
+size 723

--- a/sparse_strips/vello_cpu/snapshots/filling_unclosed_path_2.png
+++ b/sparse_strips/vello_cpu/snapshots/filling_unclosed_path_2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6f7463b4b548ecd817b96d0f779923b6129c4fffe1577e85d70c170e69ed465f
-size 202
+oid sha256:ac02e9501d077fa6cd57bf7913324f87645cd8519bd1982243296b00e7b38fc6
+size 196

--- a/sparse_strips/vello_cpu/snapshots/incorrect_filling_1.png
+++ b/sparse_strips/vello_cpu/snapshots/incorrect_filling_1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fb0d809b7cd4eaa04be3840983c1ebe3406a6670f6ae4f973a8c14af091b0aaf
-size 105
+oid sha256:4213f969a73ad625a16ddd1a91988da482cdbcad760288b8526d594afa464dd0
+size 103

--- a/sparse_strips/vello_cpu/snapshots/incorrect_filling_3.png
+++ b/sparse_strips/vello_cpu/snapshots/incorrect_filling_3.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bd1cd2c22651ce24577ae011725809731b2ad50be8b7a15ccaa4c26bde3616c2
-size 107
+oid sha256:5d14df7a3bbb91d23a7d25ea58895616418310f3474e92cd87caa13f66d25562
+size 111

--- a/sparse_strips/vello_cpu/snapshots/rectangle_above_viewport.png
+++ b/sparse_strips/vello_cpu/snapshots/rectangle_above_viewport.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b770ac7363fa1892daf857c493694897b3ad9f93c8ae61246fb4bd82a2bfbf5d
+size 83

--- a/sparse_strips/vello_cpu/snapshots/rectangle_left_of_viewport.png
+++ b/sparse_strips/vello_cpu/snapshots/rectangle_left_of_viewport.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a9f0c2188f8279e49c56f019e271ca62160724d570d2fd7894074a72590d07f
+size 80

--- a/sparse_strips/vello_cpu/snapshots/stroked_triangle.png
+++ b/sparse_strips/vello_cpu/snapshots/stroked_triangle.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aacb5c4fd6cb003ba3db1f79f12044f6c12f5be70394b71312071615fc3f7716
-size 366
+oid sha256:17a84ac769d18e19602f2c3fcd9e78757ef24b43b405a5397ec8e70429171c7a
+size 364

--- a/sparse_strips/vello_cpu/snapshots/triangle_above_and_wider_than_viewport.png
+++ b/sparse_strips/vello_cpu/snapshots/triangle_above_and_wider_than_viewport.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f2ebec36a877eb226c3b695cf8747acb6f43137f417b40fc186a2ba84d568a9
+size 86

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -167,7 +167,8 @@ impl RenderContext {
 
     // Assumes that `line_buf` contains the flattened path.
     fn render_path(&mut self, fill_rule: Fill, paint: Paint) {
-        self.tiles.make_tiles(&self.line_buf);
+        self.tiles
+            .make_tiles(&self.line_buf, self.width as u16, self.height as u16);
         self.tiles.sort_tiles();
 
         strip::render(
@@ -175,6 +176,7 @@ impl RenderContext {
             &mut self.strip_buf,
             &mut self.alphas,
             fill_rule,
+            &self.line_buf,
         );
 
         self.wide.generate(&self.strip_buf, fill_rule, paint);

--- a/sparse_strips/vello_cpu/tests/basic.rs
+++ b/sparse_strips/vello_cpu/tests/basic.rs
@@ -160,6 +160,52 @@ fn stroked_circle() {
     check_ref(&ctx, "stroked_circle");
 }
 
+/// Requires winding of the first row of tiles to be calculcated correctly for vertical lines.
+#[test]
+fn rectangle_above_viewport() {
+    let mut ctx = get_ctx(10, 10, false);
+    let rect = Rect::new(2.0, -5.0, 8.0, 8.0);
+
+    ctx.set_paint(REBECCA_PURPLE.with_alpha(0.5).into());
+    ctx.fill_rect(&rect);
+
+    check_ref(&ctx, "rectangle_above_viewport");
+}
+
+/// Requires winding of the first row of tiles to be calculcated correctly for sloped lines.
+#[test]
+fn triangle_above_and_wider_than_viewport() {
+    let mut ctx = get_ctx(10, 10, false);
+
+    let path = {
+        let mut path = BezPath::new();
+        path.move_to((5.0, -5.0));
+        path.line_to((14., 6.));
+        path.line_to((-8., 6.));
+        path.close_path();
+
+        path
+    };
+
+    ctx.set_paint(REBECCA_PURPLE.with_alpha(0.5).into());
+    ctx.fill_path(&path);
+
+    check_ref(&ctx, "triangle_above_and_wider_than_viewport");
+}
+
+/// Requires winding and pixel coverage to be calculcated correctly for tiles preceding the
+/// viewport in scan direction.
+#[test]
+fn rectangle_left_of_viewport() {
+    let mut ctx = get_ctx(10, 10, false);
+    let rect = Rect::new(-4.0, 3.0, 1.0, 8.0);
+
+    ctx.set_paint(REBECCA_PURPLE.with_alpha(0.5).into());
+    ctx.fill_rect(&rect);
+
+    check_ref(&ctx, "rectangle_left_of_viewport");
+}
+
 fn star_path() -> BezPath {
     let mut path = BezPath::new();
     path.move_to((50.0, 10.0));


### PR DESCRIPTION
This reduces the tile memory footprint and drops the requirement for tile x-coordinates to be signed. We may be able to drop the `TileIndex` indirection soon. 

Coarse winding calculation is performed in tile generation, like it more-or-less was before. In principle it requires just a single bit in the tile packing. Calculating the coarse winding could be performed in the strip generation as well, but I suspect it to be slightly more performant this way. I haven't accurately measured that.

This is one step towards what [Raph mentioned](https://xi.zulipchat.com/#narrow/channel/197075-gpu/topic/CPU.20sparse.20strip.20rendering.20to.20pixels/near/500019583). Quoting:

> pack x, y, line id, and winding number delta into a single u32 and sort that. This is a very tight packing with u32 and may overflow in some cases (very large number of lines per path), but I think should be very efficient. Then the determination of p0 and p1 within the tile happens after sorting. A major motivation for this change is that it can be done on GPU in hybrid modes, but the approach to parallelism also works with SIMD, I think.

Tiles above, to the right and below the viewport are now culled. Tiles to the left of the viewport are clamped but not culled yet. Currently strip generation has some code special-casing those tiles.

On my machine, paris-30k measures with #835 as the "before" and after the changes here as the following. (With 20 iterations, appears to be accurate to about ~0.2ms, but we should think about better benchmarking.)

```
Tile generation
    old: 24.394854ms
    new: 17.620834ms
Tile sorting
    old: 8.922622ms
    new: 8.146455ms
Strip generation
    old: 33.187645ms
    new: 31.825052ms
```