### PR TITLE
Update Skrifa to 0.30.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,7 +904,7 @@ dependencies = [
  "objc2-core-text",
  "objc2-foundation 0.3.1",
  "peniko 0.3.2",
- "read-fonts",
+ "read-fonts 0.25.3",
  "roxmltree",
  "smallvec",
  "windows",
@@ -2072,7 +2072,7 @@ dependencies = [
  "fontique",
  "hashbrown 0.15.3",
  "peniko 0.3.2",
- "skrifa",
+ "skrifa 0.26.6",
  "swash",
 ]
 
@@ -2353,6 +2353,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "read-fonts"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "600e807b48ac55bad68a8cb75cc3c7739f139b9248f7e003e01e080f589b5288"
+dependencies = [
+ "bytemuck",
+ "font-types",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2521,7 +2531,7 @@ dependencies = [
  "image",
  "rand",
  "roxmltree",
- "skrifa",
+ "skrifa 0.30.0",
  "vello",
  "web-time",
 ]
@@ -2678,7 +2688,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cc1aa86c26dbb1b63875a7180aa0819709b33348eb5b1491e4321fae388179d"
 dependencies = [
  "bytemuck",
- "read-fonts",
+ "read-fonts 0.25.3",
+]
+
+[[package]]
+name = "skrifa"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fa1e5622e4f7b98877e8a19890efddcac1230cec6198bd9de91ec0e00010dc8"
+dependencies = [
+ "bytemuck",
+ "read-fonts 0.28.0",
 ]
 
 [[package]]
@@ -2825,7 +2845,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fae9a562c7b46107d9c78cd78b75bbe1e991c16734c0aee8ff0ee711fb8b620a"
 dependencies = [
- "skrifa",
+ "skrifa 0.26.6",
  "yazi",
  "zeno",
 ]
@@ -3171,7 +3191,7 @@ dependencies = [
  "log",
  "peniko 0.4.0",
  "png",
- "skrifa",
+ "skrifa 0.30.0",
  "static_assertions",
  "thiserror 2.0.12",
  "vello_encoding",
@@ -3206,7 +3226,7 @@ version = "0.4.0"
 dependencies = [
  "bytemuck",
  "roxmltree",
- "skrifa",
+ "skrifa 0.30.0",
  "smallvec",
  "vello_api",
 ]
@@ -3236,7 +3256,7 @@ dependencies = [
  "bytemuck",
  "guillotiere",
  "peniko 0.4.0",
- "skrifa",
+ "skrifa 0.30.0",
  "smallvec",
 ]
 
@@ -3295,7 +3315,7 @@ dependencies = [
  "image",
  "oxipng",
  "pollster",
- "skrifa",
+ "skrifa 0.30.0",
  "smallvec",
  "vello_api",
  "vello_common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ vello = { version = "0.4.0", path = "vello" }
 vello_encoding = { version = "0.4.0", path = "vello_encoding" }
 vello_shaders = { version = "0.4.0", path = "vello_shaders" }
 bytemuck = { version = "1.23.0", features = ["derive"] }
-skrifa = "0.26.4"
+skrifa = "0.30.0"
 # The version of kurbo used below should be kept in sync
 # with the version of kurbo used by peniko.
 peniko = { version = "0.4.0", default-features = false }


### PR DESCRIPTION
See [#vello > 0.5.0: Skrifa Version](https://xi.zulipchat.com/#narrow/channel/197075-vello/topic/0.2E5.2E0.3A.20Skrifa.20Version/with/516191471). This can be reviewed, but I won't merge until we make a decision there.