### PR TITLE
`vello_api`: Make `no_std` and add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ env:
   # List of packages that will be checked with the minimum supported Rust version.
   # This should be limited to packages that are intended for publishing.
   RUST_MIN_VER_PKGS: "-p vello -p vello_encoding -p vello_shaders -p vello_api -p vello_common -p vello_cpu -p vello_hybrid"
+  # List of packages that will be checked for `no_std` builds.
+  # This should be limited to packages that are intended for publishing.
+  RUST_NO_STD_PKGS: "-p vello_api"
+  # List of features that depend on the standard library and will be excluded from no_std checks.
+  FEATURES_DEPENDING_ON_STD: "std,default"
   # List of packages that can not target Wasm.
   # `vello_tests` uses `nv-flip`, which doesn't support Wasm.
   NO_WASM_PKGS: "--exclude vello_tests --exclude simple_sdl2"
@@ -43,6 +48,10 @@ env:
 #
 # The MSRV jobs run only cargo check because different clippy versions can disagree on goals and
 # running tests introduces dev dependencies which may require a higher MSRV than the bare package.
+#
+# For no_std checks we target x86_64-unknown-none, because this target doesn't support std
+# and as such will error out if our dependency tree accidentally tries to use std.
+# https://doc.rust-lang.org/stable/rustc/platform-support/x86_64-unknown-none.html
 #
 # We don't save caches in the merge-group cases, because those caches will never be re-used (apart
 # from the very rare cases where there are multiple PRs in the merge queue).
@@ -105,6 +114,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_STABLE_VER }}
+          targets: x86_64-unknown-none
           components: clippy
 
       - name: install cargo-hack
@@ -121,11 +131,14 @@ jobs:
         with:
           save-if: ${{ github.event_name != 'merge_group' }}
 
+      - name: cargo clippy (no_std)
+        run: cargo hack clippy ${{ env.RUST_NO_STD_PKGS }} --locked --optional-deps --each-feature --ignore-unknown-features --features libm --exclude-features ${{ env.FEATURES_DEPENDING_ON_STD }} --target x86_64-unknown-none -- -D warnings
+
       - name: cargo clippy
-        run: cargo hack clippy --workspace --locked --optional-deps --each-feature -- -D warnings
+        run: cargo hack clippy --workspace --locked --optional-deps --each-feature --ignore-unknown-features --features std -- -D warnings
 
       - name: cargo clippy (auxiliary)
-        run: cargo hack clippy --workspace --locked --optional-deps --each-feature --tests --benches --examples -- -D warnings
+        run: cargo hack clippy --workspace --locked --optional-deps --each-feature --ignore-unknown-features --features std --tests --benches --examples -- -D warnings
 
   clippy-stable-wasm:
     name: cargo clippy (wasm32)
@@ -150,11 +163,14 @@ jobs:
         with:
           save-if: ${{ github.event_name != 'merge_group' }}
 
+      - name: cargo clippy (no_std)
+        run: cargo hack clippy ${{ env.RUST_NO_STD_PKGS }} --locked --target wasm32-unknown-unknown --optional-deps --each-feature --ignore-unknown-features --features libm --exclude-features ${{ env.FEATURES_DEPENDING_ON_STD }} -- -D warnings
+
       - name: cargo clippy
-        run: cargo hack clippy --workspace ${{ env.NO_WASM_PKGS }} --locked --target wasm32-unknown-unknown --optional-deps --each-feature -- -D warnings
+        run: cargo hack clippy --workspace ${{ env.NO_WASM_PKGS }} --locked --target wasm32-unknown-unknown --optional-deps --each-feature --ignore-unknown-features --features std -- -D warnings
 
       - name: cargo clippy (auxiliary)
-        run: cargo hack clippy --workspace ${{ env.NO_WASM_PKGS }} --locked --target wasm32-unknown-unknown --optional-deps --each-feature --tests --benches --examples -- -D warnings
+        run: cargo hack clippy --workspace ${{ env.NO_WASM_PKGS }} --locked --target wasm32-unknown-unknown --optional-deps --each-feature --ignore-unknown-features --features std --tests --benches --examples -- -D warnings
 
   prime-lfs-cache:
     name: Prime LFS Cache
@@ -334,6 +350,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_MIN_VER }}
+          targets: x86_64-unknown-none
 
       - name: install cargo-hack
         uses: taiki-e/install-action@v2
@@ -349,8 +366,11 @@ jobs:
         with:
           save-if: ${{ github.event_name != 'merge_group' }}
 
+      - name: cargo check (no_std)
+        run: cargo hack check ${{ env.RUST_NO_STD_PKGS }} --locked --optional-deps --each-feature --ignore-unknown-features --features libm --exclude-features ${{ env.FEATURES_DEPENDING_ON_STD }} --target x86_64-unknown-none
+
       - name: cargo check
