### PR TITLE
Reset whole render context in `reset`

### DIFF
--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -151,6 +151,10 @@ impl RenderContext {
 
     /// Reset the render context.
     pub fn reset(&mut self) {
+        self.line_buf.clear();
+        self.tiles.reset();
+        self.alphas.clear();
+        self.strip_buf.clear();
         self.wide.reset();
     }
 

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -245,3 +245,27 @@ impl GlyphRenderer for RenderContext {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::RenderContext;
+    use vello_common::kurbo::Rect;
+
+    #[test]
+    fn reset_render_context() {
+        let mut ctx = RenderContext::new(100, 100);
+        let rect = Rect::new(0.0, 0.0, 100.0, 100.0);
+
+        ctx.fill_rect(&rect);
+
+        assert!(!ctx.line_buf.is_empty());
+        assert!(!ctx.strip_buf.is_empty());
+        assert!(!ctx.alphas.is_empty());
+
+        ctx.reset();
+
+        assert!(ctx.line_buf.is_empty());
+        assert!(ctx.strip_buf.is_empty());
+        assert!(ctx.alphas.is_empty());
+    }
+}


### PR DESCRIPTION
Ran into an issue where running my demo tool for long enough would overflow the alpha buffer even though I called `reset`. I think everything should be cleared when you call that method.