### PR TITLE
Remove hack for tolerance of stroke expansion

### DIFF
--- a/sparse_strips/vello_common/src/flatten.rs
+++ b/sparse_strips/vello_common/src/flatten.rs
@@ -111,10 +111,7 @@ pub fn fill(path: &BezPath, affine: Affine, line_buf: &mut Vec<Line>) {
 
 /// Flatten a stroked bezier path into line segments.
 pub fn stroke(path: &BezPath, style: &Stroke, affine: Affine, line_buf: &mut Vec<Line>) {
-    // TODO: Temporary hack to ensure that strokes are scaled properly by the transform.
-    let tolerance = TOL / affine.as_coeffs()[0].abs().max(affine.as_coeffs()[3].abs());
-
-    let expanded = kurbo::stroke(path.iter(), style, &StrokeOpts::default(), tolerance);
+    let expanded = kurbo::stroke(path.iter(), style, &StrokeOpts::default(), TOL);
     fill(&expanded, affine, line_buf);
 }
 


### PR DESCRIPTION
This was needed in the initial prototype for `vello_cpu` where we were using the stroke expansion implementation of the GPU stroke expansion paper, which approximates the stroke by line segments. We had to adjust the tolerance here, because if you draw a small stroke which is then scaled up, you can very clearly notice the line approximation.

However, the current (and future) kurbo stroke do cubic-to-cubic stroke expansion, so I don't think this should be necessary here?