### PR TITLE
Fix `vello_sparse_tests` SIGSEGV when using `cargo test`

### DIFF
--- a/sparse_strips/vello_sparse_tests/tests/renderer.rs
+++ b/sparse_strips/vello_sparse_tests/tests/renderer.rs
@@ -223,9 +223,9 @@ impl Renderer for Scene {
         // ensuring only one set of device resources is alive at the same time. This slows down
         // testing when `cargo test` is used.
         //
-        // Testing with `cargo nextest` is not meaningfully slown down. `nextest` runs each test in
-        // its own process (<https://nexte.st/docs/design/why-process-per-test/>), meaning there is
-        // no contention on this mutex.
+        // Testing with `cargo nextest` (as on CI) is not meaningfully slowed down. `nextest` runs
+        // each test in its own process (<https://nexte.st/docs/design/why-process-per-test/>),
+        // meaning there is no contention on this mutex.
         let _guard = {
             use std::sync::Mutex;
             static M: Mutex<()> = Mutex::new(());

--- a/sparse_strips/vello_sparse_tests/tests/renderer.rs
+++ b/sparse_strips/vello_sparse_tests/tests/renderer.rs
@@ -216,6 +216,9 @@ impl Renderer for Scene {
         Self::set_transform(self, transform);
     }
 
+    // This method creates device resources every time it is called. This is fine for testing, but
+    // should not be used as a basis for implementing something real. This would be a very bad
+    // example for that.
     fn render_to_pixmap(&self, pixmap: &mut Pixmap, _: RenderMode) {
         // On some platforms using `cargo test` triggers segmentation faults in wgpu when the GPU
         // tests are run in parallel (likely related to the number of device resources being

--- a/sparse_strips/vello_sparse_tests/tests/renderer.rs
+++ b/sparse_strips/vello_sparse_tests/tests/renderer.rs
@@ -216,9 +216,9 @@ impl Renderer for Scene {
         Self::set_transform(self, transform);
     }
 
-    // This method creates device resources every time it is called. This is fine for testing, but
-    // should not be used as a basis for implementing something real. This would be a very bad
-    // example for that.
+    // This method creates device resources every time it is called. This does not matter much for
+    // testing, but should not be used as a basis for implementing something real. This would be a
+    // very bad example for that.
     fn render_to_pixmap(&self, pixmap: &mut Pixmap, _: RenderMode) {
         // On some platforms using `cargo test` triggers segmentation faults in wgpu when the GPU
         // tests are run in parallel (likely related to the number of device resources being


### PR DESCRIPTION
On some platforms, running the GPU tests in parallel crashes the testing process more often than not. This "fixes" it for `cargo test` and leaves `cargo nextest` mostly unimpacted.

```bash
$ cargo test --package vello_sparse_tests
# ...
error: test failed, to rerun pass `-p vello_sparse_tests --test tests`

Caused by:
  process didn't exit successfully: `[snip]/vello/target/debug/deps/tests-704ef390c4f325bc` (signal: 11, SIGSEGV: invalid memory reference)
```