### PR TITLE
Pass in `Transform` for paint types separately

### DIFF
--- a/sparse_strips/vello_api/src/paint.rs
+++ b/sparse_strips/vello_api/src/paint.rs
@@ -3,11 +3,12 @@
 
 //! Types for paints.
 
-use crate::kurbo::{Affine, Point};
 use crate::pixmap::Pixmap;
 use alloc::sync::Arc;
-use peniko::color::{AlphaColor, ColorSpaceTag, HueDirection, PremulRgba8, Srgb};
-use peniko::{ColorStops, GradientKind, ImageQuality};
+use peniko::{
+    Gradient, ImageQuality,
+    color::{AlphaColor, PremulRgba8, Srgb},
+};
 
 /// A paint that needs to be resolved via its index.
 // In the future, we might add additional flags, that's why we have
@@ -54,64 +55,6 @@ impl From<AlphaColor<Srgb>> for Paint {
     }
 }
 
-// TODO: Replace this with the peniko type, once it supports transforms.
-/// A gradient.
-#[derive(Debug, Clone)]
-pub struct Gradient {
-    /// The underlying kind of gradient.
-    pub kind: GradientKind,
-    /// The stops that makes up the gradient.
-    ///
-    /// Note that the first stop must have an offset of 0.0 and the last stop
-    /// must have an offset of 1.0. In addition to that, the stops must be sorted
-    /// with offsets in ascending order.
-    pub stops: ColorStops,
-    /// A transformation to apply to the gradient.
-    pub transform: Affine,
-    /// The extend of the gradient.
-    pub extend: peniko::Extend,
-    /// The color space to be used for interpolation.
-    ///
-    /// The colors in the color stops will be converted to this color space.
-    ///
-    /// This defaults to [sRGB](ColorSpaceTag::Srgb).
-    pub interpolation_cs: ColorSpaceTag,
-    /// When interpolating within a cylindrical color space, the direction for the hue.
-    ///
-    /// This is interpreted as described in [CSS Color Module Level 4 § 12.4].
-    ///
-    /// [CSS Color Module Level 4 § 12.4]: https://drafts.csswg.org/css-color/#hue-interpolation
-    pub hue_direction: HueDirection,
-}
-
-impl Default for Gradient {
-    fn default() -> Self {
-        Self {
-            kind: GradientKind::Linear {
-                start: Point::default(),
-                end: Point::default(),
-            },
-            transform: Affine::IDENTITY,
-            interpolation_cs: ColorSpaceTag::Srgb,
-            extend: Default::default(),
-            hue_direction: Default::default(),
-            stops: Default::default(),
-        }
-    }
-}
-
-impl Gradient {
-    /// Returns the gradient with the alpha component for all color stops
-    /// multiplied by `alpha`.
-    #[must_use]
-    pub fn multiply_alpha(mut self, alpha: f32) -> Self {
-        self.stops
-            .iter_mut()
-            .for_each(|stop| *stop = stop.multiply_alpha(alpha));
-        self
-    }
-}
-
 /// An image.
 #[derive(Debug, Clone)]
 pub struct Image {
@@ -123,8 +66,6 @@ pub struct Image {
     pub y_extend: peniko::Extend,
     /// Hint for desired rendering quality.
     pub quality: ImageQuality,
-    /// A transform to apply to the image.
-    pub transform: Affine,
 }
 
 /// A premultiplied color.

--- a/sparse_strips/vello_bench/src/cpu_fine.rs
+++ b/sparse_strips/vello_bench/src/cpu_fine.rs
@@ -10,10 +10,12 @@ use vello_common::coarse::WideTile;
 use vello_common::color::DynamicColor;
 use vello_common::color::palette::css::{BLUE, GREEN, RED, ROYAL_BLUE, YELLOW};
 use vello_common::encode::{EncodeExt, EncodedPaint};
-use vello_common::kurbo::Point;
-use vello_common::paint::{Gradient, Paint, PremulColor};
+use vello_common::kurbo::{Affine, Point};
+use vello_common::paint::{Paint, PremulColor};
 use vello_common::peniko;
-use vello_common::peniko::{BlendMode, ColorStop, ColorStops, Compose, GradientKind, Mix};
+use vello_common::peniko::{
+    BlendMode, ColorStop, ColorStops, Compose, Gradient, GradientKind, Mix,
+};
 use vello_common::tile::Tile;
 use vello_cpu::fine::{Fine, SCRATCH_BUF_SIZE};
 
@@ -75,7 +77,7 @@ pub fn fill(c: &mut Criterion) {
                 ..Default::default()
             };
 
-            let paint = grad.encode_into(&mut paints);
+            let paint = grad.encode_into(&mut paints, Affine::IDENTITY);
 
             fill_single!($name, &paint, &paints, WideTile::WIDTH as usize);
         };
