### PR TITLE
Fill out the READMEs of Vello {CPU, Common, API}

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,20 @@ jobs:
 
       - name: check copyright headers
         run: bash .github/copyright.sh
+      
+      - name: Install cargo-rdme
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-rdme
+
+      - name: Run cargo rdme (vello_cpu)
+        run: cargo rdme --check --heading-base-level=0 --workspace-project=vello_cpu
+
+      - name: Run cargo rdme (vello_common)
+        run: cargo rdme --check --heading-base-level=0 --workspace-project=vello_common
+    
+      - name: Run cargo rdme (vello_api)
+        run: cargo rdme --check --heading-base-level=0 --workspace-project=vello_api
 
   clippy-stable:
     name: cargo clippy

--- a/sparse_strips/README.md
+++ b/sparse_strips/README.md
@@ -1,6 +1,7 @@
 # Vello Sparse Strips
 
 We are developing a new implementation for Vello that aims to:
+
 - Be compatible with a wider range of devices (should be able to run on GPUs without compute shader support, using only fragment and vertex shaders).
 - Mitigate some performance cliffs.
 - Handle a wider range of memory conditions (e.g., when less memory is available).
@@ -16,6 +17,7 @@ It leverages **efficient tiling, sorting, and sparse strip allocation** to optim
 This directory contains the core crates for the Vello rendering. Each crate serves a distinct role in the architecture, allowing modular development and easier maintenance.
 
 ### Crates
+
 - **`vello_api`** – Defines the public API types shared across implementations.
 - **`vello_common`** – Provides shared data structures and utilities for rendering.
 - **`vello_cpu`** – Implements a CPU-based renderer optimized for multithreading and SIMD.
