### PR TITLE
Fix: Properly handle scene resets to ensure correct alpha rendering

### DIFF
--- a/sparse_strips/vello_hybrid/examples/svg.rs
+++ b/sparse_strips/vello_hybrid/examples/svg.rs
@@ -20,8 +20,9 @@ use vello_hybrid::{
 use wgpu::RenderPassDescriptor;
 use winit::{
     application::ApplicationHandler,
-    event::WindowEvent,
+    event::{ElementState, KeyEvent, MouseScrollDelta, WindowEvent},
     event_loop::{ActiveEventLoop, EventLoop},
+    keyboard::{Key, NamedKey},
     window::{Window, WindowId},
 };
 
@@ -42,6 +43,11 @@ fn main() {
         .run_app(&mut app)
         .expect("Couldn't run event loop");
 }
+
+// Constants for zoom behavior
+const MIN_SCALE: f64 = 0.1;
+const MAX_SCALE: f64 = 20.0;
+const ZOOM_STEP: f64 = 0.5;
 
 #[derive(Debug)]
 enum RenderState<'s> {
@@ -76,6 +82,13 @@ struct SvgVelloApp<'s> {
 
     // The parsed SVG
     parsed_svg: Option<PicoSvg>,
+}
+
+impl SvgVelloApp<'_> {
+    /// Adjust the render scale by the given delta, clamping to min/max values
+    fn adjust_scale(&mut self, delta: f64) {
+        self.render_scale = (self.render_scale + delta).clamp(MIN_SCALE, MAX_SCALE);
+    }
 }
 
 impl ApplicationHandler for SvgVelloApp<'_> {
@@ -146,6 +159,43 @@ impl ApplicationHandler for SvgVelloApp<'_> {
             WindowEvent::Resized(size) => {
                 self.context
                     .resize_surface(surface, size.width, size.height);
+            }
+
+            WindowEvent::MouseWheel {
+                delta: MouseScrollDelta::PixelDelta(pos),
+                ..
+            } => {
+                // Convert pixel delta to a scale adjustment
+                // Divide by a factor to make the zoom less sensitive
+                self.adjust_scale(pos.y * ZOOM_STEP / 50.0);
+            }
+
+            WindowEvent::PinchGesture { delta, .. } => {
+                self.adjust_scale(delta * ZOOM_STEP);
+            }
+
+            WindowEvent::KeyboardInput {
+                event:
+                    KeyEvent {
+                        logical_key,
+                        state: ElementState::Pressed,
+                        ..
+                    },
+                ..
+            } => {
+                match logical_key {
+                    Key::Character(c) => match c.as_str() {
+                        "+" | "=" => self.adjust_scale(ZOOM_STEP),
+                        "-" | "_" => self.adjust_scale(-ZOOM_STEP),
+                        // Reset to original scale
+                        "0" => {
+                            self.render_scale = 5.0;
+                        }
+                        _ => {}
+                    },
+                    Key::Named(NamedKey::Escape) => event_loop.exit(),
+                    _ => {}
+                }
             }
 
             WindowEvent::RedrawRequested => {


### PR DESCRIPTION
### Overview
This PR addresses the visual artifacts (dotted/dashed lines) that appear when rendering the same scene multiple times using the `vello_hybrid` renderer.

<img width="532" alt="image" src="https://github.com/user-attachments/assets/da632491-987e-4f6f-a4dc-2ad4fb730282" />

### Issue Description
Previously, when resetting the scene and re-rendering repeatedly, strange visual artifacts would appear at the boundaries between shapes - specifically dotted or dashed lines along what should be properly alpha sampled boundaries. These artifacts only appeared when:
- The scene was reset and re-rendered in `RedrawRequested` event handler
- The `prepare` method was called after each re-render

### Root Cause
The root cause was a misalignment between the alpha values stored in the scene and the GPU alpha texture:
- When `Scene::reset` was called, it correctly cleared the alphas array in the scene (reset added as a separate commit)
- When `render_svg` was called, it populated the scene with new alpha values
- However, `Renderer::prepare` method only created a new alpha texture when the strips buffer size increased
- This led to a situation where new alpha values were being written to a texture sized for previous frames, or, if alphas weren’t properly reset, they retained stale data from previous frames, causing textures to grow larger each frame, meantime alpha data copying size was restricted to the current texture size.
- The shader was calculating texture coordinates based on strip `col` values, but these values pointed to positions that might exceed the texture dimensions
- Due to GPU texture addressing behavior, these out-of-bounds accesses "wrapped around" silently, causing the shader to sample completely unrelated alpha values

The critical issue was that we were only checking if the strips buffer needed to be recreated, but not independently verifying if the alpha texture needed to be recreated when only the alpha values changed.

### Solution
Fixed the issue by modifying `prepare` method to:
- Separately check if the strips buffer or alpha texture needs to be recreated
- Create a new alpha texture whenever the required texture size exceeds the current texture size
- Ensure both resources are properly sized for the current frame's data before writing to them
- Add assertions to verify the alpha texture is large enough to hold all the alpha values

This ensures that the alpha texture always matches the current frame's alpha values, maintaining the correct relationship between strip `col` indices and texture coordinates, eliminating the visual artifacts.

### Notes
- `Scene::reset` method has been updated to properly (fully) reset the scene state by clearing all data

