### PR TITLE
Remove vestigial comment about x86 RGBA8 slowness

### DIFF
--- a/sparse_strips/vello_api/src/paint.rs
+++ b/sparse_strips/vello_api/src/paint.rs
@@ -47,10 +47,6 @@ pub enum Paint {
 
 impl From<AlphaColor<Srgb>> for Paint {
     fn from(value: AlphaColor<Srgb>) -> Self {
-        // TODO: This might be slow on x86, see https://github.com/linebender/color/issues/142.
-        // Since we only do that conversion once per path it might not be critical, but should
-        // still be measured. This also applies to all other usages of `to_rgba8` in the current
-        // code.
         Self::Solid(PremulColor::from_alpha_color(value))
     }
 }


### PR DESCRIPTION
This was fixed in https://github.com/linebender/color/pull/166, released in https://github.com/linebender/color/releases/tag/v0.3.0.