### PR TITLE
Be more `no_std`

### DIFF
--- a/sparse_strips/vello_api/src/lib.rs
+++ b/sparse_strips/vello_api/src/lib.rs
@@ -6,7 +6,7 @@
 //! across different implementations
 
 #![forbid(unsafe_code)]
-#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+#![no_std]
 
 pub use peniko;
 pub use peniko::color;


### PR DESCRIPTION
Instead of having `std` in scope and on by default, be `no_std` by default and use `std` more explicitly.