### PR TITLE
export WGSL shader source code directly from `vello_sparse_shaders`

### DIFF
--- a/sparse_strips/vello_hybrid/Cargo.toml
+++ b/sparse_strips/vello_hybrid/Cargo.toml
@@ -49,5 +49,5 @@ roxmltree = "0.20.0"
 
 [features]
 default = ["wgpu"]
-wgpu = ["dep:wgpu"]
-webgl = ["dep:js-sys", "dep:web-sys", "dep:vello_sparse_shaders"]
+wgpu = ["dep:wgpu", "dep:vello_sparse_shaders"]
+webgl = ["dep:js-sys", "dep:web-sys", "dep:vello_sparse_shaders", "vello_sparse_shaders/glsl"]

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -227,16 +227,12 @@ impl Programs {
 
         let strip_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("Strip Shader"),
-            source: wgpu::ShaderSource::Wgsl(
-                include_str!("../../../vello_sparse_shaders/shaders/render_strips.wgsl").into(),
-            ),
+            source: wgpu::ShaderSource::Wgsl(vello_sparse_shaders::wgsl::RENDER_STRIPS.into()),
         });
 
         let clear_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("Clear Slots Shader"),
-            source: wgpu::ShaderSource::Wgsl(
-                include_str!("../../../vello_sparse_shaders/shaders/clear_slots.wgsl").into(),
-            ),
+            source: wgpu::ShaderSource::Wgsl(vello_sparse_shaders::wgsl::CLEAR_SLOTS.into()),
         });
 
         let strip_pipeline_layout =

--- a/sparse_strips/vello_sparse_shaders/Cargo.toml
+++ b/sparse_strips/vello_sparse_shaders/Cargo.toml
@@ -17,10 +17,13 @@ default-target = "x86_64-unknown-linux-gnu"
 targets = []
 
 [dependencies]
-naga = { version = "24.0.0", features = ["wgsl-in", "glsl-out"] }
+naga = { version = "24.0.0", features = ["wgsl-in", "glsl-out"], optional = true }
 
 [build-dependencies]
-naga = { version = "24.0.0", features = ["wgsl-in", "glsl-out"] }
+naga = { version = "24.0.0", features = ["wgsl-in", "glsl-out"], optional = true }
+
+[features]
+glsl = ["dep:naga"]
 
 [lints]
 workspace = true

--- a/sparse_strips/vello_sparse_shaders/src/lib.rs
+++ b/sparse_strips/vello_sparse_shaders/src/lib.rs
@@ -3,7 +3,9 @@
 
 //! This is a utility library to help integrate `vello_hybrid` WebGPU wgsl shaders into glsl.
 
+#[cfg(feature = "glsl")]
 mod compile;
+#[cfg(feature = "glsl")]
 mod types;
 
 include!(concat!(env!("OUT_DIR"), "/compiled_shaders.rs"));

--- a/sparse_strips/vello_sparse_shaders/src/types.rs
+++ b/sparse_strips/vello_sparse_shaders/src/types.rs
@@ -79,7 +79,7 @@ impl CompiledGlsl {
     pub(crate) fn to_generated_code(&self, shader_name: &str) -> String {
         let mut code = format!("/// Compiled glsl for `{shader_name}.wgsl`\n");
         code.push_str(&format!("pub mod {shader_name} {{\n"));
-        code.push_str(r#"    #![allow(missing_docs, reason="No metadata to generate precise documentation forgenerated code.")]"#);
+        code.push_str(r#"    #![allow(missing_docs, reason="No metadata to generate precise documentation for generated code.")]"#);
         code.push_str("\n\n");
 
         code.push_str("    pub const VERTEX_SOURCE: &str = r###\"");


### PR DESCRIPTION
# Context

Addresses comment https://github.com/linebender/vello/pull/1011#discussion_r2097657320 from @DJMcNab . Replaces `include_str!` with a direct import from `vello_sparse_shaders` to get access to the wgsl source code.

### Changes

 - Adds a `wgsl` module to the build-time module generated by `vello_sparse_shaders`.

This allows `render_strips.wgsl` to be accessed via: `vello_sparse_shaders::wgsl::RENDER_STRIPS` instead of a cross-package `include_str!`.

 - Adds a `glsl` feature flag to `vello_sparse_shaders` so the default compiled module does not include `glsl` unless the `glsl` feature is used. This makes builds much leaner for wgsl without glsl.

### Test plan

Reviewed generated code, and tested both examples manually:
 - `cargo run_wasm -p wgpu_webgl --release --port 8001`
 - `cargo run_wasm -p native_webgl --release --port 8000`

Finally, CI is very thorough.