### PR TITLE
Fix sparse fills extending beyond the viewport

### DIFF
--- a/sparse_strips/vello_common/src/strip.rs
+++ b/sparse_strips/vello_common/src/strip.rs
@@ -125,10 +125,6 @@ pub fn render(
 
         // Push out the strip if we're moving to a next strip.
         if !prev_tile.same_loc(&tile) && !prev_tile.prev_loc(&tile) {
-            if !prev_tile.same_row(&tile) {
-                winding_delta = 0;
-            }
-
             debug_assert_eq!(
                 (prev_tile.x + 1) * Tile::WIDTH as i32 - strip.x,
                 alpha_buf.len() as i32 - strip.col as i32,

--- a/sparse_strips/vello_cpu/snapshots/filled_overflowing_circle.png
+++ b/sparse_strips/vello_cpu/snapshots/filled_overflowing_circle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74536443369bf9bee1bad54c7b76e8b95d138b0133563b13f76a824f0f622bd9
+size 583

--- a/sparse_strips/vello_cpu/tests/basic.rs
+++ b/sparse_strips/vello_cpu/tests/basic.rs
@@ -124,6 +124,17 @@ fn filled_circle() {
 }
 
 #[test]
+fn filled_overflowing_circle() {
+    let mut ctx = get_ctx(100, 100, false);
+    let circle = Circle::new((50.0, 50.0), 50.0 + 1.0);
+
+    ctx.set_paint(LIME.into());
+    ctx.fill_path(&circle.to_path(0.1));
+
+    check_ref(&ctx, "filled_overflowing_circle");
+}
+
+#[test]
 fn filled_circle_with_opacity() {
     let mut ctx = get_ctx(100, 100, false);
     let circle = Circle::new((50.0, 50.0), 45.0);


### PR DESCRIPTION
Fixes https://github.com/linebender/vello/issues/850.

A vestigial branch left in https://github.com/linebender/vello/pull/845 reset the `winding_delta` too early during strip rendering.