### PR TITLE
Update to `wgpu-profiler` 0.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3833,9 +3833,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-profiler"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "499e1757dca381db7b9d5e7260e1b4f6f7a272cb7b9b0c6e23cbec2403bf85fe"
+checksum = "cdda2055c0da8af2291581148d7eedcd728e97d8519cfe2a163a0b9d28d595ba"
 dependencies = [
  "parking_lot",
  "thiserror 2.0.12",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ clap = "4.5.35"
 anyhow = "1.0.97"
 pollster = "0.4.0"
 web-time = "1.1.0"
-wgpu-profiler = "0.21.0"
+wgpu-profiler = "0.22.0"
 winit = "0.30.9"
 scenes = { path = "examples/scenes" }
 svg = "0.18.0"

--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -449,9 +449,12 @@ impl Renderer {
             #[cfg(feature = "debug_layers")]
             debug,
             #[cfg(feature = "wgpu-profiler")]
-            profiler: GpuProfiler::new(GpuProfilerSettings {
-                ..Default::default()
-            })?,
+            profiler: GpuProfiler::new(
+                device,
+                GpuProfilerSettings {
+                    ..Default::default()
+                },
+            )?,
             #[cfg(feature = "wgpu-profiler")]
             profile_result: None,
         })

--- a/vello/src/wgpu_engine.rs
+++ b/vello/src/wgpu_engine.rs
@@ -393,7 +393,7 @@ impl WgpuEngine {
         let mut encoder =
             device.create_command_encoder(&CommandEncoderDescriptor { label: Some(label) });
         #[cfg(feature = "wgpu-profiler")]
-        let query = profiler.begin_query(label, &mut encoder, device);
+        let query = profiler.begin_query(label, &mut encoder);
         for command in &recording.commands {
             match command {
                 Command::Upload(buf_proxy, bytes) => {
@@ -561,7 +561,7 @@ impl WgpuEngine {
                                 encoder.begin_compute_pass(&ComputePassDescriptor::default());
                             #[cfg(feature = "wgpu-profiler")]
                             let query = profiler
-                                .begin_query(shader.label, &mut cpass, device)
+                                .begin_query(shader.label, &mut cpass)
                                 .with_parent(Some(&query));
                             #[cfg_attr(
                                 not(feature = "debug_layers"),
@@ -619,7 +619,7 @@ impl WgpuEngine {
                                 encoder.begin_compute_pass(&ComputePassDescriptor::default());
                             #[cfg(feature = "wgpu-profiler")]
                             let query = profiler
-                                .begin_query(shader.label, &mut cpass, device)
+                                .begin_query(shader.label, &mut cpass)
                                 .with_parent(Some(&query));
                             #[cfg_attr(
                                 not(feature = "debug_layers"),
@@ -685,7 +685,7 @@ impl WgpuEngine {
                     });
                     #[cfg(feature = "wgpu-profiler")]
                     let query = profiler
-                        .begin_query(label, &mut rpass, device)
+                        .begin_query(label, &mut rpass)
                         .with_parent(Some(&query));
                     let PipelineState::Render(pipeline) = &shader.pipeline else {
                         panic!("cannot issue a draw with a compute pipeline");


### PR DESCRIPTION
This still uses wgpu 24, but changes the API and will make updating to wgpu 25 slightly easier.