### PR TITLE
Use `min` and `max` instead of `clamp`

### DIFF
--- a/sparse_strips/vello_cpu/src/fine/image.rs
+++ b/sparse_strips/vello_cpu/src/fine/image.rs
@@ -272,7 +272,7 @@ fn extend(val: f32, extend: Extend, max: f32, inv_max: f32) -> f32 {
     match extend {
         // Note that max should be exclusive, so subtract a small bias to enforce that.
         // Otherwise, we might sample out-of-bounds pixels.
-        Extend::Pad => val.clamp(0.0, max - BIAS),
+        Extend::Pad => val.min(max - BIAS).max(0.0),
         Extend::Repeat => val - floor(val * inv_max) * max,
         // <https://github.com/google/skia/blob/220738774f7a0ce4a6c7bd17519a336e5e5dea5b/src/opts/SkRasterPipeline_opts.h#L3274-L3290>
         Extend::Reflect => {


### PR DESCRIPTION
Has a very nice impact on performance:

```
fine/image/transform/none_u8_scalar
                        time:   [420.06 ns 421.11 ns 422.19 ns]
                        change: [-6.1518% -5.8343% -5.5324%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

fine/image/transform/none_f32_scalar
                        time:   [550.21 ns 551.17 ns 552.26 ns]
                        change: [-11.889% -11.423% -10.971%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
```

I think the reason is that `clamp` as additional handling for `NaN`, but we don't need this.