### PR TITLE
Store alphas as `u8` instead of explicitly packing

### DIFF
--- a/sparse_strips/vello_common/src/coarse.rs
+++ b/sparse_strips/vello_common/src/coarse.rs
@@ -113,9 +113,10 @@ impl Wide {
             let next_strip = &strip_buf[i + 1];
             let x0 = strip.x;
             let strip_y = strip.strip_y();
-            let mut col = strip.col;
+            let mut col = strip.alpha_idx / u32::from(Tile::HEIGHT);
             // Can potentially be 0, if the next strip's x values is also < 0.
-            let strip_width = next_strip.col.saturating_sub(col) as u16;
+            let strip_width =
+                (next_strip.alpha_idx / u32::from(Tile::HEIGHT)).saturating_sub(col) as u16;
             let x1 = x0 + strip_width;
             let tile_x0 = x0 / WideTile::WIDTH;
             // It's possible that a strip extends into a new wide tile, but we don't actually
@@ -130,7 +131,7 @@ impl Wide {
                 let cmd = CmdAlphaFill {
                     x: x_tile_rel,
                     width,
-                    alpha_ix: col as usize,
+                    alpha_ix: (col * u32::from(Tile::HEIGHT)) as usize,
                     paint: paint.clone(),
                 };
                 x += width;

--- a/sparse_strips/vello_common/src/coarse.rs
+++ b/sparse_strips/vello_common/src/coarse.rs
@@ -114,9 +114,10 @@ impl Wide {
             let x0 = strip.x;
             let strip_y = strip.strip_y();
             let mut col = strip.alpha_idx / u32::from(Tile::HEIGHT);
-            // Can potentially be 0, if the next strip's x values is also < 0.
-            let strip_width =
-                (next_strip.alpha_idx / u32::from(Tile::HEIGHT)).saturating_sub(col) as u16;
+            let next_col = next_strip.alpha_idx / u32::from(Tile::HEIGHT);
+            // Can potentially be 0, e.g. if the strip only changes coarse winding, but this
+            // depends on exact details of strip footprints.
+            let strip_width = next_col.saturating_sub(col) as u16;
             let x1 = x0 + strip_width;
             let tile_x0 = x0 / WideTile::WIDTH;
             // It's possible that a strip extends into a new wide tile, but we don't actually

--- a/sparse_strips/vello_cpu/src/fine.rs
+++ b/sparse_strips/vello_cpu/src/fine.rs
@@ -62,7 +62,7 @@ impl<'a> Fine<'a> {
         );
     }
 
-    pub(crate) fn run_cmd(&mut self, cmd: &Cmd, alphas: &[u32]) {
+    pub(crate) fn run_cmd(&mut self, cmd: &Cmd, alphas: &[u8]) {
         match cmd {
             Cmd::Fill(f) => {
                 self.fill(f.x as usize, f.width as usize, &f.paint);
@@ -97,7 +97,7 @@ impl<'a> Fine<'a> {
         }
     }
 
-    pub(crate) fn strip(&mut self, x: usize, width: usize, alphas: &[u32], paint: &Paint) {
+    pub(crate) fn strip(&mut self, x: usize, width: usize, alphas: &[u8], paint: &Paint) {
         debug_assert!(
             alphas.len() >= width,
             "alpha buffer doesn't contain sufficient elements"
@@ -169,12 +169,15 @@ pub(crate) mod strip {
     use crate::util::scalar::div_255;
     use vello_common::tile::Tile;
 
-    pub(crate) fn src_over(target: &mut [u8], src_c: &[u8; COLOR_COMPONENTS], alphas: &[u32]) {
+    pub(crate) fn src_over(target: &mut [u8], src_c: &[u8; COLOR_COMPONENTS], alphas: &[u8]) {
         let src_a = src_c[3] as u16;
 
-        for (bg_c, masks) in target.chunks_exact_mut(TILE_HEIGHT_COMPONENTS).zip(alphas) {
+        for (bg_c, masks) in target
+            .chunks_exact_mut(TILE_HEIGHT_COMPONENTS)
+            .zip(alphas.chunks_exact(usize::from(Tile::HEIGHT)))
+        {
             for j in 0..usize::from(Tile::HEIGHT) {
-                let mask_a = ((*masks >> (j * 8)) & 0xff) as u16;
+                let mask_a = u16::from(masks[j]);
                 let inv_src_a_mask_a = 255 - div_255(mask_a * src_a);
 
                 for i in 0..COLOR_COMPONENTS {

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -23,7 +23,7 @@ pub struct RenderContext {
     pub(crate) width: u16,
     pub(crate) height: u16,
     pub(crate) wide: Wide,
-    pub(crate) alphas: Vec<u32>,
+    pub(crate) alphas: Vec<u8>,
     pub(crate) line_buf: Vec<Line>,
     pub(crate) tiles: Tiles,
     pub(crate) strip_buf: Vec<Strip>,

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -37,7 +37,7 @@ pub struct Scene {
     pub(crate) width: u16,
     pub(crate) height: u16,
     pub(crate) wide: Wide,
-    pub(crate) alphas: Vec<u32>,
+    pub(crate) alphas: Vec<u8>,
     pub(crate) line_buf: Vec<Line>,
     pub(crate) tiles: Tiles,
     pub(crate) strip_buf: Vec<Strip>,
@@ -242,7 +242,9 @@ impl Scene {
                                 y: wide_tile_y,
                                 width: cmd_strip.width,
                                 dense_width: cmd_strip.width,
-                                col: cmd_strip.alpha_ix.try_into().expect(msg),
+                                col: (cmd_strip.alpha_ix / usize::from(Tile::HEIGHT))
+                                    .try_into()
+                                    .expect(msg),
                                 rgba: color.premultiply().to_rgba8().to_u32(),
                             });
                         }


### PR DESCRIPTION
This stops packing alpha values explicitly into `u32`s, which was a leftover from using `u32` GPU alpha storage buffers. This simplifies the code a bit and is a performance improvement. On my machine, 500 iterations of Paris-30k measure as the following.

```
Strip rendering
    before: 29.770845ms
    after:  28.914503ms
CPU fine
    before: 13.367204ms
    after:  12.358518ms
```