### PR TITLE
Vello Hybrid: Render into a user-provided RenderPass

### DIFF
--- a/sparse_strips/vello_hybrid/examples/render_to_file.rs
+++ b/sparse_strips/vello_hybrid/examples/render_to_file.rs
@@ -85,7 +85,6 @@ async fn run() {
     let render_params = vello_hybrid::RenderParams {
         width: width.into(),
         height: height.into(),
-        strip_height: vello_common::tile::Tile::HEIGHT as u32,
     };
     renderer.prepare(&device, &queue, &scene, &render_params);
     // Copy texture to buffer

--- a/sparse_strips/vello_hybrid/examples/render_to_file.rs
+++ b/sparse_strips/vello_hybrid/examples/render_to_file.rs
@@ -108,7 +108,7 @@ async fn run() {
             occlusion_query_set: None,
             timestamp_writes: None,
         });
-        renderer.render_to_texture(&scene, &mut pass, &render_params);
+        renderer.render(&scene, &mut pass, &render_params);
     }
 
     // Create a buffer to copy the texture data

--- a/sparse_strips/vello_hybrid/examples/render_to_file.rs
+++ b/sparse_strips/vello_hybrid/examples/render_to_file.rs
@@ -83,7 +83,6 @@ async fn run() {
     // Create renderer and render the scene to the texture
     let mut renderer = vello_hybrid::Renderer::new(&device, &vello_hybrid::RendererOptions {});
     let render_params = vello_hybrid::RenderParams {
-        base_color: Some(peniko::Color::TRANSPARENT),
         width: width.into(),
         height: height.into(),
         strip_height: vello_common::tile::Tile::HEIGHT as u32,

--- a/sparse_strips/vello_hybrid/examples/render_to_file.rs
+++ b/sparse_strips/vello_hybrid/examples/render_to_file.rs
@@ -13,6 +13,7 @@ use std::io::BufWriter;
 use vello_common::pico_svg::PicoSvg;
 use vello_common::pixmap::Pixmap;
 use vello_hybrid::{DimensionConstraints, Scene};
+use wgpu::RenderPassDescriptor;
 
 /// Main entry point for the headless rendering example.
 /// Takes two command line arguments:
@@ -88,7 +89,27 @@ async fn run() {
         strip_height: vello_common::tile::Tile::HEIGHT as u32,
     };
     renderer.prepare(&device, &queue, &scene, &render_params);
-    renderer.render_to_texture(&device, &queue, &scene, &texture_view, &render_params);
+    // Copy texture to buffer
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("Vello Render To Buffer"),
+    });
+    {
+        let mut pass = encoder.begin_render_pass(&RenderPassDescriptor {
+            label: Some("Render Pass"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: &texture_view,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            occlusion_query_set: None,
+            timestamp_writes: None,
+        });
+        renderer.render_to_texture(&scene, &mut pass, &render_params);
+    }
 
     // Create a buffer to copy the texture data
     let bytes_per_row = (u32::from(width) * 4).next_multiple_of(256);
@@ -99,10 +120,6 @@ async fn run() {
         mapped_at_creation: false,
     });
 
-    // Copy texture to buffer
-    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-        label: Some("Copy Encoder"),
-    });
     encoder.copy_texture_to_buffer(
         wgpu::TexelCopyTextureInfo {
             texture: &texture,
@@ -124,7 +141,7 @@ async fn run() {
             depth_or_array_layers: 1,
         },
     );
-    queue.submit(std::iter::once(encoder.finish()));
+    queue.submit([encoder.finish()]);
 
     // Map the buffer for reading
     texture_copy_buffer

--- a/sparse_strips/vello_hybrid/examples/simple.rs
+++ b/sparse_strips/vello_hybrid/examples/simple.rs
@@ -168,19 +168,16 @@ impl ApplicationHandler for SimpleVelloApp<'_> {
                         occlusion_query_set: None,
                         timestamp_writes: None,
                     });
-                    self.renderers[surface.dev_id]
-                        .as_mut()
-                        .unwrap()
-                        .render_to_texture(
-                            &self.scene,
-                            &mut pass,
-                            &RenderParams {
-                                base_color: Some(palette::css::BLACK),
-                                width,
-                                height,
-                                strip_height: 4,
-                            },
-                        );
+                    self.renderers[surface.dev_id].as_mut().unwrap().render(
+                        &self.scene,
+                        &mut pass,
+                        &RenderParams {
+                            base_color: Some(palette::css::BLACK),
+                            width,
+                            height,
+                            strip_height: 4,
+                        },
+                    );
                 }
 
                 device_handle.queue.submit([encoder.finish()]);

