### PR TITLE
vello_hybrid: use canvas extents for webgl coordinate y-axis flip

### DIFF
--- a/sparse_strips/vello_dev_macros/src/test.rs
+++ b/sparse_strips/vello_dev_macros/src/test.rs
@@ -225,7 +225,7 @@ pub(crate) fn vello_test_inner(attr: TokenStream, item: TokenStream) -> TokenStr
             let mut ctx = get_ctx::<Scene>(#width, #height, #transparent);
             #input_fn_name(&mut ctx);
             if !#no_ref {
-                check_ref(&ctx, #input_fn_name_str, #webgl_fn_name_str, #hybrid_tolerance, false, RenderMode::OptimizeSpeed, #reference_image_name);
+                check_ref(&ctx, "", #webgl_fn_name_str, #hybrid_tolerance, false, RenderMode::OptimizeSpeed, #reference_image_name);
             }
         }
     };

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -134,13 +134,13 @@ impl WebGlRenderer {
 
         self.gl.blit_framebuffer(
             0,
-            render_size.height as i32,
-            render_size.width as i32,
+            self.gl.drawing_buffer_height(),
+            self.gl.drawing_buffer_width(),
             0,
             0,
             0,
-            render_size.width as i32,
-            render_size.height as i32,
+            self.gl.drawing_buffer_width(),
+            self.gl.drawing_buffer_height(),
             WebGl2RenderingContext::COLOR_BUFFER_BIT,
             WebGl2RenderingContext::LINEAR,
         );

--- a/sparse_strips/vello_sparse_tests/snapshots/scene_larger_than_surface.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/scene_larger_than_surface.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c84c102a586cdde6dd01c0ab2ed5ac98e75d6fc69b7b2ffad6860944818c4c0
+size 93

--- a/sparse_strips/vello_sparse_tests/snapshots/scene_smaller_than_surface.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/scene_smaller_than_surface.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57ce9fcc9ac98052af7274e3dfd3ac4a93a33594cd962803d80e886ec3a94804
+size 127

--- a/sparse_strips/vello_sparse_tests/tests/mod.rs
+++ b/sparse_strips/vello_sparse_tests/tests/mod.rs
@@ -36,5 +36,6 @@ mod layer;
 mod mask;
 mod mix;
 mod opacity;
+mod render_size;
 mod renderer;
 mod util;

--- a/sparse_strips/vello_sparse_tests/tests/render_size.rs
+++ b/sparse_strips/vello_sparse_tests/tests/render_size.rs
@@ -1,0 +1,209 @@
+// Copyright 2025 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Tests where the surface dimensions and scene dimensions do not match.
+//!
+//! Note: These tests do not use vello_test proc macro as they test an edge case where the render
+//! surface is a different size than the scene dimensions.
+
+use crate::renderer::Renderer;
+use crate::util::{check_ref_encoded, pixmap_to_png};
+use vello_common::color::palette::css::{LIME, REBECCA_PURPLE};
+use vello_common::kurbo::Rect;
+use vello_common::pixmap::Pixmap;
+use vello_hybrid::Scene;
+
+fn draw_simple_scene(scene: &mut Scene, width: f64, height: f64) {
+    scene.set_paint(LIME.into());
+    // Cover background of scene
+    scene.fill_rect(&Rect::new(0.0, 0.0, width, height));
+
+    scene.set_paint(REBECCA_PURPLE.into());
+    scene.fill_rect(&Rect::new(10., 20., width - 10., height - 20.));
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[test]
+fn scene_smaller_than_surface_hybrid() {
+    let scene_width = 50;
+    let scene_height = 50;
+    let surface_width = 80;
+    let surface_height = 80;
+
+    let mut scene = Scene::new(scene_width, scene_height);
+    draw_simple_scene(&mut scene, scene_width as f64, scene_height as f64);
+
+    let mut pixmap = Pixmap::new(surface_width, surface_height);
+
+    scene.render_to_pixmap(&mut pixmap, vello_cpu::RenderMode::OptimizeSpeed);
+    let encoded_image = pixmap_to_png(pixmap, surface_width as u32, surface_height as u32);
+
+    check_ref_encoded(
+        &encoded_image,
+        "scene_smaller_than_surface",
+        "scene_smaller_than_surface_hybrid",
+        1,
+        false,
+        &[],
+    );
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "webgl"))]
+#[wasm_bindgen_test::wasm_bindgen_test]
+async fn scene_smaller_than_surface_hybrid_webgl() {
+    use wasm_bindgen::JsCast;
+    use web_sys::{HtmlCanvasElement, WebGl2RenderingContext};
+
+    let scene_width = 50;
+    let scene_height = 50;
+    let surface_width = 80;
+    let surface_height = 80;
+
+    let mut scene = Scene::new(scene_width, scene_height);
+    draw_simple_scene(&mut scene, scene_width as f64, scene_height as f64);
+
+    let document = web_sys::window().unwrap().document().unwrap();
+    let canvas = document
+        .create_element("canvas")
+        .unwrap()
+        .dyn_into::<HtmlCanvasElement>()
+        .unwrap();
+
+    canvas.set_width(surface_width as u32);
+    canvas.set_height(surface_height as u32);
+
+    // Render the smaller scene to the larger canvas
+    let mut renderer = vello_hybrid::WebGlRenderer::new(&canvas);
+    let render_size = vello_hybrid::RenderSize {
+        width: scene_width as u32,
+        height: scene_height as u32,
+    };
+
+    renderer.render(&scene, &render_size).unwrap();
+
+    let gl = canvas
+        .get_context("webgl2")
+        .unwrap()
+        .unwrap()
+        .dyn_into::<WebGl2RenderingContext>()
+        .unwrap();
+
+    let mut pixels = vec![0_u8; (surface_width as usize) * (surface_height as usize) * 4];
+    gl.read_pixels_with_opt_u8_array(
+        0,
+        0,
+        surface_width.into(),
+        surface_height.into(),
+        WebGl2RenderingContext::RGBA,
+        WebGl2RenderingContext::UNSIGNED_BYTE,
+        Some(&mut pixels),
+    )
+    .unwrap();
+
+    let mut pixmap = Pixmap::new(surface_width, surface_height);
+    pixmap.data_as_u8_slice_mut().copy_from_slice(&pixels);
+
+    let encoded_image = pixmap_to_png(pixmap, surface_width as u32, surface_height as u32);
+
+    check_ref_encoded(
+        &encoded_image,
+        "",
+        "scene_smaller_than_surface_hybrid_webgl",
+        1,
+        false,
+        include_bytes!("../snapshots/scene_smaller_than_surface.png"),
+    );
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[test]
+fn scene_larger_than_surface_hybrid() {
+    let scene_width = 80;
+    let scene_height = 80;
+    let surface_width = 50;
+    let surface_height = 50;
+
+    let mut scene = Scene::new(scene_width, scene_height);
+    draw_simple_scene(&mut scene, scene_width as f64, scene_height as f64);
+
+    let mut pixmap = Pixmap::new(surface_width, surface_height);
+
+    scene.render_to_pixmap(&mut pixmap, vello_cpu::RenderMode::OptimizeSpeed);
+    let encoded_image = pixmap_to_png(pixmap, surface_width as u32, surface_height as u32);
+
+    check_ref_encoded(
+        &encoded_image,
+        "scene_larger_than_surface",
+        "scene_larger_than_surface_hybrid",
+        1,
+        false,
+        &[],
+    );
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "webgl"))]
+#[wasm_bindgen_test::wasm_bindgen_test]
+async fn scene_larger_than_surface_hybrid_webgl() {
+    use wasm_bindgen::JsCast;
+    use web_sys::{HtmlCanvasElement, WebGl2RenderingContext};
+
+    let scene_width = 80;
+    let scene_height = 80;
+    let surface_width = 50;
+    let surface_height = 50;
+
+    let mut scene = Scene::new(scene_width, scene_height);
+    draw_simple_scene(&mut scene, scene_width as f64, scene_height as f64);
+
+    let document = web_sys::window().unwrap().document().unwrap();
+    let canvas = document
+        .create_element("canvas")
+        .unwrap()
+        .dyn_into::<HtmlCanvasElement>()
+        .unwrap();
+
+    canvas.set_width(surface_width as u32);
+    canvas.set_height(surface_height as u32);
+
+    // Render the larger scene to the smaller canvas
+    let mut renderer = vello_hybrid::WebGlRenderer::new(&canvas);
+    let render_size = vello_hybrid::RenderSize {
+        width: scene_width as u32,
+        height: scene_height as u32,
+    };
+
+    renderer.render(&scene, &render_size).unwrap();
+
+    let gl = canvas
+        .get_context("webgl2")
+        .unwrap()
+        .unwrap()
+        .dyn_into::<WebGl2RenderingContext>()
+        .unwrap();
+
+    let mut pixels = vec![0_u8; (surface_width as usize) * (surface_height as usize) * 4];
+    gl.read_pixels_with_opt_u8_array(
+        0,
+        0,
+        surface_width.into(),
+        surface_height.into(),
+        WebGl2RenderingContext::RGBA,
+        WebGl2RenderingContext::UNSIGNED_BYTE,
+        Some(&mut pixels),
+    )
+    .unwrap();
+
+    let mut pixmap = Pixmap::new(surface_width, surface_height);
+    pixmap.data_as_u8_slice_mut().copy_from_slice(&pixels);
+
+    let encoded_image = pixmap_to_png(pixmap, surface_width as u32, surface_height as u32);
+
+    check_ref_encoded(
+        &encoded_image,
+        "",
+        "scene_larger_than_surface_hybrid_webgl",
+        1,
+        false,
+        include_bytes!("../snapshots/scene_larger_than_surface.png"),
+    );
+}

