### PR TITLE
Implement `Default` for `Gradient` and add missing fields

### DIFF
--- a/sparse_strips/vello_api/src/paint.rs
+++ b/sparse_strips/vello_api/src/paint.rs
@@ -3,10 +3,10 @@
 
 //! Types for paints.
 
+use crate::color::{ColorSpaceTag, HueDirection};
 use crate::kurbo::{Affine, Point};
 use peniko::color::{AlphaColor, PremulRgba8, Srgb};
 use peniko::{ColorStops, GradientKind};
-use crate::color::{ColorSpaceTag, HueDirection};
 
 /// A paint that needs to be resolved via its index.
 // In the future, we might add additional flags, that's why we have

--- a/sparse_strips/vello_api/src/paint.rs
+++ b/sparse_strips/vello_api/src/paint.rs
@@ -3,9 +3,10 @@
 
 //! Types for paints.
 
-use crate::kurbo::Affine;
+use crate::kurbo::{Affine, Point};
 use peniko::color::{AlphaColor, PremulRgba8, Srgb};
 use peniko::{ColorStops, GradientKind};
+use crate::color::{ColorSpaceTag, HueDirection};
 
 /// A paint that needs to be resolved via its index.
 // In the future, we might add additional flags, that's why we have
@@ -66,6 +67,18 @@ pub struct Gradient {
     pub stops: ColorStops,
     /// A transformation to apply to the gradient.
     pub transform: Affine,
+    /// The color space to be used for interpolation.
+    ///
+    /// The colors in the color stops will be converted to this color space.
+    ///
+    /// This defaults to [sRGB](ColorSpaceTag::Srgb).
+    pub interpolation_cs: ColorSpaceTag,
+    /// When interpolating within a cylindrical color space, the direction for the hue.
+    ///
+    /// This is interpreted as described in [CSS Color Module Level 4 § 12.4].
+    ///
+    /// [CSS Color Module Level 4 § 12.4]: https://drafts.csswg.org/css-color/#hue-interpolation
+    pub hue_direction: HueDirection,
     /// The extend of the gradient.
     pub extend: peniko::Extend,
 }
@@ -79,6 +92,22 @@ impl Gradient {
             .iter_mut()
             .for_each(|stop| *stop = stop.multiply_alpha(alpha));
         self
+    }
+}
+
+impl Default for Gradient {
+    fn default() -> Self {
+        Self {
+            kind: GradientKind::Linear {
+                start: Point::default(),
+                end: Point::default(),
+            },
+            extend: Default::default(),
+            interpolation_cs: ColorSpaceTag::Srgb,
+            hue_direction: Default::default(),
+            stops: Default::default(),
+            transform: Default::default(),
+        }
     }
 }
 

--- a/sparse_strips/vello_bench/src/cpu_fine.rs
+++ b/sparse_strips/vello_bench/src/cpu_fine.rs
@@ -10,7 +10,7 @@ use vello_common::coarse::WideTile;
 use vello_common::color::DynamicColor;
 use vello_common::color::palette::css::{BLUE, GREEN, RED, ROYAL_BLUE, YELLOW};
 use vello_common::encode::EncodeExt;
-use vello_common::kurbo::{Affine, Point};
+use vello_common::kurbo::Point;
 use vello_common::paint::{Gradient, Paint};
 use vello_common::peniko;
 use vello_common::peniko::{ColorStop, ColorStops, GradientKind};
@@ -55,7 +55,7 @@ pub fn fill(c: &mut Criterion) {
                 },
                 stops: $stops,
                 extend: peniko::Extend::$extend,
-                transform: Affine::IDENTITY,
+                ..Default::default()
             };
 
             let paint = grad.encode_into(&mut paints);
@@ -96,7 +96,7 @@ pub fn fill(c: &mut Criterion) {
                 },
                 stops: $stops,
                 extend: peniko::Extend::$extend,
-                transform: Affine::default(),
+                ..Default::default()
             };
 
             let paint = grad.encode_into(&mut paints);
@@ -141,7 +141,7 @@ pub fn fill(c: &mut Criterion) {
                 },
                 stops: $stops,
                 extend: peniko::Extend::$extend,
-                transform: Affine::default(),
+                ..Default::default()
             };
 
             let paint = grad.encode_into(&mut paints);

--- a/sparse_strips/vello_common/src/encode.rs
+++ b/sparse_strips/vello_common/src/encode.rs
@@ -634,9 +634,9 @@ mod tests {
     use super::{EncodeExt, Gradient};
     use crate::color::DynamicColor;
     use crate::color::palette::css::{BLACK, BLUE, GREEN};
-    use crate::kurbo::{Affine, Point};
+    use crate::kurbo::Point;
+    use crate::peniko::ColorStops;
     use crate::peniko::{ColorStop, GradientKind};
-    use crate::peniko::{ColorStops, Extend};
     use alloc::vec;
     use smallvec::smallvec;
 
@@ -649,9 +649,7 @@ mod tests {
                 start: Point::new(0.0, 0.0),
                 end: Point::new(20.0, 0.0),
             },
-            stops: ColorStops(smallvec![]),
-            transform: Affine::IDENTITY,
-            extend: Extend::Pad,
+            ..Default::default()
         };
 
         assert_eq!(gradient.encode_into(&mut buf), BLACK.into());
