### PR TITLE
Do not store output buffer in `Fine`

### DIFF
--- a/sparse_strips/vello_bench/src/cpu_fine.rs
+++ b/sparse_strips/vello_bench/src/cpu_fine.rs
@@ -16,8 +16,7 @@ pub fn fill(c: &mut Criterion) {
     macro_rules! fill_single {
         ($name:ident, $paint:expr) => {
             g.bench_function(stringify!($name), |b| {
-                let mut out = vec![];
-                let mut fine = Fine::new(WideTile::WIDTH, Tile::HEIGHT, &mut out);
+                let mut fine = Fine::new(WideTile::WIDTH, Tile::HEIGHT);
 
                 b.iter(|| {
                     fine.fill(0, WideTile::WIDTH as usize, $paint);
@@ -45,8 +44,7 @@ pub fn strip(c: &mut Criterion) {
     macro_rules! strip_single {
         ($name:ident, $paint:expr) => {
             g.bench_function(stringify!($name), |b| {
-                let mut out = vec![];
-                let mut fine = Fine::new(WideTile::WIDTH, Tile::HEIGHT, &mut out);
+                let mut fine = Fine::new(WideTile::WIDTH, Tile::HEIGHT);
 
                 b.iter(|| {
                     fine.strip(0, WideTile::WIDTH as usize, &alphas, $paint);

--- a/sparse_strips/vello_cpu/src/fine.rs
+++ b/sparse_strips/vello_cpu/src/fine.rs
@@ -20,22 +20,20 @@ pub(crate) type ScratchBuf = [u8; SCRATCH_BUF_SIZE];
 #[derive(Debug)]
 #[doc(hidden)]
 /// This is an internal struct, do not access directly.
-pub struct Fine<'a> {
+pub struct Fine {
     pub(crate) width: u16,
     pub(crate) height: u16,
-    pub(crate) out_buf: &'a mut [u8],
     pub(crate) scratch: Vec<ScratchBuf>,
 }
 
-impl<'a> Fine<'a> {
+impl Fine {
     /// Create a new fine rasterizer.
-    pub fn new(width: u16, height: u16, out_buf: &'a mut [u8]) -> Self {
+    pub fn new(width: u16, height: u16) -> Self {
         let scratch = [0; SCRATCH_BUF_SIZE];
 
         Self {
             width,
             height,
-            out_buf,
             scratch: vec![scratch],
         }
     }
@@ -55,10 +53,10 @@ impl<'a> Fine<'a> {
         }
     }
 
-    pub(crate) fn pack(&mut self, x: u16, y: u16) {
+    pub(crate) fn pack(&mut self, x: u16, y: u16, out_buf: &mut [u8]) {
         let scratch = self.scratch.last_mut().unwrap();
         pack(
-            self.out_buf,
+            out_buf,
             scratch,
             self.width.into(),
             self.height.into(),

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -161,7 +161,7 @@ impl RenderContext {
                 panic!("All clips must be popped before rendering");
             }
         }
-        let mut fine = Fine::new(pixmap.width, pixmap.height, &mut pixmap.buf);
+        let mut fine = Fine::new(pixmap.width, pixmap.height);
 
         let width_tiles = self.wide.width_tiles();
         let height_tiles = self.wide.height_tiles();
@@ -173,7 +173,7 @@ impl RenderContext {
                 for cmd in &wtile.cmds {
                     fine.run_cmd(cmd, &self.alphas);
                 }
-                fine.pack(x, y);
+                fine.pack(x, y, &mut pixmap.buf);
             }
         }
     }


### PR DESCRIPTION
We only need the output buffer when packing but not for just fine rasterization, so there isn't much point in storing it inside of the struct.