### PR TITLE
vello_hybrid: Account for SVG group transforms

### DIFF
--- a/sparse_strips/vello_hybrid/examples/common/mod.rs
+++ b/sparse_strips/vello_hybrid/examples/common/mod.rs
@@ -14,25 +14,29 @@ use winit::{event_loop::ActiveEventLoop, window::Window};
 /// Define a render function that works with our `pico_svg::Item` type
 #[allow(dead_code, reason = "This is a helper function for the examples")]
 pub(crate) fn render_svg(ctx: &mut Scene, scale: f64, items: &[Item]) {
-    ctx.set_transform(Affine::scale(scale));
-    for item in items {
-        match item {
-            Item::Fill(fill_item) => {
-                ctx.set_paint(fill_item.color.into());
-                ctx.fill_path(&fill_item.path);
-            }
-            Item::Stroke(stroke_item) => {
-                let style = kurbo::Stroke::new(stroke_item.width);
-                ctx.set_stroke(style);
-                ctx.set_paint(stroke_item.color.into());
-                ctx.stroke_path(&stroke_item.path);
-            }
-            Item::Group(group_item) => {
-                // TODO: apply transform from group
-                render_svg(ctx, scale, &group_item.children);
+    fn render_svg_inner(ctx: &mut Scene, items: &[Item], transform: Affine) {
+        ctx.set_transform(transform);
+        for item in items {
+            match item {
+                Item::Fill(fill_item) => {
+                    ctx.set_paint(fill_item.color.into());
+                    ctx.fill_path(&fill_item.path);
+                }
+                Item::Stroke(stroke_item) => {
+                    let style = kurbo::Stroke::new(stroke_item.width);
+                    ctx.set_stroke(style);
+                    ctx.set_paint(stroke_item.color.into());
+                    ctx.stroke_path(&stroke_item.path);
+                }
+                Item::Group(group_item) => {
+                    render_svg_inner(ctx, &group_item.children, transform * group_item.affine);
+                    ctx.set_transform(transform);
+                }
             }
         }
     }
+
+    render_svg_inner(ctx, items, Affine::scale(scale));
 }
 
 /// Helper function that creates a Winit window and returns it (wrapped in an Arc for sharing)


### PR DESCRIPTION
Not very important, as this code is likely to go away, but it makes testing a bit easier.

Paris-30k before:

![before](https://github.com/user-attachments/assets/8e0e2041-6e24-4623-884b-476bc2c9c80e)

Paris-30k after:

![after](https://github.com/user-attachments/assets/f05309c1-c18c-4edc-937f-df5292557719)

Ignore some of the rendering artifacts, those apparently only happen on some systems are unrelated to these changes.