### PR TITLE
Use `peniko::Image` for the image `PaintType`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3277,6 +3277,7 @@ version = "0.0.0"
 dependencies = [
  "image",
  "oxipng",
+ "png",
  "pollster",
  "skrifa",
  "smallvec",

--- a/sparse_strips/vello_api/src/paint.rs
+++ b/sparse_strips/vello_api/src/paint.rs
@@ -3,10 +3,8 @@
 
 //! Types for paints.
 
-use crate::pixmap::Pixmap;
-use alloc::sync::Arc;
 use peniko::{
-    Gradient, ImageQuality,
+    Gradient, Image,
     color::{AlphaColor, PremulRgba8, Srgb},
 };
 
@@ -53,19 +51,6 @@ impl From<AlphaColor<Srgb>> for Paint {
         // code.
         Self::Solid(PremulColor::new(value))
     }
-}
-
-/// An image.
-#[derive(Debug, Clone)]
-pub struct Image {
-    /// The underlying pixmap of the image.
-    pub pixmap: Arc<Pixmap>,
-    /// Extend mode in the horizontal direction.
-    pub x_extend: peniko::Extend,
-    /// Extend mode in the vertical direction.
-    pub y_extend: peniko::Extend,
-    /// Hint for desired rendering quality.
-    pub quality: ImageQuality,
 }
 
 /// A premultiplied color.

--- a/sparse_strips/vello_common/src/encode.rs
+++ b/sparse_strips/vello_common/src/encode.rs
@@ -7,15 +7,14 @@ use crate::color::palette::css::BLACK;
 use crate::color::{ColorSpaceTag, HueDirection, PremulColor, Srgb, gradient};
 use crate::encode::private::Sealed;
 use crate::kurbo::{Affine, Point, Vec2};
-use crate::peniko::{ColorStop, Extend, Gradient, GradientKind, ImageQuality};
-use crate::pixmap::Pixmap;
+use crate::peniko::{Blob, ColorStop, Extend, Gradient, GradientKind, Image, ImageQuality};
 use alloc::borrow::Cow;
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::f32::consts::PI;
 use core::iter;
 use smallvec::SmallVec;
-use vello_api::paint::{Image, IndexedPaint, Paint};
+use vello_api::color::PremulRgba8;
+use vello_api::paint::{IndexedPaint, Paint};
 
 const DEGENERATE_THRESHOLD: f32 = 1.0e-6;
 const NUDGE_VAL: f32 = 1.0e-7;