@@ -670,8 +668,7 @@ mod tests {
                 offset: 0.0,
                 color: DynamicColor::from_alpha_color(GREEN),
             }]),
-            transform: Affine::IDENTITY,
-            extend: Extend::Pad,
+            ..Default::default()
         };
 
         // Should return the color of the first stop.
@@ -697,8 +694,7 @@ mod tests {
                     color: DynamicColor::from_alpha_color(BLUE),
                 },
             ]),
-            transform: Affine::IDENTITY,
-            extend: Extend::Pad,
+            ..Default::default()
         };
 
         assert_eq!(gradient.encode_into(&mut buf), GREEN.into());
@@ -723,8 +719,7 @@ mod tests {
                     color: DynamicColor::from_alpha_color(BLUE),
                 },
             ]),
-            transform: Affine::IDENTITY,
-            extend: Extend::Pad,
+            ..Default::default()
         };
 
         assert_eq!(gradient.encode_into(&mut buf), GREEN.into());
@@ -749,8 +744,7 @@ mod tests {
                     color: DynamicColor::from_alpha_color(BLUE),
                 },
             ]),
-            transform: Affine::IDENTITY,
-            extend: Extend::Pad,
+            ..Default::default()
         };
 
         assert_eq!(gradient.encode_into(&mut buf), GREEN.into());
@@ -776,8 +770,7 @@ mod tests {
                     color: DynamicColor::from_alpha_color(BLUE),
                 },
             ]),
-            transform: Affine::IDENTITY,
-            extend: Extend::Pad,
+            ..Default::default()
         };
 
         assert_eq!(gradient.encode_into(&mut buf), GREEN.into());
@@ -804,8 +797,7 @@ mod tests {
                     color: DynamicColor::from_alpha_color(BLUE),
                 },
             ]),
-            transform: Affine::IDENTITY,
-            extend: Extend::Pad,
+            ..Default::default()
         };
 
         assert_eq!(gradient.encode_into(&mut buf), GREEN.into());

--- a/sparse_strips/vello_cpu/tests/gradient.rs
+++ b/sparse_strips/vello_cpu/tests/gradient.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use vello_common::kurbo::{Affine, Point, Rect};
+use vello_common::kurbo::{Point, Rect};
 use vello_common::paint::Gradient;
 use vello_common::peniko::GradientKind;
 use crate::util::{check_ref, get_ctx, stops_blue_green_red_yellow, stops_green_blue};
@@ -21,8 +21,7 @@ fn gradient_on_3_wide_tiles() {
             end: Point::new(600.0, 0.0),
         },
         stops: stops_green_blue(),
-        transform: Affine::IDENTITY,
-        extend: vello_common::peniko::Extend::Pad,
+        ..Default::default()
     };
 
     ctx.set_paint(gradient);
@@ -42,8 +41,7 @@ fn gradient_with_global_alpha() {
             end: Point::new(90.0, 0.0),
         },
         stops: stops_blue_green_red_yellow(),
-        transform: Affine::IDENTITY,
-        extend: vello_common::peniko::Extend::Pad,
+        ..Default::default()
     }.multiply_alpha(0.5);
 
     ctx.set_paint(gradient);
@@ -74,8 +72,7 @@ mod linear {
                 end: Point::new(90.0, 0.0),
             },
             stops: stops_green_blue(),
-            transform: Affine::IDENTITY,
-            extend: vello_common::peniko::Extend::Pad,
+            ..Default::default()
         };
 
         ctx.set_paint(gradient);
@@ -95,8 +92,7 @@ mod linear {
                 end: Point::new(90.0, 0.0),
             },
             stops: stops_green_blue_with_alpha(),
-            transform: Affine::IDENTITY,
-            extend: vello_common::peniko::Extend::Pad,
+            ..Default::default()
         };
 
         ctx.set_paint(gradient);
@@ -116,8 +112,7 @@ mod linear {
                     end: $end,
                 },
                 stops: stops_green_blue(),
-                transform: Affine::IDENTITY,
-                extend: vello_common::peniko::Extend::Pad,
+                ..Default::default()
             };
     
             ctx.set_paint(gradient);
@@ -158,8 +153,8 @@ mod linear {
                     end: Point::new(60.0, 60.0),
                 },
                 stops: stops_blue_green_red_yellow(),
-                transform: Affine::IDENTITY,
                 extend: $extend,
+                ..Default::default()
             };
 
             ctx.set_paint(gradient);
@@ -204,8 +199,7 @@ mod linear {
                 end: Point::new(90.0, 0.0),
             },
             stops: stops_blue_green_red_yellow(),
