### PR TITLE
vello_cpu: re-export types used in public api

### DIFF
--- a/sparse_strips/vello_cpu/src/lib.rs
+++ b/sparse_strips/vello_cpu/src/lib.rs
@@ -20,6 +20,9 @@ pub mod fine;
 mod util;
 
 pub use render::RenderContext;
+pub use vello_common::glyph::Glyph;
+pub use vello_common::mask::Mask;
+pub use vello_common::paint::{Image, Paint, PaintType};
 pub use vello_common::pixmap::Pixmap;
 
 /// The selected rendering mode.


### PR DESCRIPTION
These types from `vello_common` are needed in order to use `vello_cpu`s API. Re-exporting them here means consumers of`vello_cpu` don't have to explicitly depend on `vello_common`.