### PR TITLE
Add support for float colours on the GPU

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,6 +478,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "010263546cea9f9f8385a5b7aad534b9e6448e62a0d3bf9da29d583308dd11bb"
 dependencies = [
+ "bytemuck",
  "libm",
 ]
 
@@ -2100,6 +2101,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f9529efd019889b2a205193c14ffb6e2839b54ed9d2720674f10f4b04d87ac9"
 dependencies = [
+ "bytemuck",
  "color 0.3.0",
  "kurbo",
  "smallvec",

--- a/sparse_strips/vello_api/Cargo.toml
+++ b/sparse_strips/vello_api/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 publish = false
 
 [dependencies]
-peniko = { workspace = true }
+peniko = { workspace = true, features = ["bytemuck"] }
 png = { workspace = true, optional = true }
 
 [features]

--- a/sparse_strips/vello_dev_macros/src/lib.rs
+++ b/sparse_strips/vello_dev_macros/src/lib.rs
@@ -12,7 +12,7 @@
 // than 1. For example, if the target pixel is (233, 43, 64, 100), then permissible
 // values are (232, 43, 65, 101) or (233, 42, 64, 100), but not (231, 43, 64, 100).
 const DEFAULT_CPU_U8_TOLERANCE: u8 = 0;
-const DEFAULT_HYBRID_TOLERANCE: u8 = 1;
+const DEFAULT_HYBRID_TOLERANCE: u8 = 0;
 
 use proc_macro::TokenStream;
 use quote::quote;

--- a/sparse_strips/vello_hybrid/src/render.rs
+++ b/sparse_strips/vello_hybrid/src/render.rs
@@ -16,7 +16,10 @@ use alloc::vec::Vec;
 use core::fmt::Debug;
 
 use bytemuck::{Pod, Zeroable};
-use vello_common::tile::Tile;
+use vello_common::{
+    color::{PremulColor, Srgb},
+    tile::Tile,
+};
 use wgpu::{
     BindGroup, BindGroupLayout, BlendState, Buffer, ColorTargetState, ColorWrites, Device,
     PipelineCompilationOptions, Queue, RenderPass, RenderPipeline, Texture, util::DeviceExt,
@@ -114,8 +117,8 @@ pub struct GpuStrip {
     ///
     /// There are [`Config::strip_height`] alpha values per column.
     pub col: u32,
-    /// RGBA color value
-    pub rgba: u32,
+    /// RGBA color value.
+    pub rgba: PremulColor<Srgb>,
 }
 
 impl GpuStrip {
@@ -125,7 +128,7 @@ impl GpuStrip {
             0 => Uint32,
             1 => Uint32,
             2 => Uint32,
-            3 => Uint32,
+            3 => Float32x4,
         ]
     }
 }

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -211,8 +211,9 @@ impl Scene {
                 let wide_tile = &self.wide.tiles[wide_tile_idx];
                 let wide_tile_x = wide_tile_col * WideTile::WIDTH;
                 let wide_tile_y = wide_tile_row * Tile::HEIGHT;
-                let bg = wide_tile.bg.as_premul_rgba8().to_u32();
-                if bg != 0 {
+                let bg = wide_tile.bg.as_premul_f32();
+                // TODO: Is this a precise enough check for transparency?
+                if bg.components[3] > 0. {
                     strips.push(GpuStrip {
                         x: wide_tile_x,
                         y: wide_tile_y,
@@ -226,7 +227,7 @@ impl Scene {
                     match cmd {
                         vello_common::coarse::Cmd::Fill(fill) => {
                             let rgba = match &fill.paint {
-                                Paint::Solid(color) => color.as_premul_rgba8().to_u32(),
+                                Paint::Solid(color) => color.as_premul_f32(),
                                 Paint::Indexed(_) => unimplemented!(),
                             };
                             strips.push(GpuStrip {
@@ -240,7 +241,7 @@ impl Scene {
                         }
                         vello_common::coarse::Cmd::AlphaFill(cmd_strip) => {
                             let rgba = match &cmd_strip.paint {
-                                Paint::Solid(color) => color.as_premul_rgba8().to_u32(),
+                                Paint::Solid(color) => color.as_premul_f32(),
                                 Paint::Indexed(_) => unimplemented!(),
                             };
 


### PR DESCRIPTION
As requested by @LaurenzV in #967.

This probably shouldn't be merged. Note that a tolerance of zero still doesn't work, for unknown reasons.

One potential reason is that the GPU is getting better precision; because it might do blending in f32. But I don't know.