-        run: cargo hack check ${{ env.RUST_MIN_VER_PKGS }} --locked --optional-deps --each-feature
+        run: cargo hack check ${{ env.RUST_MIN_VER_PKGS }} --locked --optional-deps --each-feature --ignore-unknown-features --features std
 
   check-msrv-wasm:
     name: cargo check (msrv) (wasm32)
@@ -375,7 +395,7 @@ jobs:
           save-if: ${{ github.event_name != 'merge_group' }}
 
       - name: cargo check
-        run: cargo hack check ${{ env.RUST_MIN_VER_PKGS }} ${{ env.NO_WASM_PKGS }} --locked --target wasm32-unknown-unknown --optional-deps --each-feature
+        run: cargo hack check ${{ env.RUST_MIN_VER_PKGS }} ${{ env.NO_WASM_PKGS }} --locked --target wasm32-unknown-unknown --optional-deps --each-feature --ignore-unknown-features --features std
 
   doc:
     name: cargo doc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,6 +441,9 @@ name = "color"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c387f6cef110ee8eaf12fca5586d3d303c07c594f4a5f02c768b6470b70dbd"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "colorchoice"
@@ -1168,6 +1171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89234b2cc610a7dd927ebde6b41dd1a5d4214cffaef4cf1fb2195d592f92518f"
 dependencies = [
  "arrayvec",
+ "libm",
  "schemars",
  "smallvec",
 ]
@@ -1217,6 +1221,12 @@ dependencies = [
  "cfg-if",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "libredox"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,9 +93,9 @@ bytemuck = { version = "1.21.0", features = ["derive"] }
 skrifa = "0.26.4"
 # The version of kurbo used below should be kept in sync
 # with the version of kurbo used by peniko.
-peniko = "0.3.1"
+peniko = { version = "0.3.1", default-features = false }
 # FIXME: This can be removed once peniko supports the schemars feature.
-kurbo = "0.11.1"
+kurbo = { version = "0.11.1", default-features = false }
 futures-intrusive = "0.5.0"
 smallvec = "1.13.2"
 static_assertions = "1.1.0"
@@ -103,7 +103,7 @@ thiserror = "2.0.11"
 oxipng = { version = "9.1.4", default-features = false }
 
 # The below crates are experimental!
-vello_api = { path = "sparse_strips/vello_api" }
+vello_api = { path = "sparse_strips/vello_api", default-features = false }
 vello_common = { path = "sparse_strips/vello_common" }
 vello_cpu = { path = "sparse_strips/vello_cpu" }
 vello_hybrid = { path = "sparse_strips/vello_hybrid" }

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -44,7 +44,7 @@ log = { workspace = true }
 # tracing_android_trace
 tracing = { version = "0.1.41", features = ["log-always"] }
 # For _ci_dep_features_to_test feature tests.
-kurbo = { workspace = true, optional = true }
+kurbo = { workspace = true, optional = true, default-features = true }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
 # We use android_logger on Android

--- a/sparse_strips/vello_api/Cargo.toml
+++ b/sparse_strips/vello_api/Cargo.toml
@@ -15,6 +15,9 @@ publish = false
 peniko = { workspace = true }
 
 [features]
+default = ["std"]
+std = ["peniko/std"]
+libm = ["peniko/libm"]
 simd = []
 
 [lints]

--- a/sparse_strips/vello_api/src/lib.rs
+++ b/sparse_strips/vello_api/src/lib.rs
@@ -6,6 +6,7 @@
 //! across different implementations
 
 #![forbid(unsafe_code)]
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 
 pub use peniko;
 pub use peniko::color;

--- a/sparse_strips/vello_common/Cargo.toml
+++ b/sparse_strips/vello_common/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 publish = false
 
 [dependencies]
-vello_api = { workspace = true }
+vello_api = { workspace = true, default-features = true }
 # for pico_svg
 roxmltree = "0.20.0"
 

--- a/vello/Cargo.toml
+++ b/vello/Cargo.toml
@@ -46,7 +46,7 @@ vello_encoding = { workspace = true }
 vello_shaders = { workspace = true, optional = true }
 bytemuck = { workspace = true }
 skrifa = { workspace = true }
-peniko = { workspace = true }
+peniko = { workspace = true, default-features = true }
 wgpu = { workspace = true, optional = true }
 log = { workspace = true }
 static_assertions = { workspace = true }

--- a/vello_encoding/Cargo.toml
+++ b/vello_encoding/Cargo.toml
@@ -27,6 +27,6 @@ workspace = true
 [dependencies]
 bytemuck = { workspace = true }
 skrifa = { workspace = true }
-peniko = { workspace = true }
+peniko = { workspace = true, default-features = true }
 guillotiere = { version = "0.6.2" }
 smallvec = { workspace = true }


### PR DESCRIPTION
This makes the workspace dependencies for `kurbo` and `peniko` not enable default features, and therefore have to enable them in the crates that use them.

Add CI based on other Linebender crates, except that there is now a variable to specifically control which targets are checked for `no_std` compatibility.

This also means that `no_std` crates are checked for MSRV compliance which was not currently happening for the sparse strips crates.

Other crates will get `no_std` support in the future.