### PR TITLE
Add fast path for stripping rectangles

### DIFF
--- a/sparse_strips/vello_common/src/strip.rs
+++ b/sparse_strips/vello_common/src/strip.rs
@@ -341,18 +341,23 @@ pub fn render_rect(
         rect.max_y().min(height as f64) as f32,
     );
 
-    let top_strip_idx = y0 as u16 / Tile::HEIGHT;
+    let top_strip_idx = (y0 as u16).max(0) / Tile::HEIGHT;
     let top_strip_y = top_strip_idx * Tile::HEIGHT;
-    let bottom_strip_idx = y1 as u16 / Tile::HEIGHT;
+    // In the wide tile generation stage, there is an assertion that all strips outside the
+    // viewport must have been culled, so we cull here.
+    //
+    // This index is inclusive, i.e. pixels at row `bottom_strip_idx` 
+    // are still part of the rectangle.
+    let bottom_strip_idx = (y1 as u16).min(height - 1) / Tile::HEIGHT;
     let bottom_strip_y = bottom_strip_idx * Tile::HEIGHT;
 
     let x0_floored = x0.floor();
     let x1_floored = x1.floor();
 
-    let x_start = x0_floored as u16;
+    let x_start = (x0_floored as u16).max(0);
     // Inclusive, i.e. the pixel at column `x_end` is the very right border (possibly only anti-aliased)
     // of the rectangle, which should still be stripped.
-    let x_end = x1_floored as u16;
+    let x_end = (x1_floored as u16).min(width - 1);
 
     // Calculate the vertical/horizontal coverage of a pixel, using a start
     // and end point. The area between the start and end point is considered to be

--- a/sparse_strips/vello_common/src/strip.rs
+++ b/sparse_strips/vello_common/src/strip.rs
@@ -6,6 +6,7 @@
 use vello_api::peniko::Fill;
 
 use crate::flatten::Line;
+use crate::kurbo::Rect;
 use crate::tile::{Tile, Tiles};
 
 /// A strip.
@@ -301,4 +302,192 @@ pub fn render(
             accumulated_winding[y_idx as usize] += acc;
         }
     }
