### PR TITLE
Lift tile width restriction

### DIFF
--- a/sparse_strips/vello_common/src/tile.rs
+++ b/sparse_strips/vello_common/src/tile.rs
@@ -272,8 +272,8 @@ impl TileIndex {
 }
 
 #[cfg(test)]
-const _: () = if Tile::WIDTH != 4 || Tile::HEIGHT != 4 {
-    panic!("Can only handle 4x4 tiles for now.");
+const _: () = if Tile::HEIGHT != 4 {
+    panic!("Can only handle tiles with a height of 4 pixels for now.");
 };
 
 #[cfg(test)]


### PR DESCRIPTION
With the recent changes, the scalar code in `vello_common` and `vello_cpu` is now generic over tile width, but not yet over tile height due to the alpha mask encoding.