### PR TITLE
When hinting glyphs, round y-offsets to integers

### DIFF
--- a/sparse_strips/vello_common/src/glyph.rs
+++ b/sparse_strips/vello_common/src/glyph.rs
@@ -143,6 +143,8 @@ impl<'a, T: GlyphRenderer + 'a> GlyphRunBuilder<'a, T> {
             let mut local_transform = {
                 let mut translation = Vec2::new(glyph.x as f64 * scale, glyph.y as f64 * scale);
                 if hinting_instance.is_some() {
+                    // When hinting, ensure the y-offset is integer. The x-offset doesn't matter,
+                    // as we perform vertical-only hinting.
                     translation.y = translation.y.round();
                 }
                 Affine::translate(translation)

--- a/sparse_strips/vello_common/src/glyph.rs
+++ b/sparse_strips/vello_common/src/glyph.rs
@@ -140,8 +140,13 @@ impl<'a, T: GlyphRenderer + 'a> GlyphRunBuilder<'a, T> {
                 continue;
             }
 
-            let mut local_transform =
-                Affine::translate(Vec2::new(glyph.x as f64 * scale, glyph.y as f64 * scale));
+            let mut local_transform = {
+                let mut translation = Vec2::new(glyph.x as f64 * scale, glyph.y as f64 * scale);
+                if hinting_instance.is_some() {
+                    translation.y = translation.y.round();
+                }
+                Affine::translate(translation)
+            };
             if let Some(skew) = horizontal_skew {
                 local_transform *= Affine::skew(skew.tan() as f64, 0.0);
             }

--- a/sparse_strips/vello_cpu/snapshots/glyphs_scaled.png
+++ b/sparse_strips/vello_cpu/snapshots/glyphs_scaled.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5305569218595bbe61303802b495c4a2104b96daf228d9fd3cb2ac6c9d9a5fe5
-size 2434
+oid sha256:ffd1d0af41fe4a40ce858737a182bf2a95b993a5664acc9d8ac96e6cfd3f3029
+size 2376


### PR DESCRIPTION
Without this, while glyph outlines will be hinted to integers, the translation can bump the outlines to fractional locations again.