+}
+
+/// Draw the strips of a rectangle. This is faster than using the normal path, because we
+/// do not need to go through the "flatten", "tiling" and "sort" stages, but can instead
+/// directly emit strips.
+pub fn render_rect(
+    rect: &Rect,
+    strip_buf: &mut Vec<Strip>,
+    alpha_buf: &mut Vec<u8>,
+    width: u16,
+    height: u16,
+) {
+    // The idea for this fast path is as follows:
+    // - We generate strips of width 1 for the left as well as the ride side of the rectangle. The
+    //   left side has a winding number of 0, the right side has a winding number of 1.
+    // - We generate a strip of the full rectangle width for the top/and bottom part of the rectangle.
+    // - Of course, it's also possible that a rectangle has a width of less than 2 or a height of
+    //   less than 4. The current logic does account for those edge cases.
+    // - There could be some further optimizations (for example, if a rectangle is strip-aligned on
+    //   the y-axis, we don't need the strips for the top part of the rectangle), but I don't think
+    //   those edge cases are worth adding to the complexity of this method.
+    
+    strip_buf.clear();
+
+    // Don't try to draw empty rectangles.
+    if rect.is_zero_area() {
+        return;
+    }
+
+    // Note that we currently deal with negative-area rects as positive-area rects.
+    // Shouldn't be a problem for solid fill, but might need some tweaking for gradient
+    // and pattern fills.
+    let (x0, x1, y0, y1) = (
+        rect.min_x().max(0.0) as f32,
+        rect.max_x().min(width as f64) as f32,
+        rect.min_y().max(0.0) as f32,
+        rect.max_y().min(height as f64) as f32,
+    );
+
+    let top_strip_idx = y0 as u16 / Tile::HEIGHT;
+    let top_strip_y = top_strip_idx * Tile::HEIGHT;
+    let bottom_strip_idx = y1 as u16 / Tile::HEIGHT;
+    let bottom_strip_y = bottom_strip_idx * Tile::HEIGHT;
+
+    let x0_floored = x0.floor();
+    let x1_floored = x1.floor();
+
+    let x_start = x0_floored as u16;
+    // Inclusive, i.e. the pixel at column `x_end` is the very right border (possibly only anti-aliased)
+    // of the rectangle, which should still be stripped.
+    let x_end = x1_floored as u16;
+
+    // Calculate the vertical/horizontal coverage of a pixel, using a start
+    // and end point. The area between the start and end point is considered to be
+    // covered by the shape.
+    let pixel_coverage = |pixel_pos: u16, start: f32, end: f32| {
+        let pixel_pos = pixel_pos as f32;
+        let end = (end - pixel_pos).clamp(0.0, 1.0);
+        let start = (start - pixel_pos).clamp(0.0, 1.0);
+
+        end - start
+    };
+
+    // Calculate the alpha coverages of the strips containing the top/bottom 
+    // borders of the rectangle.
+    let vertical_alpha_coverage = |strip_y: u16| {
+        let mut buf = [0.0f32; Tile::HEIGHT as usize];
+
+        // For each row in the strip, calculate how much it is covered by given the 
+        // vertical endpoints y0 and y1.
+        for i in 0..Tile::HEIGHT {
+            buf[i as usize] = pixel_coverage(strip_y + i, y0, y1);
+        }
+
+        buf
+    };
+
+    // Note that the alpha coverage of all pixels on either the left or ride side of a
+    // rectangle is always the same (except for corners), so we just need to calculate 
+    // a single value. The coverage of corners will be calculated by adding an additional
+    // opacity mask as calculated in `horizontal_alphas`.
+    let left_alpha = pixel_coverage(x_start, x0, x1);
+    let right_alpha = pixel_coverage(x_end, x0, x1);
+
+    // Calculate the alpha coverages of a strip using an alpha mask. For example, if we
+    // want to calculate the coverage of the very first column of the top line in the
+    // rect (which might start at the horizontal offset .5), then we need to multiply
+    // all its alpha values by 0.5 to account for anti-aliasing of the left edge.
+    let push_alpha = |alphas: &[f32; 4], alpha_mask: f32, alpha_buf: &mut Vec<u8>| {
+        for i in 0..Tile::HEIGHT as usize {
+            let u8_alpha = ((alphas[i] * alpha_mask) * 255.0 + 0.5) as u8;
+            alpha_buf.push(u8_alpha);
+        }
+    };
+
+    // Create a strip for the top/bottom edge of the rectangle.
+    let horizontal_strip = |alpha_buf: &mut Vec<u8>,
+                            strip_buf: &mut Vec<Strip>,
+                            alphas: &[f32; 4],
+                            strip_y: u16| {
+        // Strip the first column, which might have an additional alpha mask due to non-integer
+        // alignment of x0. If the rectangle is less than 1 pixel wide, this will represent
+        // the total coverage of the rectangle inside the pixel.
+        let alpha_idx = alpha_buf.len() as u32;
+        push_alpha(alphas, left_alpha, alpha_buf);
+
+        // If the rect covers more than one pixel horizontally, fill all the remaining ones
+        // except for the last one with the same opacity as in `alphas`.
+        // If the rect is contained within one pixel horizontally, 
+        // then right_alpha == left_alpha, and thus the alpha we pushed above is enough.
+        if x_end - x_start >= 1 {
+            for _ in (x_start + 1)..x_end {
+                push_alpha(alphas, 1.0, alpha_buf);
+            }
+
+            // Fill the last, right column, which might also need an additional alpha mask
+            // due to non-integer alignment of x1.
+            push_alpha(alphas, right_alpha, alpha_buf);
+        }
+
+        // Push the actual strip.
+        strip_buf.push(Strip {
+            x: x0_floored as u16,
+            y: strip_y,
+            alpha_idx,
+            winding: 0,
+        });
+    };
+
+    let top_alphas = vertical_alpha_coverage(top_strip_y);
+    // Create the strip for the top part of the rectangle.
+    horizontal_strip(
+        alpha_buf,
+        strip_buf,
+        &top_alphas,
+        top_strip_y,
+    );
+
+    // If rect covers more than one strip vertically, we need to strip the vertical line
+    // segments of the rectangle, and finally the bottom horizontal line segment.
+    if top_strip_idx != bottom_strip_idx {
+        let alphas = [1.0, 1.0, 1.0, 1.0];
+
+        // Strip all parts that are inside the rectangle (i.e. neither the top nor the
+        // bottom part. In this case, all pixels will have full opacity).
+        for i in (top_strip_idx + 1)..bottom_strip_idx {
+            // Left side (and right side if rect is only one pixel wide).
+            let mut alpha_idx = alpha_buf.len() as u32;
+            push_alpha(&alphas, left_alpha, alpha_buf);
+
+            strip_buf.push(Strip {
+                x: x0_floored as u16,
+                y: i * Tile::HEIGHT,
+                alpha_idx,
+                winding: 0,
+            });
+
+            if x_end > x_start {
+                // Right side.
+                alpha_idx = alpha_buf.len() as u32;
+                push_alpha(&alphas, right_alpha, alpha_buf);
+
+                strip_buf.push(Strip {
+                    x: x1_floored as u16,
+                    y: i * Tile::HEIGHT,
+                    alpha_idx,
+                    winding: 1,
+                });
+            }
+        }
+
+        // Strip the bottom part of the rectangle.
+        let bottom_alphas = vertical_alpha_coverage(bottom_strip_y);
+        horizontal_strip(
+            alpha_buf,
+            strip_buf,
+            &bottom_alphas,
+            bottom_strip_y,
+        );
+    }
+
+    // Push sentinel strip.
+    strip_buf.push(Strip {
+        x: u16::MAX,
+        y: bottom_strip_y,
+        alpha_idx: alpha_buf.len() as u32,
+        winding: 0,
+    });
 }

