### PR TITLE
sparse_strips: Depend on kurbo/peniko via vello_api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2698,8 +2698,6 @@ dependencies = [
 name = "vello_common"
 version = "0.4.0"
 dependencies = [
- "kurbo",
- "peniko",
  "roxmltree",
  "vello_api",
 ]
@@ -2709,9 +2707,7 @@ name = "vello_cpu"
 version = "0.4.0"
 dependencies = [
  "image",
- "kurbo",
  "oxipng",
- "peniko",
  "vello_common",
 ]
 
@@ -2731,8 +2727,6 @@ name = "vello_hybrid"
 version = "0.4.0"
 dependencies = [
  "bytemuck",
- "kurbo",
- "peniko",
  "png",
  "pollster",
  "roxmltree",

--- a/sparse_strips/vello_common/Cargo.toml
+++ b/sparse_strips/vello_common/Cargo.toml
@@ -13,8 +13,6 @@ publish = false
 
 [dependencies]
 vello_api = { workspace = true }
-kurbo = { workspace = true }
-peniko = { workspace = true }
 # for pico_svg
 roxmltree = "0.20.0"
 

--- a/sparse_strips/vello_common/src/flatten.rs
+++ b/sparse_strips/vello_common/src/flatten.rs
@@ -3,9 +3,8 @@
 
 //! Flattening filled and stroked paths.
 
-use kurbo::StrokeOpts;
 use vello_api::kurbo;
-use vello_api::kurbo::{Affine, BezPath, Stroke};
+use vello_api::kurbo::{Affine, BezPath, Stroke, StrokeOpts};
 
 /// The flattening tolerance.
 const TOL: f64 = 0.25;

--- a/sparse_strips/vello_common/src/pico_svg.rs
+++ b/sparse_strips/vello_common/src/pico_svg.rs
@@ -11,9 +11,9 @@
 
 use std::str::FromStr;
 
-use kurbo::{Affine, BezPath, Point, Size, Vec2};
-use peniko::color::{AlphaColor, DynamicColor, Srgb, palette};
 use roxmltree::{Document, Node};
+use vello_api::kurbo::{Affine, BezPath, Point, Size, Vec2};
+use vello_api::peniko::color::{AlphaColor, DynamicColor, Srgb, palette};
 
 /// A simplified representation of an SVG document
 #[derive(Debug)]
@@ -287,7 +287,7 @@ fn parse_transform(transform: &str) -> Affine {
 
 fn parse_color(color: &str) -> AlphaColor<Srgb> {
     let color = color.trim();
-    peniko::color::parse_color(color.trim())
+    vello_api::peniko::color::parse_color(color.trim())
         .map(DynamicColor::to_alpha_color)
         .unwrap_or(palette::css::FUCHSIA.with_alpha(0.5))
 }
@@ -313,7 +313,7 @@ fn modify_opacity(
 #[cfg(test)]
 mod tests {
     use super::parse_color;
-    use peniko::color::{AlphaColor, Srgb, palette};
+    use vello_api::peniko::color::{AlphaColor, Srgb, palette};
 
     fn assert_close_color(c1: AlphaColor<Srgb>, c2: AlphaColor<Srgb>) {
         const EPSILON: f32 = 1e-4;

--- a/sparse_strips/vello_common/src/strip.rs
+++ b/sparse_strips/vello_common/src/strip.rs
@@ -3,7 +3,7 @@
 
 //! Rendering strips.
 
-use peniko::Fill;
+use vello_api::peniko::Fill;
 
 use crate::flatten::Line;
 use crate::tile::{Tile, Tiles};

--- a/sparse_strips/vello_cpu/Cargo.toml
+++ b/sparse_strips/vello_cpu/Cargo.toml
@@ -12,8 +12,6 @@ repository.workspace = true
 publish = false
 
 [dependencies]
-kurbo = { workspace = true }
-peniko = { workspace = true }
 vello_common = { workspace = true }
 
 [dev-dependencies]

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -5,12 +5,12 @@
 
 use crate::fine::Fine;
 use crate::util::ColorExt;
-use kurbo::{Affine, BezPath, Cap, Join, Rect, Shape, Stroke};
-use peniko::color::palette::css::BLACK;
-use peniko::{BlendMode, Compose, Fill, Mix};
 use vello_common::coarse::Wide;
 use vello_common::flatten::Line;
+use vello_common::kurbo::{Affine, BezPath, Cap, Join, Rect, Shape, Stroke};
 use vello_common::paint::Paint;
+use vello_common::peniko::color::palette::css::BLACK;
+use vello_common::peniko::{BlendMode, Compose, Fill, Mix};
 use vello_common::pixmap::Pixmap;
 use vello_common::strip::Strip;
 use vello_common::tile::Tiles;

--- a/sparse_strips/vello_cpu/src/util.rs
+++ b/sparse_strips/vello_cpu/src/util.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use peniko::color::{PremulColor, Srgb};
+use vello_common::peniko::color::{PremulColor, Srgb};
 
 pub(crate) trait ColorExt {
     /// Using the already-existing `to_rgba8` is slow on x86 because it involves rounding, so

--- a/sparse_strips/vello_hybrid/Cargo.toml
+++ b/sparse_strips/vello_hybrid/Cargo.toml
@@ -16,8 +16,6 @@ workspace = true
 
 [dependencies]
 vello_common = { workspace = true }
-peniko = { workspace = true }
-kurbo = { workspace = true }
 bytemuck = { workspace = true, features = ["derive"] }
 wgpu = { workspace = true }
 

--- a/sparse_strips/vello_hybrid/examples/common/mod.rs
+++ b/sparse_strips/vello_hybrid/examples/common/mod.rs
@@ -8,7 +8,7 @@
 
 use std::sync::Arc;
 
-use kurbo::Affine;
+use vello_common::kurbo::{Affine, Stroke};
 use vello_common::pico_svg::Item;
 use vello_hybrid::{
     Renderer, RendererOptions, Scene,
@@ -27,7 +27,7 @@ pub(crate) fn render_svg(ctx: &mut Scene, scale: f64, items: &[Item]) {
                     ctx.fill_path(&fill_item.path);
                 }
                 Item::Stroke(stroke_item) => {
-                    let style = kurbo::Stroke::new(stroke_item.width);
+                    let style = Stroke::new(stroke_item.width);
                     ctx.set_stroke(style);
                     ctx.set_paint(stroke_item.color.into());
                     ctx.stroke_path(&stroke_item.path);

--- a/sparse_strips/vello_hybrid/examples/simple.rs
+++ b/sparse_strips/vello_hybrid/examples/simple.rs
@@ -10,12 +10,12 @@
 mod common;
 
 use common::{create_vello_renderer, create_winit_window};
-use kurbo::Affine;
-use peniko::{
+use std::sync::Arc;
+use vello_common::kurbo::Affine;
+use vello_common::peniko::{
     color::palette,
     kurbo::{BezPath, Stroke},
 };
-use std::sync::Arc;
 use vello_hybrid::{
     RenderParams, Renderer, Scene,
     util::{RenderContext, RenderSurface},

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -4,12 +4,12 @@
 //! Basic render operations.
 
 use crate::render::{GpuStrip, RenderData};
-use kurbo::{Affine, BezPath, Cap, Join, Rect, Shape, Stroke};
-use peniko::color::palette::css::BLACK;
-use peniko::{BlendMode, Compose, Fill, Mix};
 use vello_common::coarse::{Wide, WideTile};
 use vello_common::flatten::Line;
+use vello_common::kurbo::{Affine, BezPath, Cap, Join, Rect, Shape, Stroke};
 use vello_common::paint::Paint;
+use vello_common::peniko::color::{AlphaColor, Srgb, palette::css::BLACK};
+use vello_common::peniko::{BlendMode, Compose, Fill, Mix};
 use vello_common::strip::Strip;
 use vello_common::tile::{Tile, Tiles};
 use vello_common::{flatten, strip};
@@ -190,11 +190,10 @@ impl Scene {
                 for cmd in &wide_tile.cmds {
                     match cmd {
                         vello_common::coarse::Cmd::Fill(fill) => {
-                            let color: peniko::color::AlphaColor<peniko::color::Srgb> =
-                                match fill.paint {
-                                    Paint::Solid(color) => color,
-                                    _ => peniko::color::AlphaColor::TRANSPARENT,
-                                };
+                            let color: AlphaColor<Srgb> = match fill.paint {
+                                Paint::Solid(color) => color,
+                                _ => AlphaColor::TRANSPARENT,
+                            };
                             strips.push(GpuStrip {
                                 x: wide_tile_x + fill.x,
                                 y: wide_tile_y,
@@ -205,11 +204,10 @@ impl Scene {
                             });
                         }
                         vello_common::coarse::Cmd::AlphaFill(cmd_strip) => {
-                            let color: peniko::color::AlphaColor<peniko::color::Srgb> =
-                                match cmd_strip.paint {
-                                    Paint::Solid(color) => color,
-                                    _ => peniko::color::AlphaColor::TRANSPARENT,
-                                };
+                            let color: AlphaColor<Srgb> = match cmd_strip.paint {
+                                Paint::Solid(color) => color,
+                                _ => AlphaColor::TRANSPARENT,
+                            };
 
                             // msg is a variable here to work around rustfmt failure
                             let msg = "GpuStrip fields use u16 and values are expected to fit within that range";


### PR DESCRIPTION
The `vello_api` dependency already provides a re-export of `kurbo` and `peniko`, so use them via that or the re-export of that in `vello_common`.