### PR TITLE
`vello_cpu`: add test of a fully overflowing circle

### DIFF
--- a/sparse_strips/vello_cpu/snapshots/filled_fully_overflowing_circle.png
+++ b/sparse_strips/vello_cpu/snapshots/filled_fully_overflowing_circle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:370f6acde4d6770f06ce24137d209c71cbc8ebd4ca07c5e3e4d9f7186876af09
+size 91

--- a/sparse_strips/vello_cpu/tests/basic.rs
+++ b/sparse_strips/vello_cpu/tests/basic.rs
@@ -135,6 +135,17 @@ fn filled_overflowing_circle() {
 }
 
 #[test]
+fn filled_fully_overflowing_circle() {
+    let mut ctx = get_ctx(100, 100, false);
+    let circle = Circle::new((50.0, 50.0), 80.0);
+
+    ctx.set_paint(LIME.into());
+    ctx.fill_path(&circle.to_path(0.1));
+
+    check_ref(&ctx, "filled_fully_overflowing_circle");
+}
+
+#[test]
 fn filled_circle_with_opacity() {
     let mut ctx = get_ctx(100, 100, false);
     let circle = Circle::new((50.0, 50.0), 45.0);


### PR DESCRIPTION
This is subtly different from the existing test `filled_overflowing_circle` as in this new test the circle's path is multiple tiles away from the viewport. Depending on logic changes, that might have different failure modes.