### PR TITLE
Fix out-of-bounds access in clipping

### DIFF
--- a/sparse_strips/vello_common/src/coarse.rs
+++ b/sparse_strips/vello_common/src/coarse.rs
@@ -682,9 +682,26 @@ impl Wide {
                 // If fill extends to next tile, pop current and handle next
                 if x2 > (cur_wtile_x + 1) * WideTile::WIDTH {
                     self.get_mut(cur_wtile_x, cur_wtile_y).pop_clip();
+                    pop_pending = false;
+
                     let width2 = x2 % WideTile::WIDTH;
                     cur_wtile_x = x2 / WideTile::WIDTH;
+
+                    // If the strip is outside the clipping box, we don't need to do any
+                    // filling, so we continue (also to prevent out-of-bounds access).
+                    if cur_wtile_x >= clip_bbox.x1() {
+                        continue;
+                    }
+
                     if width2 > 0 {
+                        // An important thing to note: Note that we are only applying
+                        // `clip_fill` to the wide tile that is actually covered by the next
+                        // strip, and not the ones in-between! For example, if the first strip
+                        // is in wide tile 1 and the second in wide tile 4, we will do a clip
+                        // fill in wide tile 1 and 4, but not in 2 and 3. The reason for thi is
+                        // that any tile in-between is fully covered and thus no clipping is
+                        // necessary at all. See also the `push_clip` function, where we don't
+                        // push a new buffer for such tiles.
                         self.get_mut(cur_wtile_x, cur_wtile_y)
                             .clip_fill(0, width2 as u32);
                     }

--- a/sparse_strips/vello_common/src/coarse.rs
+++ b/sparse_strips/vello_common/src/coarse.rs
@@ -698,7 +698,7 @@ impl Wide {
                         // `clip_fill` to the wide tile that is actually covered by the next
                         // strip, and not the ones in-between! For example, if the first strip
                         // is in wide tile 1 and the second in wide tile 4, we will do a clip
-                        // fill in wide tile 1 and 4, but not in 2 and 3. The reason for thi is
+                        // fill in wide tile 1 and 4, but not in 2 and 3. The reason for this is
                         // that any tile in-between is fully covered and thus no clipping is
                         // necessary at all. See also the `push_clip` function, where we don't
                         // push a new buffer for such tiles.

--- a/sparse_strips/vello_common/src/coarse.rs
+++ b/sparse_strips/vello_common/src/coarse.rs
@@ -652,7 +652,11 @@ impl Wide {
                 // Apply the clip strip command and update state
                 self.get_mut(wtile_x, cur_wtile_y).clip_strip(cmd);
                 cur_wtile_x = wtile_x;
-                pop_pending = true;
+
+                // Only request a pop if the x coordinate is actually inside the bounds.
+                if cur_wtile_x < clip_bbox.x1() {
+                    pop_pending = true;
+                }
             }
 
             // Handle fill regions between strips based on fill rule
@@ -661,6 +665,10 @@ impl Wide {
                 Fill::EvenOdd => next_strip.winding % 2 != 0,
             };
             if is_inside && strip_y == next_strip.strip_y() {
+                if cur_wtile_x >= clip_bbox.x1() {
+                    continue;
+                }
+
                 let x2 = next_strip.x;
                 let clipped_x2 = x2.min((cur_wtile_x + 1) * WideTile::WIDTH);
                 let width = clipped_x2.saturating_sub(x1);

--- a/sparse_strips/vello_sparse_tests/tests/clip.rs
+++ b/sparse_strips/vello_sparse_tests/tests/clip.rs
@@ -251,3 +251,10 @@ fn clip_exceeding_viewport(ctx: &mut impl Renderer) {
     ctx.fill_rect(&Rect::new(0.0, 0.0, 100.0, 100.0));
     ctx.pop_layer();
 }
+
+// See <https://github.com/linebender/vello/pull/975#issuecomment-2858372366>
+#[vello_test(no_ref)]
+fn clip_completely_in_out_of_bounds_wide_tile(ctx: &mut impl Renderer) {
+    ctx.push_clip_layer(&Rect::new(300.0, 8.0, 350.0, 48.0).to_path(0.1));
+    ctx.pop_layer();
+}

--- a/sparse_strips/vello_sparse_tests/tests/clip.rs
+++ b/sparse_strips/vello_sparse_tests/tests/clip.rs
@@ -243,3 +243,11 @@ fn draw_clipping_outline(ctx: &mut impl Renderer, path: &BezPath) {
     ctx.set_stroke(stroke);
     ctx.stroke_path(path);
 }
+
+// See <https://github.com/linebender/vello/issues/917>
+#[vello_test(no_ref)]
+fn clip_exceeding_viewport(ctx: &mut impl Renderer) {
+    ctx.push_clip_layer(&Rect::new(0.0, 0.0, 500.0, 10.0).to_path(0.1));
+    ctx.fill_rect(&Rect::new(0.0, 0.0, 100.0, 100.0));
+    ctx.pop_layer();
+}


### PR DESCRIPTION
Fixes #917. I am not a 100% sure that this is the proper fix, but existing tests pass and I also tried my interactive clip path tool and am not seeing any regressions, so I believe this should be safe to land.