### PR TITLE
Refactor `vello::util`

### DIFF
--- a/examples/headless/src/main.rs
+++ b/examples/headless/src/main.rs
@@ -90,10 +90,10 @@ fn main() -> Result<()> {
 async fn render(mut scenes: SceneSet, index: usize, args: &Args) -> Result<()> {
     let mut context = RenderContext::new();
     let device_id = context
-        .device(None)
+        .find_or_create_device(None)
         .await
         .ok_or_else(|| anyhow!("No compatible device found"))?;
-    let device_handle = &mut context.devices[device_id];
+    let device_handle = &mut context.device_pool[device_id];
     let device = &device_handle.device;
     let queue = &device_handle.queue;
     let mut renderer = vello::Renderer::new(

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -70,7 +70,7 @@ impl ApplicationHandler for SimpleVelloApp<'_> {
 
         // Create a vello Renderer for the surface (using its device id)
         self.renderers
-            .resize_with(self.context.devices.len(), || None);
+            .resize_with(self.context.device_pool.len(), || None);
         self.renderers[surface.dev_id]
             .get_or_insert_with(|| create_vello_renderer(&self.context, &surface));
 
@@ -105,8 +105,7 @@ impl ApplicationHandler for SimpleVelloApp<'_> {
 
             // Resize the surface when the window is resized
             WindowEvent::Resized(size) => {
-                self.context
-                    .resize_surface(surface, size.width, size.height);
+                surface.resize(size.width, size.height);
             }
 
             // This is where all the rendering happens
@@ -123,7 +122,7 @@ impl ApplicationHandler for SimpleVelloApp<'_> {
                 let height = surface.config.height;
 
                 // Get a handle to the device
-                let device_handle = &self.context.devices[surface.dev_id];
+                let device_handle = &self.context.device_pool[surface.dev_id];
 
                 // Render to a texture, which we will later copy into the surface
                 self.renderers[surface.dev_id]
@@ -204,7 +203,7 @@ fn create_winit_window(event_loop: &ActiveEventLoop) -> Arc<Window> {
 /// Helper function that creates a vello `Renderer` for a given `RenderContext` and `RenderSurface`
 fn create_vello_renderer(render_cx: &RenderContext, surface: &RenderSurface<'_>) -> Renderer {
     Renderer::new(
-        &render_cx.devices[surface.dev_id].device,
+        &render_cx.device_pool[surface.dev_id].device,
         RendererOptions::default(),
     )
     .expect("Couldn't create renderer")

--- a/vello/src/util.rs
+++ b/vello/src/util.rs
@@ -4,43 +4,66 @@
 //! Simple helpers for managing wgpu state and surfaces.
 
 use std::future::Future;
-
 use wgpu::{
-    Adapter, Device, Instance, Limits, MemoryHints, Queue, Surface, SurfaceConfiguration,
+    Adapter, Device, Features, Instance, Limits, MemoryHints, Queue, Surface, SurfaceConfiguration,
     SurfaceTarget, Texture, TextureFormat, TextureView, util::TextureBlitter,
 };
 
-use crate::{Error, Result};
+use crate::Error as VelloError;
 
 /// Simple render context that maintains wgpu state for rendering the pipeline.
 pub struct RenderContext {
+    /// A WGPU `Instance`. This only needs to be created once per application.
     pub instance: Instance,
-    pub devices: Vec<DeviceHandle>,
+    /// A pool of already-created devices so that we can avoid recreating devices
+    /// when we already have a suitable one available
+    pub device_pool: Vec<DeviceHandle>,
+
+    // Config
+    extra_features: Option<Features>,
+    override_limits: Option<Limits>,
 }
 
+/// A wgpu `Device`, it's associated `Queue`, and the adapter used to create it.
+/// Q: could we drop the adapter here? wgpu docs say adapters do not need to be kept around...
+#[derive(Clone, Debug)]
 pub struct DeviceHandle {
     adapter: Adapter,
     pub device: Device,
     pub queue: Queue,
 }
 
+impl DeviceHandle {
+    /// Returns the adapter associated with the device.
+    pub fn adapter(&self) -> &Adapter {
+        &self.adapter
+    }
+}
+
+impl Default for RenderContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl RenderContext {
-    #[expect(
-        clippy::new_without_default,
-        reason = "Creating a wgpu Instance is something which should only be done rarely"
-    )]
     pub fn new() -> Self {
-        let backends = wgpu::Backends::from_env().unwrap_or_default();
-        let flags = wgpu::InstanceFlags::from_build_config().with_env();
-        let backend_options = wgpu::BackendOptions::from_env_or_default();
-        let instance = Instance::new(&wgpu::InstanceDescriptor {
-            backends,
-            flags,
-            backend_options,
-        });
+        Self::with_features_and_limits(None, None)
+    }
+
+    pub fn with_features_and_limits(
+        extra_features: Option<Features>,
+        override_limits: Option<Limits>,
+    ) -> Self {
         Self {
-            instance,
-            devices: Vec::new(),
+            instance: Instance::new(&wgpu::InstanceDescriptor {
+                backends: wgpu::Backends::from_env().unwrap_or_default(),
+                flags: wgpu::InstanceFlags::from_build_config().with_env(),
+                backend_options: wgpu::BackendOptions::from_env_or_default(),
+            }),
+            device_pool: Vec::new(),
+            extra_features,
+            override_limits,
         }
     }
 
@@ -51,134 +74,81 @@ impl RenderContext {
         width: u32,
         height: u32,
         present_mode: wgpu::PresentMode,
-    ) -> Result<RenderSurface<'w>> {
-        self.create_render_surface(
-            self.instance.create_surface(window.into())?,
-            width,
-            height,
-            present_mode,
-        )
-        .await
-    }
+    ) -> Result<RenderSurface<'w>, VelloError> {
+        // Create a surface from the window handle
+        let surface = self.instance.create_surface(window.into())?;
 
-    /// Creates a new render surface for the specified window and dimensions.
-    pub async fn create_render_surface<'w>(
-        &mut self,
-        surface: Surface<'w>,
-        width: u32,
-        height: u32,
-        present_mode: wgpu::PresentMode,
-    ) -> Result<RenderSurface<'w>> {
+        // Find or create a suitable device for rendering to the surface
         let dev_id = self
-            .device(Some(&surface))
+            .find_or_create_device(Some(&surface))
             .await
-            .ok_or(Error::NoCompatibleDevice)?;
+            .ok_or(VelloError::NoCompatibleDevice)?;
+        let device_handle = self.device_pool[dev_id].clone();
 
-        let device_handle = &self.devices[dev_id];
-        let capabilities = surface.get_capabilities(&device_handle.adapter);
-        let format = capabilities
-            .formats
-            .into_iter()
-            .find(|it| matches!(it, TextureFormat::Rgba8Unorm | TextureFormat::Bgra8Unorm))
-            .ok_or(Error::UnsupportedSurfaceFormat)?;
-
-        let config = SurfaceConfiguration {
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-            format,
-            width,
-            height,
-            present_mode,
-            desired_maximum_frame_latency: 2,
-            alpha_mode: wgpu::CompositeAlphaMode::Auto,
-            view_formats: vec![],
-        };
-        let (target_texture, target_view) = create_targets(width, height, &device_handle.device);
-        let surface = RenderSurface {
-            surface,
-            config,
-            dev_id,
-            format,
-            target_texture,
-            target_view,
-            blitter: TextureBlitter::new(&device_handle.device, format),
-        };
-        self.configure_surface(&surface);
-        Ok(surface)
-    }
-
-    /// Resizes the surface to the new dimensions.
-    pub fn resize_surface(&self, surface: &mut RenderSurface<'_>, width: u32, height: u32) {
-        let (texture, view) = create_targets(width, height, &self.devices[surface.dev_id].device);
-        // TODO: Use clever resize semantics to avoid thrashing the memory allocator during a resize
-        // especially important on metal.
-        surface.target_texture = texture;
-        surface.target_view = view;
-        surface.config.width = width;
-        surface.config.height = height;
-        self.configure_surface(surface);
-    }
-
-    pub fn set_present_mode(
-        &self,
-        surface: &mut RenderSurface<'_>,
-        present_mode: wgpu::PresentMode,
-    ) {
-        surface.config.present_mode = present_mode;
-        self.configure_surface(surface);
-    }
-
-    fn configure_surface(&self, surface: &RenderSurface<'_>) {
-        let device = &self.devices[surface.dev_id].device;
-        surface.surface.configure(device, &surface.config);
+        RenderSurface::new(surface, device_handle, dev_id, width, height, present_mode).await
     }
 
     /// Finds or creates a compatible device handle id.
