### PR TITLE
ci: Check MSRV for sparse strips packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
   RUST_MIN_VER: "1.85"
   # List of packages that will be checked with the minimum supported Rust version.
   # This should be limited to packages that are intended for publishing.
-  RUST_MIN_VER_PKGS: "-p vello -p vello_encoding -p vello_shaders"
+  RUST_MIN_VER_PKGS: "-p vello -p vello_encoding -p vello_shaders -p vello_api -p vello_common -p vello_cpu -p vello_hybrid"
   # List of packages that can not target Wasm.
   # `vello_tests` uses `nv-flip`, which doesn't support Wasm.
   NO_WASM_PKGS: "--exclude vello_tests --exclude simple_sdl2"


### PR DESCRIPTION
These aren't published yet but they will be and we'll want to make sure that we're keeping a handle on the MSRV.

Since the Rust stable and MSRV are currently both the same, this wasn't an issue to date, but we'll be bumping the Rust stable version prior to bumping the MSRV again.