--- a/sparse_strips/vello_hybrid/examples/simple.rs
+++ b/sparse_strips/vello_hybrid/examples/simple.rs
@@ -20,6 +20,7 @@ use vello_hybrid::{
     RenderParams, Renderer, Scene,
     util::{RenderContext, RenderSurface},
 };
+use wgpu::RenderPassDescriptor;
 use winit::{
     application::ApplicationHandler,
     event::WindowEvent,
@@ -137,41 +138,51 @@ impl ApplicationHandler for SimpleVelloApp<'_> {
                 let height = surface.config.height;
                 let device_handle = &self.context.devices[surface.dev_id];
 
-                self.renderers[surface.dev_id]
-                    .as_mut()
-                    .unwrap()
-                    .render_to_texture(
-                        &device_handle.device,
-                        &device_handle.queue,
-                        &self.scene,
-                        &surface.target_view,
-                        &RenderParams {
-                            base_color: Some(palette::css::BLACK),
-                            width,
-                            height,
-                            strip_height: 4,
-                        },
-                    );
-
                 let surface_texture = surface
                     .surface
                     .get_current_texture()
                     .expect("failed to get surface texture");
 
+                let texture_view = surface_texture
+                    .texture
+                    .create_view(&wgpu::TextureViewDescriptor::default());
+
                 let mut encoder =
                     device_handle
                         .device
                         .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                            label: Some("Surface Blit"),
+                            label: Some("Vello Render to Surface pass"),
                         });
-                surface.blitter.copy(
-                    &device_handle.device,
-                    &mut encoder,
-                    &surface.target_view,
-                    &surface_texture
-                        .texture
-                        .create_view(&wgpu::TextureViewDescriptor::default()),
-                );
+                {
+                    let mut pass = encoder.begin_render_pass(&RenderPassDescriptor {
+                        label: Some("Redner to Texture Pass"),
+                        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                            view: &texture_view,
+                            resolve_target: None,
+                            ops: wgpu::Operations {
+                                load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                                store: wgpu::StoreOp::Store,
+                            },
+                        })],
+                        depth_stencil_attachment: None,
+                        occlusion_query_set: None,
+                        timestamp_writes: None,
+                    });
+                    self.renderers[surface.dev_id]
+                        .as_mut()
+                        .unwrap()
+                        .render_to_texture(
+                            &self.scene,
+                            &mut pass,
+                            &RenderParams {
+                                base_color: Some(palette::css::BLACK),
+                                width,
+                                height,
+                                strip_height: 4,
+                            },
+                        );
+                }
+
                 device_handle.queue.submit([encoder.finish()]);
                 surface_texture.present();
 

--- a/sparse_strips/vello_hybrid/examples/simple.rs
+++ b/sparse_strips/vello_hybrid/examples/simple.rs
@@ -105,7 +105,6 @@ impl ApplicationHandler for SimpleVelloApp<'_> {
             &RenderParams {
                 width: surface.config.width,
                 height: surface.config.height,
-                strip_height: 4,
             },
         );
 
@@ -170,11 +169,7 @@ impl ApplicationHandler for SimpleVelloApp<'_> {
                     self.renderers[surface.dev_id].as_mut().unwrap().render(
                         &self.scene,
                         &mut pass,
-                        &RenderParams {
-                            width,
-                            height,
-                            strip_height: 4,
-                        },
+                        &RenderParams { width, height },
                     );
                 }
 