@@ -466,14 +465,17 @@ impl EncodeExt for Image {
         let transform = transform.inverse();
         // TODO: This is somewhat expensive for large images, maybe it's not worth optimizing
         // non-opaque images in the first place..
-        let has_opacities = self.pixmap.data().chunks(4).any(|c| c[3] != 255);
+        let has_opacities = self.alpha != 1. || self.data.data().chunks(4).any(|c| c[3] != 255);
 
         let (x_advance, y_advance) = x_y_advances(&transform);
 
         let encoded = EncodedImage {
-            pixmap: self.pixmap.clone(),
+            blob: self.data.clone(),
+            width: self.width as u16,
+            height: self.height as u16,
             extends: (self.x_extend, self.y_extend),
             quality: self.quality,
+            alpha: self.alpha,
             has_opacities,
             transform,
             x_advance,
@@ -505,11 +507,17 @@ impl From<EncodedGradient> for EncodedPaint {
 #[derive(Debug)]
 pub struct EncodedImage {
     /// The underlying pixmap of the image.
-    pub pixmap: Arc<Pixmap>,
+    pub blob: Blob<u8>,
+    /// Width of the image.
+    pub width: u16,
+    /// Height of the image.
+    pub height: u16,
     /// The extends in the horizontal and vertical direction.
     pub extends: (Extend, Extend),
     /// The rendering quality of the image.
     pub quality: ImageQuality,
+    /// An additional alpha multiplier to use with the image.
+    pub alpha: f32,
     /// Whether the image has opacities.
     pub has_opacities: bool,
     /// A transform to apply to the image.
@@ -518,6 +526,24 @@ pub struct EncodedImage {
     pub x_advance: Vec2,
     /// The advance in image coordinates for one step in the y direction.
     pub y_advance: Vec2,
+}
+
+impl EncodedImage {
+    /// Sample a premultiplied RGBA8 pixel from the encoded image.
+    #[inline(always)]
+    pub fn sample(&self, x: u16, y: u16) -> PremulRgba8 {
+        let idx = 4 * (self.width as usize * y as usize + x as usize);
+        let data = &self.blob.data()[idx..][..4];
+
+        let global_alpha = (self.alpha * 255. + 0.5) as u8;
+        let alpha = ((data[3] as u16 * global_alpha as u16) / 255) as u8;
+        PremulRgba8 {
+            r: ((data[0] as u16 * alpha as u16) / 255) as u8,
+            g: ((data[1] as u16 * alpha as u16) / 255) as u8,
+            b: ((data[2] as u16 * alpha as u16) / 255) as u8,
+            a: alpha,
+        }
+    }
 }
 
 /// Computed properties of a linear gradient.

--- a/sparse_strips/vello_cpu/src/fine/image.rs
+++ b/sparse_strips/vello_cpu/src/fine/image.rs
@@ -59,7 +59,7 @@ impl<'a> ImageFiller<'a> {
                     // we always floor to get the target pixel.
                     (self.cur_pos.y + y_advance * idx as f64).floor() as f32,
                     self.image.extends.1,
-                    self.image.pixmap.height() as f32,
+                    self.image.height as f32,
                 );
             }
 
@@ -70,7 +70,7 @@ impl<'a> ImageFiller<'a> {
                         // As above, always floor.
                         x_pos.floor() as f32,
                         self.image.extends.0,
-                        self.image.pixmap.width() as f32,
+                        self.image.width as f32,
                     );
                     self.run_simple_column(column, extended_x_pos, &y_positions);
                     x_pos += x_advance;
@@ -89,11 +89,11 @@ impl<'a> ImageFiller<'a> {
             .zip(y_positions.iter())
         {
             let sample = match self.image.quality {
-                ImageQuality::Low => self.image.pixmap.sample(x_pos as u16, *y_pos as u16),
+                ImageQuality::Low => self.image.sample(x_pos as u16, *y_pos as u16),
                 ImageQuality::Medium | ImageQuality::High => unimplemented!(),
             };
 
-            pixel.copy_from_slice(sample);
+            pixel.copy_from_slice(&sample.to_u8_array());
         }
     }
 
@@ -103,12 +103,12 @@ impl<'a> ImageFiller<'a> {
             point.x = extend(
                 point.x.floor() as f32,
                 self.image.extends.0,
-                self.image.pixmap.width() as f32,
+                self.image.width as f32,
             ) as f64;
             point.y = extend(
                 point.y.floor() as f32,
                 self.image.extends.1,
-                self.image.pixmap.height() as f32,
+                self.image.height as f32,
             ) as f64;
 
             point
@@ -122,8 +122,8 @@ impl<'a> ImageFiller<'a> {
                 // Simply takes the nearest pixel to our current position.
                 ImageQuality::Low => {
                     let point = extend_point(pos);
-                    let sample = self.image.pixmap.sample(point.x as u16, point.y as u16);
-                    pixel.copy_from_slice(sample);
+                    let sample = self.image.sample(point.x as u16, point.y as u16);
+                    pixel.copy_from_slice(&sample.to_u8_array());
                 }
                 ImageQuality::Medium | ImageQuality::High => {
                     // We have two versions of filtering: `Medium` (bilinear filtering) and
@@ -165,7 +165,7 @@ impl<'a> ImageFiller<'a> {
 
                     let mut f32_color = [0.0_f32; 4];
 
-                    let sample = |p: Point| self.image.pixmap.sample(p.x as u16, p.y as u16);
+                    let sample = |p: Point| self.image.sample(p.x as u16, p.y as u16).to_u8_array();
 
                     if self.image.quality == ImageQuality::Medium {
                         let cx = [1.0 - x_fract, x_fract];

--- a/sparse_strips/vello_sparse_tests/Cargo.toml
+++ b/sparse_strips/vello_sparse_tests/Cargo.toml
@@ -20,6 +20,7 @@ vello_common = { workspace = true }
 vello_cpu = { workspace = true }
 vello_hybrid = { workspace = true }
 wgpu = { workspace = true }
+png = { workspace = true }
 pollster = { workspace = true }
 vello_dev_macros = { workspace = true }
 oxipng = { workspace = true, features = ["freestanding", "parallel"] }

--- a/sparse_strips/vello_sparse_tests/tests/mix.rs
+++ b/sparse_strips/vello_sparse_tests/tests/mix.rs
@@ -8,9 +8,7 @@ use vello_api::peniko::Gradient;
 use vello_common::color::palette::css::{BLUE, LIME, MAGENTA, RED, YELLOW};
 use vello_common::color::{AlphaColor, DynamicColor, Srgb};
 use vello_common::kurbo::{Affine, Point, Rect};
-use vello_common::paint::Image;
-use vello_common::peniko::{BlendMode, Compose, Extend, Mix};
-use vello_common::peniko::{ColorStop, ColorStops, GradientKind, ImageQuality};
+use vello_common::peniko::{BlendMode, ColorStop, ColorStops, Compose, Extend, GradientKind, Mix};
 use vello_dev_macros::vello_test;
 
 // The outputs have been compared visually with tiny-skia, and except for two cases (where tiny-skia
@@ -48,12 +46,7 @@ fn mix(ctx: &mut impl Renderer, blend_mode: BlendMode) {
         ..Default::default()
     };
 
-    let image = Image {
-        pixmap: load_image("cowboy"),
-        x_extend: Extend::Pad,
-        y_extend: Extend::Pad,
-        quality: ImageQuality::Low,
-    };
+    let image = load_image("cowboy").with_extend(Extend::Pad);
 
     ctx.set_transform(Affine::translate((10.0, 10.0)));
     ctx.set_paint(image);


### PR DESCRIPTION
This is more or less a continuation of https://github.com/linebender/vello/pull/944, which enabled more easily using ecosystem types.

Note `vello_api` allows constructing a `Pixmap` from PNG data, but this PR does not currently implement the same for a `peniko::Image`.

Further, because `Pixmap` holds premultiplied RGBA8, it is not trivial to convert a `Pixmap` to a `peniko::Image`, as the latter for the moment only holds regular RGBA8. Doing PNG data -> `Pixmap` -> `peniko::Image` is lossy because of all the rounding.

For the moment, this does the premultiplication for rendering during sampling pixel values for fine rasterization. That might not be the best option, especially if at some point in the future `peniko::Image` supports more formats than just RGBA8.