### PR TITLE
Replace `simple_sdl2` with `simple_sdl3`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ env:
   FEATURES_DEPENDING_ON_STD: "std,default"
   # List of packages that can not target Wasm.
   # `vello_tests` uses `nv-flip`, which doesn't support Wasm.
-  NO_WASM_PKGS: "--exclude vello_tests --exclude simple_sdl2"
+  NO_WASM_PKGS: "--exclude vello_tests --exclude simple_sdl3"
   # The files stored in LFS the tests need to access, in JSON format
   LFS_FILES: '["vello_tests/snapshots/*.png", "sparse_strips/vello_cpu/snapshots/*.png"]'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ This release has an [MSRV][] of 1.85.
 
 <!-- TODO: Wgpu 24 (#791); override_image change (#802) -->
 
+### Changed
+
+- The SDL2 example (`simple_sdl2`) has been replaced by `simple_sdl3` using SDL3. ([#887][] by [@waywardmonkeys][])
+
+
 ### Removed
 
 - Breaking: The `Renderer::render_to_surface` has been removed. ([#803][] by [@DJMcNab][])
@@ -257,6 +262,7 @@ This release has an [MSRV][] of 1.75.
 [#796]: https://github.com/linebender/vello/pull/796
 [#803]: https://github.com/linebender/vello/pull/803
 [#841]: https://github.com/linebender/vello/pull/841
+[#887]: https://github.com/linebender/vello/pull/887
 
 <!-- Note that this still comparing against 0.4.0, because 0.4.1 is a cherry-picked patch -->
 [Unreleased]: https://github.com/linebender/vello/compare/v0.4.0...HEAD

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
- "objc2",
+ "objc2 0.5.2",
 ]
 
 [[package]]
@@ -1511,6 +1511,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3531f65190d9cff863b77a99857e74c314dd16bf56c538c4b57c7cbc3f3a6e59"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2-app-kit"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1519,7 +1528,7 @@ dependencies = [
  "bitflags 2.8.0",
  "block2",
  "libc",
- "objc2",
+ "objc2 0.5.2",
  "objc2-core-data",
  "objc2-core-image",
  "objc2-foundation",
@@ -1534,7 +1543,7 @@ checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
  "bitflags 2.8.0",
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-core-location",
  "objc2-foundation",
 ]
@@ -1546,7 +1555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
 dependencies = [
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-foundation",
 ]
 
@@ -1558,7 +1567,7 @@ checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
  "bitflags 2.8.0",
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-foundation",
 ]
 
@@ -1569,7 +1578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
 dependencies = [
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-foundation",
  "objc2-metal",
 ]
@@ -1581,16 +1590,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
 dependencies = [
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-contacts",
  "objc2-foundation",
 ]
 
 [[package]]
 name = "objc2-encode"
-version = "4.0.3"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-foundation"
@@ -1602,7 +1611,7 @@ dependencies = [
  "block2",
  "dispatch",
  "libc",
- "objc2",
+ "objc2 0.5.2",
 ]
 
 [[package]]
@@ -1612,7 +1621,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
 dependencies = [
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-app-kit",
  "objc2-foundation",
 ]
@@ -1625,7 +1634,7 @@ checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
  "bitflags 2.8.0",
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-foundation",
 ]
 
@@ -1637,7 +1646,7 @@ checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
  "bitflags 2.8.0",
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-foundation",
  "objc2-metal",
 ]
@@ -1648,7 +1657,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
 dependencies = [
- "objc2",
+ "objc2 0.5.2",
  "objc2-foundation",
 ]
 
@@ -1660,7 +1669,7 @@ checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
  "bitflags 2.8.0",
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-cloud-kit",
  "objc2-core-data",
  "objc2-core-image",
@@ -1680,7 +1689,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
 dependencies = [
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-foundation",
 ]
 
@@ -1692,7 +1701,7 @@ checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
  "bitflags 2.8.0",
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-core-location",
  "objc2-foundation",
 ]
@@ -2083,6 +2092,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
+name = "rpkg-config"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a2d2f3481209a6b42eec2fbb49063fb4e8d35b57023401495d4fe0f85c817f0"
+
+[[package]]
 name = "run_wasm"
 version = "0.0.0"
 dependencies = [
@@ -2208,28 +2223,72 @@ dependencies = [
 ]
 
 [[package]]
-name = "sdl2"
-version = "0.37.0"
+name = "sdl3"
+version = "0.14.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b498da7d14d1ad6c839729bd4ad6fc11d90a57583605f3b4df2cd709a9cd380"
+checksum = "5c906148cd9ca61300e446d0c8cb36d40fad27e76e91d062d0bca759d7521e97"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.8.0",
  "lazy_static",
  "libc",
+ "objc2 0.6.0",
  "raw-window-handle",
- "sdl2-sys",
+ "sdl3-image-sys",
+ "sdl3-sys",
+ "sdl3-ttf-sys",
 ]
 
 [[package]]
-name = "sdl2-sys"
-version = "0.37.0"
+name = "sdl3-image-src"
+version = "3.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951deab27af08ed9c6068b7b0d05a93c91f0a8eb16b6b816a5e73452a43521d3"
+checksum = "c4d0c6070f236297a8e7931cbe5f652e3f0e5a8a214b12984357bd4904874cc7"
+
+[[package]]
+name = "sdl3-image-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0df364a60f4c203e2cfb24e574100ccabb73736d8bf66fcdb40e8064e74537d7"
 dependencies = [
- "cfg-if",
  "cmake",
- "libc",
- "version-compare",
+ "rpkg-config",
+ "sdl3-image-src",
+ "sdl3-sys",
+]
+
+[[package]]
+name = "sdl3-src"
+version = "3.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e677fa126db179fb8f03c982163321496ddf57a6d8a1e41eeef4600f956038b1"
+
+[[package]]
+name = "sdl3-sys"
+version = "0.4.7+SDL3-3.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d16a8a3623a4cb39a3661c81d9d4c5fd77ada27fc056e320b3651bf7bde1b1"
+dependencies = [
+ "cmake",
+ "rpkg-config",
+ "sdl3-src",
+]
+
+[[package]]
+name = "sdl3-ttf-src"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8deaa09c46d6aa8e8a81a601eb4685b2a57f2ce8a4ea3c59e8b623b526d1125"
+
+[[package]]
+name = "sdl3-ttf-sys"
+version = "0.1.1+SDL3-ttf-3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4823164cd24c3e7ac95bdf92e7ac409f070424da6778eb2d52231fe65973a9c"
+dependencies = [
+ "cmake",
+ "rpkg-config",
+ "sdl3-sys",
+ "sdl3-ttf-src",
 ]
 
 [[package]]
@@ -2313,11 +2372,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "simple_sdl2"
+name = "simple_sdl3"
 version = "0.0.0"
 dependencies = [
  "pollster",
- "sdl2",
+ "sdl3",
  "vello",
 ]
 
@@ -2787,12 +2846,6 @@ dependencies = [
  "svg",
  "vello_common",
 ]
-
-[[package]]
-name = "version-compare"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
 
 [[package]]
 name = "version_check"
@@ -3619,7 +3672,7 @@ dependencies = [
  "libc",
  "memmap2",
  "ndk",
- "objc2",
+ "objc2 0.5.2",
  "objc2-app-kit",
  "objc2-foundation",
  "objc2-ui-kit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
     "examples/run_wasm",
     "examples/scenes",
     "examples/simple",
-    "examples/simple_sdl2",
+    "examples/simple_sdl3",
     "examples/with_winit",
 
     "sparse_strips/vello_api",
@@ -28,7 +28,7 @@ members = [
 # NOTE: When bumping this, remember to also bump the aforementioned other packages'
 #       version in the dependencies section at the bottom of this file.
 #       Additionally, bump the Vello dependency version in the 'simple'
-#       and `simple_sdl2` examples.
+#       and `simple_sdl3` examples.
 version = "0.4.0"
 
 edition = "2024"

--- a/examples/simple_sdl3/Cargo.toml
+++ b/examples/simple_sdl3/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "simple_sdl2"
+name = "simple_sdl3"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -14,4 +14,4 @@ workspace = true
 # remove the path property of the following Vello dependency requirement.
 vello = { version = "0.4.0", path = "../../vello" }
 pollster = "0.4.0"
-sdl2 = { version = "0.37.0", features = ["raw-window-handle", "bundled"] }
+sdl3 = { version = "0.14.20", features = ["raw-window-handle", "build-from-source-static"] }

--- a/examples/simple_sdl3/src/main.rs
+++ b/examples/simple_sdl3/src/main.rs
@@ -2,14 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! Vello can also be used with non-Winit crates which provide a `RawWindowHandle`.
-//! This example uses it with [`sdl2`].
+//! This example uses it with [`sdl3`].
 //!
 //! Vello however is primarily designed for Xilem, which uses Winit, and so support for non-Winit crates
 //! is on a tier-2 basis, i.e. it is checked in CI, but is not rarely manually validated.
-extern crate sdl2;
 
-use sdl2::event::Event;
-use sdl2::keyboard::Keycode;
+use sdl3::event::Event;
+use sdl3::keyboard::Keycode;
 
 use std::num::NonZeroUsize;
 
@@ -22,14 +21,14 @@ use vello::{AaConfig, Renderer, RendererOptions, Scene};
 use vello::wgpu;
 
 fn main() {
-    let sdl_context = sdl2::init().unwrap();
+    let sdl_context = sdl3::init().unwrap();
     let video_subsystem = sdl_context.video().unwrap();
 
     let width: u32 = 800;
     let height: u32 = 600;
 
     let window = video_subsystem
-        .window("Vello SDL2 Demo", width, height)
+        .window("Vello SDL3 Demo", width, height)
         .position_centered()
         .metal_view()
         .build()


### PR DESCRIPTION
SDL2 has an issue in CI with newer versions of cmake and instead of figuring out how to fix that, we can just use SDL3 now since it has been released.