### PR TITLE
Ignore new `result_large_error` clippy lint

### DIFF
--- a/vello_shaders/src/compile/mod.rs
+++ b/vello_shaders/src/compile/mod.rs
@@ -85,7 +85,7 @@ pub struct ShaderInfo {
 }
 
 impl ShaderInfo {
-    #[allow(clippy::result_large_err, reason = "Large error expected.")]
+    #[expect(clippy::result_large_err, reason = "Deferred: This is a cold code path.")]
     pub fn new(name: &str, source: String, entry_point: &str) -> Result<Self> {
         let module = wgsl::parse_str(&source).map_err(|error| Error::new(&source, name, error))?;
         let module_info = naga::valid::Validator::new(ValidationFlags::all(), Capabilities::all())

--- a/vello_shaders/src/compile/mod.rs
+++ b/vello_shaders/src/compile/mod.rs
@@ -85,7 +85,10 @@ pub struct ShaderInfo {
 }
 
 impl ShaderInfo {
-    #[expect(clippy::result_large_err, reason = "Deferred: This is a cold code path.")]
+    #[expect(
+        clippy::result_large_err,
+        reason = "Deferred: This is a cold code path."
+    )]
     pub fn new(name: &str, source: String, entry_point: &str) -> Result<Self> {
         let module = wgsl::parse_str(&source).map_err(|error| Error::new(&source, name, error))?;
         let module_info = naga::valid::Validator::new(ValidationFlags::all(), Capabilities::all())

--- a/vello_shaders/src/compile/mod.rs
+++ b/vello_shaders/src/compile/mod.rs
@@ -85,7 +85,7 @@ pub struct ShaderInfo {
 }
 
 impl ShaderInfo {
-    #[allow(clippy::result_large_err, reason="Large error expected.")]
+    #[allow(clippy::result_large_err, reason = "Large error expected.")]
     pub fn new(name: &str, source: String, entry_point: &str) -> Result<Self> {
         let module = wgsl::parse_str(&source).map_err(|error| Error::new(&source, name, error))?;
         let module_info = naga::valid::Validator::new(ValidationFlags::all(), Capabilities::all())

--- a/vello_shaders/src/compile/mod.rs
+++ b/vello_shaders/src/compile/mod.rs
@@ -85,6 +85,7 @@ pub struct ShaderInfo {
 }
 
 impl ShaderInfo {
+    #[allow(clippy::result_large_err, reason="Large error expected.")]
     pub fn new(name: &str, source: String, entry_point: &str) -> Result<Self> {
         let module = wgsl::parse_str(&source).map_err(|error| Error::new(&source, name, error))?;
         let module_info = naga::valid::Validator::new(ValidationFlags::all(), Capabilities::all())


### PR DESCRIPTION
### Context

New PRs being opened against Vello are failing CI due to the new [clippy lint `result_large_err`](https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err).

E.g. Blocked PRs:
 - https://github.com/linebender/vello/pull/1020
 - https://github.com/linebender/vello/pull/1012

### Fix

Temporarily silence this clippy lint explicitly. Happy to change the reason to something else or a TODO if that would be preferred and more explicit.

### Test plan

Passing CI.

### Risk

I don't think this should have any impact on end users as this is a clippy attribute addition.