--- a/sparse_strips/vello_hybrid/examples/simple.rs
+++ b/sparse_strips/vello_hybrid/examples/simple.rs
@@ -155,7 +155,7 @@ impl ApplicationHandler for SimpleVelloApp<'_> {
                         });
                 {
                     let mut pass = encoder.begin_render_pass(&RenderPassDescriptor {
-                        label: Some("Redner to Texture Pass"),
+                        label: Some("Render to Texture Pass"),
                         color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                             view: &texture_view,
                             resolve_target: None,

--- a/sparse_strips/vello_hybrid/examples/simple.rs
+++ b/sparse_strips/vello_hybrid/examples/simple.rs
@@ -103,7 +103,6 @@ impl ApplicationHandler for SimpleVelloApp<'_> {
             &device_handle.queue,
             &self.scene,
             &RenderParams {
-                base_color: Some(palette::css::BLACK),
                 width: surface.config.width,
                 height: surface.config.height,
                 strip_height: 4,
@@ -172,7 +171,6 @@ impl ApplicationHandler for SimpleVelloApp<'_> {
                         &self.scene,
                         &mut pass,
                         &RenderParams {
-                            base_color: Some(palette::css::BLACK),
                             width,
                             height,
                             strip_height: 4,

--- a/sparse_strips/vello_hybrid/examples/svg.rs
+++ b/sparse_strips/vello_hybrid/examples/svg.rs
@@ -114,7 +114,6 @@ impl ApplicationHandler for SvgVelloApp<'_> {
             &device_handle.queue,
             &self.scene,
             &RenderParams {
-                base_color: Some(palette::css::BLACK),
                 width: surface.config.width,
                 height: surface.config.height,
                 strip_height: 4,
@@ -194,7 +193,6 @@ impl ApplicationHandler for SvgVelloApp<'_> {
                         &self.scene,
                         &mut pass,
                         &RenderParams {
-                            base_color: Some(palette::css::BLACK), // Background color
                             width,
                             height,
                             strip_height: 4,

--- a/sparse_strips/vello_hybrid/examples/svg.rs
+++ b/sparse_strips/vello_hybrid/examples/svg.rs
@@ -190,19 +190,16 @@ impl ApplicationHandler for SvgVelloApp<'_> {
                         occlusion_query_set: None,
                         timestamp_writes: None,
                     });
-                    self.renderers[surface.dev_id]
-                        .as_mut()
-                        .unwrap()
-                        .render_to_texture(
-                            &self.scene,
-                            &mut pass,
-                            &RenderParams {
-                                base_color: Some(palette::css::BLACK), // Background color
-                                width,
-                                height,
-                                strip_height: 4,
-                            },
-                        );
+                    self.renderers[surface.dev_id].as_mut().unwrap().render(
+                        &self.scene,
+                        &mut pass,
+                        &RenderParams {
+                            base_color: Some(palette::css::BLACK), // Background color
+                            width,
+                            height,
+                            strip_height: 4,
+                        },
+                    );
                 }
                 device_handle.queue.submit([encoder.finish()]);
                 surface_texture.present();

--- a/sparse_strips/vello_hybrid/examples/svg.rs
+++ b/sparse_strips/vello_hybrid/examples/svg.rs
@@ -12,7 +12,6 @@ mod common;
 use std::sync::Arc;
 
 use common::{create_vello_renderer, create_winit_window, render_svg};
-use peniko::color::palette;
 use vello_common::pico_svg::PicoSvg;
 use vello_hybrid::{
     RenderParams, Renderer, Scene,
@@ -116,7 +115,6 @@ impl ApplicationHandler for SvgVelloApp<'_> {
             &RenderParams {
                 width: surface.config.width,
                 height: surface.config.height,
-                strip_height: 4,
             },
         );
 
@@ -192,11 +190,7 @@ impl ApplicationHandler for SvgVelloApp<'_> {
                     self.renderers[surface.dev_id].as_mut().unwrap().render(
                         &self.scene,
                         &mut pass,
-                        &RenderParams {
-                            width,
-                            height,
-                            strip_height: 4,
-                        },
+                        &RenderParams { width, height },
                     );
                 }
                 device_handle.queue.submit([encoder.finish()]);

--- a/sparse_strips/vello_hybrid/src/render.rs
+++ b/sparse_strips/vello_hybrid/src/render.rs
@@ -25,8 +25,6 @@ use crate::scene::Scene;
 /// Parameters for the renderer
 #[derive(Debug)]
 pub struct RenderParams {
-    /// Background color
-    pub base_color: Option<peniko::Color>,
     /// Width of the rendering target
     pub width: u32,
     /// Height of the rendering target

--- a/sparse_strips/vello_hybrid/src/render.rs
+++ b/sparse_strips/vello_hybrid/src/render.rs
@@ -16,9 +16,8 @@ use std::fmt::Debug;
 
 use bytemuck::{Pod, Zeroable};
 use wgpu::{
-    BindGroup, BindGroupLayout, BlendState, Buffer, ColorTargetState, ColorWrites,
-    CommandEncoderDescriptor, Device, PipelineCompilationOptions, Queue, RenderPipeline, Texture,
-    TextureView, util::DeviceExt,
+    BindGroup, BindGroupLayout, BlendState, Buffer, ColorTargetState, ColorWrites, Device,
+    PipelineCompilationOptions, Queue, RenderPass, RenderPipeline, Texture, util::DeviceExt,
 };
 
 use crate::scene::Scene;
@@ -325,48 +324,19 @@ impl Renderer {
     /// Render to a texture
     pub fn render_to_texture(
         &mut self,
-        device: &Device,
-        queue: &Queue,
         scene: &Scene,
-        texture_view: &TextureView,
-        render_params: &RenderParams,
+        render_pass: &mut RenderPass<'_>,
+        _render_params: &RenderParams,
     ) {
         // If we don't have the required resources, return empty data
         let Some(resources) = &self.resources else {
             return;
         };
         let render_data = scene.prepare_render_data();
-        let mut encoder = device.create_command_encoder(&CommandEncoderDescriptor::default());
-        {
-            let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                label: Some("Redner to Texture Pass"),
-                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                    view: texture_view,
-                    resolve_target: None,
-                    ops: wgpu::Operations {
-                        load: match render_params.base_color {
-                            Some(c) => wgpu::LoadOp::Clear(wgpu::Color {
-                                r: c.components[0] as f64,
-                                g: c.components[1] as f64,
-                                b: c.components[2] as f64,
-                                a: c.components[3] as f64,
-                            }),
-                            None => wgpu::LoadOp::Load,
-                        },
-                        store: wgpu::StoreOp::Store,
-                    },
-                })],
-                depth_stencil_attachment: None,
-                occlusion_query_set: None,
-                timestamp_writes: None,
-            });
-
-            render_pass.set_pipeline(&self.render_pipeline);
-            render_pass.set_bind_group(0, &resources.render_bind_group, &[]);
-            render_pass.set_vertex_buffer(0, resources.strips_buffer.slice(..));
-            let strips_to_draw = render_data.strips.len();
-            render_pass.draw(0..4, 0..u32::try_from(strips_to_draw).unwrap());
-        }
-        queue.submit([encoder.finish()]);
+        render_pass.set_pipeline(&self.render_pipeline);
+        render_pass.set_bind_group(0, &resources.render_bind_group, &[]);
+        render_pass.set_vertex_buffer(0, resources.strips_buffer.slice(..));
+        let strips_to_draw = render_data.strips.len();
+        render_pass.draw(0..4, 0..u32::try_from(strips_to_draw).unwrap());
     }
 }

