### PR TITLE
Fix overflow in coarse rasterization

### DIFF
--- a/sparse_strips/vello_common/src/coarse.rs
+++ b/sparse_strips/vello_common/src/coarse.rs
@@ -108,7 +108,7 @@ impl Wide {
     pub fn new(width: u16, height: u16) -> Self {
         let width_tiles = width.div_ceil(WideTile::WIDTH);
         let height_tiles = height.div_ceil(Tile::HEIGHT);
-        let mut tiles = Vec::with_capacity(usize::from(width_tiles)  * usize::from(height_tiles));
+        let mut tiles = Vec::with_capacity(usize::from(width_tiles) * usize::from(height_tiles));
 
         for w in 0..width_tiles {
             for h in 0..height_tiles {

--- a/sparse_strips/vello_common/src/coarse.rs
+++ b/sparse_strips/vello_common/src/coarse.rs
@@ -108,7 +108,7 @@ impl Wide {
     pub fn new(width: u16, height: u16) -> Self {
         let width_tiles = width.div_ceil(WideTile::WIDTH);
         let height_tiles = height.div_ceil(Tile::HEIGHT);
-        let mut tiles = Vec::with_capacity(usize::from(width_tiles * height_tiles));
+        let mut tiles = Vec::with_capacity(usize::from(width_tiles)  * usize::from(height_tiles));
 
         for w in 0..width_tiles {
             for h in 0..height_tiles {


### PR DESCRIPTION
This can overflow for not too big sizes (I encountered it while trying to render on a canvas with 10000x10000 pixels.