@@ -43,5 +45,3 @@ Licensed under either of
 at your option.
 
 [Rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct
-[Vello]: https://github.com/linebender/vello
-[the changelog]: https://github.com/linebender/vello/tree/main/CHANGELOG.md

--- a/sparse_strips/vello_api/README.md
+++ b/sparse_strips/vello_api/README.md
@@ -24,14 +24,14 @@ See https://linebender.org/blog/doc-include/ for related discussion. -->
 
 <!-- cargo-rdme start -->
 
-This crate defines the public API types used by both Vello CPU and Vello Hybrid
+This crate defines the public API types used by both Vello CPU and Vello Hybrid.
 
 ## Usage
 
 This crate should not be used on its own, and you should instead use one of the renderers which use it.
 At the moment, only [Vello CPU](crates.io/crates/vello_cpu) is published, and you probably want to use that.
 
-We also develop [Vello](crates.io/crates/vello), which makes use of the GPU for 2d rendering and has higher performance than Vello CPU.
+We also develop [Vello](crates.io/crates/vello), which makes use of the GPU for 2D rendering and has higher performance than Vello CPU.
 Vello CPU is being developed as part of work to address shortcomings in Vello.
 Vello does not use this crate.
 
@@ -41,7 +41,7 @@ Vello does not use this crate.
 
 ## Usage
 
-This crate is intended to be used by other Vello components
+This crate is intended to be used by other Vello components.
 
 <!-- cargo-rdme end -->
 

--- a/sparse_strips/vello_api/README.md
+++ b/sparse_strips/vello_api/README.md
@@ -11,15 +11,34 @@
 
 </div>
 
-This crate defines the public API types for the Vello rendering. It provides common interfaces and data structures used across different implementations, including CPU, GPU, and hybrid rendering backends.
+<!-- We use cargo-rdme to update the README with the contents of lib.rs.
+To edit the following section, update it in lib.rs, then run:
+cargo rdme --workspace-project=vello_api --heading-base-level=0
+Full documentation at https://github.com/orium/cargo-rdme -->
+
+<!-- Intra-doc links used in lib.rs should be evaluated here.
+See https://linebender.org/blog/doc-include/ for related discussion. -->
+
+<!-- cargo-rdme start -->
+
+This crate defines the public API types, providing a stable interface for CPU and hybrid
+CPU/GPU rendering implementations. It provides common interfaces and data structures used
+across different implementations
+
+This crate defines the public API types for the Vello rendering.
+It provides common interfaces and data structures used across different implementations, including CPU, GPU, and hybrid rendering backends.
 
 ## Features
+
 - Shared API types for Vello's rendering pipeline.
 - Interfaces for render contexts and rendering options.
 - Designed for compatibility across CPU and GPU implementations.
 
 ## Usage
+
 This crate is intended to be used by other Vello components and external consumers needing a stable API.
+
+<!-- cargo-rdme end -->
 
 ## Minimum supported Rust Version (MSRV)
 

--- a/sparse_strips/vello_api/README.md
+++ b/sparse_strips/vello_api/README.md
@@ -24,22 +24,24 @@ See https://linebender.org/blog/doc-include/ for related discussion. -->
 
 <!-- cargo-rdme start -->
 
-This crate defines the public API types, providing a stable interface for CPU and hybrid
-CPU/GPU rendering implementations. It provides common interfaces and data structures used
-across different implementations
+This crate defines the public API types used by both Vello CPU and Vello Hybrid
 
-This crate defines the public API types for the Vello rendering.
-It provides common interfaces and data structures used across different implementations, including CPU, GPU, and hybrid rendering backends.
+## Usage
+
+This crate should not be used on its own, and you should instead use one of the renderers which use it.
+At the moment, only [Vello CPU](crates.io/crates/vello_cpu) is published, and you probably want to use that.
+
+We also develop [Vello](crates.io/crates/vello), which makes use of the GPU for 2d rendering and has higher performance than Vello CPU.
+Vello CPU is being developed as part of work to address shortcomings in Vello.
+Vello does not use this crate.
 
 ## Features
 
 - Shared API types for Vello's rendering pipeline.
-- Interfaces for render contexts and rendering options.
-- Designed for compatibility across CPU and GPU implementations.
 
 ## Usage
 
-This crate is intended to be used by other Vello components and external consumers needing a stable API.
+This crate is intended to be used by other Vello components
 
 <!-- cargo-rdme end -->
 

--- a/sparse_strips/vello_api/README.md
+++ b/sparse_strips/vello_api/README.md
@@ -4,10 +4,13 @@
 
 **Public API types**
 
+[![Latest published version.](https://img.shields.io/crates/v/vello_api.svg)](https://crates.io/crates/vello_api)
+[![Documentation build status.](https://img.shields.io/docsrs/vello_api.svg)](https://docs.rs/vello_api)
 [![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
 \
 [![Linebender Zulip chat.](https://img.shields.io/badge/Linebender-%23vello-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/197075-vello)
 [![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/linebender/vello/ci.yml?logo=github&label=CI)](https://github.com/linebender/vello/actions)
+[![Dependency staleness status.](https://deps.rs/crate/vello_api/latest/status.svg)](https://deps.rs/crate/vello_api)
 
 </div>
 
@@ -78,5 +81,3 @@ Licensed under either of
 at your option.
 
 [Rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct
-[Vello]: https://github.com/linebender/vello
-[the changelog]: https://github.com/linebender/vello/tree/main/CHANGELOG.md

--- a/sparse_strips/vello_api/src/lib.rs
+++ b/sparse_strips/vello_api/src/lib.rs
@@ -1,14 +1,14 @@
 // Copyright 2025 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-//! This crate defines the public API types used by both Vello CPU and Vello Hybrid
+//! This crate defines the public API types used by both Vello CPU and Vello Hybrid.
 //!
 //! ## Usage
 //!
 //! This crate should not be used on its own, and you should instead use one of the renderers which use it.
 //! At the moment, only [Vello CPU](crates.io/crates/vello_cpu) is published, and you probably want to use that.
 //!
-//! We also develop [Vello](crates.io/crates/vello), which makes use of the GPU for 2d rendering and has higher performance than Vello CPU.
+//! We also develop [Vello](crates.io/crates/vello), which makes use of the GPU for 2D rendering and has higher performance than Vello CPU.
 //! Vello CPU is being developed as part of work to address shortcomings in Vello.
 //! Vello does not use this crate.
 //!
@@ -20,7 +20,7 @@
 //!
 //! ## Usage
 //!
-//! This crate is intended to be used by other Vello components
+//! This crate is intended to be used by other Vello components.
 //and external consumers needing a stable API.
 
 #![forbid(unsafe_code)]

--- a/sparse_strips/vello_api/src/lib.rs
+++ b/sparse_strips/vello_api/src/lib.rs
@@ -1,22 +1,27 @@
 // Copyright 2025 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-//! This crate defines the public API types, providing a stable interface for CPU and hybrid
-//! CPU/GPU rendering implementations. It provides common interfaces and data structures used
-//! across different implementations
+//! This crate defines the public API types used by both Vello CPU and Vello Hybrid
 //!
-//! This crate defines the public API types for the Vello rendering.
-//! It provides common interfaces and data structures used across different implementations, including CPU, GPU, and hybrid rendering backends.
+//! ## Usage
+//!
+//! This crate should not be used on its own, and you should instead use one of the renderers which use it.
+//! At the moment, only [Vello CPU](crates.io/crates/vello_cpu) is published, and you probably want to use that.
+//!
+//! We also develop [Vello](crates.io/crates/vello), which makes use of the GPU for 2d rendering and has higher performance than Vello CPU.
+//! Vello CPU is being developed as part of work to address shortcomings in Vello.
+//! Vello does not use this crate.
 //!
 //! ## Features
 //!
 //! - Shared API types for Vello's rendering pipeline.
-//! - Interfaces for render contexts and rendering options.
-//! - Designed for compatibility across CPU and GPU implementations.
+// - Interfaces for render contexts and rendering options.
+// - Designed for compatibility across CPU and GPU implementations.
 //!
 //! ## Usage
 //!
-//! This crate is intended to be used by other Vello components and external consumers needing a stable API.
+//! This crate is intended to be used by other Vello components
+//and external consumers needing a stable API.
 
 #![forbid(unsafe_code)]
 #![no_std]

--- a/sparse_strips/vello_api/src/lib.rs
+++ b/sparse_strips/vello_api/src/lib.rs
@@ -4,6 +4,19 @@
 //! This crate defines the public API types, providing a stable interface for CPU and hybrid
 //! CPU/GPU rendering implementations. It provides common interfaces and data structures used
 //! across different implementations
+//!
+//! This crate defines the public API types for the Vello rendering.
+//! It provides common interfaces and data structures used across different implementations, including CPU, GPU, and hybrid rendering backends.
+//!
+//! ## Features
+//!
+//! - Shared API types for Vello's rendering pipeline.
+//! - Interfaces for render contexts and rendering options.
+//! - Designed for compatibility across CPU and GPU implementations.
+//!
+//! ## Usage
+//!
+//! This crate is intended to be used by other Vello components and external consumers needing a stable API.
 
 #![forbid(unsafe_code)]
 #![no_std]

--- a/sparse_strips/vello_common/README.md
+++ b/sparse_strips/vello_common/README.md
@@ -11,15 +11,34 @@
 
 </div>
 
-This crate contains core data structures and utilities shared across the Vello rendering. It includes common geometry representations, tiling logic, and other fundamental components used by both `vello_cpu` and `vello_hybrid`.
+<!-- We use cargo-rdme to update the README with the contents of lib.rs.
+To edit the following section, update it in lib.rs, then run:
+cargo rdme --workspace-project=vello_common --heading-base-level=0
+Full documentation at https://github.com/orium/cargo-rdme -->
+
+<!-- Intra-doc links used in lib.rs should be evaluated here.
+See https://linebender.org/blog/doc-include/ for related discussion. -->
+
+<!-- cargo-rdme start -->
+
+This crate contains core data structures and utilities shared across crates. It includes
+foundational types for path geometry, tiling, and other common operations used in both CPU and
+hybrid CPU/GPU rendering.
+
+This crate contains core data structures and utilities shared across the Vello rendering.
+It includes common geometry representations, tiling logic, and other fundamental components used by both `vello_cpu` and `vello_hybrid`.
 
 ## Features
+
 - Shared data structures for paths, tiles, and strips
 - Geometry processing utilities
 - Common logic for rendering stages
 
 ## Usage
+
 This crate acts as a foundation for `vello_cpu` and `vello_hybrid`, providing essential components to minimize duplication.
+
+<!-- cargo-rdme end -->
 
 ## Minimum supported Rust Version (MSRV)
 

--- a/sparse_strips/vello_common/README.md
+++ b/sparse_strips/vello_common/README.md
@@ -24,14 +24,14 @@ See https://linebender.org/blog/doc-include/ for related discussion. -->
 
 <!-- cargo-rdme start -->
 
-This crate includes common geometry representations, tiling logic, and other fundamental components used by both Vello CPU and Vello Hybrid.
+This crate includes common geometry representations, tiling logic, and other fundamental components used by both [Vello CPU][vello_cpu] and Vello Hybrid.
 
 ## Usage
 
 This crate should not be used on its own, and you should instead use one of the renderers which use it.
-At the moment, only [Vello CPU](crates.io/crates/vello_cpu) is published, and you probably want to use that.
+At the moment, only [Vello CPU][vello_cpu] is published, and you probably want to use that.
 
-We also develop [Vello](crates.io/crates/vello), which makes use of the GPU for 2d rendering and has higher performance than Vello CPU.
+We also develop [Vello](https://crates.io/crates/vello), which makes use of the GPU for 2D rendering and has higher performance than Vello CPU.
 Vello CPU is being developed as part of work to address shortcomings in Vello.
 Vello does not use this crate.
 
@@ -42,6 +42,8 @@ Vello does not use this crate.
 - Common logic for rendering stages
 
 This crate acts as a foundation for `vello_cpu` and `vello_hybrid`, providing essential components to minimize duplication.
+
+[vello_cpu]: https://crates.io/crates/vello_cpu
 
 <!-- cargo-rdme end -->
 

--- a/sparse_strips/vello_common/README.md
+++ b/sparse_strips/vello_common/README.md
@@ -4,10 +4,13 @@
 
 **Shared data structures**
 
+[![Latest published version.](https://img.shields.io/crates/v/vello_common.svg)](https://crates.io/crates/vello_common)
+[![Documentation build status.](https://img.shields.io/docsrs/vello_common.svg)](https://docs.rs/vello_common)
 [![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
 \
 [![Linebender Zulip chat.](https://img.shields.io/badge/Linebender-%23vello-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/197075-vello)
 [![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/linebender/vello/ci.yml?logo=github&label=CI)](https://github.com/linebender/vello/actions)
+[![Dependency staleness status.](https://deps.rs/crate/vello_common/latest/status.svg)](https://deps.rs/crate/vello_common)
 
 </div>
 
@@ -78,5 +81,3 @@ Licensed under either of
 at your option.
 
 [Rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct
-[Vello]: https://github.com/linebender/vello
-[the changelog]: https://github.com/linebender/vello/tree/main/CHANGELOG.md

--- a/sparse_strips/vello_common/README.md
+++ b/sparse_strips/vello_common/README.md
@@ -24,20 +24,22 @@ See https://linebender.org/blog/doc-include/ for related discussion. -->
 
 <!-- cargo-rdme start -->
 
-This crate contains core data structures and utilities shared across crates. It includes
-foundational types for path geometry, tiling, and other common operations used in both CPU and
-hybrid CPU/GPU rendering.
+This crate includes common geometry representations, tiling logic, and other fundamental components used by both Vello CPU and Vello Hybrid.
 
-This crate contains core data structures and utilities shared across the Vello rendering.
-It includes common geometry representations, tiling logic, and other fundamental components used by both `vello_cpu` and `vello_hybrid`.
+## Usage
+
+This crate should not be used on its own, and you should instead use one of the renderers which use it.
+At the moment, only [Vello CPU](crates.io/crates/vello_cpu) is published, and you probably want to use that.
+
+We also develop [Vello](crates.io/crates/vello), which makes use of the GPU for 2d rendering and has higher performance than Vello CPU.
+Vello CPU is being developed as part of work to address shortcomings in Vello.
+Vello does not use this crate.
 
 ## Features
 
 - Shared data structures for paths, tiles, and strips
 - Geometry processing utilities
 - Common logic for rendering stages
-
-## Usage
 
 This crate acts as a foundation for `vello_cpu` and `vello_hybrid`, providing essential components to minimize duplication.
 

--- a/sparse_strips/vello_common/src/lib.rs
+++ b/sparse_strips/vello_common/src/lib.rs
@@ -4,6 +4,19 @@
 //! This crate contains core data structures and utilities shared across crates. It includes
 //! foundational types for path geometry, tiling, and other common operations used in both CPU and
 //! hybrid CPU/GPU rendering.
+//!
+//! This crate contains core data structures and utilities shared across the Vello rendering.
+//! It includes common geometry representations, tiling logic, and other fundamental components used by both `vello_cpu` and `vello_hybrid`.
+//!
+//! ## Features
+//!
+//! - Shared data structures for paths, tiles, and strips
+//! - Geometry processing utilities
+//! - Common logic for rendering stages
+//!
+//! ## Usage
+//!
+//! This crate acts as a foundation for `vello_cpu` and `vello_hybrid`, providing essential components to minimize duplication.
 
 #![cfg_attr(not(feature = "simd"), forbid(unsafe_code))]
 #![expect(

--- a/sparse_strips/vello_common/src/lib.rs
+++ b/sparse_strips/vello_common/src/lib.rs
@@ -1,14 +1,14 @@
 // Copyright 2025 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-//! This crate includes common geometry representations, tiling logic, and other fundamental components used by both Vello CPU and Vello Hybrid.
+//! This crate includes common geometry representations, tiling logic, and other fundamental components used by both [Vello CPU][vello_cpu] and Vello Hybrid.
 //!
 //! ## Usage
 //!
 //! This crate should not be used on its own, and you should instead use one of the renderers which use it.
-//! At the moment, only [Vello CPU](crates.io/crates/vello_cpu) is published, and you probably want to use that.
+//! At the moment, only [Vello CPU][vello_cpu] is published, and you probably want to use that.
 //!
-//! We also develop [Vello](crates.io/crates/vello), which makes use of the GPU for 2d rendering and has higher performance than Vello CPU.
+//! We also develop [Vello](https://crates.io/crates/vello), which makes use of the GPU for 2D rendering and has higher performance than Vello CPU.
 //! Vello CPU is being developed as part of work to address shortcomings in Vello.
 //! Vello does not use this crate.
 //!
@@ -19,6 +19,8 @@
 //! - Common logic for rendering stages
 //!
 //! This crate acts as a foundation for `vello_cpu` and `vello_hybrid`, providing essential components to minimize duplication.
+//!
+//! [vello_cpu]: https://crates.io/crates/vello_cpu
 
 #![cfg_attr(not(feature = "simd"), forbid(unsafe_code))]
 #![expect(

--- a/sparse_strips/vello_common/src/lib.rs
+++ b/sparse_strips/vello_common/src/lib.rs
@@ -1,20 +1,22 @@
 // Copyright 2025 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-//! This crate contains core data structures and utilities shared across crates. It includes
-//! foundational types for path geometry, tiling, and other common operations used in both CPU and
-//! hybrid CPU/GPU rendering.
+//! This crate includes common geometry representations, tiling logic, and other fundamental components used by both Vello CPU and Vello Hybrid.
 //!
-//! This crate contains core data structures and utilities shared across the Vello rendering.
-//! It includes common geometry representations, tiling logic, and other fundamental components used by both `vello_cpu` and `vello_hybrid`.
+//! ## Usage
+//!
+//! This crate should not be used on its own, and you should instead use one of the renderers which use it.
+//! At the moment, only [Vello CPU](crates.io/crates/vello_cpu) is published, and you probably want to use that.
+//!
+//! We also develop [Vello](crates.io/crates/vello), which makes use of the GPU for 2d rendering and has higher performance than Vello CPU.
+//! Vello CPU is being developed as part of work to address shortcomings in Vello.
+//! Vello does not use this crate.
 //!
 //! ## Features
 //!
 //! - Shared data structures for paths, tiles, and strips
 //! - Geometry processing utilities
 //! - Common logic for rendering stages
-//!
-//! ## Usage
 //!
 //! This crate acts as a foundation for `vello_cpu` and `vello_hybrid`, providing essential components to minimize duplication.
 

--- a/sparse_strips/vello_cpu/Cargo.toml
+++ b/sparse_strips/vello_cpu/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "vello_cpu"
+# When moving past 0.0.x, also update caveats in the README
 version.workspace = true
 description = "A CPU-based renderer for Vello, optimized for SIMD and multithreaded execution."
 categories = ["rendering", "graphics"]

--- a/sparse_strips/vello_cpu/README.md
+++ b/sparse_strips/vello_cpu/README.md
@@ -36,14 +36,14 @@ Vello CPU is a 2D graphics rendering engine written in Rust, for devices with no
 It is currently available as an alpha.
 See the [Caveats](#caveats) section for things you need to be aware of.
 
-We also develop [Vello](crates.io/crates/vello), which makes use of the GPU for 2d rendering and has higher performance than Vello CPU..
+We also develop [Vello](https://crates.io/crates/vello), which makes use of the GPU for 2D rendering and has higher performance than Vello CPU.
 Vello CPU is being developed as part of work to address shortcomings in Vello.
 
 ## Usage
 
 To use Vello CPU, you need to:
 
-- Create a [`RenderContext`][], a 2d drawing context for a fixed-size target area.
+- Create a [`RenderContext`][], a 2D drawing context for a fixed-size target area.
 - For each object in your scene:
   - Set how the object will be painted, using [`set_paint`][RenderContext::set_paint].
   - Set the shape to be drawn for that object, using methods like [`fill_path`][RenderContext::fill_path],
@@ -97,10 +97,10 @@ We have known plans to change the API around how image resources are used.
 
 We have not yet put any work into documentation.
 
-### Optimisation
+### Performance
 
-We have several important optimisation planned, including use of multithreading and SIMD.
-These are not yet implemented, so performance is not representative of the potential performance.
+We do not perform several important optimisations, such as the use of multithreading and SIMD.
+Additionally, some algorithms we use aren't final, and will be replaced with higher-performance variants.
 
 ## Implementation
 

--- a/sparse_strips/vello_cpu/README.md
+++ b/sparse_strips/vello_cpu/README.md
@@ -22,24 +22,86 @@ Full documentation at https://github.com/orium/cargo-rdme -->
 <!-- Intra-doc links used in lib.rs should be evaluated here.
 See https://linebender.org/blog/doc-include/ for related discussion. -->
 
+[`RenderContext`]: https://docs.rs/vello_cpu/latest/vello_cpu/struct.RenderContext.html
+[RenderContext::set_paint]: https://docs.rs/vello_cpu/latest/vello_cpu/struct.RenderContext.html#method.set_paint
+[RenderContext::fill_path]: https://docs.rs/vello_cpu/latest/vello_cpu/struct.RenderContext.html#method.fill_path
+[RenderContext::stroke_path]: https://docs.rs/vello_cpu/latest/vello_cpu/struct.RenderContext.html#method.stroke_path
+[RenderContext::glyph_run]: https://docs.rs/vello_cpu/latest/vello_cpu/struct.RenderContext.html#method.glyph_run
+[`RenderContext::render_to_pixmap`]: https://docs.rs/vello_cpu/latest/vello_cpu/struct.RenderContext.html#method.render_to_pixmap
+
 <!-- cargo-rdme start -->
 
-This crate implements the CPU-based renderer for Vello.
-It is optimized for running on lower-end GPUs or CPU-only environments, leveraging parallelism and SIMD acceleration where possible.
+Vello CPU is a 2D graphics rendering engine written in Rust, for devices with no or underpowered GPUs.
 
-This crate implements a CPU-based renderer, optimized for SIMD and multithreaded execution.
-It is optimized for CPU-bound workloads and serves as a standalone renderer for systems
-without GPU acceleration.
-
-## Features
-
-- Fully CPU-based path rendering pipeline
-- SIMD and multithreading optimizations
-- Fine rasterization and antialiasing techniques
+It is currently available as an alpha.
+See the [Caveats](#caveats) section for things you need to be aware of.
 
 ## Usage
 
-This crate serves as a standalone renderer or as a fallback when GPU resources are constrained.
+To use Vello CPU, you need to:
+
+- Create a [`RenderContext`][], a 2d drawing context for a fixed-size target area.
+- For each object in your scene:
+  - Set how the object will be painted, using [`set_paint`][RenderContext::set_paint].
+  - Set the shape to be drawn for that object, using methods like [`fill_path`][RenderContext::fill_path],
+    [`stroke_path`][RenderContext::stroke_path], or [`glyph_run`][RenderContext::glyph_run].
+- Render it to an image using [`RenderContext::render_to_pixmap`][].
+
+```rust
+use vello_cpu::{RenderContext, Pixmap, RenderMode};
+use vello_cpu::{color::{palette::css, PremulRgba8}, kurbo::Rect};
+let width = 10;
+let height = 5;
+let mut context = RenderContext::new(width, height);
+context.set_paint(css::MAGENTA);
+context.fill_rect(&Rect::from_points((3., 1.), (7., 4.)));
+
+let mut target = Pixmap::new(width, height);
+context.render_to_pixmap(&mut target, RenderMode::default());
+
+let expected_render = b"\
+    0000000000\
+    0001111000\
+    0001111000\
+    0001111000\
+    0000000000";
+let magenta = css::MAGENTA.premultiply().to_rgba8();
+let transparent = PremulRgba8 {r: 0, g: 0, b: 0, a: 0};
+let mut result = Vec::new();
+for pixel in target.data() {
+    if *pixel == magenta {
+        result.push(b'1');
+    } else if *pixel == transparent {
+        result.push(b'0');
+    } else {
+         panic!("Got unexpected pixel value {pixel:?}");
+    }
+}
+assert_eq!(&result, expected_render);
+```
+
+## Caveats
+
+Vello CPU is an alpha for several reasons, including the following.
+
+### API stability
+
+This API has been developed for an initial version, and has no stability guarantees.
+Whilst we are in the `0.0.x` release series, any release is likely to breaking.
+We have known plans to change the API around how image resources are used.
+
+### Documentation
+
+We have not yet put any work into documentation.
+
+### Optimisation
+
+We have several important optimisation planned, including use of multithreading and SIMD.
+These are not yet implemented, so performance is not representative of the potential performance.
+
+## Implementation
+
+TODO: Point to documentation of sparse strips pattern.
 
 <!-- cargo-rdme end -->
 

--- a/sparse_strips/vello_cpu/README.md
+++ b/sparse_strips/vello_cpu/README.md
@@ -4,10 +4,13 @@
 
 **CPU-based renderer**
 
+[![Latest published version.](https://img.shields.io/crates/v/vello_cpu.svg)](https://crates.io/crates/vello_cpu)
+[![Documentation build status.](https://img.shields.io/docsrs/vello_cpu.svg)](https://docs.rs/vello_cpu)
 [![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
 \
 [![Linebender Zulip chat.](https://img.shields.io/badge/Linebender-%23vello-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/197075-vello)
 [![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/linebender/vello/ci.yml?logo=github&label=CI)](https://github.com/linebender/vello/actions)
+[![Dependency staleness status.](https://deps.rs/crate/vello_cpu/latest/status.svg)](https://deps.rs/crate/vello_cpu)
 
 </div>
 
@@ -78,5 +81,3 @@ Licensed under either of
 at your option.
 
 [Rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct
-[Vello]: https://github.com/linebender/vello
-[the changelog]: https://github.com/linebender/vello/tree/main/CHANGELOG.md

--- a/sparse_strips/vello_cpu/README.md
+++ b/sparse_strips/vello_cpu/README.md
@@ -11,15 +11,34 @@
 
 </div>
 
-This crate implements the CPU-based renderer for Vello. It is optimized for running on lower-end GPUs or CPU-only environments, leveraging parallelism and SIMD acceleration where possible.
+<!-- We use cargo-rdme to update the README with the contents of lib.rs.
+To edit the following section, update it in lib.rs, then run:
+cargo rdme --workspace-project=vello_cpu --heading-base-level=0
+Full documentation at https://github.com/orium/cargo-rdme -->
+
+<!-- Intra-doc links used in lib.rs should be evaluated here.
+See https://linebender.org/blog/doc-include/ for related discussion. -->
+
+<!-- cargo-rdme start -->
+
+This crate implements the CPU-based renderer for Vello.
+It is optimized for running on lower-end GPUs or CPU-only environments, leveraging parallelism and SIMD acceleration where possible.
+
+This crate implements a CPU-based renderer, optimized for SIMD and multithreaded execution.
+It is optimized for CPU-bound workloads and serves as a standalone renderer for systems
+without GPU acceleration.
 
 ## Features
+
 - Fully CPU-based path rendering pipeline
 - SIMD and multithreading optimizations
 - Fine rasterization and antialiasing techniques
 
 ## Usage
+
 This crate serves as a standalone renderer or as a fallback when GPU resources are constrained.
+
+<!-- cargo-rdme end -->
 
 ## Minimum supported Rust Version (MSRV)
 

--- a/sparse_strips/vello_cpu/README.md
+++ b/sparse_strips/vello_cpu/README.md
@@ -36,6 +36,9 @@ Vello CPU is a 2D graphics rendering engine written in Rust, for devices with no
 It is currently available as an alpha.
 See the [Caveats](#caveats) section for things you need to be aware of.
 
+We also develop [Vello](crates.io/crates/vello), which makes use of the GPU for 2d rendering and has higher performance than Vello CPU..
+Vello CPU is being developed as part of work to address shortcomings in Vello.
+
 ## Usage
 
 To use Vello CPU, you need to:

--- a/sparse_strips/vello_cpu/src/lib.rs
+++ b/sparse_strips/vello_cpu/src/lib.rs
@@ -1,9 +1,22 @@
 // Copyright 2025 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+//! This crate implements the CPU-based renderer for Vello.
+//! It is optimized for running on lower-end GPUs or CPU-only environments, leveraging parallelism and SIMD acceleration where possible.
+//!
 //! This crate implements a CPU-based renderer, optimized for SIMD and multithreaded execution.
 //! It is optimized for CPU-bound workloads and serves as a standalone renderer for systems
 //! without GPU acceleration.
+//!
+//! ## Features
+//!
+//! - Fully CPU-based path rendering pipeline
+//! - SIMD and multithreading optimizations
+//! - Fine rasterization and antialiasing techniques
+//!
+//! ## Usage
+//!
+//! This crate serves as a standalone renderer or as a fallback when GPU resources are constrained.
 
 #![expect(
     clippy::cast_possible_truncation,

--- a/sparse_strips/vello_cpu/src/lib.rs
+++ b/sparse_strips/vello_cpu/src/lib.rs
@@ -1,22 +1,77 @@
 // Copyright 2025 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-//! This crate implements the CPU-based renderer for Vello.
-//! It is optimized for running on lower-end GPUs or CPU-only environments, leveraging parallelism and SIMD acceleration where possible.
+//! Vello CPU is a 2D graphics rendering engine written in Rust, for devices with no or underpowered GPUs.
 //!
-//! This crate implements a CPU-based renderer, optimized for SIMD and multithreaded execution.
-//! It is optimized for CPU-bound workloads and serves as a standalone renderer for systems
-//! without GPU acceleration.
-//!
-//! ## Features
-//!
-//! - Fully CPU-based path rendering pipeline
-//! - SIMD and multithreading optimizations
-//! - Fine rasterization and antialiasing techniques
+//! It is currently available as an alpha.
+//! See the [Caveats](#caveats) section for things you need to be aware of.
 //!
 //! ## Usage
 //!
-//! This crate serves as a standalone renderer or as a fallback when GPU resources are constrained.
+//! To use Vello CPU, you need to:
+//!
+//! - Create a [`RenderContext`][], a 2d drawing context for a fixed-size target area.
+//! - For each object in your scene:
+//!   - Set how the object will be painted, using [`set_paint`][RenderContext::set_paint].
+//!   - Set the shape to be drawn for that object, using methods like [`fill_path`][RenderContext::fill_path],
+//!     [`stroke_path`][RenderContext::stroke_path], or [`glyph_run`][RenderContext::glyph_run].
+//! - Render it to an image using [`RenderContext::render_to_pixmap`][].
+//!
+//! ```rust
+//! use vello_cpu::{RenderContext, Pixmap, RenderMode};
+//! use vello_cpu::{color::{palette::css, PremulRgba8}, kurbo::Rect};
+//! let width = 10;
+//! let height = 5;
+//! let mut context = RenderContext::new(width, height);
+//! context.set_paint(css::MAGENTA);
+//! context.fill_rect(&Rect::from_points((3., 1.), (7., 4.)));
+//!
+//! let mut target = Pixmap::new(width, height);
+//! context.render_to_pixmap(&mut target, RenderMode::default());
+//!
+//! let expected_render = b"\
+//!     0000000000\
+//!     0001111000\
+//!     0001111000\
+//!     0001111000\
+//!     0000000000";
+//! let magenta = css::MAGENTA.premultiply().to_rgba8();
+//! let transparent = PremulRgba8 {r: 0, g: 0, b: 0, a: 0};
+//! let mut result = Vec::new();
+//! for pixel in target.data() {
+//!     if *pixel == magenta {
+//!         result.push(b'1');
+//!     } else if *pixel == transparent {
+//!         result.push(b'0');
+//!     } else {
+//!          panic!("Got unexpected pixel value {pixel:?}");
+//!     }
+//! }
+//! assert_eq!(&result, expected_render);
+//! ```
+//!
+//! ## Caveats
+//!
+//! Vello CPU is an alpha for several reasons, including the following.
+//!
+//! ### API stability
+//!
+//! This API has been developed for an initial version, and has no stability guarantees.
+//! Whilst we are in the `0.0.x` release series, any release is likely to breaking.
+//! We have known plans to change the API around how image resources are used.
+//!
+//! ### Documentation
+//!
+//! We have not yet put any work into documentation.
+//!
+//! ### Optimisation
+//!
+//! We have several important optimisation planned, including use of multithreading and SIMD.
+//! These are not yet implemented, so performance is not representative of the potential performance.
+//!
+//! ## Implementation
+//!
+//! TODO: Point to documentation of sparse strips pattern.
 
 #![expect(
     clippy::cast_possible_truncation,
@@ -37,6 +92,7 @@ pub use vello_common::glyph::Glyph;
 pub use vello_common::mask::Mask;
 pub use vello_common::paint::{Image, Paint, PaintType};
 pub use vello_common::pixmap::Pixmap;
+pub use vello_common::{color, kurbo, peniko};
 
 /// The selected rendering mode.
 #[derive(Copy, Clone, Debug, Default)]

--- a/sparse_strips/vello_cpu/src/lib.rs
+++ b/sparse_strips/vello_cpu/src/lib.rs
@@ -67,10 +67,10 @@
 //!
 //! We have not yet put any work into documentation.
 //!
-//! ### Optimisation
+//! ### Performance
 //!
-//! We have several important optimisation planned, including use of multithreading and SIMD.
-//! These are not yet implemented, so performance is not representative of the potential performance.
+//! We do not perform several important optimisations, such as the use of multithreading and SIMD.
+//! Additionally, some algorithms we use aren't final, and will be replaced with higher-performance variants.
 //!
 //! ## Implementation
 //!

--- a/sparse_strips/vello_cpu/src/lib.rs
+++ b/sparse_strips/vello_cpu/src/lib.rs
@@ -6,14 +6,14 @@
 //! It is currently available as an alpha.
 //! See the [Caveats](#caveats) section for things you need to be aware of.
 //!
-//! We also develop [Vello](crates.io/crates/vello), which makes use of the GPU for 2d rendering and has higher performance than Vello CPU..
+//! We also develop [Vello](https://crates.io/crates/vello), which makes use of the GPU for 2D rendering and has higher performance than Vello CPU.
 //! Vello CPU is being developed as part of work to address shortcomings in Vello.
 //!
 //! ## Usage
 //!
 //! To use Vello CPU, you need to:
 //!
-//! - Create a [`RenderContext`][], a 2d drawing context for a fixed-size target area.
+//! - Create a [`RenderContext`][], a 2D drawing context for a fixed-size target area.
 //! - For each object in your scene:
 //!   - Set how the object will be painted, using [`set_paint`][RenderContext::set_paint].
 //!   - Set the shape to be drawn for that object, using methods like [`fill_path`][RenderContext::fill_path],

--- a/sparse_strips/vello_cpu/src/lib.rs
+++ b/sparse_strips/vello_cpu/src/lib.rs
@@ -6,6 +6,9 @@
 //! It is currently available as an alpha.
 //! See the [Caveats](#caveats) section for things you need to be aware of.
 //!
+//! We also develop [Vello](crates.io/crates/vello), which makes use of the GPU for 2d rendering and has higher performance than Vello CPU..
+//! Vello CPU is being developed as part of work to address shortcomings in Vello.
+//!
 //! ## Usage
 //!
 //! To use Vello CPU, you need to:


### PR DESCRIPTION
This moves to updating these READMEs using [`cargo-rdme`](https://crates.io/crates/cargo-rdme), which is the pattern we're using for more and more READMEs.

I'm also planning on updating the badges to prepare for a release.

Nice round PR number today!