### PR TITLE
Lift image extend calculation out of the hot loop for the simple case

### DIFF
--- a/sparse_strips/vello_cpu/src/fine/image.rs
+++ b/sparse_strips/vello_cpu/src/fine/image.rs
@@ -83,7 +83,7 @@ impl<'a> ImageFiller<'a> {
                     self.height_inv,
                 );
             }
-            
+
             match self.image.extends.0 {
                 peniko::Extend::Pad => self.run_simple::<F, Pad>(target, &y_positions),
                 peniko::Extend::Repeat => self.run_simple::<F, Repeat>(target, &y_positions),


### PR DESCRIPTION
Based on top of #1041. This PR lifts the check for the image extend out of the loop, which (as shown by the benchmarks) seems to take up a significant chunk of time for the `Pad` case. Since the code is relatively short, I don't think there are any concers about having this method be generic. 

For bilinear/bicubic filtering, this is not worth having because it would bloat the code size and will not be the bottleneck.

Those are the benchmark results I'm getting for the `Pad` case now (compared to #1041):
```
fine/image/transform/none_u8_scalar
                        time:   [326.32 ns 326.70 ns 327.11 ns]
                        change: [-25.214% -25.074% -24.931%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low severe
  2 (2.00%) low mild
  3 (3.00%) high mild
  4 (4.00%) high severe

fine/image/transform/scale_u8_scalar
                        time:   [343.22 ns 343.56 ns 343.91 ns]
                        change: [-24.942% -24.780% -24.619%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 22 outliers among 100 measurements (22.00%)
  4 (4.00%) low severe
  4 (4.00%) low mild
  3 (3.00%) high mild
  11 (11.00%) high severe

fine/image/transform/rotate_u8_scalar
                        time:   [2.4611 µs 2.4640 µs 2.4673 µs]
                        change: [-0.4451% -0.1810% +0.0581%] (p = 0.16 > 0.05)
                        No change in performance detected.
Found 13 outliers among 100 measurements (13.00%)
  4 (4.00%) low severe
  3 (3.00%) low mild
  5 (5.00%) high mild
  1 (1.00%) high severe

fine/image/extend/pad_u8_scalar
                        time:   [347.47 ns 348.00 ns 348.58 ns]
                        change: [-27.252% -26.488% -25.857%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low severe
  2 (2.00%) low mild
  6 (6.00%) high mild
  2 (2.00%) high severe
```