### PR TITLE
Let `Pixmap::from_png` use `Read` directly

### DIFF
--- a/sparse_strips/vello_api/src/pixmap.rs
+++ b/sparse_strips/vello_api/src/pixmap.rs
@@ -6,6 +6,9 @@
 use alloc::vec;
 use alloc::vec::Vec;
 
+#[cfg(feature = "png")]
+extern crate std;
+
 /// A pixmap backed by u8.
 #[derive(Debug, Clone)]
 pub struct Pixmap {
@@ -47,7 +50,7 @@ impl Pixmap {
 
     /// Create a pixmap from a PNG file.
     #[cfg(feature = "png")]
-    pub fn from_png(data: &[u8]) -> Result<Self, png::DecodingError> {
+    pub fn from_png(data: impl std::io::Read) -> Result<Self, png::DecodingError> {
         let mut decoder = png::Decoder::new(data);
         decoder.set_transformations(
             png::Transformations::normalize_to_color8() | png::Transformations::ALPHA,

--- a/sparse_strips/vello_sparse_tests/tests/image.rs
+++ b/sparse_strips/vello_sparse_tests/tests/image.rs
@@ -15,7 +15,7 @@ use vello_dev_macros::vello_test;
 
 pub(crate) fn load_image(name: &str) -> Arc<Pixmap> {
     let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(format!("tests/assets/{name}.png"));
-    Arc::new(Pixmap::from_png(&std::fs::read(path).unwrap()).unwrap())
+    Arc::new(Pixmap::from_png(std::fs::File::open(path).unwrap()).unwrap())
 }
 
 fn rgb_img_10x10() -> Arc<Pixmap> {


### PR DESCRIPTION
This allows decoding from a `Read` directly without first having to copy to memory.