### PR TITLE
Fix panic in nested clip paths

### DIFF
--- a/sparse_strips/vello_common/src/coarse.rs
+++ b/sparse_strips/vello_common/src/coarse.rs
@@ -615,7 +615,7 @@ impl Wide {
             let next_strip = &strips[i + 1];
             let strip_width =
                 ((next_strip.alpha_idx - strip.alpha_idx) / u32::from(Tile::HEIGHT)) as u16;
-            let x1 = x0 + strip_width;
+            let mut x1 = x0 + strip_width;
             let wtile_x0 = (x0 / WideTile::WIDTH).max(clip_bbox.x0());
             let wtile_x1 = x1.div_ceil(WideTile::WIDTH).min(clip_bbox.x1());
 
@@ -626,6 +626,7 @@ impl Wide {
             if clip_x > x {
                 col += u32::from(clip_x - x);
                 x = clip_x;
+                x1 = clip_x.max(x1);
             }
 
             // Render clip strips for each affected tile and mark for popping

--- a/sparse_strips/vello_common/src/coarse.rs
+++ b/sparse_strips/vello_common/src/coarse.rs
@@ -688,8 +688,9 @@ impl Wide {
 
                 // If fill extends to next tile, pop current and handle next
                 if x2 > (cur_wtile_x + 1) * WideTile::WIDTH {
-                    self.get_mut(cur_wtile_x, cur_wtile_y).pop_clip();
-                    pop_pending = false;
+                    if core::mem::take(&mut pop_pending) {
+                        self.get_mut(cur_wtile_x, cur_wtile_y).pop_clip();
+                    }
 
                     let width2 = x2 % WideTile::WIDTH;
                     cur_wtile_x = x2 / WideTile::WIDTH;

--- a/sparse_strips/vello_sparse_tests/snapshots/nested_clip_path_panic_2.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/nested_clip_path_panic_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b0ecf76b64dbbc5b5d4e45bacae78062751daab68373b1d22c5d7afc77332f3
+size 96

--- a/sparse_strips/vello_sparse_tests/snapshots/nested_clip_path_panic_2.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/nested_clip_path_panic_2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4b0ecf76b64dbbc5b5d4e45bacae78062751daab68373b1d22c5d7afc77332f3
-size 96
+oid sha256:91df01ad3fae2cb2034fadc75d9f32af6bdbcb7b4631577408191b8913ce0af0
+size 95

--- a/sparse_strips/vello_sparse_tests/tests/issues.rs
+++ b/sparse_strips/vello_sparse_tests/tests/issues.rs
@@ -275,14 +275,3 @@ fn nested_clip_path_panic_2(ctx: &mut impl Renderer) {
     ctx.pop_layer();
     ctx.pop_layer();
 }
-
-#[vello_test(no_ref, width = 300, height = 4)]
-// https://github.com/linebender/vello/issues/1032
-fn nested_clip_path_panic(ctx: &mut impl Renderer) {
-    let path1 = Rect::new(256.0, 0.0, 257.0, 2.0).to_path(0.1);
-    ctx.push_clip_layer(&path1);
-    let path2 = Rect::new(181.0, -200.0, 760.0, 618.0).to_path(0.1);
-    ctx.push_clip_layer(&path2);
-    ctx.pop_layer();
-    ctx.pop_layer();
-}

--- a/sparse_strips/vello_sparse_tests/tests/issues.rs
+++ b/sparse_strips/vello_sparse_tests/tests/issues.rs
@@ -7,6 +7,7 @@ use crate::renderer::Renderer;
 use vello_common::color::palette::css::{DARK_BLUE, LIME, REBECCA_PURPLE};
 use vello_common::kurbo::{BezPath, Rect, Shape, Stroke};
 use vello_common::peniko::Fill;
+use vello_cpu::color::palette::css::RED;
 use vello_dev_macros::vello_test;
 
 #[vello_test(width = 8, height = 8)]
@@ -258,6 +259,19 @@ fn nested_clip_path_panic(ctx: &mut impl Renderer) {
     ctx.push_clip_layer(&path1);
     let path2 = Rect::new(181.0, -200.0, 760.0, 618.0).to_path(0.1);
     ctx.push_clip_layer(&path2);
+    ctx.pop_layer();
+    ctx.pop_layer();
+}
+
+#[vello_test(width = 612, height = 4)]
+// https://github.com/linebender/vello/issues/1034
+fn nested_clip_path_panic_2(ctx: &mut impl Renderer) {
+    let path1 = Rect::new(256.0, 0.0, 280.0, 2.0).to_path(0.1);
+    ctx.push_clip_layer(&path1);
+    let path2 = &Rect::new(0.0, 0.0, 511.0, 4.0).to_path(0.1);
+    ctx.push_clip_layer(&path2);
+    ctx.set_paint(RED);
+    ctx.fill_path(&Rect::new(0.0, 0.0, 511.0, 4.0).to_path(0.1));
     ctx.pop_layer();
     ctx.pop_layer();
 }

--- a/sparse_strips/vello_sparse_tests/tests/issues.rs
+++ b/sparse_strips/vello_sparse_tests/tests/issues.rs
@@ -268,7 +268,7 @@ fn nested_clip_path_panic(ctx: &mut impl Renderer) {
 fn nested_clip_path_panic_2(ctx: &mut impl Renderer) {
     let path1 = Rect::new(256.0, 0.0, 280.0, 2.0).to_path(0.1);
     ctx.push_clip_layer(&path1);
-    let path2 = &Rect::new(0.0, 0.0, 511.0, 4.0).to_path(0.1);
+    let path2 = Rect::new(0.0, 0.0, 511.0, 4.0).to_path(0.1);
     ctx.push_clip_layer(&path2);
     ctx.set_paint(RED);
     ctx.fill_path(&Rect::new(0.0, 0.0, 511.0, 4.0).to_path(0.1));

--- a/sparse_strips/vello_sparse_tests/tests/issues.rs
+++ b/sparse_strips/vello_sparse_tests/tests/issues.rs
@@ -263,7 +263,7 @@ fn nested_clip_path_panic(ctx: &mut impl Renderer) {
     ctx.pop_layer();
 }
 
-#[vello_test(width = 612, height = 4)]
+#[vello_test(width = 512, height = 4)]
 // https://github.com/linebender/vello/issues/1034
 fn nested_clip_path_panic_2(ctx: &mut impl Renderer) {
     let path1 = Rect::new(256.0, 0.0, 280.0, 2.0).to_path(0.1);

--- a/sparse_strips/vello_sparse_tests/tests/issues.rs
+++ b/sparse_strips/vello_sparse_tests/tests/issues.rs
@@ -250,3 +250,14 @@ fn out_of_viewport_clip(ctx: &mut impl Renderer) {
     ctx.fill_rect(&Rect::new(0.0, 0.0, 100.0, 100.0));
     ctx.pop_layer();
 }
+
+#[vello_test(no_ref, width = 300, height = 4)]
+// https://github.com/linebender/vello/issues/1032
+fn nested_clip_path_panic(ctx: &mut impl Renderer) {
+    let path1 = Rect::new(256.0, 0.0, 257.0, 2.0).to_path(0.1);
+    ctx.push_clip_layer(&path1);
+    let path2 = Rect::new(181.0, -200.0, 760.0, 618.0).to_path(0.1);
+    ctx.push_clip_layer(&path2);
+    ctx.pop_layer();
+    ctx.pop_layer();
+}


### PR DESCRIPTION
This is an attempt at fixing #1034, and is based on #1033, which should be merged first. I am not 100% confident that this is the correct solution, so a careful review would be appreciated.

The problem is as follows: The first clip path is a very small rectangle, which means that the clip bbox will only cover the wile (1, 0). The second clip path is much bigger and starts at the wide tile (0, 0).

Because of this, once we pop the second clip path, the assignment
```rs
let mut x1 = x0 + strip_width;
```

will end up yielding 4 (since the second, bigger clip path starts at x = 0, and it's strip will be 4 wide). However, since the second clip path starts outside of the clip bbox,

```rs
let clip_x = clip_bbox.x0() * WideTile::WIDTH;
if clip_x > x {
    col += u32::from(clip_x - x);
    x1 = clip_x.max(x1);
}
```

The `x` value will be adjusted to 256 (since the clip bbox starts at the first wide tile in the x direction), but note that our x1 is still 4! Because of this

```rs
 let x2 = next_strip.x;
let clipped_x2 = x2.min((cur_wtile_x + 1) * WideTile::WIDTH);
let width = clipped_x2.saturating_sub(x1);
```

the width calculated here will be much bigger than 256, and thus lead to a panic.