--- a/sparse_strips/vello_cpu/snapshots/filled_unaligned_rect_as_path.png
+++ b/sparse_strips/vello_cpu/snapshots/filled_unaligned_rect_as_path.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c6b0b8a2410d7e97531280f11dc4f4fa7db508cd7d1a4dc4cb8ec6df9e8c08a
+size 108

--- a/sparse_strips/vello_cpu/snapshots/filled_vertical_hairline_rect_as_path.png
+++ b/sparse_strips/vello_cpu/snapshots/filled_vertical_hairline_rect_as_path.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93477cb8b8ac262a0f14748c2a24f36d1139da4d8f7cbafc74f28c2f6b4eb2a1
+size 77

--- a/sparse_strips/vello_cpu/tests/basic.rs
+++ b/sparse_strips/vello_cpu/tests/basic.rs
@@ -318,6 +318,17 @@ fn filled_unaligned_rect() {
 }
 
 #[test]
+fn filled_unaligned_rect_as_path() {
+    let mut ctx = get_ctx(30, 20, false);
+    let rect = Rect::new(1.5, 1.5, 28.5, 18.5).to_path(0.1);
+
+    ctx.set_paint(REBECCA_PURPLE.with_alpha(0.5).into());
+    ctx.fill_path(&rect);
+
+    check_ref(&ctx, "filled_unaligned_rect_as_path");
+}
+
+#[test]
 fn filled_transformed_rect_1() {
     let mut ctx = get_ctx(30, 30, false);
     let rect = Rect::new(0.0, 0.0, 10.0, 10.0);
@@ -436,6 +447,17 @@ fn strip_inscribed_rect() {
     ctx.fill_rect(&rect);
 
     check_ref(&ctx, "strip_inscribed_rect");
+}
+
+#[test]
+fn filled_vertical_hairline_rect_as_path() {
+    let mut ctx = get_ctx(5, 8, false);
+    let rect = Rect::new(2.25, 0.0, 2.75, 8.0).to_path(0.1);
+
+    ctx.set_paint(REBECCA_PURPLE.with_alpha(0.5).into());
+    ctx.fill_path(&rect);
+
+    check_ref(&ctx, "filled_vertical_hairline_rect_as_path");
 }
 
 #[test]


### PR DESCRIPTION
This re-adds my previously implemented fast path for rectangles. In my test scene with 20000 rectangles, this reduces the rendering time from around 37ms to 19ms!