### PR TITLE
fix(coarse): respect clipping bounds for fill command

### DIFF
--- a/sparse_strips/vello_common/src/coarse.rs
+++ b/sparse_strips/vello_common/src/coarse.rs
@@ -244,6 +244,7 @@ impl Wide {
             // Generate alpha fill commands for each wide tile intersected by this strip
             for wtile_x in wtile_x0..wtile_x1 {
                 let x_wtile_rel = x % WideTile::WIDTH;
+                // Restrict the width of the fill to the width of the wide tile
                 let width = x1.min((wtile_x + 1) * WideTile::WIDTH) - x;
                 let cmd = CmdAlphaFill {
                     x: x_wtile_rel,
@@ -266,7 +267,8 @@ impl Wide {
             // If region should be filled and both strips are on the same row,
             // generate fill commands for the region between them
             if active_fill && strip_y == next_strip.strip_y() {
-                x = x1;
+                // Clamp the fill to the clip bounding box
+                x = x1.max(bbox.x0() * WideTile::WIDTH);
                 let x2 = next_strip
                     .x
                     .min(self.width.next_multiple_of(WideTile::WIDTH));

--- a/sparse_strips/vello_cpu/snapshots/fill_command_respects_clip_bounds.png
+++ b/sparse_strips/vello_cpu/snapshots/fill_command_respects_clip_bounds.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ce47e8dfe449ec3eb487e353956e24f679f7ab6d4465f99ed58eb8ca8a5aca4
+size 189

--- a/sparse_strips/vello_cpu/tests/issues.rs
+++ b/sparse_strips/vello_cpu/tests/issues.rs
@@ -4,8 +4,8 @@
 //! Tests for GitHub issues.
 
 use crate::util::{check_ref, get_ctx, render_pixmap};
-use vello_common::color::palette::css::{DARK_BLUE, LIME};
-use vello_common::kurbo::{BezPath, Stroke};
+use vello_common::color::palette::css::{DARK_BLUE, LIME, REBECCA_PURPLE};
+use vello_common::kurbo::{BezPath, Rect, Shape, Stroke};
 use vello_common::peniko::Fill;
 
 #[test]
@@ -289,4 +289,15 @@ fn eo_filling_missing_anti_aliasing() {
     ctx.fill_path(&path);
 
     check_ref(&ctx, "eo_filling_missing_anti_aliasing");
+}
+
+#[test]
+// https://github.com/linebender/vello/issues/906
+fn fill_command_respects_clip_bounds() {
+    let mut ctx = get_ctx(600, 600, true);
+    ctx.clip(&Rect::new(400.0, 400.0, 500.0, 500.0).to_path(0.1));
+    ctx.set_paint(REBECCA_PURPLE.into());
+    ctx.fill_rect(&Rect::new(0.0, 0.0, 600.0, 600.0));
+    ctx.finish();
+    check_ref(&ctx, "fill_command_respects_clip_bounds");
 }


### PR DESCRIPTION
Fixes #906 

Fix wide tile fill width calculation to respect clip boundaries. This PR fixes an issue where fill commands could generate widths exceeding the wide tile boundaries, causing "index out of range" errors. While the code correctly clamped wide tile indices using the bounding box for strips, it didn’t apply the same clipping logic to fills.