-    pub async fn device(&mut self, compatible_surface: Option<&Surface<'_>>) -> Option<usize> {
-        let compatible = match compatible_surface {
+    pub async fn find_or_create_device(
+        &mut self,
+        compatible_surface: Option<&Surface<'_>>,
+    ) -> Option<usize> {
+        match self.find_existing_device(compatible_surface) {
+            Some(device_id) => Some(device_id),
+            None => self.create_device(compatible_surface).await,
+        }
+    }
+
+    /// Finds or creates a compatible device handle id.
+    fn find_existing_device(&self, compatible_surface: Option<&Surface<'_>>) -> Option<usize> {
+        match compatible_surface {
             Some(s) => self
-                .devices
+                .device_pool
                 .iter()
                 .enumerate()
                 .find(|(_, d)| d.adapter.is_surface_supported(s))
                 .map(|(i, _)| i),
-            None => (!self.devices.is_empty()).then_some(0),
-        };
-        if compatible.is_none() {
-            return self.new_device(compatible_surface).await;
+            None => (!self.device_pool.is_empty()).then_some(0),
         }
-        compatible
     }
 
     /// Creates a compatible device handle id.
-    async fn new_device(&mut self, compatible_surface: Option<&Surface<'_>>) -> Option<usize> {
+    async fn create_device(&mut self, compatible_surface: Option<&Surface<'_>>) -> Option<usize> {
         let adapter =
             wgpu::util::initialize_adapter_from_env_or_default(&self.instance, compatible_surface)
                 .await?;
-        let features = adapter.features();
-        let limits = Limits::default();
-        let maybe_features = wgpu::Features::CLEAR_TEXTURE | wgpu::Features::PIPELINE_CACHE;
-        #[cfg(feature = "wgpu-profiler")]
-        let maybe_features = maybe_features | wgpu_profiler::GpuProfiler::ALL_WGPU_TIMER_FEATURES;
 
-        let (device, queue) = adapter
-            .request_device(
-                &wgpu::DeviceDescriptor {
-                    label: None,
-                    required_features: features & maybe_features,
-                    required_limits: limits,
-                    memory_hints: MemoryHints::default(),
-                },
-                None,
-            )
-            .await
-            .ok()?;
+        // Determine features to request
+        // The user may request additional features
+        let extra_features = self.extra_features.unwrap_or(Features::empty());
+        let vello_features = wgpu::Features::CLEAR_TEXTURE | wgpu::Features::PIPELINE_CACHE;
+        let requested_features = vello_features | extra_features;
+        let available_features = adapter.features();
+        let required_features = requested_features & available_features;
+
+        // Determine limits to request
+        // The user may override the limits
+        let required_limits = self.override_limits.clone().unwrap_or_default();
+
+        // Create the device and the queue
+        let descriptor = wgpu::DeviceDescriptor {
+            label: None,
+            required_features,
+            required_limits,
+            memory_hints: MemoryHints::default(),
+        };
+        let (device, queue) = adapter.request_device(&descriptor, None).await.ok()?;
+
+        // Create the device handle and store in the pool
         let device_handle = DeviceHandle {
             adapter,
             device,
             queue,
         };
-        self.devices.push(device_handle);
-        Some(self.devices.len() - 1)
+        self.device_pool.push(device_handle);
+
+        // Return the ID
+        Some(self.device_pool.len() - 1)
     }
 }
 
@@ -186,7 +156,7 @@ impl RenderContext {
 /// texture in most cases.
 ///
 /// Because of this, we need to create an "intermediate" texture which we render to, and then blit to the surface.
-fn create_targets(width: u32, height: u32, device: &Device) -> (Texture, TextureView) {
+fn create_intermediate_texture(width: u32, height: u32, device: &Device) -> (Texture, TextureView) {
     let target_texture = device.create_texture(&wgpu::TextureDescriptor {
         label: None,
         size: wgpu::Extent3d {
@@ -205,21 +175,23 @@ fn create_targets(width: u32, height: u32, device: &Device) -> (Texture, Texture
     (target_texture, target_view)
 }
 
-impl DeviceHandle {
-    /// Returns the adapter associated with the device.
-    pub fn adapter(&self) -> &Adapter {
-        &self.adapter
-    }
-}
-
 /// Combination of surface and its configuration.
 pub struct RenderSurface<'s> {
+    // The device and queue for rendering to the surface
+    pub dev_id: usize,
+    pub device_handle: DeviceHandle,
+
+    // The surface, it's configuration and format
     pub surface: Surface<'s>,
     pub config: SurfaceConfiguration,
-    pub dev_id: usize,
     pub format: TextureFormat,
+
+    // Intermediate Texture which we render to because compute shaders cannot always render directly
+    // to surfaces, and associated TextureView.
     pub target_texture: Texture,
     pub target_view: TextureView,
+
+    // Blitter for blitting from the intermediate texture to the surface.
     pub blitter: TextureBlitter,
 }
 
@@ -228,7 +200,7 @@ impl std::fmt::Debug for RenderSurface<'_> {
         f.debug_struct("RenderSurface")
             .field("surface", &self.surface)
             .field("config", &self.config)
-            .field("dev_id", &self.dev_id)
+            .field("device_handle", &self.device_handle)
             .field("format", &self.format)
             .field("target_texture", &self.target_texture)
             .field("target_view", &self.target_view)
@@ -237,10 +209,72 @@ impl std::fmt::Debug for RenderSurface<'_> {
     }
 }
 
-struct NullWake;
+impl<'s> RenderSurface<'s> {
+    /// Creates a new render surface for the specified window and dimensions.
+    pub async fn new<'w>(
+        surface: Surface<'w>,
+        device_handle: DeviceHandle,
+        dev_id: usize,
+        width: u32,
+        height: u32,
+        present_mode: wgpu::PresentMode,
+    ) -> Result<RenderSurface<'w>, VelloError> {
+        let capabilities = surface.get_capabilities(&device_handle.adapter);
+        let format = capabilities
+            .formats
+            .into_iter()
+            .find(|it| matches!(it, TextureFormat::Rgba8Unorm | TextureFormat::Bgra8Unorm))
+            .ok_or(VelloError::UnsupportedSurfaceFormat)?;
 
-impl std::task::Wake for NullWake {
-    fn wake(self: std::sync::Arc<Self>) {}
+        let config = SurfaceConfiguration {
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            format,
+            width,
+            height,
+            present_mode,
+            desired_maximum_frame_latency: 2,
+            alpha_mode: wgpu::CompositeAlphaMode::Auto,
+            view_formats: vec![],
+        };
+        let (target_texture, target_view) =
+            create_intermediate_texture(width, height, &device_handle.device);
+        let blitter = TextureBlitter::new(&device_handle.device, format);
+        let surface = RenderSurface {
+            dev_id,
+            device_handle,
+            surface,
+            config,
+            format,
+            target_texture,
+            target_view,
+            blitter,
+        };
+        surface.configure();
+        Ok(surface)
+    }
+
+    /// Resizes the surface to the new dimensions.
+    pub fn resize(&mut self, width: u32, height: u32) {
+        let (texture, view) =
+            create_intermediate_texture(width, height, &self.device_handle.device);
+        // TODO: Use clever resize semantics to avoid thrashing the memory allocator during a resize
+        // especially important on metal.
+        self.target_texture = texture;
+        self.target_view = view;
+        self.config.width = width;
+        self.config.height = height;
+        self.configure();
+    }
+
+    pub fn set_present_mode(&mut self, present_mode: wgpu::PresentMode) {
+        self.config.present_mode = present_mode;
+        self.configure();
+    }
+
+    fn configure(&self) {
+        self.surface
+            .configure(&self.device_handle.device, &self.config);
+    }
 }
 
 /// Block on a future, polling the device as needed.
@@ -249,10 +283,19 @@ impl std::task::Wake for NullWake {
 #[cfg_attr(docsrs, doc(hidden))]
 pub fn block_on_wgpu<F: Future>(device: &Device, mut fut: F) -> F::Output {
     if cfg!(target_arch = "wasm32") {
-        panic!("Blocking can't work on WASM, so don't try");
+        panic!("WGPU is inherently async on WASM, so blocking doesn't work.");
     }
+
+    // Dummy waker
+    struct NullWake;
+    impl std::task::Wake for NullWake {
+        fn wake(self: std::sync::Arc<Self>) {}
+    }
+
+    // Create context to poll future with
     let waker = std::task::Waker::from(std::sync::Arc::new(NullWake));
     let mut context = std::task::Context::from_waker(&waker);
+
     // Same logic as `pin_mut!` macro from `pin_utils`.
     let mut fut = std::pin::pin!(fut);
     loop {

--- a/vello_tests/src/lib.rs
+++ b/vello_tests/src/lib.rs
@@ -103,10 +103,10 @@ pub async fn render_then_debug(scene: &Scene, params: &TestParams) -> Result<Ima
 pub async fn get_scene_image(params: &TestParams, scene: &Scene) -> Result<Image, anyhow::Error> {
     let mut context = RenderContext::new();
     let device_id = context
-        .device(None)
+        .find_or_create_device(None)
         .await
         .ok_or_else(|| anyhow!("No compatible device found"))?;
-    let device_handle = &mut context.devices[device_id];
+    let device_handle = &mut context.device_pool[device_id];
     let device = &device_handle.device;
     let queue = &device_handle.queue;
     let mut renderer = vello::Renderer::new(


### PR DESCRIPTION
- A lot of general cleanup, adding comments, etc.
- Split out a `find_existing_device` method
- Store a copy of `DeviceHandle` inside `RenderSurface`
- Move methods from `RenderContext` to `RenderSurface`
- Allow users to customise `Features` and `Limits` (possibly these should be less global)

(the latter was the initial motivation for me interacting with this code - I need to be able to configure these for the `override_image` demo (both vello and blitz))

Some questions:

- Should `RenderContext` be global? (actually static? suggested to be Arc<Mutex>>?)
- Should `RenderContext` also hold `VelloRenderer`s? Why is `with_winit` reusing `VelloRenderer` instances?
- Should util / `RenderContext` provide utility methods to help with pipeline caching?