### PR TITLE
fix(vello_hybrid): update config on resize

### DIFF
--- a/sparse_strips/vello_hybrid/examples/render_to_file.rs
+++ b/sparse_strips/vello_hybrid/examples/render_to_file.rs
@@ -81,15 +81,17 @@ async fn run() {
     // Create renderer and render the scene to the texture
     let mut renderer = vello_hybrid::Renderer::new(
         &device,
-        &vello_hybrid::RendererOptions {
+        &vello_hybrid::RenderTargetConfig {
             format: texture.format(),
+            width: width.into(),
+            height: height.into(),
         },
     );
-    let render_params = vello_hybrid::RenderParams {
+    let render_size = vello_hybrid::RenderSize {
         width: width.into(),
         height: height.into(),
     };
-    renderer.prepare(&device, &queue, &scene, &render_params);
+    renderer.prepare(&device, &queue, &scene, &render_size);
     // Copy texture to buffer
     let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
         label: Some("Vello Render To Buffer"),
@@ -109,7 +111,7 @@ async fn run() {
             occlusion_query_set: None,
             timestamp_writes: None,
         });
-        renderer.render(&scene, &mut pass, &render_params);
+        renderer.render(&scene, &mut pass);
     }
 
     // Create a buffer to copy the texture data

--- a/sparse_strips/vello_hybrid/examples/webgl/src/lib.rs
+++ b/sparse_strips/vello_hybrid/examples/webgl/src/lib.rs
@@ -101,8 +101,8 @@ impl RendererWrapper {
             &device,
             &vello_hybrid::RenderTargetConfig {
                 format: surface_format,
-                width: width.into(),
-                height: height.into(),
+                width,
+                height,
             },
         );
 

--- a/sparse_strips/vello_hybrid/examples/webgl/src/lib.rs
+++ b/sparse_strips/vello_hybrid/examples/webgl/src/lib.rs
@@ -99,8 +99,10 @@ impl RendererWrapper {
 
         let renderer = vello_hybrid::Renderer::new(
             &device,
-            &vello_hybrid::RendererOptions {
+            &vello_hybrid::RenderTargetConfig {
                 format: surface_format,
+                width: width.into(),
+                height: height.into(),
             },
         );
 
@@ -176,7 +178,7 @@ impl AppState {
         // Render the current scene with transform
         self.scenes[self.current_scene].render(&mut self.scene, self.transform);
 
-        let params = vello_hybrid::RenderParams {
+        let render_size = vello_hybrid::RenderSize {
             width: self.width,
             height: self.height,
         };
@@ -185,7 +187,7 @@ impl AppState {
             &self.renderer_wrapper.device,
             &self.renderer_wrapper.queue,
             &self.scene,
-            &params,
+            &render_size,
         );
 
         let surface_texture = self.renderer_wrapper.surface.get_current_texture().unwrap();
@@ -215,7 +217,7 @@ impl AppState {
 
             self.renderer_wrapper
                 .renderer
-                .render(&self.scene, &mut pass, &params);
+                .render(&self.scene, &mut pass);
         }
 
         self.renderer_wrapper.queue.submit([encoder.finish()]);
@@ -511,11 +513,11 @@ pub async fn render_scene(scene: vello_hybrid::Scene, width: u16, height: u16) {
         surface,
     } = RendererWrapper::new(canvas).await;
 
-    let params = vello_hybrid::RenderParams {
+    let render_size = vello_hybrid::RenderSize {
         width: width as u32,
         height: height as u32,
     };
-    renderer.prepare(&device, &queue, &scene, &params);
+    renderer.prepare(&device, &queue, &scene, &render_size);
 
     let surface_texture = surface.get_current_texture().unwrap();
     let surface_texture_view = surface_texture
@@ -539,7 +541,7 @@ pub async fn render_scene(scene: vello_hybrid::Scene, width: u16, height: u16) {
             occlusion_query_set: None,
             timestamp_writes: None,
         });
-        renderer.render(&scene, &mut pass, &params);
+        renderer.render(&scene, &mut pass);
     }
 
     queue.submit([encoder.finish()]);

--- a/sparse_strips/vello_hybrid/examples/winit/src/main.rs
+++ b/sparse_strips/vello_hybrid/examples/winit/src/main.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use vello_common::color::palette::css::WHITE;
 use vello_common::color::{AlphaColor, Srgb};
 use vello_common::kurbo::{Affine, Vec2};
-use vello_hybrid::{RenderParams, Renderer, Scene};
+use vello_hybrid::{RenderSize, Renderer, Scene};
 use vello_hybrid_scenes::{AnyScene, get_example_scenes};
 use wgpu::RenderPassDescriptor;
 use winit::{
@@ -164,6 +164,7 @@ impl ApplicationHandler for App<'_> {
             WindowEvent::Resized(size) => {
                 self.context
                     .resize_surface(surface, size.width, size.height);
+                self.scene = Scene::new(size.width as u16, size.height as u16);
             }
             WindowEvent::KeyboardInput {
                 event:
@@ -263,7 +264,7 @@ impl ApplicationHandler for App<'_> {
                 self.scenes[self.current_scene].render(&mut self.scene, self.transform);
 
                 let device_handle = &self.context.devices[surface.dev_id];
-                let render_params = RenderParams {
+                let render_size = RenderSize {
                     width: surface.config.width,
                     height: surface.config.height,
                 };
@@ -271,7 +272,7 @@ impl ApplicationHandler for App<'_> {
                     &device_handle.device,
                     &device_handle.queue,
                     &self.scene,
-                    &render_params,
+                    &render_size,
                 );
 
                 let surface_texture = surface
@@ -304,11 +305,10 @@ impl ApplicationHandler for App<'_> {
                         occlusion_query_set: None,
                         timestamp_writes: None,
                     });
-                    self.renderers[surface.dev_id].as_mut().unwrap().render(
-                        &self.scene,
-                        &mut pass,
-                        &render_params,
-                    );
+                    self.renderers[surface.dev_id]
+                        .as_mut()
+                        .unwrap()
+                        .render(&self.scene, &mut pass);
                 }
 
                 device_handle.queue.submit([encoder.finish()]);

--- a/sparse_strips/vello_hybrid/examples/winit/src/main.rs
+++ b/sparse_strips/vello_hybrid/examples/winit/src/main.rs
@@ -164,7 +164,10 @@ impl ApplicationHandler for App<'_> {
             WindowEvent::Resized(size) => {
                 self.context
                     .resize_surface(surface, size.width, size.height);
-                self.scene = Scene::new(size.width as u16, size.height as u16);
+                self.scene = Scene::new(
+                    u16::try_from(size.width).unwrap(),
+                    u16::try_from(size.height).unwrap(),
+                );
             }
             WindowEvent::KeyboardInput {
                 event:

--- a/sparse_strips/vello_hybrid/examples/winit/src/render_context.rs
+++ b/sparse_strips/vello_hybrid/examples/winit/src/render_context.rs
@@ -8,9 +8,7 @@
 
 use std::sync::Arc;
 
-use vello_common::kurbo::{Affine, Stroke};
-use vello_common::pico_svg::Item;
-use vello_hybrid::{Renderer, RendererOptions, Scene};
+use vello_hybrid::{RenderTargetConfig, Renderer};
 use wgpu::{
     Adapter, Device, Features, Instance, Limits, MemoryHints, Queue, Surface, SurfaceConfiguration,
     SurfaceTarget, TextureFormat,
@@ -26,7 +24,7 @@ pub(crate) fn create_winit_window(
 ) -> Arc<Window> {
     let attr = Window::default_attributes()
         .with_inner_size(winit::dpi::PhysicalSize::new(width, height))
-        .with_resizable(false)
+        .with_resizable(true)
         .with_title("Vello SVG Renderer")
         .with_visible(initially_visible)
         .with_active(true);
@@ -40,8 +38,10 @@ pub(crate) fn create_vello_renderer(
 ) -> Renderer {
     Renderer::new(
         &render_cx.devices[surface.dev_id].device,
-        &RendererOptions {
+        &RenderTargetConfig {
             format: surface.config.format,
+            width: surface.config.width,
+            height: surface.config.height,
         },
     )
 }

--- a/sparse_strips/vello_hybrid/examples/winit/src/render_context.rs
+++ b/sparse_strips/vello_hybrid/examples/winit/src/render_context.rs
@@ -17,33 +17,6 @@ use wgpu::{
 };
 use winit::{event_loop::ActiveEventLoop, window::Window};
 
-/// Define a render function that works with our `pico_svg::Item` type
-pub(crate) fn render_svg(ctx: &mut Scene, scale: f64, items: &[Item]) {
-    fn render_svg_inner(ctx: &mut Scene, items: &[Item], transform: Affine) {
-        ctx.set_transform(transform);
-        for item in items {
-            match item {
-                Item::Fill(fill_item) => {
-                    ctx.set_paint(fill_item.color.into());
-                    ctx.fill_path(&fill_item.path);
-                }
-                Item::Stroke(stroke_item) => {
-                    let style = Stroke::new(stroke_item.width);
-                    ctx.set_stroke(style);
-                    ctx.set_paint(stroke_item.color.into());
-                    ctx.stroke_path(&stroke_item.path);
-                }
-                Item::Group(group_item) => {
-                    render_svg_inner(ctx, &group_item.children, transform * group_item.affine);
-                    ctx.set_transform(transform);
-                }
-            }
-        }
-    }
-
-    render_svg_inner(ctx, items, Affine::scale(scale));
-}
-
 /// Helper function that creates a Winit window and returns it (wrapped in an Arc for sharing)
 pub(crate) fn create_winit_window(
     event_loop: &ActiveEventLoop,

--- a/sparse_strips/vello_hybrid/src/lib.rs
+++ b/sparse_strips/vello_hybrid/src/lib.rs
@@ -33,7 +33,7 @@ mod render;
 mod scene;
 pub mod util;
 
-pub use render::{Config, GpuStrip, RenderData, RenderParams, Renderer, RendererOptions};
+pub use render::{Config, GpuStrip, RenderData, RenderSize, RenderTargetConfig, Renderer};
 pub use scene::Scene;
 pub use util::DimensionConstraints;
 pub use vello_common::pixmap::Pixmap;

--- a/sparse_strips/vello_hybrid/src/render.rs
+++ b/sparse_strips/vello_hybrid/src/render.rs
@@ -227,7 +227,6 @@ impl Renderer {
         let render_data = scene.prepare_render_data();
         let required_strips_size = size_of::<GpuStrip>() as u64 * render_data.strips.len() as u64;
 
-        // Check if dimensions changed
         let (needs_new_strips_buffer, needs_new_alpha_texture, dimensions_changed) =
             match &self.resources {
                 Some(resources) => {


### PR DESCRIPTION
`velly_hybrid` resizing issue was caused by not updating `Config` when the viewport size changed. As a result, the vertex positions in the shader were being calculated based on the previous config, which led to distorted rendered content.

Before:


https://github.com/user-attachments/assets/561e0bb3-408d-4afc-8946-48bc3e98db15



After:

https://github.com/user-attachments/assets/51ac9591-fa67-4e2d-aa66-dff746680547

https://github.com/user-attachments/assets/963497cf-7061-47d8-ba8a-4723e456d4b5


Images in the videos may flicker during resizing because of the problem seems related to wpu (more details in [#vello > Vello Hybrid: Resizing @ 💬](https://xi.zulipchat.com/#narrow/channel/197075-vello/topic/Vello.20Hybrid.3A.20Resizing/near/510114878)):

https://github.com/user-attachments/assets/7feeb008-8f97-42c0-9ab5-da6eb53dec75
