### PR TITLE
Fix wrong issuing of `pop_clip` command

### DIFF
--- a/sparse_strips/vello_common/src/coarse.rs
+++ b/sparse_strips/vello_common/src/coarse.rs
@@ -688,8 +688,9 @@ impl Wide {
 
                 // If fill extends to next tile, pop current and handle next
                 if x2 > (cur_wtile_x + 1) * WideTile::WIDTH {
-                    self.get_mut(cur_wtile_x, cur_wtile_y).pop_clip();
-                    pop_pending = false;
+                    if core::mem::take(&mut pop_pending) {
+                        self.get_mut(cur_wtile_x, cur_wtile_y).pop_clip();
+                    }
 
                     let width2 = x2 % WideTile::WIDTH;
                     cur_wtile_x = x2 / WideTile::WIDTH;

--- a/sparse_strips/vello_sparse_tests/tests/issues.rs
+++ b/sparse_strips/vello_sparse_tests/tests/issues.rs
@@ -250,3 +250,14 @@ fn out_of_viewport_clip(ctx: &mut impl Renderer) {
     ctx.fill_rect(&Rect::new(0.0, 0.0, 100.0, 100.0));
     ctx.pop_layer();
 }
+
+#[vello_test(no_ref, width = 300, height = 4)]
+// https://github.com/linebender/vello/issues/1032
+fn nested_clip_path_panic(ctx: &mut impl Renderer) {
+    let path1 = Rect::new(256.0, 0.0, 257.0, 2.0).to_path(0.1);
+    ctx.push_clip_layer(&path1);
+    let path2 = Rect::new(181.0, -200.0, 760.0, 618.0).to_path(0.1);
+    ctx.push_clip_layer(&path2);
+    ctx.pop_layer();
+    ctx.pop_layer();
+}


### PR DESCRIPTION
The basic problem was that for the wide tile (1, 0), the first clip path would trigger a `push_clip`, but the second one would not (since the strip of the second clip path does not lie on that wide tile). However, we did trigger a `pop_clip` command. This patch seems to fix the issue.

Fixes #1032