### PR TITLE
Pack `Tile` into 64 bits

### DIFF
--- a/sparse_strips/vello_common/src/strip.rs
+++ b/sparse_strips/vello_common/src/strip.rs
@@ -61,8 +61,7 @@ pub fn render(
     const SENTINEL: Tile = Tile {
         x: u16::MAX,
         y: u16::MAX,
-        line_idx: 0,
-        winding: false,
+        packed_winding_line_idx: 0,
     };
 
     // The strip we're building.
@@ -74,7 +73,7 @@ pub fn render(
     };
 
     for tile in tiles.iter().copied().chain([SENTINEL]) {
-        let line = lines[tile.line_idx as usize];
+        let line = lines[tile.line_idx() as usize];
         let tile_left_x = tile.x as f32 * Tile::WIDTH as f32;
         let tile_top_y = tile.y as f32 * Tile::HEIGHT as f32;
         let p0_x = line.p0.x - tile_left_x;
@@ -222,7 +221,7 @@ pub fn render(
         let y_slope = (line_bottom_y - line_top_y) / (line_bottom_x - line_top_x);
         let x_slope = 1. / y_slope;
 
-        winding_delta += sign as i32 * tile.winding as i32;
+        winding_delta += sign as i32 * tile.winding() as i32;
 
         // TODO: this should be removed when out-of-viewport tiles are culled at the
         // tile-generation stage. That requires calculating and forwarding winding to strip

--- a/sparse_strips/vello_common/src/strip.rs
+++ b/sparse_strips/vello_common/src/strip.rs
@@ -62,16 +62,16 @@ pub fn render(
 
     // The strip we're building.
     let mut strip = Strip {
-        x: prev_tile.x() * Tile::WIDTH,
-        y: prev_tile.y() * Tile::HEIGHT,
+        x: prev_tile.x * Tile::WIDTH,
+        y: prev_tile.y * Tile::HEIGHT,
         col: alpha_buf.len() as u32,
         winding: 0,
     };
 
-    for tile in tiles.iter().copied().chain([SENTINEL]) {
+    for (tile_idx, tile) in tiles.iter().copied().chain([SENTINEL]).enumerate() {
         let line = lines[tile.line_idx() as usize];
-        let tile_left_x = tile.x() as f32 * Tile::WIDTH as f32;
-        let tile_top_y = tile.y() as f32 * Tile::HEIGHT as f32;
+        let tile_left_x = tile.x as f32 * Tile::WIDTH as f32;
+        let tile_top_y = tile.y as f32 * Tile::HEIGHT as f32;
         let p0_x = line.p0.x - tile_left_x;
         let p0_y = line.p0.y - tile_top_y;
         let p1_x = line.p1.x - tile_left_x;
@@ -117,13 +117,13 @@ pub fn render(
         // Push out the strip if we're moving to a next strip.
         if !prev_tile.same_loc(&tile) && !prev_tile.prev_loc(&tile) {
             debug_assert_eq!(
-                (prev_tile.x() + 1) * Tile::WIDTH - strip.x,
+                (prev_tile.x + 1) * Tile::WIDTH - strip.x,
                 (alpha_buf.len() - strip.col as usize) as u16,
                 "The number of columns written to the alpha buffer should equal the number of columns spanned by this strip."
             );
             strip_buf.push(strip);
 
-            let is_sentinel = tile.y() == u16::MAX && tile.x() == u16::MAX;
+            let is_sentinel = tile_idx == tiles.len() as usize;
             if !prev_tile.same_row(&tile) {
                 // Emit a final strip in the row if there is non-zero winding for the sparse fill,
                 // or unconditionally if we've reached the sentinel tile to end the path (the `col`
@@ -131,7 +131,7 @@ pub fn render(
                 if winding_delta != 0 || is_sentinel {
                     strip_buf.push(Strip {
                         x: u16::MAX,
-                        y: prev_tile.y() * Tile::HEIGHT,
+                        y: prev_tile.y * Tile::HEIGHT,
                         col: alpha_buf.len() as u32,
                         winding: winding_delta,
                     });
@@ -151,8 +151,8 @@ pub fn render(
             }
 
             strip = Strip {
-                x: tile.x() * Tile::WIDTH,
-                y: tile.y() * Tile::HEIGHT,
+                x: tile.x * Tile::WIDTH,
+                y: tile.y * Tile::HEIGHT,
                 col: alpha_buf.len() as u32,
                 winding: winding_delta,
             };
@@ -222,7 +222,7 @@ pub fn render(
         // TODO: this should be removed when out-of-viewport tiles are culled at the
         // tile-generation stage. That requires calculating and forwarding winding to strip
         // generation.
-        if tile.x() == 0 && line_left_x < 0. {
+        if tile.x == 0 && line_left_x < 0. {
             let (ymin, ymax) = if line.p0.x == line.p1.x {
                 (line_top_y, line_bottom_y)
             } else {

--- a/sparse_strips/vello_common/src/tile.rs
+++ b/sparse_strips/vello_common/src/tile.rs
@@ -239,11 +239,7 @@ impl Tiles {
         let tile_columns = width.div_ceil(Tile::WIDTH);
         let tile_rows = height.div_ceil(Tile::HEIGHT);
 
-        for (line_idx, line) in lines
-            .iter()
-            .take((MAX_LINES_PER_PATH as usize).saturating_add(1))
-            .enumerate()
-        {
+        for (line_idx, line) in lines.iter().take(MAX_LINES_PER_PATH as usize).enumerate() {
             let line_idx = line_idx as u32;
 
             let p0_x = line.p0.x / Tile::WIDTH as f32;

--- a/sparse_strips/vello_common/src/tile.rs
+++ b/sparse_strips/vello_common/src/tile.rs
@@ -22,12 +22,12 @@ pub struct Tile(
     ///
     /// The layout is as follows, with the bit indices from least to most significant.
     ///
-    /// [ 0, 31): The 31-bit index of the line this tile belongs to into the line buffer;
-    /// [31, 32): The 1-bit coarse winding of the tile. This is `1` if and only if the lines
+    /// - `[ 0, 31)`: The 31-bit index of the line this tile belongs to into the line buffer;
+    /// - `[31, 32)`: The 1-bit coarse winding of the tile. This is `1` if and only if the lines
     /// crosses the tile's top edge. Lines making this crossing increment or decrement the coarse
     /// tile winding, depending on the line direction;
-    /// [32, 48): The 16-bit x-coordinate; and
-    /// [48, 64): The 16-bit y-coordinate.
+    /// - `[32, 48)`: The 16-bit x-coordinate; and
+    /// - `[48, 64)`: The 16-bit y-coordinate.
     ///
     /// Note the byte layout in memory depends on the endianness of the compilation target.
     pub u64,

--- a/sparse_strips/vello_common/src/tile.rs
+++ b/sparse_strips/vello_common/src/tile.rs
@@ -22,8 +22,7 @@ pub struct Tile(
     ///
     /// The layout is as follows, with the bit indices from least to most significant.
     ///
-    /// [ 0, 31): The 31-bit index of the line this tile belongs to into the line buffer, plus
-    /// whether the line crosses the top edge of the tile, packed together;
+    /// [ 0, 31): The 31-bit index of the line this tile belongs to into the line buffer;
     /// [31, 32): The 1-bit coarse winding of the tile. This is `1` if and only if the lines
     /// crosses the tile's top edge. Lines making this crossing increment or decrement the coarse
     /// tile winding, depending on the line direction;

--- a/sparse_strips/vello_common/src/tile.rs
+++ b/sparse_strips/vello_common/src/tile.rs
@@ -74,7 +74,7 @@ impl Tile {
         Self {
             x,
             y,
-            packed_winding_line_idx: (winding as u32) << 31 | line_idx,
+            packed_winding_line_idx: ((winding as u32) << 31) | line_idx,
         }
     }
 
@@ -116,8 +116,8 @@ impl Tile {
     /// This is the u64 interpretation of `(y, x, packed_winding_line_idx)` where `y` is the
     /// most-significant part of the number and `packed_winding_line_idx` the least significant.
     #[inline(always)]
-    const fn to_bits(&self) -> u64 {
-        (self.y as u64) << 48 | (self.x as u64) << 32 | self.packed_winding_line_idx as u64
+    const fn to_bits(self) -> u64 {
+        ((self.y as u64) << 48) | ((self.x as u64) << 32) | self.packed_winding_line_idx as u64
     }
 }
 

--- a/sparse_strips/vello_common/src/tile.rs
+++ b/sparse_strips/vello_common/src/tile.rs
@@ -24,8 +24,8 @@ pub struct Tile(
     ///
     /// - `[ 0, 31)`: The 31-bit index of the line this tile belongs to into the line buffer;
     /// - `[31, 32)`: The 1-bit coarse winding of the tile. This is `1` if and only if the lines
-    /// crosses the tile's top edge. Lines making this crossing increment or decrement the coarse
-    /// tile winding, depending on the line direction;
+    ///   crosses the tile's top edge. Lines making this crossing increment or decrement the coarse
+    ///   tile winding, depending on the line direction;
     /// - `[32, 48)`: The 16-bit x-coordinate; and
     /// - `[48, 64)`: The 16-bit y-coordinate.
     ///

--- a/sparse_strips/vello_toy/src/debug.rs
+++ b/sparse_strips/vello_toy/src/debug.rs
@@ -174,8 +174,8 @@ fn draw_tile_areas(document: &mut Document, tiles: &Tiles) {
 
     for i in 0..tiles.len() {
         let tile = tiles.get(i);
-        let x = tile.x * Tile::WIDTH;
-        let y = tile.y * Tile::HEIGHT;
+        let x = tile.x() * Tile::WIDTH;
+        let y = tile.y() * Tile::HEIGHT;
 
         if seen.contains(&(x, y)) {
             continue;

--- a/sparse_strips/vello_toy/src/debug.rs
+++ b/sparse_strips/vello_toy/src/debug.rs
@@ -174,8 +174,8 @@ fn draw_tile_areas(document: &mut Document, tiles: &Tiles) {
 
     for i in 0..tiles.len() {
         let tile = tiles.get(i);
-        let x = tile.x() * Tile::WIDTH;
-        let y = tile.y() * Tile::HEIGHT;
+        let x = tile.x * Tile::WIDTH;
+        let y = tile.y * Tile::HEIGHT;
 
         if seen.contains(&(x, y)) {
             continue;


### PR DESCRIPTION
(Split off from https://github.com/linebender/vello/pull/847.)

The fields of `Tile` are now packed such that its value in memory can readily be interpreted as a `u64` consisting, from most to least significant, of the numeric values of 16-bit `y`, 16-bit `x`, 1-bit `winding`, and 31-bit `line_index`. This means its value in memory can be used directly for sorting the tiles.

Sorting on a `u32` of only `y` and `x` is slightly faster for sorting (by about ~0.3 ms on paris-30k), but sorting the entire `u64` speeds up strip rendering (by about ~1.5ms on paris-30k). Presumably sorted line indices help cache locality during strip rendering, and ordering the winding bit before the line index also improves strip rendering performance, maybe because of branch predictability during strip rendering (see [this comment](https://github.com/linebender/vello/pull/847#discussion_r1990081159)).

On my machine, averaging over 500 iterations paris-30k on main and in this PR measure as:

```
Tile generation
    before: 17.329454ms
    after:  16.633348ms
Tile sorting
    before: 8.120621ms
    after:  7.3823915ms
Strip generation
    before: 31.896929ms
    after:  29.898085ms
```