### PR TITLE
Return GL from WebGLRenderer

### DIFF
--- a/sparse_strips/vello_hybrid/examples/native_webgl/src/lib.rs
+++ b/sparse_strips/vello_hybrid/examples/native_webgl/src/lib.rs
@@ -30,7 +30,7 @@ struct RendererWrapper {
 impl RendererWrapper {
     #[cfg(target_arch = "wasm32")]
     fn new(canvas: web_sys::HtmlCanvasElement) -> Self {
-        let renderer = vello_hybrid::WebGlRenderer::new(&canvas);
+        let (renderer, _) = vello_hybrid::WebGlRenderer::new(&canvas);
 
         Self { renderer }
     }
@@ -380,7 +380,7 @@ pub async fn render_scene(scene: vello_hybrid::Scene, width: u16, height: u16) {
         .append_child(&canvas)
         .unwrap();
 
-    let mut renderer = vello_hybrid::WebGlRenderer::new(&canvas);
+    let (mut renderer, _) = vello_hybrid::WebGlRenderer::new(&canvas);
 
     let render_size = vello_hybrid::RenderSize {
         width: width as u32,

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -56,7 +56,7 @@ pub struct WebGlRenderer {
 
 impl WebGlRenderer {
     /// Creates a new WebGL2 renderer
-    pub fn new(canvas: &web_sys::HtmlCanvasElement) -> Self {
+    pub fn new(canvas: &web_sys::HtmlCanvasElement) -> (Self, web_sys::WebGl2RenderingContext) {
         super::common::maybe_warn_about_webgl_feature_conflict();
 
         // The WebGL context must be created with anti-aliasing disabled such that we can blit the
@@ -81,11 +81,14 @@ impl WebGlRenderer {
         let total_slots: usize =
             (get_max_texture_dimension_2d(&gl) / u32::from(Tile::HEIGHT)) as usize;
 
-        Self {
-            programs: WebGlPrograms::new(gl.clone(), total_slots),
-            scheduler: Scheduler::new(total_slots),
+        (
+            Self {
+                programs: WebGlPrograms::new(gl.clone(), total_slots),
+                scheduler: Scheduler::new(total_slots),
+                gl: gl.clone(),
+            },
             gl,
-        }
+        )
     }
 
     /// Render `scene` using WebGL2

--- a/sparse_strips/vello_sparse_tests/tests/renderer.rs
+++ b/sparse_strips/vello_sparse_tests/tests/renderer.rs
@@ -385,7 +385,7 @@ impl Renderer for Scene {
         canvas.set_width(width.into());
         canvas.set_height(height.into());
 
-        let mut renderer = vello_hybrid::WebGlRenderer::new(&canvas);
+        let (mut renderer, _) = vello_hybrid::WebGlRenderer::new(&canvas);
         let render_size = vello_hybrid::RenderSize {
             width: width.into(),
             height: height.into(),


### PR DESCRIPTION
I don't know how different browsers and their versions handle creating WebGL2 contexts with differing context options (e.g. enabling/disabling `antialias`).

The specification states that the [first call wins](https://arc.net/l/quote/otbncojz): " The WebGLContextAttributes object is only used on the first call to getContext. No facility is provided to change the attributes of the drawing buffer after its creation.".

For this reason, I think we should return the GL context created for the renderer for use by external consumers. 