### PR TITLE
sparse_strips: Update examples to parley 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,12 +468,6 @@ dependencies = [
 
 [[package]]
 name = "color"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c387f6cef110ee8eaf12fca5586d3d303c07c594f4a5f02c768b6470b70dbd"
-
-[[package]]
-name = "color"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "010263546cea9f9f8385a5b7aad534b9e6448e62a0d3bf9da29d583308dd11bb"
@@ -850,15 +844,6 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "font-types"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa6a5e5a77b5f3f7f9e32879f484aa5b3632ddfbe568a16266c904a6f32cdaf"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
-name = "font-types"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02a596f5713680923a2080d86de50fe472fb290693cf0f701187a1c8b36996b7"
@@ -901,20 +886,21 @@ dependencies = [
 
 [[package]]
 name = "fontique"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b5fcb214137f01bc842c4fd633236255c51f8a24c6d3923eb8361c6d0940737"
+checksum = "64763d1f274c8383333851435b6cdf071c31cfcdb39fd5860d20943205a007a7"
 dependencies = [
  "bytemuck",
  "fontconfig-cache-parser",
  "hashbrown 0.15.3",
  "icu_locid",
  "memmap2",
+ "objc2 0.6.1",
  "objc2-core-foundation",
  "objc2-core-text",
  "objc2-foundation 0.3.1",
- "peniko 0.3.2",
- "read-fonts 0.25.3",
+ "peniko",
+ "read-fonts",
  "roxmltree",
  "smallvec",
  "windows",
@@ -2075,14 +2061,14 @@ dependencies = [
 
 [[package]]
 name = "parley"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d1c2b33b240c246f06cfceac48dc6c96040cb177d2aa5348899982b298b5577"
+checksum = "e28dadbe655332fd7d996794ec8d0c376695f6ca47bc75aa01e0967c7f28e42a"
 dependencies = [
  "fontique",
  "hashbrown 0.15.3",
- "peniko 0.3.2",
- "skrifa 0.26.6",
+ "peniko",
+ "skrifa",
  "swash",
 ]
 
@@ -2094,24 +2080,12 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "peniko"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1f594c54ccdc9bd177a726885f066bf28d20e17169e31a8a1456217b1316b4"
-dependencies = [
- "color 0.2.3",
- "kurbo",
- "peniko 0.4.0",
- "smallvec",
-]
-
-[[package]]
-name = "peniko"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f9529efd019889b2a205193c14ffb6e2839b54ed9d2720674f10f4b04d87ac9"
 dependencies = [
  "bytemuck",
- "color 0.3.0",
+ "color",
  "kurbo",
  "smallvec",
 ]
@@ -2355,22 +2329,12 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f9e8a4f503e5c8750e4cd3b32a4e090035c46374b305a15c70bad833dca05f"
-dependencies = [
- "bytemuck",
- "font-types 0.8.4",
-]
-
-[[package]]
-name = "read-fonts"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ce8e2ca6b24313587a03ca61bb74c384e2a815bd90cf2866cfc9f5fb7a11fa0"
 dependencies = [
  "bytemuck",
- "font-types 0.9.0",
+ "font-types",
 ]
 
 [[package]]
@@ -2542,7 +2506,7 @@ dependencies = [
  "image",
  "rand",
  "roxmltree",
- "skrifa 0.31.0",
+ "skrifa",
  "vello",
  "web-time",
 ]
@@ -2694,22 +2658,12 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "skrifa"
-version = "0.26.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cc1aa86c26dbb1b63875a7180aa0819709b33348eb5b1491e4321fae388179d"
-dependencies = [
- "bytemuck",
- "read-fonts 0.25.3",
-]
-
-[[package]]
-name = "skrifa"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbe6666ab11018ab91ff7b03f1a3b9fdbecfb610848436fefa5ce50343d3d913"
 dependencies = [
  "bytemuck",
- "read-fonts 0.29.0",
+ "read-fonts",
 ]
 
 [[package]]
@@ -2852,11 +2806,11 @@ dependencies = [
 
 [[package]]
 name = "swash"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fae9a562c7b46107d9c78cd78b75bbe1e991c16734c0aee8ff0ee711fb8b620a"
+checksum = "5dce3f0af95643c855cdc449fbaa17d8c2cd08e0b00a49a6babcbe6e71667f3d"
 dependencies = [
- "skrifa 0.26.6",
+ "skrifa",
  "yazi",
  "zeno",
 ]
@@ -3200,9 +3154,9 @@ dependencies = [
  "bytemuck",
  "futures-intrusive",
  "log",
- "peniko 0.4.0",
+ "peniko",
  "png",
- "skrifa 0.31.0",
+ "skrifa",
  "static_assertions",
  "thiserror 2.0.12",
  "vello_encoding",
@@ -3216,7 +3170,7 @@ name = "vello_api"
 version = "0.4.0"
 dependencies = [
  "bytemuck",
- "peniko 0.4.0",
+ "peniko",
  "png",
 ]
 
@@ -3238,7 +3192,7 @@ version = "0.4.0"
 dependencies = [
  "bytemuck",
  "roxmltree",
- "skrifa 0.31.0",
+ "skrifa",
  "smallvec",
  "vello_api",
 ]
@@ -3265,8 +3219,8 @@ version = "0.4.0"
 dependencies = [
  "bytemuck",
  "guillotiere",
- "peniko 0.4.0",
- "skrifa 0.31.0",
+ "peniko",
+ "skrifa",
  "smallvec",
 ]
 
@@ -3327,7 +3281,7 @@ dependencies = [
  "image",
  "oxipng",
  "pollster",
- "skrifa 0.31.0",
+ "skrifa",
  "smallvec",
  "vello_api",
  "vello_common",
@@ -4356,9 +4310,9 @@ checksum = "e01738255b5a16e78bbb83e7fbba0a1e7dd506905cfc53f4622d89015a03fbb5"
 
 [[package]]
 name = "zeno"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc0de2315dc13d00e5df3cd6b8d2124a6eaec6a2d4b6a1c5f37b7efad17fcc17"
+checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"

--- a/sparse_strips/vello_hybrid/examples/scenes/Cargo.toml
+++ b/sparse_strips/vello_hybrid/examples/scenes/Cargo.toml
@@ -15,7 +15,7 @@ vello_hybrid = { workspace = true }
 vello_common = { workspace = true, features = ["pico_svg"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-parley = { version = "0.3.0", default-features = false, features = ["std"] }
+parley = { version = "0.4.0", default-features = false, features = ["std"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-parley = { version = "0.3.0", default-features = true }
+parley = { version = "0.4.0", default-features = true }

--- a/sparse_strips/vello_hybrid/examples/scenes/src/text.rs
+++ b/sparse_strips/vello_hybrid/examples/scenes/src/text.rs
@@ -63,11 +63,13 @@ impl TextScene {
         #[cfg(target_arch = "wasm32")]
         let mut font_cx = {
             let mut font_cx = FontContext::new();
-            font_cx.collection.register_fonts(ROBOTO_FONT.to_vec());
+            font_cx
+                .collection
+                .register_fonts(ROBOTO_FONT.to_vec().into(), None);
             font_cx
         };
 
-        let mut builder = layout_cx.ranged_builder(&mut font_cx, text, 1.0);
+        let mut builder = layout_cx.ranged_builder(&mut font_cx, text, 1.0, true);
         builder.push_default(FontFamily::parse("Roboto").unwrap());
         builder.push_default(StyleProperty::LineHeight(1.3));
         builder.push_default(StyleProperty::FontSize(32.0));


### PR DESCRIPTION
This is used in the examples.