@@ -116,7 +118,7 @@ pub fn fill(c: &mut Criterion) {
                 ..Default::default()
             };
 
-            let paint = grad.encode_into(&mut paints);
+            let paint = grad.encode_into(&mut paints, Affine::IDENTITY);
 
             fill_single!($name, &paint, &paints, WideTile::WIDTH as usize);
         };
@@ -161,7 +163,7 @@ pub fn fill(c: &mut Criterion) {
                 ..Default::default()
             };
 
-            let paint = grad.encode_into(&mut paints);
+            let paint = grad.encode_into(&mut paints, Affine::IDENTITY);
 
             fill_single!($name, &paint, &paints, WideTile::WIDTH as usize);
         };

--- a/sparse_strips/vello_common/src/encode.rs
+++ b/sparse_strips/vello_common/src/encode.rs
@@ -7,7 +7,7 @@ use crate::color::palette::css::BLACK;
 use crate::color::{ColorSpaceTag, HueDirection, PremulColor, Srgb, gradient};
 use crate::encode::private::Sealed;
 use crate::kurbo::{Affine, Point, Vec2};
-use crate::peniko::{ColorStop, Extend, GradientKind, ImageQuality};
+use crate::peniko::{ColorStop, Extend, Gradient, GradientKind, ImageQuality};
 use crate::pixmap::Pixmap;
 use alloc::borrow::Cow;
 use alloc::sync::Arc;
@@ -15,7 +15,7 @@ use alloc::vec::Vec;
 use core::f32::consts::PI;
 use core::iter;
 use smallvec::SmallVec;
-use vello_api::paint::{Gradient, Image, IndexedPaint, Paint};
+use vello_api::paint::{Image, IndexedPaint, Paint};
 
 const DEGENERATE_THRESHOLD: f32 = 1.0e-6;
 const NUDGE_VAL: f32 = 1.0e-7;
