### PR TITLE
Back `Pixmap` with a `Vec<PremulRgba8>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3316,6 +3316,7 @@ dependencies = [
 name = "vello_sparse_tests"
 version = "0.0.0"
 dependencies = [
+ "bytemuck",
  "image",
  "oxipng",
  "pollster",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,6 +478,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "010263546cea9f9f8385a5b7aad534b9e6448e62a0d3bf9da29d583308dd11bb"
 dependencies = [
+ "bytemuck",
  "libm",
 ]
 
@@ -2100,6 +2101,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f9529efd019889b2a205193c14ffb6e2839b54ed9d2720674f10f4b04d87ac9"
 dependencies = [
+ "bytemuck",
  "color 0.3.0",
  "kurbo",
  "smallvec",
@@ -3204,6 +3206,7 @@ dependencies = [
 name = "vello_api"
 version = "0.4.0"
 dependencies = [
+ "bytemuck",
  "peniko 0.4.0",
  "png",
 ]

--- a/sparse_strips/vello_api/Cargo.toml
+++ b/sparse_strips/vello_api/Cargo.toml
@@ -12,7 +12,8 @@ repository.workspace = true
 publish = false
 
 [dependencies]
-peniko = { workspace = true }
+bytemuck = { workspace = true, features = [] }
+peniko = { workspace = true, features = ["bytemuck"] }
 png = { workspace = true, optional = true }
 
 [features]

--- a/sparse_strips/vello_api/src/mask.rs
+++ b/sparse_strips/vello_api/src/mask.rs
@@ -29,16 +29,16 @@ impl Mask {
     fn new_with(pixmap: &Pixmap, alpha_mask: bool) -> Self {
         let mut data = Vec::with_capacity(pixmap.width() as usize * pixmap.height() as usize);
 
-        for pixel in pixmap.data().chunks_exact(4) {
+        for pixel in pixmap.data() {
             if alpha_mask {
-                data.push(pixel[3]);
+                data.push(pixel.a);
             } else {
-                let mut r = pixel[0] as f32 / 255.0;
-                let mut g = pixel[1] as f32 / 255.0;
-                let mut b = pixel[2] as f32 / 255.0;
-                let a = pixel[3] as f32 / 255.0;
+                let mut r = pixel.r as f32 / 255.0;
+                let mut g = pixel.g as f32 / 255.0;
+                let mut b = pixel.b as f32 / 255.0;
+                let a = pixel.a as f32 / 255.0;
 
-                if pixel[3] != 0 {
+                if pixel.a != 0 {
                     r /= a;
                     g /= a;
                     b /= a;

--- a/sparse_strips/vello_api/src/pixmap.rs
+++ b/sparse_strips/vello_api/src/pixmap.rs
@@ -5,6 +5,7 @@
 
 use alloc::vec;
 use alloc::vec::Vec;
+use peniko::color::Rgba8;
 
 use crate::peniko::color::PremulRgba8;
 
@@ -215,17 +216,22 @@ impl Pixmap {
     ///
     /// The pixels are in row-major order. Each pixel consists of four bytes in the order
     /// `[r, g, b, a]`.
-    pub fn take_unpremultiplied(self) -> Vec<u8> {
+    pub fn take_unpremultiplied(self) -> Vec<Rgba8> {
         self.buf
             .into_iter()
-            .flat_map(|PremulRgba8 { r, g, b, a }| {
+            .map(|PremulRgba8 { r, g, b, a }| {
                 let alpha = 255.0 / a as f32;
                 if a != 0 {
                     #[expect(clippy::cast_possible_truncation, reason = "deliberate quantization")]
                     let unpremultiply = |component| (component as f32 * alpha + 0.5) as u8;
-                    [unpremultiply(r), unpremultiply(g), unpremultiply(b), a]
+                    Rgba8 {
+                        r: unpremultiply(r),
+                        g: unpremultiply(g),
+                        b: unpremultiply(b),
+                        a,
+                    }
                 } else {
-                    [r, g, b, a]
+                    Rgba8 { r, g, b, a }
                 }
             })
             .collect()

--- a/sparse_strips/vello_api/src/pixmap.rs
+++ b/sparse_strips/vello_api/src/pixmap.rs
@@ -98,7 +98,7 @@ impl Pixmap {
                 .height
                 .try_into()
                 .map_err(|_| png::DecodingError::LimitsExceeded)?;
-            Pixmap::new(width, height)
+            Self::new(width, height)
         };
 
         // Note `reader.info()` returns the pre-transformation color type output, whereas
@@ -118,11 +118,19 @@ impl Pixmap {
                 unreachable!("Transformation should have expanded indexed images")
             }
             png::ColorType::Rgba => {
-                debug_assert_eq!(pixmap.data_as_u8_slice().len(), reader.output_buffer_size());
+                debug_assert_eq!(
+                    pixmap.data_as_u8_slice().len(),
+                    reader.output_buffer_size(),
+                    "The pixmap buffer should have the same number of bytes as the image."
+                );
                 reader.next_frame(pixmap.data_as_u8_slice_mut())?;
             }
             png::ColorType::GrayscaleAlpha => {
-                debug_assert_eq!(pixmap.data().len() * 2, reader.output_buffer_size());
+                debug_assert_eq!(
+                    pixmap.data().len() * 2,
+                    reader.output_buffer_size(),
+                    "The pixmap buffer should have twice the number of bytes of the grayscale image."
+                );
                 let mut grayscale_data = vec![0; reader.output_buffer_size()];
                 reader.next_frame(&mut grayscale_data)?;
 

--- a/sparse_strips/vello_api/src/pixmap.rs
+++ b/sparse_strips/vello_api/src/pixmap.rs
@@ -18,32 +18,31 @@ pub struct Pixmap {
     width: u16,
     /// Height of the pixmap in pixels.
     height: u16,
-    /// Buffer of the pixmap in RGBA format.
-    buf: Vec<u8>,
+    /// Buffer of the pixmap in RGBA8 format.
+    buf: Vec<PremulRgba8>,
 }
 
 impl Pixmap {
     /// Create a new pixmap with the given width and height in pixels.
     pub fn new(width: u16, height: u16) -> Self {
-        let buf = vec![0; width as usize * height as usize * 4];
+        let buf = vec![PremulRgba8::from_u32(0); width as usize * height as usize];
         Self { width, height, buf }
     }
 
-    /// Create a new pixmap with the given underlying data interpreted as premultiplied RGBA8.
+    /// Create a new pixmap with the given underlying data premultiplied RGBA8 data.
     ///
-    /// The `data` vector must be of length `width * height * 4` exactly.
+    /// The `data` vector must be of length `width * height` exactly.
     ///
-    /// The pixels are in row-major order. Each pixel consists of four bytes in the order
-    /// `[r, g, b, a]`.
+    /// The pixels are in row-major order.
     ///
     /// # Panics
     ///
-    /// Panics if the `data` vector is not of length `width * height * 4`.
-    pub fn from_parts(data: Vec<u8>, width: u16, height: u16) -> Self {
+    /// Panics if the `data` vector is not of length `width * height`.
+    pub fn from_parts(data: Vec<PremulRgba8>, width: u16, height: u16) -> Self {
         assert_eq!(
             data.len(),
-            usize::from(width) * usize::from(height) * 4,
-            "Expected `data` to have length of exactly `width * height * 4`"
+            usize::from(width) * usize::from(height),
+            "Expected `data` to have length of exactly `width * height`"
         );
         Self {
             width,
@@ -68,8 +67,15 @@ impl Pixmap {
             clippy::cast_possible_truncation,
             reason = "cannot overflow in this case"
         )]
-        for comp in self.data_mut() {
-            *comp = ((alpha as u16 * *comp as u16) / 255) as u8;
+        let multiply = |component| ((alpha as u16 * component as u16) / 255) as u8;
+
+        for pixel in self.data_mut() {
+            *pixel = PremulRgba8 {
+                r: multiply(pixel.r),
+                g: multiply(pixel.g),
+                b: multiply(pixel.b),
+                a: multiply(pixel.a),
+            };
         }
     }
 
@@ -82,87 +88,101 @@ impl Pixmap {
         );
 
         let mut reader = decoder.read_info()?;
-        let mut img_data = vec![0; reader.output_buffer_size()];
-        let info = reader.next_frame(&mut img_data)?;
+        let mut pixmap = {
+            let info = reader.info();
+            let width: u16 = info
+                .width
+                .try_into()
+                .map_err(|_| png::DecodingError::LimitsExceeded)?;
+            let height: u16 = info
+                .height
+                .try_into()
+                .map_err(|_| png::DecodingError::LimitsExceeded)?;
+            Pixmap::new(width, height)
+        };
+
+        // Note `reader.info()` returns the pre-transformation color type output, whereas
+        // `reader.output_color_type()` takes the transformation into account.
+        let (color_type, bit_depth) = reader.output_color_type();
         debug_assert_eq!(
-            info.bit_depth,
+            bit_depth,
             png::BitDepth::Eight,
             "normalize_to_color8 means the bit depth is always 8."
         );
 
-        let decoded_data = match info.color_type {
+        match color_type {
             png::ColorType::Rgb | png::ColorType::Grayscale => {
                 unreachable!("We set a transformation to always convert to alpha")
             }
             png::ColorType::Indexed => {
                 unreachable!("Transformation should have expanded indexed images")
             }
-            png::ColorType::Rgba => img_data,
+            png::ColorType::Rgba => {
+                debug_assert_eq!(pixmap.data_as_u8_slice().len(), reader.output_buffer_size());
+                reader.next_frame(pixmap.data_as_u8_slice_mut())?;
+            }
             png::ColorType::GrayscaleAlpha => {
-                let mut rgba_data = Vec::with_capacity(img_data.len() * 2);
-                for slice in img_data.chunks(2) {
-                    let gray = slice[0];
-                    let alpha = slice[1];
-                    rgba_data.push(gray);
-                    rgba_data.push(gray);
-                    rgba_data.push(gray);
-                    rgba_data.push(alpha);
-                }
+                debug_assert_eq!(pixmap.data().len() * 2, reader.output_buffer_size());
+                let mut grayscale_data = vec![0; reader.output_buffer_size()];
+                reader.next_frame(&mut grayscale_data)?;
 
-                rgba_data
+                for (grayscale_pixel, pixmap_pixel) in
+                    grayscale_data.chunks_exact(2).zip(pixmap.data_mut())
+                {
+                    let [gray, alpha] = grayscale_pixel.try_into().unwrap();
+                    *pixmap_pixel = PremulRgba8 {
+                        r: gray,
+                        g: gray,
+                        b: gray,
+                        a: alpha,
+                    };
+                }
             }
         };
 
-        let premultiplied = decoded_data
-            .chunks_exact(4)
-            .flat_map(|d| {
-                let alpha = d[3] as u16;
-                #[expect(
-                    clippy::cast_possible_truncation,
-                    reason = "Overflow should be impossible."
-                )]
-                let premultiply = |e: u8| ((e as u16 * alpha) / 255) as u8;
+        for pixel in pixmap.data_mut() {
+            let alpha = pixel.a as u16;
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "Overflow should be impossible."
+            )]
+            let premultiply = |e: u8| ((e as u16 * alpha) / 255) as u8;
+            pixel.r = premultiply(pixel.r);
+            pixel.g = premultiply(pixel.g);
+            pixel.b = premultiply(pixel.b);
+        }
 
-                if alpha == 0 {
-                    [0, 0, 0, 0]
-                } else {
-                    [
-                        premultiply(d[0]),
-                        premultiply(d[1]),
-                        premultiply(d[2]),
-                        d[3],
-                    ]
-                }
-            })
-            .collect::<Vec<_>>();
+        Ok(pixmap)
+    }
 
-        Ok(Self {
-            width: info
-                .width
-                .try_into()
-                .map_err(|_| png::DecodingError::LimitsExceeded)?,
-            height: info
-                .height
-                .try_into()
-                .map_err(|_| png::DecodingError::LimitsExceeded)?,
-            buf: premultiplied,
-        })
+    /// Returns a reference to the underlying data as premultiplied RGBA8.
+    ///
+    /// The pixels are in row-major order.
+    pub fn data(&self) -> &[PremulRgba8] {
+        &self.buf
+    }
+
+    /// Returns a mutable reference to the underlying data as premultiplied RGBA8.
+    ///
+    /// The pixels are in row-major order.
+    pub fn data_mut(&mut self) -> &mut [PremulRgba8] {
+        &mut self.buf
     }
 
     /// Returns a reference to the underlying data as premultiplied RGBA8.
     ///
     /// The pixels are in row-major order. Each pixel consists of four bytes in the order
     /// `[r, g, b, a]`.
-    pub fn data(&self) -> &[u8] {
-        &self.buf
+    pub fn data_as_u8_slice(&self) -> &[u8] {
+        bytemuck::cast_slice(&self.buf)
     }
 
     /// Returns a mutable reference to the underlying data as premultiplied RGBA8.
     ///
     /// The pixels are in row-major order. Each pixel consists of four bytes in the order
     /// `[r, g, b, a]`.
-    pub fn data_mut(&mut self) -> &mut [u8] {
-        &mut self.buf
+    pub fn data_as_u8_slice_mut(&mut self) -> &mut [u8] {
+        bytemuck::cast_slice_mut(&mut self.buf)
     }
 
     /// Sample a pixel from the pixmap.
@@ -170,19 +190,14 @@ impl Pixmap {
     /// The pixel data is [premultiplied RGBA8][PremulRgba8].
     #[inline(always)]
     pub fn sample(&self, x: u16, y: u16) -> PremulRgba8 {
-        let idx = 4 * (self.width as usize * y as usize + x as usize);
-
-        // The conversion here is a no-op, as `PremulRgba8`'s fields are in the same memory order
-        // as the pixel data.
-        PremulRgba8::from_u8_array(self.buf[idx..][..4].try_into().unwrap())
+        let idx = self.width as usize * y as usize + x as usize;
+        self.buf[idx]
     }
 
-    /// Consume the pixmap, returning the data as the underlying [`Vec`] of premultiplied RGBA8
-    /// bytes.
+    /// Consume the pixmap, returning the data as the underlying [`Vec`] of premultiplied RGBA8.
     ///
-    /// The pixels are in row-major order. Each pixel consists of four bytes in the order
-    /// `[r, g, b, a]`.
-    pub fn take(self) -> Vec<u8> {
+    /// The pixels are in row-major order.
+    pub fn take(self) -> Vec<PremulRgba8> {
         self.buf
     }
 
@@ -192,18 +207,19 @@ impl Pixmap {
     ///
     /// The pixels are in row-major order. Each pixel consists of four bytes in the order
     /// `[r, g, b, a]`.
-    pub fn take_unpremultiplied(mut self) -> Vec<u8> {
-        for rgba in self.buf.chunks_exact_mut(4) {
-            let alpha = 255.0 / rgba[3] as f32;
-
-            #[expect(clippy::cast_possible_truncation, reason = "deliberate quantization")]
-            if rgba[3] != 0 {
-                rgba[0] = (rgba[0] as f32 * alpha + 0.5) as u8;
-                rgba[1] = (rgba[1] as f32 * alpha + 0.5) as u8;
-                rgba[2] = (rgba[2] as f32 * alpha + 0.5) as u8;
-            }
-        }
-
+    pub fn take_unpremultiplied(self) -> Vec<u8> {
         self.buf
+            .into_iter()
+            .flat_map(|PremulRgba8 { r, g, b, a }| {
+                let alpha = 255.0 / a as f32;
+                if a != 0 {
+                    #[expect(clippy::cast_possible_truncation, reason = "deliberate quantization")]
+                    let unpremultiply = |component| (component as f32 * alpha + 0.5) as u8;
+                    [unpremultiply(r), unpremultiply(g), unpremultiply(b), a]
+                } else {
+                    [r, g, b, a]
+                }
+            })
+            .collect()
     }
 }

--- a/sparse_strips/vello_api/src/pixmap.rs
+++ b/sparse_strips/vello_api/src/pixmap.rs
@@ -30,7 +30,7 @@ impl Pixmap {
         Self { width, height, buf }
     }
 
-    /// Create a new pixmap with the given underlying data premultiplied RGBA8 data.
+    /// Create a new pixmap with the given premultiplied RGBA8 data.
     ///
     /// The `data` vector must be of length `width * height` exactly.
     ///

--- a/sparse_strips/vello_common/src/encode.rs
+++ b/sparse_strips/vello_common/src/encode.rs
@@ -467,7 +467,7 @@ impl EncodeExt for Image {
         let transform = transform.inverse();
         // TODO: This is somewhat expensive for large images, maybe it's not worth optimizing
         // non-opaque images in the first place..
-        let has_opacities = self.pixmap.data().chunks(4).any(|c| c[3] != 255);
+        let has_opacities = self.pixmap.data().iter().any(|pixel| pixel.a != 255);
 
         let (x_advance, y_advance) = x_y_advances(&transform);
 

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -309,7 +309,7 @@ impl RenderContext {
     pub fn render_to_pixmap(&self, pixmap: &mut Pixmap) {
         let width = pixmap.width();
         let height = pixmap.height();
-        self.render_to_buffer(pixmap.data_mut(), width, height);
+        self.render_to_buffer(pixmap.data_as_u8_slice_mut(), width, height);
     }
 
     /// Return the width of the pixmap.

--- a/sparse_strips/vello_hybrid/examples/render_to_file.rs
+++ b/sparse_strips/vello_hybrid/examples/render_to_file.rs
@@ -148,13 +148,13 @@ async fn run() {
     device.poll(wgpu::Maintain::Wait);
 
     // Read back the pixel data
-    let mut img_data = Vec::with_capacity(usize::from(width) * usize::from(height) * 4);
+    let mut img_data = Vec::with_capacity(usize::from(width) * usize::from(height));
     for row in texture_copy_buffer
         .slice(..)
         .get_mapped_range()
         .chunks_exact(bytes_per_row as usize)
     {
-        img_data.extend_from_slice(&row[0..usize::from(width) * 4]);
+        img_data.extend_from_slice(bytemuck::cast_slice(&row[0..usize::from(width) * 4]));
     }
     texture_copy_buffer.unmap();
 

--- a/sparse_strips/vello_hybrid/examples/render_to_file.rs
+++ b/sparse_strips/vello_hybrid/examples/render_to_file.rs
@@ -168,7 +168,7 @@ async fn run() {
     png_encoder.set_color(png::ColorType::Rgba);
     let mut writer = png_encoder.write_header().unwrap();
     writer
-        .write_image_data(&pixmap.take_unpremultiplied())
+        .write_image_data(bytemuck::cast_slice(&pixmap.take_unpremultiplied()))
         .unwrap();
 }
 

--- a/sparse_strips/vello_sparse_tests/Cargo.toml
+++ b/sparse_strips/vello_sparse_tests/Cargo.toml
@@ -22,6 +22,7 @@ vello_hybrid = { workspace = true }
 wgpu = { workspace = true }
 pollster = { workspace = true }
 vello_dev_macros = { workspace = true }
+bytemuck = { workspace = true }
 oxipng = { workspace = true, features = ["freestanding", "parallel"] }
 image = { workspace = true, features = ["png"] }
 skrifa = { workspace = true }

--- a/sparse_strips/vello_sparse_tests/tests/renderer.rs
+++ b/sparse_strips/vello_sparse_tests/tests/renderer.rs
@@ -333,7 +333,11 @@ impl Renderer for Scene {
             .slice(..)
             .get_mapped_range()
             .chunks_exact(bytes_per_row as usize)
-            .zip(pixmap.data_mut().chunks_exact_mut(width as usize * 4))
+            .zip(
+                pixmap
+                    .data_as_u8_slice_mut()
+                    .chunks_exact_mut(width as usize * 4),
+            )
         {
             buf.copy_from_slice(&row[0..width as usize * 4]);
         }

--- a/sparse_strips/vello_sparse_tests/tests/util.rs
+++ b/sparse_strips/vello_sparse_tests/tests/util.rs
@@ -186,7 +186,12 @@ pub(crate) fn pixmap_to_png(pixmap: Pixmap, width: u32, height: u32) -> Vec<u8> 
     let cursor = Cursor::new(&mut png_data);
     let encoder = PngEncoder::new(cursor);
     encoder
-        .write_image(&img_buf, width, height, ExtendedColorType::Rgba8)
+        .write_image(
+            bytemuck::cast_slice(&img_buf),
+            width,
+            height,
+            ExtendedColorType::Rgba8,
+        )
         .expect("Failed to encode image");
     png_data
 }


### PR DESCRIPTION
This moves to more meaningful types, that can be cast to byte slices for interop. It will allow removing patterns like `pixels.chunks_exact(COLOR_COMPONENTS)`. See some prior discussion at https://github.com/linebender/vello/pull/830#pullrequestreview-2661393989, https://github.com/linebender/vello/pull/830#pullrequestreview-2662177735, https://github.com/linebender/vello/pull/964#discussion_r2075400876.

Operations on `&[u8]` / `&mut[u8]` are still possible through Bytemuck casting.