### PR TITLE
Round vertical hinting offset in Vello Classic

### DIFF
--- a/examples/scenes/src/simple_text.rs
+++ b/examples/scenes/src/simple_text.rs
@@ -1,6 +1,10 @@
 // Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+//! A minimal text infrastructure, which SHOULD not be used for production use cases.
+//!
+//! Most users should prefer to use [Parley](https://github.com/linebender/parley), which is a full text layout library.
+
 use std::sync::Arc;
 
 use skrifa::{
@@ -70,6 +74,7 @@ impl SimpleText {
             glyph_transform,
             style,
             text,
+            false,
         );
     }
 
@@ -101,6 +106,7 @@ impl SimpleText {
             glyph_transform,
             style,
             text,
+            false,
         );
     }
 
@@ -125,9 +131,14 @@ impl SimpleText {
             glyph_transform,
             style,
             text,
+            false,
         );
     }
 
+    /// Add a glyph run with the specified parameters.
+    ///
+    /// We know that there are too many parameters here.
+    /// Migrating to Parley for this code is probably the right solution here.
     pub fn add_var_run<'a>(
         &mut self,
         scene: &mut Scene,
@@ -139,6 +150,7 @@ impl SimpleText {
         glyph_transform: Option<Affine>,
         style: impl Into<StyleRef<'a>>,
         text: &str,
+        hint: bool,
     ) {
         let default_font = if variations.is_empty() {
             &self.roboto
@@ -165,7 +177,7 @@ impl SimpleText {
             .glyph_transform(glyph_transform)
             .normalized_coords(bytemuck::cast_slice(var_loc.coords()))
             .brush(brush)
-            .hint(false)
+            .hint(hint)
             .draw(
                 style,
                 text.chars().filter_map(|ch| {

--- a/examples/scenes/src/test_scenes.rs
+++ b/examples/scenes/src/test_scenes.rs
@@ -718,6 +718,7 @@ mod impls {
             None,
             Fill::NonZero,
             "And some Vello\ntext with a newline",
+            false, /* hint */
         );
         let th = params.time;
         let center = Point::new(500.0, 500.0);

--- a/vello_encoding/src/resolve.rs
+++ b/vello_encoding/src/resolve.rs
@@ -422,6 +422,8 @@ impl Resolver {
                             scale = transform.matrix[0];
                             font_size *= scale;
                             transform.matrix = [1.0, 0.0, 0.0, 1.0];
+                            // Hinting assumes that the baseline is rounded; otherwise, we are missing the point of hinting.
+                            transform.translation[1] = transform.translation[1].round();
                         } else {
                             hint = false;
                         }

--- a/vello_encoding/src/resolve.rs
+++ b/vello_encoding/src/resolve.rs
@@ -318,6 +318,7 @@ impl Resolver {
                     glyphs: _,
                     transform,
                     scale,
+                    hint,
                 } = patch
                 {
                     let run = &resources.glyph_runs[*index];
@@ -328,21 +329,27 @@ impl Resolver {
                     }
                     if let Some(glyph_transform) = run.glyph_transform {
                         for glyph in &resources.glyphs[run.glyphs.clone()] {
-                            let xform = *transform
+                            let mut xform = *transform
                                 * Transform {
                                     matrix: [1.0, 0.0, 0.0, -1.0],
                                     translation: [glyph.x * scale, glyph.y * scale],
                                 }
                                 * glyph_transform;
+                            if *hint {
+                                xform.translation[1] = xform.translation[1].round();
+                            }
                             data.extend_from_slice(bytemuck::bytes_of(&xform));
                         }
                     } else {
                         for glyph in &resources.glyphs[run.glyphs.clone()] {
-                            let xform = *transform
+                            let mut xform = *transform
                                 * Transform {
                                     matrix: [1.0, 0.0, 0.0, -1.0],
                                     translation: [glyph.x * scale, glyph.y * scale],
                                 };
+                            if *hint {
+                                xform.translation[1] = xform.translation[1].round();
+                            }
                             data.extend_from_slice(bytemuck::bytes_of(&xform));
                         }
                     }
@@ -422,8 +429,6 @@ impl Resolver {
                             scale = transform.matrix[0];
                             font_size *= scale;
                             transform.matrix = [1.0, 0.0, 0.0, 1.0];
-                            // Hinting assumes that the baseline is rounded; otherwise, we are missing the point of hinting.
-                            transform.translation[1] = transform.translation[1].round();
                         } else {
                             hint = false;
                         }
@@ -459,6 +464,7 @@ impl Resolver {
                         glyphs: glyph_start..glyph_end,
                         transform,
                         scale,
+                        hint,
                     });
                 }
                 Patch::Image {
@@ -559,6 +565,11 @@ enum ResolvedPatch {
         transform: Transform,
         /// Additional scale factor to apply to translation.
         scale: f32,
+        /// Whether the glyph was hinted.
+        ///
+        /// This determines whether the y-coordinate of the final position
+        /// needs to be rounded.
+        hint: bool,
     },
     Image {
         /// Index of pending image element.

--- a/vello_tests/snapshots/integer_translation.png
+++ b/vello_tests/snapshots/integer_translation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ec4cbe4341b0a2f947aa027dd381f75b4d34e0af70c696fed50b729d61dab67
+size 3178

--- a/vello_tests/snapshots/non_integer_translation.png
+++ b/vello_tests/snapshots/non_integer_translation.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:03c9356bc12d8d4e82e79fe6502ee26321c26ae014449ae08cbb49660bc30b59
-size 3553
+oid sha256:51cb7033d35c9c8c2dfb23720faa7536334172a8d5fd2297dcc29d204a95d392
+size 3178

--- a/vello_tests/snapshots/non_integer_translation.png
+++ b/vello_tests/snapshots/non_integer_translation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:03c9356bc12d8d4e82e79fe6502ee26321c26ae014449ae08cbb49660bc30b59
+size 3553

--- a/vello_tests/snapshots/scaled_hinted.png
+++ b/vello_tests/snapshots/scaled_hinted.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f933817a45ecc911b93d37de215369332fab79b515c87c431b952a29a45c9b8
+size 5723

--- a/vello_tests/snapshots/simple_hinted.png
+++ b/vello_tests/snapshots/simple_hinted.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a81f17cf473d5d2d4ed5b0c88e352abbb739bb2d8a49f8a5b76904f74e63b25
+size 3123

--- a/vello_tests/tests/hinting.rs
+++ b/vello_tests/tests/hinting.rs
@@ -1,0 +1,110 @@
+// Copyright 2025 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Snapshot tests for text hinting
+
+// The following lints are part of the Linebender standard set,
+// but resolving them has been deferred for now.
+// Feel free to send a PR that solves one or more of these.
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::allow_attributes_without_reason
+)]
+
+use scenes::SimpleText;
+use vello::{
+    Scene,
+    kurbo::Affine,
+    peniko::{Brush, Fill, color::palette},
+};
+use vello_tests::{TestParams, snapshot_test_sync};
+
+fn encode_hinted_text(text: &str, font_size: f32) -> Scene {
+    let mut scene = Scene::new();
+    let mut simple_text = SimpleText::new();
+
+    let transform = Affine::translate((0., f64::from(font_size)));
+    simple_text.add_var_run(
+        &mut scene,
+        None,
+        font_size,
+        &[],
+        &Brush::Solid(palette::css::WHITE),
+        transform,
+        None,
+        Fill::EvenOdd,
+        text,
+        true,
+    );
+
+    scene
+}
+
+#[test]
+#[cfg_attr(skip_gpu_tests, ignore)]
+fn simple_hinted() {
+    let font_size = 12.;
+    let scene = encode_hinted_text("The quick brown fox", font_size);
+    let params = TestParams::new(
+        "simple_hinted",
+        (font_size * 10.) as _,
+        (font_size * 1.1).ceil() as _,
+    );
+    snapshot_test_sync(scene, &params)
+        .unwrap()
+        .assert_mean_less_than(0.002);
+}
+
+#[test]
+#[cfg_attr(skip_gpu_tests, ignore)]
+fn scaled_hinted() {
+    let font_size = 12.;
+    let text_scene = encode_hinted_text("The quick brown fox", font_size);
+    let mut scene = Scene::new();
+    scene.append(&text_scene, Some(Affine::scale(1.5)));
+
+    let params = TestParams::new(
+        "scaled_hinted",
+        (font_size * 15.) as _,
+        (font_size * 1.65).ceil() as _,
+    );
+    snapshot_test_sync(scene, &params)
+        .unwrap()
+        .assert_mean_less_than(0.002);
+}
+
+#[test]
+#[cfg_attr(skip_gpu_tests, ignore)]
+fn integer_translation() {
+    let font_size = 12.;
+    let text_scene = encode_hinted_text("The quick brown fox", font_size);
+    let mut scene = Scene::new();
+    scene.append(&text_scene, Some(Affine::translate((0., 5.))));
+
+    let params = TestParams::new(
+        "integer_translation",
+        (font_size * 10.) as _,
+        (font_size * 1.1 + 10.).ceil() as _,
+    );
+    snapshot_test_sync(scene, &params)
+        .unwrap()
+        .assert_mean_less_than(0.002);
+}
+
+#[test]
+#[cfg_attr(skip_gpu_tests, ignore)]
+fn non_integer_translation() {
+    let font_size = 12.;
+    let text_scene = encode_hinted_text("The quick brown fox", font_size);
+    let mut scene = Scene::new();
+    scene.append(&text_scene, Some(Affine::translate((0., 5.5))));
+
+    let params = TestParams::new(
+        "non_integer_translation",
+        (font_size * 10.) as _,
+        (font_size * 1.1 + 10.).ceil() as _,
+    );
+    snapshot_test_sync(scene, &params)
+        .unwrap()
+        .assert_mean_less_than(0.002);
+}

--- a/vello_tests/tests/hinting.rs
+++ b/vello_tests/tests/hinting.rs
@@ -52,7 +52,7 @@ fn simple_hinted() {
     );
     snapshot_test_sync(scene, &params)
         .unwrap()
-        .assert_mean_less_than(0.002);
+        .assert_mean_less_than(0.02);
 }
 
 #[test]
@@ -70,7 +70,7 @@ fn scaled_hinted() {
     );
     snapshot_test_sync(scene, &params)
         .unwrap()
-        .assert_mean_less_than(0.002);
+        .assert_mean_less_than(0.02);
 }
 
 #[test]
@@ -88,7 +88,7 @@ fn integer_translation() {
     );
     snapshot_test_sync(scene, &params)
         .unwrap()
-        .assert_mean_less_than(0.002);
+        .assert_mean_less_than(0.02);
 }
 
 #[test]
@@ -106,5 +106,5 @@ fn non_integer_translation() {
     );
     snapshot_test_sync(scene, &params)
         .unwrap()
-        .assert_mean_less_than(0.002);
+        .assert_mean_less_than(0.02);
 }


### PR DESCRIPTION
See [#vello > Hinting: y-alignment](https://xi.zulipchat.com/#narrow/channel/197075-vello/topic/Hinting.3A.20y-alignment/with/515265682).

This matches the code in Vello Common.