### PR TITLE
Clean up coordinate data types

### DIFF
--- a/sparse_strips/vello_common/src/tile.rs
+++ b/sparse_strips/vello_common/src/tile.rs
@@ -13,7 +13,7 @@ use crate::flatten::Line;
 #[derive(Debug, Clone, Copy)]
 pub struct Tile {
     /// The index of the tile in the x direction.
-    pub x: i32,
+    pub x: u16,
     /// The index of the tile in the y direction.
     pub y: u16,
     /// The index of the line this tile belongs to into the line buffer.
@@ -33,7 +33,7 @@ impl Tile {
     pub const HEIGHT: u16 = 4;
 
     /// Create a new tile.
-    pub fn new(x: i32, y: u16, line_idx: u32, winding: bool) -> Self {
+    pub fn new(x: u16, y: u16, line_idx: u32, winding: bool) -> Self {
         Self {
             x,
             y,
@@ -188,7 +188,7 @@ impl Tiles {
                 for y_idx in y_top_tiles..y_bottom_tiles {
                     let y = y_idx as f32;
 
-                    let tile = Tile::new(x as i32, y_idx, line_idx, y >= line_top_y);
+                    let tile = Tile::new(x, y_idx, line_idx, y >= line_top_y);
                     self.tile_index_buf
                         .push(TileIndex::from_tile(self.tile_buf.len() as u32, &tile));
                     self.tile_buf.push(tile);
@@ -229,7 +229,7 @@ impl Tiles {
                         line_row_left_x as u16..=(line_row_right_x as u16).min(tile_columns - 1)
                     {
                         let tile = Tile::new(
-                            x_idx as i32,
+                            x_idx,
                             y_idx,
                             line_idx,
                             y >= line_top_y && x_idx == winding_x,
@@ -254,7 +254,7 @@ struct TileIndex {
 
 impl TileIndex {
     pub(crate) fn from_tile(index: u32, tile: &Tile) -> Self {
-        let x = (tile.x + 1).max(0) as u16;
+        let x = tile.x;
         let y = tile.y;
 
         Self { x, y, index }

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -20,8 +20,8 @@ pub(crate) const DEFAULT_TOLERANCE: f64 = 0.1;
 /// A render context.
 #[derive(Debug)]
 pub struct RenderContext {
-    pub(crate) width: usize,
-    pub(crate) height: usize,
+    pub(crate) width: u16,
+    pub(crate) height: u16,
     pub(crate) wide: Wide,
     pub(crate) alphas: Vec<u32>,
     pub(crate) line_buf: Vec<Line>,
@@ -37,8 +37,7 @@ pub struct RenderContext {
 impl RenderContext {
     /// Create a new render context with the given width and height in pixels.
     pub fn new(width: u16, height: u16) -> Self {
-        // TODO: Use u16 for width/height everywhere else, too.
-        let wide = Wide::new(width.into(), height.into());
+        let wide = Wide::new(width, height);
 
         let alphas = vec![];
         let line_buf = vec![];
@@ -58,8 +57,8 @@ impl RenderContext {
         let blend_mode = BlendMode::new(Mix::Normal, Compose::SrcOver);
 
         Self {
-            width: width.into(),
-            height: height.into(),
+            width,
+            height,
             wide,
             alphas,
             line_buf,
@@ -132,12 +131,7 @@ impl RenderContext {
 
     /// Render the current context into a pixmap.
     pub fn render_to_pixmap(&self, pixmap: &mut Pixmap) {
-        // TODO: Use u16 here, too, instead of casting.
-        let mut fine = Fine::new(
-            pixmap.width as usize,
-            pixmap.height as usize,
-            &mut pixmap.buf,
-        );
+        let mut fine = Fine::new(pixmap.width, pixmap.height, &mut pixmap.buf);
 
         let width_tiles = self.wide.width_tiles();
         let height_tiles = self.wide.height_tiles();
@@ -156,18 +150,18 @@ impl RenderContext {
 
     /// Return the width of the pixmap.
     pub fn width(&self) -> u16 {
-        self.width as u16
+        self.width
     }
 
     /// Return the height of the pixmap.
     pub fn height(&self) -> u16 {
-        self.height as u16
+        self.height
     }
 
     // Assumes that `line_buf` contains the flattened path.
     fn render_path(&mut self, fill_rule: Fill, paint: Paint) {
         self.tiles
-            .make_tiles(&self.line_buf, self.width as u16, self.height as u16);
+            .make_tiles(&self.line_buf, self.width, self.height);
         self.tiles.sort_tiles();
 
         strip::render(

--- a/sparse_strips/vello_hybrid/examples/render_to_file.rs
+++ b/sparse_strips/vello_hybrid/examples/render_to_file.rs
@@ -86,7 +86,7 @@ async fn run() {
         base_color: Some(peniko::Color::TRANSPARENT),
         width: width as u32,
         height: height as u32,
-        strip_height: vello_common::strip::STRIP_HEIGHT as u32,
+        strip_height: vello_common::tile::Tile::HEIGHT as u32,
     };
     renderer.prepare(&device, &queue, &scene, &render_params);
     renderer.render_to_texture(&device, &queue, &scene, &texture_view, &render_params);


### PR DESCRIPTION
(For ease of review, this PR has been split. The second part now lives here: https://github.com/linebender/vello/pull/852).

This cleans up the data types around integer `Tile`, `Strip`, `WideTile` and pixel coordinates: 1-dimensional indices are now consistently `u16`, and indices into 2-dimensional buffers are (mostly) `usize`. Making tile x-coordinates unsigned is possible since the left-of-viewport winding calculation changes in https://github.com/linebender/vello/pull/845.