### PR TITLE
Implement `Image::from_peniko_image`

### DIFF
--- a/sparse_strips/vello_common/src/paint.rs
+++ b/sparse_strips/vello_common/src/paint.rs
@@ -74,6 +74,8 @@ impl Image {
     ///
     /// This panics if `image` has a `width` or `height` greater than `u16::MAX`.
     pub fn from_peniko_image(image: &peniko::Image) -> Self {
+        // TODO: how do we deal with `peniko::ImageFormat` growing? See also
+        // <https://github.com/linebender/vello/pull/996#discussion_r2080510863>.
         if image.format != peniko::ImageFormat::Rgba8 {
             unimplemented!("Unsupported image format: {:?}", image.format);
         }


### PR DESCRIPTION
Probably a temporary method until there's better resource binding; in the meantime this is useful for clients already using `Peniko::Image`.

Perhaps `Pixmap` should get a method to do the conversion to premultiplied RGBA8 from `&[Rgba8]`, or perhaps `Vec<Rgba8>` using Bytemuck with the `extern_crate_alloc` feature (though the latter doesn't help with `Peniko::Image`, which stores data in an `Arc`).