### PR TITLE
Add support for multi-threaded fine rasterization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   # This should be limited to packages that are intended for publishing.
   RUST_NO_STD_PKGS: "-p vello_api -p vello_common -p vello_cpu"
   # List of features that depend on the standard library and will be excluded from no_std checks.
-  FEATURES_DEPENDING_ON_STD: "std,default,png,pico_svg"
+  FEATURES_DEPENDING_ON_STD: "std,default,png,pico_svg,multithreading"
   # List of packages that can not target Wasm.
   # `vello_tests` uses `nv-flip`, which doesn't support Wasm.
   NO_WASM_PKGS: "--exclude vello_tests"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3213,6 +3213,8 @@ name = "vello_cpu"
 version = "0.0.1"
 dependencies = [
  "libm",
+ "rayon",
+ "thread_local",
  "vello_common",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,8 @@ static_assertions = "1.1.0"
 thiserror = "2.0.12"
 oxipng = { version = "9.1.5", default-features = false }
 png = "0.17.16"
+rayon = { version = "1.10.0" }
+thread_local = "1.1.8"
 
 # The below crates are experimental!
 vello_api = { path = "sparse_strips/vello_api", default-features = false }

--- a/sparse_strips/vello_bench/Cargo.toml
+++ b/sparse_strips/vello_bench/Cargo.toml
@@ -18,6 +18,12 @@ rand = { workspace = true }
 smallvec = { workspace = true }
 usvg = { workspace = true }
 
+[features]
+# We need this because the `pack` benchmark cannot be run with multithreading enabled, but
+# `cargo nextest` in CI will attempt to do so. So we disable the benchmark when that feature
+# is enabled.
+multithreading = ["vello_cpu/multithreading"]
+
 [[bench]]
 name = "main"
 harness = false

--- a/sparse_strips/vello_bench/benches/main.rs
+++ b/sparse_strips/vello_bench/benches/main.rs
@@ -8,7 +8,6 @@ use vello_bench::{fine, strip, tile};
 
 criterion_group!(fine_solid, fine::fill);
 criterion_group!(fine_strip, fine::strip);
-#[cfg(not(feature = "multithreading"))]
 criterion_group!(fine_pack, fine::pack);
 criterion_group!(fine_gradient, fine::gradient);
 criterion_group!(fine_rounded_blurred_rect, fine::rounded_blurred_rect);

--- a/sparse_strips/vello_bench/benches/main.rs
+++ b/sparse_strips/vello_bench/benches/main.rs
@@ -8,6 +8,7 @@ use vello_bench::{fine, strip, tile};
 
 criterion_group!(fine_solid, fine::fill);
 criterion_group!(fine_strip, fine::strip);
+#[cfg(not(feature = "multithreading"))]
 criterion_group!(fine_pack, fine::pack);
 criterion_group!(fine_gradient, fine::gradient);
 criterion_group!(fine_rounded_blurred_rect, fine::rounded_blurred_rect);

--- a/sparse_strips/vello_bench/src/fine/mod.rs
+++ b/sparse_strips/vello_bench/src/fine/mod.rs
@@ -18,15 +18,21 @@ pub use gradient::*;
 pub use image::*;
 pub use rounded_blurred_rect::*;
 pub use strip::*;
+use vello_common::coarse::WideTile;
 use vello_common::peniko::{BlendMode, Compose, Mix};
+use vello_common::tile::Tile;
+use vello_cpu::region::Regions;
 
 #[vello_bench]
 pub fn pack<F: FineType>(b: &mut Bencher<'_>, fine: &mut Fine<F>) {
     let mut buf = vec![0; SCRATCH_BUF_SIZE];
+    let mut regions = Regions::new(WideTile::WIDTH, Tile::HEIGHT, &mut buf);
 
-    b.iter(|| {
-        fine.pack(&mut buf);
-        std::hint::black_box(&buf);
+    regions.update_regions(|r| {
+        b.iter(|| {
+            fine.pack(r);
+            std::hint::black_box(&r);
+        });
     });
 }
 

--- a/sparse_strips/vello_bench/src/fine/mod.rs
+++ b/sparse_strips/vello_bench/src/fine/mod.rs
@@ -7,35 +7,22 @@ mod gradient;
 mod image;
 mod rounded_blurred_rect;
 mod strip;
-
-use criterion::Bencher;
-use vello_cpu::fine::{Fine, FineType, SCRATCH_BUF_SIZE};
-use vello_dev_macros::vello_bench;
+// CI will attempt to build this crate with all features enabled, but the problem
+// is that the `update_regions` function has a slightly different signature with multithreading
+// enabled, which makes it incompatible with the `Bencher` closure. Because of this, we add
+// this feature to `vello_bench` as well and disable the benchmark in case it's enabled.
+#[cfg(not(feature = "multithreading"))]
+mod pack;
 
 pub use blend::*;
 pub use fill::*;
 pub use gradient::*;
 pub use image::*;
+#[cfg(not(feature = "multithreading"))]
+pub use pack::*;
 pub use rounded_blurred_rect::*;
 pub use strip::*;
-use vello_common::coarse::WideTile;
 use vello_common::peniko::{BlendMode, Compose, Mix};
-use vello_common::tile::Tile;
-use vello_cpu::region::Regions;
-
-#[cfg(not(feature = "multithreading"))]
-#[vello_bench]
-pub fn pack<F: FineType>(b: &mut Bencher<'_>, fine: &mut Fine<F>) {
-    let mut buf = vec![0; SCRATCH_BUF_SIZE];
-    let mut regions = Regions::new(WideTile::WIDTH, Tile::HEIGHT, &mut buf);
-
-    b.iter(|| {
-        regions.update_regions(|r| {
-            fine.pack(r);
-            std::hint::black_box(&r);
-        });
-    });
-}
 
 pub(crate) fn default_blend() -> BlendMode {
     BlendMode::new(Mix::Normal, Compose::SrcOver)

--- a/sparse_strips/vello_bench/src/fine/mod.rs
+++ b/sparse_strips/vello_bench/src/fine/mod.rs
@@ -23,13 +23,14 @@ use vello_common::peniko::{BlendMode, Compose, Mix};
 use vello_common::tile::Tile;
 use vello_cpu::region::Regions;
 
+#[cfg(not(feature = "multithreading"))]
 #[vello_bench]
 pub fn pack<F: FineType>(b: &mut Bencher<'_>, fine: &mut Fine<F>) {
     let mut buf = vec![0; SCRATCH_BUF_SIZE];
     let mut regions = Regions::new(WideTile::WIDTH, Tile::HEIGHT, &mut buf);
 
-    regions.update_regions(|r| {
-        b.iter(|| {
+    b.iter(|| {
+        regions.update_regions(|r| {
             fine.pack(r);
             std::hint::black_box(&r);
         });

--- a/sparse_strips/vello_bench/src/fine/mod.rs
+++ b/sparse_strips/vello_bench/src/fine/mod.rs
@@ -11,14 +11,12 @@ mod strip;
 // is that the `update_regions` function has a slightly different signature with multithreading
 // enabled, which makes it incompatible with the `Bencher` closure. Because of this, we add
 // this feature to `vello_bench` as well and disable the benchmark in case it's enabled.
-#[cfg(not(feature = "multithreading"))]
 mod pack;
 
 pub use blend::*;
 pub use fill::*;
 pub use gradient::*;
 pub use image::*;
-#[cfg(not(feature = "multithreading"))]
 pub use pack::*;
 pub use rounded_blurred_rect::*;
 pub use strip::*;

--- a/sparse_strips/vello_bench/src/fine/pack.rs
+++ b/sparse_strips/vello_bench/src/fine/pack.rs
@@ -1,13 +1,21 @@
 // Copyright 2025 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+// See the comment in `Cargo.toml` for why we have those feature gates.
+
 use criterion::Bencher;
+#[cfg(not(feature = "multithreading"))]
 use vello_common::coarse::WideTile;
+#[cfg(not(feature = "multithreading"))]
 use vello_common::tile::Tile;
-use vello_cpu::fine::{Fine, FineType, SCRATCH_BUF_SIZE};
+#[cfg(not(feature = "multithreading"))]
+use vello_cpu::fine::SCRATCH_BUF_SIZE;
+use vello_cpu::fine::{Fine, FineType};
+#[cfg(not(feature = "multithreading"))]
 use vello_cpu::region::Regions;
 use vello_dev_macros::vello_bench;
 
+#[cfg(not(feature = "multithreading"))]
 #[vello_bench]
 pub fn pack<F: FineType>(b: &mut Bencher<'_>, fine: &mut Fine<F>) {
     let mut buf = vec![0; SCRATCH_BUF_SIZE];
@@ -19,4 +27,10 @@ pub fn pack<F: FineType>(b: &mut Bencher<'_>, fine: &mut Fine<F>) {
             std::hint::black_box(&r);
         });
     });
+}
+
+#[cfg(feature = "multithreading")]
+#[vello_bench]
+pub fn pack<F: FineType>(_: &mut Bencher<'_>, _: &mut Fine<F>) {
+    unimplemented!()
 }

--- a/sparse_strips/vello_bench/src/fine/pack.rs
+++ b/sparse_strips/vello_bench/src/fine/pack.rs
@@ -1,3 +1,6 @@
+// Copyright 2025 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use criterion::Bencher;
 use vello_common::coarse::WideTile;
 use vello_common::tile::Tile;

--- a/sparse_strips/vello_bench/src/fine/pack.rs
+++ b/sparse_strips/vello_bench/src/fine/pack.rs
@@ -1,0 +1,19 @@
+use criterion::Bencher;
+use vello_common::coarse::WideTile;
+use vello_common::tile::Tile;
+use vello_cpu::fine::{Fine, FineType, SCRATCH_BUF_SIZE};
+use vello_cpu::region::Regions;
+use vello_dev_macros::vello_bench;
+
+#[vello_bench]
+pub fn pack<F: FineType>(b: &mut Bencher<'_>, fine: &mut Fine<F>) {
+    let mut buf = vec![0; SCRATCH_BUF_SIZE];
+    let mut regions = Regions::new(WideTile::WIDTH, Tile::HEIGHT, &mut buf);
+
+    b.iter(|| {
+        regions.update_regions(|r| {
+            fine.pack(r);
+            std::hint::black_box(&r);
+        });
+    });
+}

--- a/sparse_strips/vello_cpu/Cargo.toml
+++ b/sparse_strips/vello_cpu/Cargo.toml
@@ -19,6 +19,9 @@ targets = []
 [dependencies]
 libm = { version = "0.2.15", optional = true }
 vello_common = { workspace = true }
+rayon = { workspace = true, optional = true }
+thread_local = { workspace = true, optional = true }
+
 
 [features]
 default = ["std", "png"]
@@ -28,6 +31,7 @@ std = ["vello_common/std"]
 libm = ["vello_common/libm", "dep:libm"]
 # Allow loading Pixmap from PNG, and drawing png glyphs.
 png = ["vello_common/png"]
+multithreading = ["std", "dep:rayon", "dep:thread_local"]
 
 [lints]
 workspace = true

--- a/sparse_strips/vello_cpu/src/fine/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/mod.rs
@@ -91,13 +91,13 @@ impl<F: FineType> Fine<F> {
     pub fn pack(&mut self, region: &mut Region<'_>) {
         let blend_buf = self.blend_buf.last().unwrap();
 
-        for y in 0..Tile::HEIGHT as usize {
+        for y in 0..Tile::HEIGHT {
             for (x, pixel) in region
                 .row_mut(y)
                 .chunks_exact_mut(COLOR_COMPONENTS)
                 .enumerate()
             {
-                let idx = COLOR_COMPONENTS * (Tile::HEIGHT as usize * x + y);
+                let idx = COLOR_COMPONENTS * (usize::from(Tile::HEIGHT) * x + usize::from(y));
                 pixel.copy_from_slice(&F::to_rgba8(&blend_buf[idx..][..COLOR_COMPONENTS]));
             }
         }

--- a/sparse_strips/vello_cpu/src/fine/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/mod.rs
@@ -47,6 +47,12 @@ pub struct Fine<F: FineType> {
     pub(crate) color_buf: ScratchBuf<F>,
 }
 
+impl<F: FineType> Default for Fine<F> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<F: FineType> Fine<F> {
     /// Create a new fine rasterizer.
     pub fn new() -> Self {

--- a/sparse_strips/vello_cpu/src/fine/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/mod.rs
@@ -12,6 +12,7 @@ mod rounded_blurred_rect;
 use crate::fine::gradient::GradientFiller;
 use crate::fine::image::ImageFiller;
 use crate::fine::rounded_blurred_rect::BlurredRoundedRectFiller;
+use crate::region::Region;
 use crate::util::scalar::div_255;
 use alloc::vec;
 use alloc::vec::Vec;
@@ -41,8 +42,6 @@ pub type FineF32 = ScratchBuf<f32>;
 #[doc(hidden)]
 /// This is an internal struct, do not access directly.
 pub struct Fine<F: FineType> {
-    pub(crate) width: u16,
-    pub(crate) height: u16,
     pub(crate) wide_coords: (u16, u16),
     pub(crate) blend_buf: Vec<ScratchBuf<F>>,
     pub(crate) color_buf: ScratchBuf<F>,
@@ -50,13 +49,11 @@ pub struct Fine<F: FineType> {
 
 impl<F: FineType> Fine<F> {
     /// Create a new fine rasterizer.
-    pub fn new(width: u16, height: u16) -> Self {
+    pub fn new() -> Self {
         let blend_buf = [F::ZERO; SCRATCH_BUF_SIZE];
         let color_buf = [F::ZERO; SCRATCH_BUF_SIZE];
 
         Self {
-            width,
-            height,
             wide_coords: (0, 0),
             blend_buf: vec![blend_buf],
             color_buf,
@@ -85,17 +82,19 @@ impl<F: FineType> Fine<F> {
     }
 
     #[doc(hidden)]
-    pub fn pack(&mut self, out_buf: &mut [u8]) {
-        let blend_buf = self.blend_buf.last_mut().unwrap();
+    pub fn pack(&mut self, region: &mut Region<'_>) {
+        let blend_buf = self.blend_buf.last().unwrap();
 
-        pack(
-            out_buf,
-            blend_buf,
-            self.width.into(),
-            self.height.into(),
-            self.wide_coords.0.into(),
-            self.wide_coords.1.into(),
-        );
+        for y in 0..Tile::HEIGHT as usize {
+            for (x, pixel) in region
+                .row_mut(y)
+                .chunks_exact_mut(COLOR_COMPONENTS)
+                .enumerate()
+            {
+                let idx = COLOR_COMPONENTS * (Tile::HEIGHT as usize * x + y);
+                pixel.copy_from_slice(&F::to_rgba8(&blend_buf[idx..][..COLOR_COMPONENTS]));
+            }
+        }
     }
 
     pub(crate) fn run_cmd(&mut self, cmd: &Cmd, alphas: &[u8], paints: &[EncodedPaint]) {
@@ -417,39 +416,6 @@ impl<F: FineType> Fine<F> {
     }
 }
 
-fn pack<F: FineType>(
-    out_buf: &mut [u8],
-    scratch: &ScratchBuf<F>,
-    width: usize,
-    height: usize,
-    x: usize,
-    y: usize,
-) {
-    let base_ix = (y * usize::from(Tile::HEIGHT) * width + x * usize::from(WideTile::WIDTH))
-        * COLOR_COMPONENTS;
-
-    // Make sure we don't process rows outside the range of the pixmap.
-    let max_height = (height - y * usize::from(Tile::HEIGHT)).min(usize::from(Tile::HEIGHT));
-
-    for j in 0..max_height {
-        let line_ix = base_ix + j * width * COLOR_COMPONENTS;
-
-        // Make sure we don't process columns outside the range of the pixmap.
-        let max_width =
-            (width - x * usize::from(WideTile::WIDTH)).min(usize::from(WideTile::WIDTH));
-        let target_len = max_width * COLOR_COMPONENTS;
-        // This helps the compiler to understand that any access to `dest` cannot
-        // be out of bounds, and thus saves corresponding checks in the for loop.
-        let dest = &mut out_buf[line_ix..][..target_len];
-
-        for i in 0..max_width {
-            let src = &scratch[(i * usize::from(Tile::HEIGHT) + j) * COLOR_COMPONENTS..]
-                [..COLOR_COMPONENTS];
-            dest[i * COLOR_COMPONENTS..][..COLOR_COMPONENTS].copy_from_slice(&F::to_rgba8(src));
-        }
-    }
-}
-
 pub(crate) mod fill {
     // See https://www.w3.org/TR/compositing-1/#porterduffcompositingoperators for the
     // formulas.
@@ -649,6 +615,8 @@ pub trait FineType:
     + Mul<Self, Output = Self>
     + Sub<Self, Output = Self>
     + Debug
+    + Send
+    + Sync
 {
     type Widened: Widened<Self>;
 

--- a/sparse_strips/vello_cpu/src/lib.rs
+++ b/sparse_strips/vello_cpu/src/lib.rs
@@ -113,6 +113,8 @@ mod render;
 #[doc(hidden)]
 /// This is an internal module, do not access directly.
 pub mod fine;
+#[doc(hidden)]
+pub mod region;
 mod util;
 
 pub use render::RenderContext;

--- a/sparse_strips/vello_cpu/src/region.rs
+++ b/sparse_strips/vello_cpu/src/region.rs
@@ -51,7 +51,11 @@ impl<'a> Regions<'a> {
                     next_lines[h] = tail;
                 }
 
-                regions.push(Region::new(areas, x, y));
+                regions.push(Region::new(
+                    areas,
+                    u16::try_from(x).unwrap(),
+                    u16::try_from(y).unwrap(),
+                ));
             }
         }
 
@@ -73,25 +77,25 @@ impl<'a> Regions<'a> {
 }
 
 /// A rectangular region containing the pixels from one wide tile.
-/// 
+///
 /// For wide tiles at the right/bottom edge, it might contain less pixels
 /// than the actual wide tile, if the pixmap width/height isn't a multiple of the
 /// tile width/height.
 #[derive(Default, Debug)]
 pub struct Region<'a> {
     /// The x coordinate of the wide tile this region covers.
-    pub(crate) x: usize,
+    pub(crate) x: u16,
     /// The y coordinate of the wide tile this region covers.
-    pub(crate) y: usize,
+    pub(crate) y: u16,
     areas: [&'a mut [u8]; Tile::HEIGHT as usize],
 }
 
 impl<'a> Region<'a> {
-    pub(crate) fn new(areas: [&'a mut [u8]; Tile::HEIGHT as usize], x: usize, y: usize) -> Self {
+    pub(crate) fn new(areas: [&'a mut [u8]; Tile::HEIGHT as usize], x: u16, y: u16) -> Self {
         Self { areas, x, y }
     }
 
-    pub(crate) fn row_mut(&mut self, y: usize) -> &mut [u8] {
-        self.areas[y]
+    pub(crate) fn row_mut(&mut self, y: u16) -> &mut [u8] {
+        self.areas[usize::from(y)]
     }
 }

--- a/sparse_strips/vello_cpu/src/region.rs
+++ b/sparse_strips/vello_cpu/src/region.rs
@@ -1,3 +1,6 @@
+// Copyright 2025 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! Splitting a single mutable buffer into regions that can be accessed concurrently.
 
 use crate::fine::COLOR_COMPONENTS;

--- a/sparse_strips/vello_cpu/src/region.rs
+++ b/sparse_strips/vello_cpu/src/region.rs
@@ -1,0 +1,90 @@
+//! Splitting a single mutable buffer into regions that can be accessed concurrently.
+
+use crate::fine::COLOR_COMPONENTS;
+use alloc::vec::Vec;
+use vello_common::coarse::WideTile;
+use vello_common::tile::Tile;
+
+#[derive(Debug)]
+pub struct Regions<'a> {
+    regions: Vec<Region<'a>>,
+}
+
+impl<'a> Regions<'a> {
+    pub fn new(width: u16, height: u16, mut buffer: &'a mut [u8]) -> Self {
+        let buf_width = usize::from(width);
+        let buf_height = usize::from(height);
+
+        let row_advance = buf_width * COLOR_COMPONENTS;
+
+        let height_regions = buf_height.div_ceil(usize::from(Tile::HEIGHT));
+        let width_regions = buf_width.div_ceil(usize::from(WideTile::WIDTH));
+
+        let mut regions = Vec::with_capacity(height_regions * width_regions);
+
+        let mut next_lines: [&'a mut [u8]; Tile::HEIGHT as usize] =
+            [&mut [], &mut [], &mut [], &mut []];
+
+        for y in 0..height_regions {
+            let base_y = y * usize::from(Tile::HEIGHT);
+            let region_height = usize::from(Tile::HEIGHT).min(buf_height - base_y);
+
+            for line in next_lines.iter_mut().take(region_height) {
+                let (head, tail) = buffer.split_at_mut(row_advance);
+                *line = head;
+                buffer = tail;
+            }
+
+            for x in 0..width_regions {
+                let mut areas: [&mut [u8]; Tile::HEIGHT as usize] =
+                    [&mut [], &mut [], &mut [], &mut []];
+
+                for h in 0..region_height {
+                    let region_width =
+                        (usize::from(WideTile::WIDTH) * COLOR_COMPONENTS).min(next_lines[h].len());
+                    let next = core::mem::take(&mut next_lines[h]);
+                    let (head, tail) = next.split_at_mut(region_width);
+                    areas[h] = head;
+                    next_lines[h] = tail;
+                }
+
+                regions.push(Region::new(areas, x, y));
+            }
+        }
+
+        Self { regions }
+    }
+
+    #[cfg(feature = "multithreading")]
+    pub fn update_regions(&mut self, func: impl Fn(&mut Region<'_>) + Send + Sync) {
+        use rayon::iter::ParallelIterator;
+        use rayon::prelude::IntoParallelRefMutIterator;
+
+        self.regions.par_iter_mut().for_each(|e| func(e));
+    }
+
+    #[cfg(not(feature = "multithreading"))]
+    pub fn update_regions(&mut self, func: impl FnMut(&mut Region<'_>)) {
+        self.regions.iter_mut().for_each(func);
+    }
+}
+
+/// A region that covers the pixel that fall into a specific wide tile.
+#[derive(Default, Debug)]
+pub struct Region<'a> {
+    /// The x coordinate of the wide tile this region covers.
+    pub(crate) x: usize,
+    /// The y coordinate of the wide tile this region covers.
+    pub(crate) y: usize,
+    areas: [&'a mut [u8]; Tile::HEIGHT as usize],
+}
+
+impl<'a> Region<'a> {
+    pub(crate) fn new(areas: [&'a mut [u8]; Tile::HEIGHT as usize], x: usize, y: usize) -> Self {
+        Self { areas, x, y }
+    }
+
+    pub(crate) fn row_mut(&mut self, y: usize) -> &mut [u8] {
+        self.areas[y]
+    }
+}

--- a/sparse_strips/vello_cpu/src/region.rs
+++ b/sparse_strips/vello_cpu/src/region.rs
@@ -63,7 +63,7 @@ impl<'a> Regions<'a> {
         use rayon::iter::ParallelIterator;
         use rayon::prelude::IntoParallelRefMutIterator;
 
-        self.regions.par_iter_mut().for_each(|e| func(e));
+        self.regions.par_iter_mut().for_each(func);
     }
 
     #[cfg(not(feature = "multithreading"))]

--- a/sparse_strips/vello_cpu/src/region.rs
+++ b/sparse_strips/vello_cpu/src/region.rs
@@ -72,7 +72,11 @@ impl<'a> Regions<'a> {
     }
 }
 
-/// A region that covers the pixel that fall into a specific wide tile.
+/// A rectangular region containing the pixels from one wide tile.
+/// 
+/// For wide tiles at the right/bottom edge, it might contain less pixels
+/// than the actual wide tile, if the pixmap width/height isn't a multiple of the
+/// tile width/height.
 #[derive(Default, Debug)]
 pub struct Region<'a> {
     /// The x coordinate of the wide tile this region covers.

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -340,8 +340,8 @@ impl RenderContext {
                     .get_or(|| core::cell::RefCell::new(Fine::new()))
                     .borrow_mut();
 
-                let wtile = self.wide.get(x as u16, y as u16);
-                fine.set_coords(x as u16, y as u16);
+                let wtile = self.wide.get(x, y);
+                fine.set_coords(x, y);
 
                 fine.clear(F::extract_color(&wtile.bg));
                 for cmd in &wtile.cmds {

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -354,9 +354,9 @@ impl RenderContext {
 
         #[cfg(feature = "multithreading")]
         if let Some(pool) = &self.thread_pool {
-            pool.install(|| render())
+            pool.install(|| render());
         } else {
-            render()
+            render();
         }
 
         #[cfg(not(feature = "multithreading"))]

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -354,7 +354,7 @@ impl RenderContext {
 
         #[cfg(feature = "multithreading")]
         if let Some(pool) = &self.thread_pool {
-            pool.install(|| render());
+            pool.install(&mut render);
         } else {
             render();
         }

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -5,6 +5,7 @@
 
 use crate::RenderMode;
 use crate::fine::{Fine, FineType};
+use crate::region::Regions;
 use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
@@ -43,6 +44,8 @@ pub struct RenderContext {
     pub(crate) transform: Affine,
     pub(crate) fill_rule: Fill,
     pub(crate) encoded_paints: Vec<EncodedPaint>,
+    #[cfg(feature = "multithreading")]
+    pub(crate) thread_pool: Option<rayon::ThreadPool>,
 }
 
 impl RenderContext {
@@ -82,6 +85,8 @@ impl RenderContext {
             fill_rule,
             stroke,
             encoded_paints,
+            #[cfg(feature = "multithreading")]
+            thread_pool: None,
         }
     }
 
@@ -107,6 +112,14 @@ impl RenderContext {
         flatten::fill(path, self.transform, &mut self.line_buf);
         let paint = self.encode_current_paint();
         self.render_path(self.fill_rule, paint);
+    }
+
+    /// Set the thread pool that should be used for multi-threaded rendering.
+    ///
+    /// If not set, the global rayon thread pool will be used instead.
+    #[cfg(feature = "multithreading")]
+    pub fn set_thread_pool(&mut self, pool: rayon::ThreadPool) {
+        self.thread_pool = Some(pool);
     }
 
     /// Stroke a path.
@@ -299,31 +312,55 @@ impl RenderContext {
 
         match render_mode {
             RenderMode::OptimizeSpeed => {
-                let mut fine = Fine::<u8>::new(width, height);
-                self.do_fine(buffer, &mut fine);
+                self.do_fine::<u8>(buffer);
             }
             RenderMode::OptimizeQuality => {
-                let mut fine = Fine::<f32>::new(width, height);
-                self.do_fine(buffer, &mut fine);
+                self.do_fine::<f32>(buffer);
             }
         }
     }
 
-    fn do_fine<F: FineType>(&self, buffer: &mut [u8], fine: &mut Fine<F>) {
-        let width_tiles = self.wide.width_tiles();
-        let height_tiles = self.wide.height_tiles();
-        for y in 0..height_tiles {
-            for x in 0..width_tiles {
-                let wtile = self.wide.get(x, y);
-                fine.set_coords(x, y);
+    fn do_fine<F: FineType>(&self, buffer: &mut [u8]) {
+        let width = self.width;
+        let height = self.height;
+        let mut buffer = Regions::new(width, height, buffer);
+
+        #[cfg(feature = "multithreading")]
+        let fines = thread_local::ThreadLocal::new();
+        #[cfg(not(feature = "multithreading"))]
+        let mut fine = Fine::new();
+
+        let mut render = || {
+            buffer.update_regions(|region| {
+                let x = region.x;
+                let y = region.y;
+
+                #[cfg(feature = "multithreading")]
+                let mut fine = fines
+                    .get_or(|| core::cell::RefCell::new(Fine::new()))
+                    .borrow_mut();
+
+                let wtile = self.wide.get(x as u16, y as u16);
+                fine.set_coords(x as u16, y as u16);
 
                 fine.clear(F::extract_color(&wtile.bg));
                 for cmd in &wtile.cmds {
                     fine.run_cmd(cmd, &self.alphas, &self.encoded_paints);
                 }
-                fine.pack(buffer);
-            }
+
+                fine.pack(region);
+            });
+        };
+
+        #[cfg(feature = "multithreading")]
+        if let Some(pool) = &self.thread_pool {
+            pool.install(|| render())
+        } else {
+            render()
         }
+
+        #[cfg(not(feature = "multithreading"))]
+        render();
     }
 
     /// Render the current context into a pixmap.

--- a/sparse_strips/vello_dev_macros/src/bench.rs
+++ b/sparse_strips/vello_dev_macros/src/bench.rs
@@ -36,12 +36,12 @@ pub(crate) fn vello_bench_inner(_: TokenStream, item: TokenStream) -> TokenStrea
             }
 
             c.bench_function(&get_bench_name(&#input_fn_name_str, "u8_scalar"), |b| {
-                let mut fine = Fine::<u8>::new(WideTile::WIDTH, Tile::HEIGHT);
+                let mut fine = Fine::<u8>::new();
                 #inner_fn_name(b, &mut fine);
             });
 
             c.bench_function(&get_bench_name(&#input_fn_name_str, "f32_scalar"), |b| {
-                let mut fine = Fine::<f32>::new(WideTile::WIDTH, Tile::HEIGHT);
+                let mut fine = Fine::<f32>::new();
                 #inner_fn_name(b, &mut fine);
             });
         }


### PR DESCRIPTION
This PR adds support for multi-threaded fine rasterization for `vello_cpu`. See here for a small demo, as you can see, we get near-linear speedup for large scenes where fine rasterization is the main bottleneck (note the frame count in the top right):

https://github.com/user-attachments/assets/bc1daab3-f1cf-48a7-b1bb-0c59cfd135e5

I also wanted to make sure that there is no significant performance impact from doing the splitting up into regions. Because of this, I rendered two simple scenes (with just a single rect) multiple times and then compared the timings:

10000 iterations to 600x600:

Before: 1.106366416s
After: 1.16696825s

1000 iterations to 3840x2160:

Before: 2.161953042s
After: 2.226217167s

So while there is a small slowdown, I don't think it's enough to justify creating a separate path for the single thread case. It's also a bit hard to test this automatically since it's based on feature flags, but I ran the tests manually and the diverging code is small enough that I think it should be manageable, at least for now. If making strip-rendering multi-threaded turns out to be more complicated perhaps we have to figure something out, though.