### PR TITLE
Prepare `vello_cpu` 0.0.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3179,7 +3179,7 @@ dependencies = [
 
 [[package]]
 name = "vello_common"
-version = "0.5.0"
+version = "0.0.1"
 dependencies = [
  "bytemuck",
  "libm",
@@ -3192,7 +3192,7 @@ dependencies = [
 
 [[package]]
 name = "vello_cpu"
-version = "0.5.0"
+version = "0.0.1"
 dependencies = [
  "libm",
  "vello_common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ png = "0.17.16"
 
 # The below crates are experimental!
 vello_api = { path = "sparse_strips/vello_api", default-features = false }
-vello_common = { path = "sparse_strips/vello_common", default-features = false }
+vello_common = { version = "0.0.1", path = "sparse_strips/vello_common", default-features = false }
 vello_cpu = { path = "sparse_strips/vello_cpu" }
 vello_hybrid = { path = "sparse_strips/vello_hybrid" }
 vello_hybrid_scenes = { path = "sparse_strips/vello_hybrid/examples/scenes" }

--- a/sparse_strips/vello_common/Cargo.toml
+++ b/sparse_strips/vello_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vello_common"
-# When updating, also version update in workspace dependency in root Cargo.toml
+# When updating, also update the version in the workspace dependency in the root Cargo.toml
 version = "0.0.1"
 description = "Core data structures and utilities shared across the Vello rendering, including geometry processing and tiling logic."
 categories = ["rendering", "graphics"]

--- a/sparse_strips/vello_common/Cargo.toml
+++ b/sparse_strips/vello_common/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "vello_common"
+# When updating, also version update in workspace dependency in root Cargo.toml
 version = "0.0.1"
 description = "Core data structures and utilities shared across the Vello rendering, including geometry processing and tiling logic."
 categories = ["rendering", "graphics"]

--- a/sparse_strips/vello_common/Cargo.toml
+++ b/sparse_strips/vello_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vello_common"
-version.workspace = true
+version = "0.0.1"
 description = "Core data structures and utilities shared across the Vello rendering, including geometry processing and tiling logic."
 categories = ["rendering", "graphics"]
 keywords = ["2d", "vector-graphics"]

--- a/sparse_strips/vello_common/Cargo.toml
+++ b/sparse_strips/vello_common/Cargo.toml
@@ -8,8 +8,6 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-# Prevent accidental publishing until the initial release
-publish = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/sparse_strips/vello_cpu/Cargo.toml
+++ b/sparse_strips/vello_cpu/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vello_cpu"
 # When moving past 0.0.x, also update caveats in the README
-version.workspace = true
+version = "0.0.1"
 description = "A CPU-based renderer for Vello, optimized for SIMD and multithreaded execution."
 categories = ["rendering", "graphics"]
 keywords = ["2d", "vector-graphics"]
@@ -19,7 +19,7 @@ default-target = "x86_64-unknown-linux-gnu"
 targets = []
 
 [dependencies]
-vello_common = { workspace = true }
+vello_common = { version = "0.0.1", workspace = true }
 libm = { version = "0.2.15", optional = true }
 
 [features]

--- a/sparse_strips/vello_cpu/Cargo.toml
+++ b/sparse_strips/vello_cpu/Cargo.toml
@@ -9,8 +9,6 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-# Prevent accidental publishing until the initial release
-publish = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/sparse_strips/vello_cpu/Cargo.toml
+++ b/sparse_strips/vello_cpu/Cargo.toml
@@ -17,8 +17,8 @@ default-target = "x86_64-unknown-linux-gnu"
 targets = []
 
 [dependencies]
-vello_common = { version = "0.0.1", workspace = true }
 libm = { version = "0.2.15", optional = true }
+vello_common = { workspace = true }
 
 [features]
 default = ["std", "png"]


### PR DESCRIPTION
- Sets version number to `0.0.1` for `vello_cpu`, `vello_common` and `vello_api` crates
- Adds warning message to `vello_cpu` crate