--- a/sparse_strips/vello_hybrid/src/render.rs
+++ b/sparse_strips/vello_hybrid/src/render.rs
@@ -321,8 +321,12 @@ impl Renderer {
         }
     }
 
-    /// Render to a texture
-    pub fn render_to_texture(
+    /// Render `scene` into the provided render pass.
+    ///
+    /// You must call [`prepare`](Self::prepare) with this scene before
+    /// calling `render`.
+    /// The provided pass can be rendering to a surface, or to a "off-screen" buffer.
+    pub fn render(
         &mut self,
         scene: &Scene,
         render_pass: &mut RenderPass<'_>,

--- a/sparse_strips/vello_hybrid/src/render.rs
+++ b/sparse_strips/vello_hybrid/src/render.rs
@@ -15,6 +15,7 @@
 use std::fmt::Debug;
 
 use bytemuck::{Pod, Zeroable};
+use vello_common::tile::Tile;
 use wgpu::{
     BindGroup, BindGroupLayout, BlendState, Buffer, ColorTargetState, ColorWrites, Device,
     PipelineCompilationOptions, Queue, RenderPass, RenderPipeline, Texture, util::DeviceExt,
@@ -29,8 +30,6 @@ pub struct RenderParams {
     pub width: u32,
     /// Height of the rendering target
     pub height: u32,
-    /// Height of a strip in the rendering
-    pub strip_height: u32,
 }
 
 /// Options for the renderer
@@ -253,7 +252,7 @@ impl Renderer {
                 contents: bytemuck::bytes_of(&Config {
                     width: render_params.width,
                     height: render_params.height,
-                    strip_height: render_params.strip_height,
+                    strip_height: Tile::HEIGHT.into(),
                 }),
                 usage: wgpu::BufferUsages::UNIFORM,
             });


### PR DESCRIPTION
Some of the follow-up from #831.

This strategy might not work as well if/when we start doing clipping and blending. Things get messy there; ultimately I *suspect* it's still right to do the "final" render into a user-provided pass, but we want to do intermediate renders ourselves? 
Nevertheless, for the current state this is the correct API; we definitely should not be doing our own queue submission, anyway.

I've run out of time for today, so have only run the `svg` example (which worked as expected). I expect the others to work, but I'd recommend checking that