### PR TITLE
Tidy up handling of truncation and lints in Vello Hybrid

### DIFF
--- a/sparse_strips/vello_hybrid/examples/common/mod.rs
+++ b/sparse_strips/vello_hybrid/examples/common/mod.rs
@@ -1,6 +1,11 @@
 // Copyright 2025 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#![allow(
+    dead_code,
+    reason = "This is a shared module between examples; not all examples use all functionality from it"
+)]
+
 use std::sync::Arc;
 
 use kurbo::Affine;
@@ -12,7 +17,6 @@ use vello_hybrid::{
 use winit::{event_loop::ActiveEventLoop, window::Window};
 
 /// Define a render function that works with our `pico_svg::Item` type
-#[allow(dead_code, reason = "This is a helper function for the examples")]
 pub(crate) fn render_svg(ctx: &mut Scene, scale: f64, items: &[Item]) {
     ctx.set_transform(Affine::scale(scale));
     for item in items {
@@ -36,7 +40,6 @@ pub(crate) fn render_svg(ctx: &mut Scene, scale: f64, items: &[Item]) {
 }
 
 /// Helper function that creates a Winit window and returns it (wrapped in an Arc for sharing)
-#[allow(dead_code, reason = "This is a helper function for the examples")]
 pub(crate) fn create_winit_window(
     event_loop: &ActiveEventLoop,
     width: u32,
@@ -53,7 +56,6 @@ pub(crate) fn create_winit_window(
 }
 
 /// Helper function that creates a Vello Hybrid renderer
-#[allow(dead_code, reason = "This is a helper function for the examples")]
 pub(crate) fn create_vello_renderer(
     render_cx: &RenderContext,
     surface: &RenderSurface<'_>,

--- a/sparse_strips/vello_hybrid/examples/render_to_file.rs
+++ b/sparse_strips/vello_hybrid/examples/render_to_file.rs
@@ -9,13 +9,7 @@
 mod common;
 
 use common::render_svg;
-use std::{
-    io::BufWriter,
-    sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    },
-};
+use std::io::BufWriter;
 use vello_common::pico_svg::PicoSvg;
 use vello_common::pixmap::Pixmap;
 use vello_hybrid::{DimensionConstraints, Scene};

--- a/sparse_strips/vello_hybrid/examples/render_to_file.rs
+++ b/sparse_strips/vello_hybrid/examples/render_to_file.rs
@@ -9,7 +9,13 @@
 mod common;
 
 use common::render_svg;
-use std::io::BufWriter;
+use std::{
+    io::BufWriter,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
 use vello_common::pico_svg::PicoSvg;
 use vello_common::pixmap::Pixmap;
 use vello_hybrid::{DimensionConstraints, Scene};
@@ -24,10 +30,6 @@ fn main() {
     pollster::block_on(run());
 }
 
-#[allow(
-    clippy::cast_possible_truncation,
-    reason = "Width and height are expected to fit within u16 range"
-)]
 async fn run() {
     let mut args = std::env::args().skip(1);
     let svg_filename: String = args.next().expect("svg filename is first arg");
@@ -41,7 +43,10 @@ async fn run() {
     let svg_height = parsed.size.height * render_scale;
     let (width, height) = constraints.calculate_dimensions(svg_width, svg_height);
 
-    let mut scene = Scene::new(width as u16, height as u16);
+    let width = DimensionConstraints::convert_dimension(width);
+    let height = DimensionConstraints::convert_dimension(height);
+
+    let mut scene = Scene::new(width, height);
     render_svg(&mut scene, render_scale, &parsed.items);
 
     // Initialize wgpu device and queue for GPU rendering
@@ -67,8 +72,8 @@ async fn run() {
     let texture = device.create_texture(&wgpu::TextureDescriptor {
         label: Some("Render Target"),
         size: wgpu::Extent3d {
-            width: width as u32,
-            height: height as u32,
+            width: width.into(),
+            height: height.into(),
             depth_or_array_layers: 1,
         },
         mip_level_count: 1,
@@ -84,19 +89,18 @@ async fn run() {
     let mut renderer = vello_hybrid::Renderer::new(&device, &vello_hybrid::RendererOptions {});
     let render_params = vello_hybrid::RenderParams {
         base_color: Some(peniko::Color::TRANSPARENT),
-        width: width as u32,
-        height: height as u32,
+        width: width.into(),
+        height: height.into(),
         strip_height: vello_common::tile::Tile::HEIGHT as u32,
     };
     renderer.prepare(&device, &queue, &scene, &render_params);
     renderer.render_to_texture(&device, &queue, &scene, &texture_view, &render_params);
 
     // Create a buffer to copy the texture data
-    let bytes_per_row = (width as u32 * 4).next_multiple_of(256);
-    let buffer_size = (bytes_per_row * height as u32) as u64;
+    let bytes_per_row = (u32::from(width) * 4).next_multiple_of(256);
     let texture_copy_buffer = device.create_buffer(&wgpu::BufferDescriptor {
         label: Some("Output Buffer"),
-        size: buffer_size,
+        size: u64::from(bytes_per_row) * u64::from(height),
         usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
         mapped_at_creation: false,
     });
@@ -121,8 +125,8 @@ async fn run() {
             },
         },
         wgpu::Extent3d {
-            width: width as u32,
-            height: height as u32,
+            width: width.into(),
+            height: height.into(),
             depth_or_array_layers: 1,
         },
     );
@@ -139,7 +143,7 @@ async fn run() {
     device.poll(wgpu::Maintain::Wait);
 
     // Read back the pixel data
-    let mut img_data = Vec::with_capacity((width as u32 * height as u32 * 4) as usize);
+    let mut img_data = Vec::with_capacity(usize::from(width) * usize::from(height) * 4);
     for row in texture_copy_buffer
         .slice(..)
         .get_mapped_range()
@@ -159,14 +163,14 @@ async fn run() {
     }
 
     // Create a pixmap and set the buffer
-    let mut pixmap = Pixmap::new(width as u16, height as u16);
+    let mut pixmap = Pixmap::new(width, height);
     pixmap.buf = rgba_buffer;
     pixmap.unpremultiply();
 
     // Write the pixmap to a file
     let file = std::fs::File::create(output_filename).unwrap();
     let w = BufWriter::new(file);
-    let mut png_encoder = png::Encoder::new(w, width as u32, height as u32);
+    let mut png_encoder = png::Encoder::new(w, width.into(), height.into());
     png_encoder.set_color(png::ColorType::Rgba);
     let mut writer = png_encoder.write_header().unwrap();
     writer.write_image_data(&pixmap.buf).unwrap();

--- a/sparse_strips/vello_hybrid/examples/simple.rs
+++ b/sparse_strips/vello_hybrid/examples/simple.rs
@@ -66,10 +66,6 @@ impl ApplicationHandler for SimpleVelloApp<'_> {
         }
     }
 
-    #[allow(
-        clippy::cast_possible_truncation,
-        reason = "Width and height are expected to fit within u16 range"
-    )]
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
         let RenderState::Suspended(cached_window) = &mut self.state else {
             return;
@@ -78,8 +74,8 @@ impl ApplicationHandler for SimpleVelloApp<'_> {
         let window = cached_window.take().unwrap_or_else(|| {
             create_winit_window(
                 event_loop,
-                self.scene.width() as u32,
-                self.scene.height() as u32,
+                self.scene.width().into(),
+                self.scene.height().into(),
                 true,
             )
         });

--- a/sparse_strips/vello_hybrid/examples/svg.rs
+++ b/sparse_strips/vello_hybrid/examples/svg.rs
@@ -71,10 +71,6 @@ struct SvgVelloApp<'s> {
 }
 
 impl ApplicationHandler for SvgVelloApp<'_> {
-    #[allow(
-        clippy::cast_possible_truncation,
-        reason = "Width and height are expected to fit within u16 range"
-    )]
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
         let RenderState::Suspended(cached_window) = &mut self.state else {
             return;
@@ -83,8 +79,8 @@ impl ApplicationHandler for SvgVelloApp<'_> {
         let window = cached_window.take().unwrap_or_else(|| {
             create_winit_window(
                 event_loop,
-                self.scene.width() as u32,
-                self.scene.height() as u32,
+                self.scene.width().into(),
+                self.scene.height().into(),
                 true,
             )
         });

--- a/sparse_strips/vello_hybrid/src/render.rs
+++ b/sparse_strips/vello_hybrid/src/render.rs
@@ -16,8 +16,9 @@ use std::fmt::Debug;
 
 use bytemuck::{Pod, Zeroable};
 use wgpu::{
-    BindGroup, BindGroupLayout, BlendState, Buffer, ColorTargetState, ColorWrites, Device,
-    PipelineCompilationOptions, Queue, RenderPipeline, Texture, TextureView, util::DeviceExt,
+    BindGroup, BindGroupLayout, BlendState, Buffer, ColorTargetState, ColorWrites,
+    CommandEncoderDescriptor, Device, PipelineCompilationOptions, Queue, RenderPipeline, Texture,
+    TextureView, util::DeviceExt,
 };
 
 use crate::scene::Scene;
@@ -163,7 +164,7 @@ impl Renderer {
                 module: &render_shader,
                 entry_point: Some("vs_main"),
                 buffers: &[wgpu::VertexBufferLayout {
-                    array_stride: std::mem::size_of::<GpuStrip>() as u64,
+                    array_stride: size_of::<GpuStrip>() as u64,
                     step_mode: wgpu::VertexStepMode::Instance,
                     attributes: &GpuStrip::vertex_attributes(),
                 }],
@@ -205,8 +206,7 @@ impl Renderer {
         render_params: &RenderParams,
     ) {
         let render_data = scene.prepare_render_data();
-        let required_strips_size =
-            std::mem::size_of::<GpuStrip>() as u64 * render_data.strips.len() as u64;
+        let required_strips_size = size_of::<GpuStrip>() as u64 * render_data.strips.len() as u64;
 
         // Check if we need to create new resources or resize existing ones
         let needs_new_resources = match &self.resources {
@@ -336,7 +336,7 @@ impl Renderer {
             return;
         };
         let render_data = scene.prepare_render_data();
-        let mut encoder = device.create_command_encoder(&Default::default());
+        let mut encoder = device.create_command_encoder(&CommandEncoderDescriptor::default());
         {
             let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("Redner to Texture Pass"),

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -133,28 +133,16 @@ impl Scene {
     }
 
     /// Get the width of the render context.
-    #[allow(
-        clippy::cast_possible_truncation,
-        reason = "Width is expected to fit within u16 range"
-    )]
     pub fn width(&self) -> u16 {
         self.width
     }
 
     /// Get the height of the render context.
-    #[allow(
-        clippy::cast_possible_truncation,
-        reason = "Height is expected to fit within u16 range"
-    )]
     pub fn height(&self) -> u16 {
         self.height
     }
 
     // Assumes that `line_buf` contains the flattened path.
-    #[allow(
-        clippy::cast_possible_truncation,
-        reason = "Width and height are expected to fit within u16 range"
-    )]
     fn render_path(&mut self, fill_rule: Fill, paint: Paint) {
         self.tiles
             .make_tiles(&self.line_buf, self.width, self.height);
@@ -177,10 +165,6 @@ impl Scene {
     ///
     /// This method converts the rendering context's state into a format
     /// suitable for GPU rendering, including strips and alpha values.
-    #[allow(
-        clippy::cast_possible_truncation,
-        reason = "GpuStrip fields use u16 and values are expected to fit within that range"
-    )]
     pub fn prepare_render_data(&self) -> RenderData {
         let mut strips: Vec<GpuStrip> = Vec::new();
         let wide_tiles_per_row = (self.width).div_ceil(WideTile::WIDTH);
@@ -226,12 +210,15 @@ impl Scene {
                                     Paint::Solid(color) => color,
                                     _ => peniko::color::AlphaColor::TRANSPARENT,
                                 };
+
+                            // msg is a variable here to work around rustfmt failure
+                            let msg = "GpuStrip fields use u16 and values are expected to fit within that range";
                             strips.push(GpuStrip {
                                 x: wide_tile_x + cmd_strip.x,
                                 y: wide_tile_y,
                                 width: cmd_strip.width,
                                 dense_width: cmd_strip.width,
-                                col: cmd_strip.alpha_ix as u32,
+                                col: cmd_strip.alpha_ix.try_into().expect(msg),
                                 rgba: color.premultiply().to_rgba8().to_u32(),
                             });
                         }

--- a/sparse_strips/vello_hybrid/src/util.rs
+++ b/sparse_strips/vello_hybrid/src/util.rs
@@ -308,6 +308,11 @@ impl DimensionConstraints {
     }
 
     /// Calculate dimensions while preserving aspect ratio within constraints
+    ///
+    /// Some viewboxes could never fit inside this constraint. For example, if the constraint for both axes
+    /// is 100.0..=2000.0, if `original_width` is `2.` and `original_height` is `1000.`, there is clearly
+    /// no way for that to fit within the constraints.
+    /// In these cases, this method clamps to within the ranges (respecting the constraints but losing the aspect ratio).
     pub fn calculate_dimensions(&self, original_width: f64, original_height: f64) -> (f64, f64) {
         // Ensure we have non-zero input dimensions
         let original_width = original_width.max(1.0);
@@ -335,10 +340,6 @@ impl DimensionConstraints {
         } else {
             (original_width, original_height)
         };
-        // Some viewboxes could never fit inside the given ranges (for example, for a constraint on both axes
-        // of 100.0..=2000.0), an `original_width` of `2.` with an `original_height` of `1000.`, there is clearly
-        // no way to fit that within the constraints.
-        // For these cases, we just clamp. Note that in theory.
         (
             width.clamp(min_width, max_width),
             height.clamp(min_height, max_height),

--- a/sparse_strips/vello_hybrid/src/util.rs
+++ b/sparse_strips/vello_hybrid/src/util.rs
@@ -374,3 +374,39 @@ impl Default for DimensionConstraints {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::DimensionConstraints;
+
+    #[test]
+    fn calculate_dimensions_in_range() {
+        let new = DimensionConstraints::new;
+        for (test_name, constraints) in [
+            ("Default", DimensionConstraints::default()),
+            (
+                "Max width different to max height",
+                new(100., 100., 500., 1000.),
+            ),
+            ("Max width equal to min width", new(100., 100., 100., 1000.)),
+            ("Very loose constraints", new(10., 10., 10_000., 10_000.)),
+        ] {
+            for [test_width, test_height] in [
+                [100., 100.],
+                [50., 200.],
+                [10., 2_000.],
+                [10_000., 10_000.],
+                // Larger than `u16::MAX`
+                [128_000., 128_000.],
+            ] {
+                let (width, height) = constraints.calculate_dimensions(test_width, test_height);
+                assert!(
+                    constraints.width_range.contains(&width),
+                    "Constraints in {test_name} should have a width in the supported range.\n\
+                    Got {width}x{height} from {test_width}x{test_height} in {constraints:?}"
+                );
+                assert!(constraints.height_range.contains(&height));
+            }
+        }
+    }
+}

--- a/sparse_strips/vello_hybrid/src/util.rs
+++ b/sparse_strips/vello_hybrid/src/util.rs
@@ -346,13 +346,13 @@ impl DimensionConstraints {
     }
 
     /// Converts a floating point dimension to a u16.
-    /// This can be used for values returned from [`calculate_dimensions`](Self::calculate_dimensions).
-    /// Note that:
-    /// 1) If the
+    /// For the [default](DimensionConstraints::default) constraints, if the input value
+    /// was returned from [`calculate_dimensions`](Self::calculate_dimensions), this function can't
+    /// fail. But note that this does not necessarily apply for custom constraints.
     ///
     /// # Panics
     ///
-    /// If value is negative or more than [`u16::MAX`].
+    /// If `value` is negative or larger than [`u16::MAX`].
     #[expect(
         clippy::cast_possible_truncation,
         reason = "Any truncation will be caught by the (saturating) casts into a wider type"


### PR DESCRIPTION
The main new API is `DimensionConstraints::convert_dimension(value: f64) -> u16`, which is a panicking conversion from `f64` to `u16`.

This also changes `DimensionConstraints::calculate_dimensions` to always return a value within the range, even if it means that the aspect ratio is clamped.
