### PR TITLE
Use u8/u16 for clipping fine rasterization

### DIFF
--- a/sparse_strips/vello_cpu/snapshots/clip_rectangle_and_circle.png
+++ b/sparse_strips/vello_cpu/snapshots/clip_rectangle_and_circle.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7705c02bfb0f273ad98fbc02af3a516d7d78c2377444ac26a0b961de23943224
+oid sha256:ba1651c909d6b5b3080cf5c1399e3bb286262a0e21b52d704b26dcea94364f18
 size 813

--- a/sparse_strips/vello_cpu/snapshots/clip_rectangle_with_star_evenodd.png
+++ b/sparse_strips/vello_cpu/snapshots/clip_rectangle_with_star_evenodd.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dbfb956f4659a24b654ac8e5c85522830b0855f17cfa8fa1cea9e7a02c4aefd2
+oid sha256:c1c88d36d27b16023f2fd737b30020437ad3ac1f2c2e1540db953222c76e6b8f
 size 899

--- a/sparse_strips/vello_cpu/snapshots/clip_rectangle_with_star_nonzero.png
+++ b/sparse_strips/vello_cpu/snapshots/clip_rectangle_with_star_nonzero.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:40787b1bb21a37d0f25d214ea62370cbc387d2515b275ba92fadb4dd034d2626
+oid sha256:fbc2be6c162106a6caff9488af499ace5799cb6845490aa65338bf5c5fd4b335
 size 781

--- a/sparse_strips/vello_cpu/snapshots/clip_transformed_rect.png
+++ b/sparse_strips/vello_cpu/snapshots/clip_transformed_rect.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:842d643e5780ae909806988df70f78a7cf166b0e54f1ca13b9dee2ffe17343f2
+oid sha256:a791ea6f3c2c3064efe62d2a9ee527f6f50f73df79e158397e4a28466fb5ad8e
 size 344

--- a/sparse_strips/vello_cpu/snapshots/clip_triangle_with_star.png
+++ b/sparse_strips/vello_cpu/snapshots/clip_triangle_with_star.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eeae77f49d758928a3899b98ba417964aa4bf1204d9c38e2bd895f963b34ee12
-size 1758
+oid sha256:2a577d5d1950bd58f46510400b7c91d1c7b8a8fc5252a4a4857f475c951e6026
+size 1748

--- a/sparse_strips/vello_cpu/snapshots/clip_with_multiple_transforms.png
+++ b/sparse_strips/vello_cpu/snapshots/clip_with_multiple_transforms.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e79112e14e692bea247f3d0b2defb174ef4bc0d6d74e8747faf110d1fbf265f1
+oid sha256:649e59dfb9f996d77cac55a6db704172a864b31febaf2b80dc11a2bafa47259d
 size 476

--- a/sparse_strips/vello_cpu/snapshots/clip_with_rotate.png
+++ b/sparse_strips/vello_cpu/snapshots/clip_with_rotate.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ee069c92da7bcf201411d8c957a8b6b6baf48efe9d603a3a0540a4436fcbe20d
+oid sha256:afb7bbbe9366aaa5b51a06af9072ada24d998f3d15b4ab8c5d653ad814dbe41a
 size 370

--- a/sparse_strips/vello_cpu/snapshots/clip_with_save_restore.png
+++ b/sparse_strips/vello_cpu/snapshots/clip_with_save_restore.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b4da4af3c07446008ddf7b6f2b197063ba47387b125d3570b53f88b43de8ba5a
+oid sha256:8bf8baff9bb856e1b5864f6bf85f3cd3182dcec19434e12d343a68d6851b84c9
 size 444

--- a/sparse_strips/vello_cpu/src/fine.rs
+++ b/sparse_strips/vello_cpu/src/fine.rs
@@ -4,6 +4,7 @@
 //! Fine rasterization runs the commands in each wide tile to determine the final RGBA value
 //! of each pixel and pack it into the pixmap.
 
+use crate::util::scalar::div_255;
 use vello_common::{
     coarse::{Cmd, WideTile},
     paint::Paint,
@@ -145,14 +146,14 @@ impl Fine {
         for col_idx in 0..width {
             for row_idx in 0..usize::from(Tile::HEIGHT) {
                 let px_offset = (x + col_idx) * TILE_HEIGHT_COMPONENTS + row_idx * COLOR_COMPONENTS;
-                let source_alpha = source_buffer[px_offset + 3] as f32 / 255.0;
-                let inverse_alpha = 1.0 - source_alpha;
+                let source_alpha = source_buffer[px_offset + 3] as u16;
+                let inverse_alpha = 255 - source_alpha;
 
                 for channel_idx in 0..COLOR_COMPONENTS {
-                    let dest = target_buffer[px_offset + channel_idx] as f32;
-                    let src = source_buffer[px_offset + channel_idx] as f32;
+                    let dest = target_buffer[px_offset + channel_idx] as u16;
+                    let src = source_buffer[px_offset + channel_idx] as u16;
                     target_buffer[px_offset + channel_idx] =
-                        (dest * inverse_alpha + src * source_alpha) as u8;
+                        div_255(dest * inverse_alpha + src * source_alpha) as u8;
                 }
             }
         }
@@ -169,15 +170,15 @@ impl Fine {
         {
             for (row_idx, &alpha) in column_alphas.iter().enumerate() {
                 let px_offset = (x + col_idx) * TILE_HEIGHT_COMPONENTS + row_idx * COLOR_COMPONENTS;
-                let mask_alpha = alpha as f32 / 255.0;
-                let source_alpha = source_buffer[px_offset + 3] as f32 / 255.0;
-                let inverse_alpha = 1.0 - mask_alpha * source_alpha;
+                let mask_alpha = alpha as u16;
+                let source_alpha = source_buffer[px_offset + 3] as u16;
+                let inverse_alpha = 255 - div_255(mask_alpha * source_alpha);
 
                 for channel_idx in 0..COLOR_COMPONENTS {
-                    let dest = target_buffer[px_offset + channel_idx] as f32;
-                    let source = source_buffer[px_offset + channel_idx] as f32;
+                    let dest = target_buffer[px_offset + channel_idx] as u16;
+                    let source = source_buffer[px_offset + channel_idx] as u16;
                     target_buffer[px_offset + channel_idx] =
-                        (dest * inverse_alpha + mask_alpha * source) as u8;
+                        div_255(dest * inverse_alpha + mask_alpha * source) as u8;
                 }
             }
         }


### PR DESCRIPTION
Sorry, I probably should have noticed this in the original PR.  But since everything in the current version of the pipeline uses u8/u16, I think it makes sense for clipping to do that as well (especially since SIMD will also be important for clipping performance)? Maybe I'm missing the reason why it was done using f32, though.