--- a/sparse_strips/vello_sparse_tests/tests/renderer.rs
+++ b/sparse_strips/vello_sparse_tests/tests/renderer.rs
@@ -236,8 +236,8 @@ impl Renderer for Scene {
             M.lock().unwrap()
         };
 
-        let width = self.width();
-        let height = self.height();
+        let width = pixmap.width();
+        let height = pixmap.height();
 
         // Copied from vello_hybrid/examples/`render_to_file.rs`.
 
@@ -369,8 +369,8 @@ impl Renderer for Scene {
         use wasm_bindgen::JsCast;
         use web_sys::{HtmlCanvasElement, WebGl2RenderingContext};
 
-        let width = self.width();
-        let height = self.height();
+        let width = pixmap.width();
+        let height = pixmap.height();
 
         // Create an offscreen HTMLCanvasElement, render the test image to it, and finally read off
         // the pixmap for diff checking.


### PR DESCRIPTION
### Context

When integrating the WebGL backend internally, @taj-p found a bug with the y-axis coordinate flip.


We were _only_ flipping the height of the scene, when we should be flipping the full canvas height ([as per wgpu's implementation](https://github.com/gfx-rs/wgpu/blob/f139e223e218f3bbe74e84645c3d47d209f7b755/wgpu-hal/src/gles/web.rs#L266-L277)).


### Fix

Use the `drawingBufferWidth` and `drawingBufferHeight` per the first point on https://webgl2fundamentals.org/webgl/lessons/webgl-anti-patterns.html .

### Test plan

No test plan currently – I'm conflicted about how to add a test for this as the `vello_test` macro does not provide a way to decouple surface dimensions and scene dimensions.

Should I add a bespoke hand-rolled test, or extend the `vello_test` macro?