### PR TITLE
sparse_strips: Mark as `no_std` but use `std`

### DIFF
--- a/sparse_strips/vello_common/src/coarse.rs
+++ b/sparse_strips/vello_common/src/coarse.rs
@@ -8,6 +8,8 @@ use crate::{
     strip::Strip,
     tile::Tile,
 };
+use alloc::vec;
+use alloc::vec::Vec;
 use vello_api::color::PremulRgba8;
 use vello_api::{paint::Paint, peniko::Fill};
 

--- a/sparse_strips/vello_common/src/encode.rs
+++ b/sparse_strips/vello_common/src/encode.rs
@@ -7,10 +7,11 @@ use crate::color::Srgb;
 use crate::color::palette::css::BLACK;
 use crate::kurbo::{Affine, Point, Vec2};
 use crate::peniko::{ColorStop, Extend, GradientKind};
+use alloc::borrow::Cow;
+use alloc::vec::Vec;
+use core::f32::consts::PI;
+use core::iter;
 use smallvec::SmallVec;
-use std::borrow::Cow;
-use std::f32::consts::PI;
-use std::iter;
 use vello_api::paint::{Gradient, IndexedPaint, Paint};
 
 const DEGENERATE_THRESHOLD: f32 = 1.0e-6;
@@ -53,7 +54,7 @@ impl EncodeExt for Gradient {
 
                 // For simplicity, ensure that the gradient line always goes from left to right.
                 if p0.x >= p1.x {
-                    std::mem::swap(&mut p0, &mut p1);
+                    core::mem::swap(&mut p0, &mut p1);
 
                     stops = Cow::Owned(
                         stops
@@ -636,6 +637,7 @@ mod tests {
     use crate::kurbo::{Affine, Point};
     use crate::peniko::{ColorStop, GradientKind};
     use crate::peniko::{ColorStops, Extend};
+    use alloc::vec;
     use smallvec::smallvec;
 
     #[test]

--- a/sparse_strips/vello_common/src/flatten.rs
+++ b/sparse_strips/vello_common/src/flatten.rs
@@ -3,6 +3,7 @@
 
 //! Flattening filled and stroked paths.
 
+use alloc::vec::Vec;
 use vello_api::kurbo;
 use vello_api::kurbo::{Affine, BezPath, Stroke, StrokeOpts};
 
@@ -28,7 +29,7 @@ impl Point {
     }
 }
 
-impl std::ops::Add for Point {
+impl core::ops::Add for Point {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self {
@@ -36,7 +37,7 @@ impl std::ops::Add for Point {
     }
 }
 
-impl std::ops::Sub for Point {
+impl core::ops::Sub for Point {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self {
@@ -44,7 +45,7 @@ impl std::ops::Sub for Point {
     }
 }
 
-impl std::ops::Mul<f32> for Point {
+impl core::ops::Mul<f32> for Point {
     type Output = Self;
 
     fn mul(self, rhs: f32) -> Self {

--- a/sparse_strips/vello_common/src/lib.rs
+++ b/sparse_strips/vello_common/src/lib.rs
@@ -11,6 +11,9 @@
     reason = "We temporarily ignore those because the casts\
 only break in edge cases, and some of them are also only related to conversions from f64 to f32."
 )]
+#![no_std]
+
+extern crate alloc;
 
 pub mod coarse;
 pub mod encode;

--- a/sparse_strips/vello_common/src/pico_svg.rs
+++ b/sparse_strips/vello_common/src/pico_svg.rs
@@ -9,7 +9,13 @@
 //! for demonstration purposes. It supports basic SVG features like paths,
 //! fill, stroke, and grouping.
 
-use std::str::FromStr;
+extern crate std;
+
+use alloc::boxed::Box;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::str::FromStr;
+use std::eprintln;
 
 use roxmltree::{Document, Node};
 use vello_api::kurbo::{Affine, BezPath, Point, Size, Vec2};
@@ -70,7 +76,7 @@ struct Parser {
 
 impl PicoSvg {
     /// Load an SVG document from a string
-    pub fn load(xml_string: &str, scale: f64) -> Result<Self, Box<dyn std::error::Error>> {
+    pub fn load(xml_string: &str, scale: f64) -> Result<Self, Box<dyn core::error::Error>> {
         let doc = Document::parse(xml_string)?;
         let root = doc.root_element();
         let mut parser = Parser::new(scale);
@@ -163,7 +169,7 @@ impl Parser {
         node: Node<'_, '_>,
         properties: &RecursiveProperties,
         items: &mut Vec<Item>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Box<dyn core::error::Error>> {
         if node.is_element() {
             let mut properties = properties.clone();
             if let Some(fill_color) = node.attribute("fill") {

--- a/sparse_strips/vello_common/src/pixmap.rs
+++ b/sparse_strips/vello_common/src/pixmap.rs
@@ -3,6 +3,9 @@
 
 //! A simple pixmap type.
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 /// A pixmap backed by u8.
 #[derive(Debug)]
 pub struct Pixmap {

--- a/sparse_strips/vello_common/src/strip.rs
+++ b/sparse_strips/vello_common/src/strip.rs
@@ -3,6 +3,7 @@
 
 //! Rendering strips.
 
+use alloc::vec::Vec;
 use vello_api::peniko::Fill;
 
 use crate::flatten::Line;

--- a/sparse_strips/vello_common/src/tile.rs
+++ b/sparse_strips/vello_common/src/tile.rs
@@ -4,6 +4,8 @@
 //! Primitives for creating tiles.
 
 use crate::flatten::Line;
+use alloc::vec;
+use alloc::vec::Vec;
 
 /// The max number of lines per path.
 ///
@@ -121,28 +123,28 @@ impl Tile {
     }
 }
 
-impl std::cmp::PartialEq for Tile {
+impl core::cmp::PartialEq for Tile {
     #[inline(always)]
     fn eq(&self, other: &Self) -> bool {
         self.to_bits() == other.to_bits()
     }
 }
 
-impl std::cmp::Ord for Tile {
+impl core::cmp::Ord for Tile {
     #[inline(always)]
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         self.to_bits().cmp(&other.to_bits())
     }
 }
 
-impl std::cmp::PartialOrd for Tile {
+impl core::cmp::PartialOrd for Tile {
     #[inline(always)]
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl std::cmp::Eq for Tile {}
+impl core::cmp::Eq for Tile {}
 
 /// Handles the tiling of paths.
 #[derive(Clone, Debug)]

--- a/sparse_strips/vello_cpu/src/fine/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/mod.rs
@@ -5,9 +5,12 @@
 //! of each pixel and pack it into the pixmap.
 
 mod gradient;
+
 use crate::fine::gradient::GradientFiller;
 use crate::util::scalar::div_255;
-use std::iter;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::iter;
 use vello_common::encode::{EncodedKind, EncodedPaint, GradientLike};
 use vello_common::paint::Paint;
 use vello_common::{

--- a/sparse_strips/vello_cpu/src/lib.rs
+++ b/sparse_strips/vello_cpu/src/lib.rs
@@ -9,6 +9,9 @@
     clippy::cast_possible_truncation,
     reason = "We cast u16s to u8 in various places where we know for sure that it's < 256"
 )]
+#![no_std]
+
+extern crate alloc;
 
 mod render;
 

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -4,6 +4,8 @@
 //! Basic render operations.
 
 use crate::fine::Fine;
+use alloc::vec;
+use alloc::vec::Vec;
 use vello_common::coarse::{SceneState, Wide};
 use vello_common::encode::{EncodeExt, EncodedPaint};
 use vello_common::flatten::Line;

--- a/sparse_strips/vello_hybrid/src/lib.rs
+++ b/sparse_strips/vello_hybrid/src/lib.rs
@@ -29,6 +29,10 @@
 //!
 //! See the individual module documentation for more details on usage and implementation.
 
+#![no_std]
+
+extern crate alloc;
+
 mod render;
 mod scene;
 pub mod util;

--- a/sparse_strips/vello_hybrid/src/render.rs
+++ b/sparse_strips/vello_hybrid/src/render.rs
@@ -12,7 +12,8 @@
 //! The hybrid approach combines CPU-side path processing with efficient GPU rendering
 //! to balance flexibility and performance.
 
-use std::fmt::Debug;
+use alloc::vec::Vec;
+use core::fmt::Debug;
 
 use bytemuck::{Pod, Zeroable};
 use vello_common::tile::Tile;

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -4,6 +4,8 @@
 //! Basic render operations.
 
 use crate::render::{GpuStrip, RenderData};
+use alloc::vec;
+use alloc::vec::Vec;
 use vello_common::coarse::{Wide, WideTile};
 use vello_common::color::PremulRgba8;
 use vello_common::flatten::Line;

--- a/sparse_strips/vello_hybrid/src/util.rs
+++ b/sparse_strips/vello_hybrid/src/util.rs
@@ -5,7 +5,7 @@
 
 //! Simple helpers for managing wgpu state and surfaces.
 
-use std::ops::RangeInclusive;
+use core::ops::RangeInclusive;
 
 /// Represents dimension constraints for surfaces
 #[derive(Debug)]


### PR DESCRIPTION
This can't be enforced in CI yet, but marks these crates as `no_std` and then uses `std` in one spot in `vello_common`.

This can be improved and refined in subsequent PRs.