@@ -24,12 +24,12 @@ const NUDGE_VAL: f32 = 1.0e-7;
 pub trait EncodeExt: private::Sealed {
     /// Encode the gradient and push it into a vector of encoded paints, returning
     /// the corresponding paint in the process. This will also validate the gradient.
-    fn encode_into(&self, paints: &mut Vec<EncodedPaint>) -> Paint;
+    fn encode_into(&self, paints: &mut Vec<EncodedPaint>, transform: Affine) -> Paint;
 }
 
 impl EncodeExt for Gradient {
     /// Encode the gradient into a paint.
-    fn encode_into(&self, paints: &mut Vec<EncodedPaint>) -> Paint {
+    fn encode_into(&self, paints: &mut Vec<EncodedPaint>, transform: Affine) -> Paint {
         // First make sure that the gradient is valid and not degenerate.
         if let Err(paint) = validate(self) {
             return paint;
@@ -205,8 +205,8 @@ impl EncodeExt for Gradient {
         // adding 0.5.
         // Finally, we need to apply the _inverse_ transform to the point so that we can account
         // for the transform on the gradient.
-        let transform = Affine::translate((x_offset as f64 + 0.5, y_offset as f64 + 0.5))
-            * self.transform.inverse();
+        let transform =
+            Affine::translate((x_offset as f64 + 0.5, y_offset as f64 + 0.5)) * transform.inverse();
 
         // One possible approach of calculating the positions would be to apply the above
         // transform to _each_ pixel that we render in the wide tile. However, a much better
@@ -460,10 +460,10 @@ fn x_y_advances(transform: &Affine) -> (Vec2, Vec2) {
 impl Sealed for Image {}
 
 impl EncodeExt for Image {
-    fn encode_into(&self, paints: &mut Vec<EncodedPaint>) -> Paint {
+    fn encode_into(&self, paints: &mut Vec<EncodedPaint>, transform: Affine) -> Paint {
         let idx = paints.len();
 
-        let transform = self.transform.inverse();
+        let transform = transform.inverse();
         // TODO: This is somewhat expensive for large images, maybe it's not worth optimizing
         // non-opaque images in the first place..
         let has_opacities = self.pixmap.data().chunks(4).any(|c| c[3] != 255);
@@ -702,12 +702,10 @@ impl GradientLike for RadialKind {
 }
 
 mod private {
-    use vello_api::paint::Gradient;
-
     #[allow(unnameable_types, reason = "We make it unnameable on purpose")]
     pub trait Sealed {}
 
-    impl Sealed for Gradient {}
+    impl Sealed for super::Gradient {}
 }
 
 #[cfg(test)]
@@ -719,6 +717,7 @@ mod tests {
     use crate::peniko::{ColorStop, ColorStops, GradientKind};
     use alloc::vec;
     use smallvec::smallvec;
+    use vello_api::kurbo::Affine;
 
     #[test]
     fn gradient_missing_stops() {
@@ -732,7 +731,10 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(gradient.encode_into(&mut buf), BLACK.into());
+        assert_eq!(
+            gradient.encode_into(&mut buf, Affine::IDENTITY),
+            BLACK.into()
+        );
     }
 
     #[test]
@@ -752,7 +754,10 @@ mod tests {
         };
 
         // Should return the color of the first stop.
-        assert_eq!(gradient.encode_into(&mut buf), GREEN.into());
+        assert_eq!(
+            gradient.encode_into(&mut buf, Affine::IDENTITY),
+            GREEN.into()
+        );
     }
 
     #[test]
@@ -777,7 +782,10 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(gradient.encode_into(&mut buf), GREEN.into());
+        assert_eq!(
+            gradient.encode_into(&mut buf, Affine::IDENTITY),
+            GREEN.into()
+        );
     }
 
     #[test]
@@ -802,7 +810,10 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(gradient.encode_into(&mut buf), GREEN.into());
+        assert_eq!(
+            gradient.encode_into(&mut buf, Affine::IDENTITY),
+            GREEN.into()
+        );
     }
 
     #[test]
@@ -827,7 +838,10 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(gradient.encode_into(&mut buf), GREEN.into());
+        assert_eq!(
+            gradient.encode_into(&mut buf, Affine::IDENTITY),
+            GREEN.into()
+        );
     }
 
     #[test]
@@ -853,7 +867,10 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(gradient.encode_into(&mut buf), GREEN.into());
+        assert_eq!(
+            gradient.encode_into(&mut buf, Affine::IDENTITY),
+            GREEN.into()
+        );
     }
 
     #[test]
@@ -880,6 +897,9 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(gradient.encode_into(&mut buf), GREEN.into());
+        assert_eq!(
+            gradient.encode_into(&mut buf, Affine::IDENTITY),
+            GREEN.into()
+        );
     }
 }

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -202,6 +202,10 @@ impl RenderContext {
     }
 
     /// Set the current paint transform.
+    ///
+    /// The paint transform is applied to the paint after the transform of the geometry the paint
+    /// is drawn in, i.e., the paint transform is applied after the global transform. This allows
+    /// transforming the paint independently from the drawn geometry.
     pub fn set_paint_transform(&mut self, paint_transform: Affine) {
         self.paint_transform = paint_transform;
     }

--- a/sparse_strips/vello_cpu/tests/gradient.rs
+++ b/sparse_strips/vello_cpu/tests/gradient.rs
@@ -6,8 +6,7 @@ use smallvec::smallvec;
 use vello_common::color::palette::css::{BLACK, BLUE, WHITE, YELLOW};
 use vello_common::color::{ColorSpaceTag, DynamicColor};
 use vello_common::kurbo::{Point, Rect};
-use vello_common::paint::Gradient;
-use vello_common::peniko::{ColorStop, ColorStops, GradientKind};
+use vello_common::peniko::{ColorStop, ColorStops, Gradient, GradientKind};
 
 pub(crate) const fn tan_45() -> f64 {
     1.0
@@ -134,8 +133,7 @@ mod linear {
     };
     use std::f64::consts::PI;
     use vello_common::kurbo::{Affine, Point, Rect};
-    use vello_common::paint::Gradient;
-    use vello_common::peniko::GradientKind;
+    use vello_common::peniko::{Gradient, GradientKind};
 
     #[test]
     fn gradient_linear_2_stops() {
@@ -541,8 +539,7 @@ mod radial {
     };
     use std::f64::consts::PI;
     use vello_common::kurbo::{Affine, Point, Rect};
-    use vello_common::paint::Gradient;
-    use vello_common::peniko::GradientKind::Radial;
+    use vello_common::peniko::{Gradient, GradientKind::Radial};
 
     macro_rules! simple {
         ($stops:expr, $name:expr) => {
@@ -958,8 +955,7 @@ mod sweep {
     };
     use std::f64::consts::PI;
     use vello_common::kurbo::{Affine, Point, Rect};
-    use vello_common::paint::Gradient;
-    use vello_common::peniko::GradientKind;
+    use vello_common::peniko::{Gradient, GradientKind};
 
     macro_rules! basic {
         ($stops:expr, $name:expr, $center:expr) => {

--- a/sparse_strips/vello_cpu/tests/image.rs
+++ b/sparse_strips/vello_cpu/tests/image.rs
@@ -51,8 +51,8 @@ macro_rules! repeat {
             x_extend: $x_repeat,
             y_extend: $y_repeat,
             quality: ImageQuality::Low,
-            transform: Affine::translate((45.0, 45.0)),
         });
+        ctx.set_paint_transform(Affine::translate((45.0, 45.0)));
         ctx.fill_rect(&rect);
 
         check_ref(&ctx, $name);
@@ -98,7 +98,6 @@ macro_rules! transform {
             x_extend: Extend::Repeat,
             y_extend: Extend::Repeat,
             quality: ImageQuality::Low,
-            transform: Affine::IDENTITY,
         };
 
         ctx.set_transform($transform);
@@ -270,7 +269,6 @@ fn image_complex_shape() {
         x_extend: Extend::Repeat,
         y_extend: Extend::Repeat,
         quality: ImageQuality::Low,
-        transform: Affine::IDENTITY,
     };
 
     ctx.set_paint(image);
@@ -292,7 +290,6 @@ fn image_global_alpha() {
         x_extend: Extend::Repeat,
         y_extend: Extend::Repeat,
         quality: ImageQuality::Low,
-        transform: Affine::IDENTITY,
     };
 
     ctx.set_paint(image);
@@ -311,7 +308,6 @@ macro_rules! image_format {
             x_extend: Extend::Repeat,
             y_extend: Extend::Repeat,
             quality: ImageQuality::Low,
-            transform: Affine::IDENTITY,
         };
 
         ctx.set_paint(image);
@@ -351,10 +347,10 @@ macro_rules! quality {
             x_extend: $extend,
             y_extend: $extend,
             quality: $quality,
-            transform: $transform,
         };
 
         ctx.set_paint(image);
+        ctx.set_paint_transform($transform);
         ctx.fill_rect(&rect);
 
         check_ref(&ctx, $name);

--- a/sparse_strips/vello_cpu/tests/mask.rs
+++ b/sparse_strips/vello_cpu/tests/mask.rs
@@ -7,8 +7,7 @@ use vello_common::color::DynamicColor;
 use vello_common::color::palette::css::{BLACK, LIME, RED, YELLOW};
 use vello_common::kurbo::{Point, Rect};
 use vello_common::mask::Mask;
-use vello_common::paint::Gradient;
-use vello_common::peniko::{ColorStop, ColorStops, GradientKind};
+use vello_common::peniko::{ColorStop, ColorStops, Gradient, GradientKind};
 use vello_cpu::{Pixmap, RenderContext};
 
 pub(crate) fn example_mask(alpha_mask: bool) -> Mask {

--- a/sparse_strips/vello_cpu/tests/mix.rs
+++ b/sparse_strips/vello_cpu/tests/mix.rs
@@ -7,8 +7,8 @@ use smallvec::smallvec;
 use vello_common::color::palette::css::{BLUE, LIME, MAGENTA, RED, YELLOW};
 use vello_common::color::{AlphaColor, DynamicColor, Srgb};
 use vello_common::kurbo::{Affine, Point, Rect};
-use vello_common::paint::{Gradient, Image};
-use vello_common::peniko::{BlendMode, Compose, Extend, Mix};
+use vello_common::paint::Image;
+use vello_common::peniko::{BlendMode, Compose, Extend, Gradient, Mix};
 use vello_common::peniko::{ColorStop, ColorStops, GradientKind, ImageQuality};
 
 // The outputs have been compared visually with tiny-skia, and except for two cases (where tiny-skia
@@ -52,7 +52,6 @@ fn mix(name: &str, blend_mode: BlendMode) {
         x_extend: Extend::Pad,
         y_extend: Extend::Pad,
         quality: ImageQuality::Low,
-        transform: Affine::IDENTITY,
     };
 
     ctx.set_transform(Affine::translate((10.0, 10.0)));


### PR DESCRIPTION
This proposes passing in `Transform` for paint types separately through methods on the render context, moving the field out of the `PaintType` types' structs. This allows using existing ecosystem types directly (like `peniko::Gradient`).