### PR TITLE
Fix an overflow in clipping

### DIFF
--- a/sparse_strips/vello_common/src/coarse.rs
+++ b/sparse_strips/vello_common/src/coarse.rs
@@ -521,10 +521,10 @@ impl Wide {
 
             // Calculate starting position and column for alpha mask
             let mut x = x0;
-            let mut col = (strip.alpha_idx / u32::from(Tile::HEIGHT)) as u16;
+            let mut col = strip.alpha_idx / u32::from(Tile::HEIGHT);
             let clip_x = clip_bbox.x0() * WideTile::WIDTH;
             if clip_x > x {
-                col += clip_x - x;
+                col += (clip_x - x) as u32;
                 x = clip_x;
             }
 
@@ -543,10 +543,10 @@ impl Wide {
                 let cmd = CmdClipAlphaFill {
                     x: x_rel,
                     width: width as u32,
-                    alpha_idx: (col * Tile::HEIGHT) as usize,
+                    alpha_idx: col as usize * Tile::HEIGHT as usize,
                 };
                 x += width;
-                col += width;
+                col += width as u32;
 
                 // Apply the clip strip command and update state
                 self.get_mut(wtile_x, cur_wtile_y).clip_strip(cmd);

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -275,8 +275,8 @@ impl GlyphRenderer for RenderContext {
 
 #[cfg(test)]
 mod tests {
-    use core::iter;
     use crate::RenderContext;
+    use core::iter;
     use vello_common::kurbo::{Rect, Shape};
 
     #[test]
@@ -296,13 +296,14 @@ mod tests {
         assert!(ctx.strip_buf.is_empty());
         assert!(ctx.alphas.is_empty());
     }
-    
+
     #[test]
     fn clip_overflow() {
         let mut ctx = RenderContext::new(100, 100);
-        
-        ctx.alphas.extend(iter::repeat(255).take(u16::MAX as usize + 1));
-        
+
+        ctx.alphas
+            .extend(iter::repeat(255).take(u16::MAX as usize + 1));
+
         ctx.clip(&Rect::new(20.0, 20.0, 180.0, 180.0).to_path(0.1));
         ctx.finish();
     }

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -275,8 +275,9 @@ impl GlyphRenderer for RenderContext {
 
 #[cfg(test)]
 mod tests {
+    use core::iter;
     use crate::RenderContext;
-    use vello_common::kurbo::Rect;
+    use vello_common::kurbo::{Rect, Shape};
 
     #[test]
     fn reset_render_context() {
@@ -294,5 +295,15 @@ mod tests {
         assert!(ctx.line_buf.is_empty());
         assert!(ctx.strip_buf.is_empty());
         assert!(ctx.alphas.is_empty());
+    }
+    
+    #[test]
+    fn clip_overflow() {
+        let mut ctx = RenderContext::new(100, 100);
+        
+        ctx.alphas.extend(iter::repeat(255).take(u16::MAX as usize + 1));
+        
+        ctx.clip(&Rect::new(20.0, 20.0, 180.0, 180.0).to_path(0.1));
+        ctx.finish();
     }
 }


### PR DESCRIPTION
For complex scenes it is pretty easy to reach u16::MAX for the number of stored alpha values.