-            transform: Affine::IDENTITY,
-            extend: vello_common::peniko::Extend::Pad,
+            ..Default::default()
         };
 
         ctx.set_paint(gradient);
@@ -225,8 +219,7 @@ mod linear {
                 end: Point::new(100.0, 0.0),
             },
             stops: stops_blue_green_red_yellow(),
-            transform: Affine::IDENTITY,
-            extend: vello_common::peniko::Extend::Pad,
+            ..Default::default()
         };
 
         ctx.set_paint(gradient);
@@ -246,8 +239,8 @@ mod linear {
                 end: Point::new(50.5, 52.5),
             },
             stops: stops_blue_green_red_yellow(),
-            transform: Affine::IDENTITY,
             extend: vello_common::peniko::Extend::Repeat,
+            ..Default::default()
         };
 
         ctx.set_paint(gradient);
@@ -267,8 +260,8 @@ mod linear {
                 end: Point::new(50.5, 52.5),
             },
             stops: stops_blue_green_red_yellow(),
-            transform: Affine::IDENTITY,
             extend: vello_common::peniko::Extend::Reflect,
+            ..Default::default()
         };
 
         ctx.set_paint(gradient);
@@ -288,8 +281,7 @@ mod linear {
                     end: Point::new($p2, $p3),
                 },
                 stops: stops_blue_green_red_yellow(),
-                transform: Affine::IDENTITY,
-                extend: vello_common::peniko::Extend::Pad,
+                ..Default::default()
             };
 
             ctx.set_transform($transform);
@@ -473,8 +465,7 @@ mod radial {
                     end_radius: 40.0,
                 },
                 stops: $stops,
-                transform: Affine::IDENTITY,
-                extend: vello_common::peniko::Extend::Pad,
+                ..Default::default()
             };
 
             ctx.set_paint(gradient);
@@ -515,8 +506,8 @@ mod radial {
                     end_radius: 25.0,
                 },
                 stops: stops_blue_green_red_yellow(),
-                transform: Affine::IDENTITY,
                 extend: $extend,
+                ..Default::default()
             };
 
             ctx.set_paint(gradient);
@@ -563,8 +554,8 @@ mod radial {
                     end_radius: 40.0,
                 },
                 stops: stops_blue_green_red_yellow(),
-                transform: Affine::IDENTITY,
                 extend: vello_common::peniko::Extend::Repeat,
+                ..Default::default()
             };
 
             ctx.set_paint(gradient);
@@ -619,8 +610,7 @@ mod radial {
                 end_radius: 10.0,
             },
             stops: stops_blue_green_red_yellow(),
-            transform: Affine::IDENTITY,
-            extend: vello_common::peniko::Extend::Pad,
+            ..Default::default()
         };
 
         ctx.set_paint(gradient);
@@ -642,8 +632,7 @@ mod radial {
                     end_radius: 20.0,
                 },
                 stops: stops_blue_green_red_yellow(),
-                transform: Affine::IDENTITY,
-                extend: vello_common::peniko::Extend::Pad,
+                ..Default::default()
             };
 
             ctx.set_paint(gradient);
@@ -686,8 +675,7 @@ mod radial {
                 end_radius: 35.0,
             },
             stops: stops_blue_green_red_yellow(),
-            transform: Affine::IDENTITY,
-            extend: vello_common::peniko::Extend::Pad,
+            ..Default::default()
         };
 
         ctx.set_paint(gradient);
@@ -710,8 +698,7 @@ mod radial {
                     end_radius: 35.0,
                 },
                 stops: stops_blue_green_red_yellow(),
-                transform: Affine::IDENTITY,
-                extend: vello_common::peniko::Extend::Pad,
+                ..Default::default()
             };
 
             ctx.set_transform($transform);
@@ -894,8 +881,7 @@ mod sweep {
                     end_angle: 360.0,
                 },
                 stops: $stops,
-                extend: vello_common::peniko::Extend::Pad,
-                transform: Affine::IDENTITY,
+                ..Default::default()
             };
 
             ctx.set_paint(gradient);
@@ -953,8 +939,7 @@ mod sweep {
                 end_angle: 360.0,
             },
             stops: stops_blue_green_red_yellow(),
-            extend: vello_common::peniko::Extend::Pad,
-            transform: Affine::IDENTITY,
+            ..Default::default()
         };
 
         ctx.set_paint(gradient);
@@ -976,7 +961,7 @@ mod sweep {
                 },
                 stops: stops_blue_green_red_yellow(),
                 extend: $extend,
-                transform: Affine::IDENTITY,
+                ..Default::default()
             };
 
             ctx.set_paint(gradient);
@@ -1022,8 +1007,7 @@ mod sweep {
                     end_angle: 210.0,
                 },
                 stops: stops_blue_green_red_yellow(),
-                extend: vello_common::peniko::Extend::Pad,
-                transform: Affine::IDENTITY,
+                ..Default::default()
             };
 
             ctx.set_transform($transform);


### PR DESCRIPTION
In preparation for adding proper support for gradient interpolation in different color spaces.