### PR TITLE
Follow-up fix for encoding data as `u32`

### DIFF
--- a/vello_encoding/src/path.rs
+++ b/vello_encoding/src/path.rs
@@ -683,7 +683,7 @@ impl<'a> PathEncoder<'a> {
             self.close();
         }
         if self.state == PathState::MoveTo {
-            let new_len = self.data.len() - 8;
+            let new_len = self.data.len() - 2;
             self.data.truncate(new_len);
         }
         if self.n_encoded_segments != 0 {


### PR DESCRIPTION
The original work was done in PR #817 and as noticed in issue #875, there was still a place where there was a length manipulation that was in terms of `u8` rather than `u32`.

Fixes #875.