### PR TITLE
First sketch of porting strip rendering to SIMD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,6 +800,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "fearless_simd"
+version = "0.2.0"
+
+[[package]]
 name = "file-id"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3200,6 +3204,7 @@ name = "vello_common"
 version = "0.0.1"
 dependencies = [
  "bytemuck",
+ "fearless_simd",
  "libm",
  "peniko",
  "png",

--- a/sparse_strips/vello_bench/src/strip.rs
+++ b/sparse_strips/vello_bench/src/strip.rs
@@ -5,6 +5,7 @@ use crate::data::get_data_items;
 use criterion::Criterion;
 use vello_common::peniko::Fill;
 use vello_common::strip;
+use vello_common::fearless_simd::Level;
 
 pub fn render_strips(c: &mut Criterion) {
     let mut g = c.benchmark_group("render_strips");
@@ -22,8 +23,11 @@ pub fn render_strips(c: &mut Criterion) {
                 b.iter(|| {
                     strip_buf.clear();
                     alpha_buf.clear();
+                    
+                    let level = Level::new();
 
-                    strip::render(
+                    vello_common::strip_simd::render(
+                        level,
                         &tiles,
                         &mut strip_buf,
                         &mut alpha_buf,

--- a/sparse_strips/vello_common/Cargo.toml
+++ b/sparse_strips/vello_common/Cargo.toml
@@ -19,6 +19,7 @@ targets = []
 [dependencies]
 bytemuck = { workspace = true, features = [] }
 peniko = { workspace = true, features = ["bytemuck"] }
+fearless_simd = { path = "../../../fearless_simd/fearless_simd" }
 png = { workspace = true, optional = true }
 roxmltree = { version = "0.20.0", optional = true }
 skrifa = { workspace = true }

--- a/sparse_strips/vello_common/src/lib.rs
+++ b/sparse_strips/vello_common/src/lib.rs
@@ -51,7 +51,7 @@
     reason = "We temporarily ignore those because the casts\
 only break in edge cases, and some of them are also only related to conversions from f64 to f32."
 )]
-#![no_std]
+// #![no_std]
 
 // Suppress the unused_crate_dependencies lint when both std and libm are specified.
 #[cfg(all(feature = "std", feature = "libm"))]
@@ -74,8 +74,10 @@ pub mod paint;
 pub mod pico_svg;
 pub mod pixmap;
 pub mod strip;
+pub mod strip_simd;
 pub mod tile;
 
 pub use peniko;
 pub use peniko::color;
 pub use peniko::kurbo;
+pub use fearless_simd;

--- a/sparse_strips/vello_common/src/strip_simd.rs
+++ b/sparse_strips/vello_common/src/strip_simd.rs
@@ -1,0 +1,308 @@
+// Copyright 2025 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Rendering strips.
+
+use crate::flatten::Line;
+use crate::peniko::Fill;
+use crate::tile::{Tile, Tiles};
+use alloc::vec::Vec;
+use fearless_simd::*;
+#[cfg(not(feature = "std"))]
+use peniko::kurbo::common::FloatFuncs as _;
+use crate::strip::Strip;
+
+simd_dispatch!(pub render(
+    level,
+    tiles: &Tiles,
+    strip_buf: &mut Vec<Strip>,
+    alpha_buf: &mut Vec<u8>,
+    fill_rule: Fill,
+    lines: &[Line],
+) = render_impl);
+
+/// Render the tiles stored in `tiles` into the strip and alpha buffer.
+/// The strip buffer will be cleared in the beginning.
+pub fn render_impl<S: Simd>(
+    s: S,
+    tiles: &Tiles,
+    strip_buf: &mut Vec<Strip>,
+    alpha_buf: &mut Vec<u8>,
+    fill_rule: Fill,
+    lines: &[Line],
+) {
+    strip_buf.clear();
+
+    if tiles.is_empty() {
+        return;
+    }
+
+    // The accumulated tile winding delta. A line that crosses the top edge of a tile
+    // increments the delta if the line is directed upwards, and decrements it if goes
+    // downwards. Horizontal lines leave it unchanged.
+    let mut winding_delta: i32 = 0;
+
+    // The previous tile visited.
+    let mut prev_tile = *tiles.get(0);
+    // The accumulated (fractional) winding of the tile-sized location we're currently at.
+    // Note multiple tiles can be at the same location.
+    let mut location_winding = [f32x4::splat(s, 0.0); Tile::WIDTH as usize];
+    // The accumulated (fractional) windings at this location's right edge. When we move to the
+    // next location, this is splatted to that location's starting winding.
+    let mut accumulated_winding = f32x4::splat(s, 0.0);
+
+    /// A special tile to keep the logic below simple.
+    const SENTINEL: Tile = Tile::new(u16::MAX, u16::MAX, 0, false);
+
+    // The strip we're building.
+    let mut strip = Strip {
+        x: prev_tile.x * Tile::WIDTH,
+        y: prev_tile.y * Tile::HEIGHT,
+        alpha_idx: alpha_buf.len() as u32,
+        winding: 0,
+    };
+
+    for (tile_idx, tile) in tiles.iter().copied().chain([SENTINEL]).enumerate() {
+        let line = lines[tile.line_idx() as usize];
+        let tile_left_x= f32::from(tile.x) * f32::from(Tile::WIDTH);
+        let tile_top_y = f32::from(tile.y) * f32::from(Tile::HEIGHT);
+        let p0_x = line.p0.x - tile_left_x;
+        let p0_y = line.p0.y - tile_top_y;
+        let p1_x = line.p1.x - tile_left_x;
+        let p1_y = line.p1.y - tile_top_y;
+
+        // Push out the winding as an alpha mask when we move to the next location (i.e., a tile
+        // without the same location).
+        if !prev_tile.same_loc(&tile) {
+            match fill_rule {
+                Fill::NonZero => {
+                    for x in 0..Tile::WIDTH as usize {
+                        let area = location_winding[x];
+                        let coverage = area.abs();
+                        let mulled = coverage * 255.0 + 0.5;
+                        let slice = mulled.val;
+                        // TODO: Improve this
+                        alpha_buf.push(slice[0] as u8);
+                        alpha_buf.push(slice[1] as u8);
+                        alpha_buf.push(slice[2] as u8);
+                        alpha_buf.push(slice[3] as u8);
+                    }
+                }
+                Fill::EvenOdd => {
+                    for x in 0..Tile::WIDTH as usize {
+                        let area = location_winding[x];
+                        let coverage = (area - 2.0 * ((0.5 * area) + 0.5).floor()).abs();
+                        let mulled = coverage * 255.0 + 0.5;
+                        let slice = mulled.val;
+                        // TODO: Improve this
+                        alpha_buf.push(slice[0] as u8);
+                        alpha_buf.push(slice[1] as u8);
+                        alpha_buf.push(slice[2] as u8);
+                        alpha_buf.push(slice[3] as u8);
+                    }
+                }
+            };
+
+            #[expect(clippy::needless_range_loop, reason = "dimension clarity")]
+            for x in 0..Tile::WIDTH as usize {
+                location_winding[x] = accumulated_winding;
+            }
+        }
+
+        // Push out the strip if we're moving to a next strip.
+        if !prev_tile.same_loc(&tile) && !prev_tile.prev_loc(&tile) {
+            debug_assert_eq!(
+                (prev_tile.x + 1) * Tile::WIDTH - strip.x,
+                ((alpha_buf.len() - strip.alpha_idx as usize) / usize::from(Tile::HEIGHT)) as u16,
+                "The number of columns written to the alpha buffer should equal the number of columns spanned by this strip."
+            );
+            strip_buf.push(strip);
+
+            let is_sentinel = tile_idx == tiles.len() as usize;
+            if !prev_tile.same_row(&tile) {
+                // Emit a final strip in the row if there is non-zero winding for the sparse fill,
+                // or unconditionally if we've reached the sentinel tile to end the path (the
+                // `alpha_idx` field is used for width calculations).
+                if winding_delta != 0 || is_sentinel {
+                    strip_buf.push(Strip {
+                        x: u16::MAX,
+                        y: prev_tile.y * Tile::HEIGHT,
+                        alpha_idx: alpha_buf.len() as u32,
+                        winding: winding_delta,
+                    });
+                }
+
+                winding_delta = 0;
+                accumulated_winding = f32x4::splat(s, 0.0);
+
+                #[expect(clippy::needless_range_loop, reason = "dimension clarity")]
+                for x in 0..Tile::WIDTH as usize {
+                    location_winding[x] = accumulated_winding;
+                }
+            }
+
+            if is_sentinel {
+                break;
+            }
+
+            strip = Strip {
+                x: tile.x * Tile::WIDTH,
+                y: tile.y * Tile::HEIGHT,
+                alpha_idx: alpha_buf.len() as u32,
+                winding: winding_delta,
+            };
+            // Note: this fill is mathematically not necessary. It provides a way to reduce
+            // accumulation of float rounding errors.
+            accumulated_winding = f32x4::splat(s, winding_delta as f32);
+        }
+        prev_tile = tile;
+
+        // TODO: horizontal geometry has no impact on winding. This branch will be removed when
+        // horizontal geometry is culled at the tile-generation stage.
+        if p0_y == p1_y {
+            continue;
+        }
+
+        // Lines moving upwards (in a y-down coordinate system) add to winding; lines moving
+        // downwards subtract from winding.
+        let sign = (p0_y - p1_y).signum();
+
+        // Calculate winding / pixel area coverage.
+        //
+        // Conceptually, horizontal rays are shot from left to right. Every time the ray crosses a
+        // line that is directed upwards (decreasing `y`), the winding is incremented. Every time
+        // the ray crosses a line moving downwards (increasing `y`), the winding is decremented.
+        // The fractional area coverage of a pixel is the integral of the winding within it.
+        //
+        // Practically, to calculate this, each pixel is considered individually, and we determine
+        // whether the line moves through this pixel. The line's y-delta within this pixel is
+        // accumulated and added to the area coverage of pixels to the right. Within the pixel
+        // itself, the area to the right of the line segment forms a trapezoid (or a triangle in
+        // the degenerate case). The area of this trapezoid is added to the pixel's area coverage.
+        //
+        // For example, consider the following pixel square, with a line indicated by asterisks
+        // starting inside the pixel and crossing its bottom edge. The area covered is the
+        // trapezoid on the bottom-right enclosed by the line and the pixel square. The area is
+        // positive if the line moves down, and negative otherwise.
+        //
+        //  __________________
+        //  |                |
+        //  |         *------|
+        //  |        *       |
+        //  |       *        |
+        //  |      *         |
+        //  |     *          |
+        //  |    *           |
+        //  |___*____________|
+        //     *
+        //    *
+
+        let (line_top_y, line_top_x, line_bottom_y, line_bottom_x) = if p0_y < p1_y {
+            (p0_y, p0_x, p1_y, p1_x)
+        } else {
+            (p1_y, p1_x, p0_y, p0_x)
+        };
+
+        let (line_left_x, line_left_y, line_right_x) = if p0_x < p1_x {
+            (p0_x, p0_y, p1_x)
+        } else {
+            (p1_x, p1_y, p0_x)
+        };
+
+        let y_slope = (line_bottom_y - line_top_y) / (line_bottom_x - line_top_x);
+        let x_slope = 1. / y_slope;
+
+        winding_delta += sign as i32 * i32::from(tile.winding());
+
+        // TODO: this should be removed when out-of-viewport tiles are culled at the
+        // tile-generation stage. That requires calculating and forwarding winding to strip
+        // generation.
+        if tile.x == 0 && line_left_x < 0. {
+            let (ymin, ymax) = if line.p0.x == line.p1.x {
+                (line_top_y, line_bottom_y)
+            } else {
+                let line_viewport_left_y = (line_top_y - line_top_x * y_slope)
+                    .max(line_top_y)
+                    .min(line_bottom_y);
+
+                (
+                    f32::min(line_left_y, line_viewport_left_y),
+                    f32::max(line_left_y, line_viewport_left_y),
+                )
+            };
+            
+            let ymin: f32x4<_> = ymin.simd_into(s);
+            let ymax: f32x4<_> = ymax.simd_into(s);
+            
+            let px_top_y: f32x4<_> = [0.0, 1.0, 2.0, 3.0].simd_into(s);
+            let px_bottom_y = 1.0 + px_top_y;
+            let ymin = px_top_y.max(ymin);
+            let ymax = px_bottom_y.min(ymax);
+            let h = (ymax - ymin).max(0.0);
+            accumulated_winding = accumulated_winding.madd(sign, h);
+            for x_idx in 0..Tile::WIDTH {
+                location_winding[x_idx as usize] = location_winding[x_idx as usize].madd(sign, h);
+            }
+
+            if line_right_x < 0. {
+                // Early exit, as no part of the line is inside the tile.
+                continue;
+            }
+        }
+
+        let line_top_y = f32x4::splat(s, line_top_y);
+        let line_bottom_y = f32x4::splat(s, line_bottom_y);
+
+        let y_idx = f32x4::from_slice(s, &[0.0, 1.0, 2.0, 3.0]);
+        let px_top_y = y_idx;
+        let px_bottom_y = 1. + y_idx;
+
+        let ymin = line_top_y.max(px_top_y);
+        let ymax = line_bottom_y.min(px_bottom_y);
+
+        let mut acc = f32x4::splat(s, 0.0);
+
+        for x_idx in 0..Tile::WIDTH {
+            let x_idx_s = f32x4::splat(s, x_idx as f32);
+            let px_left_x = x_idx_s;
+            let px_right_x = 1.0 + x_idx_s;
+
+            // The y-coordinate of the intersections between the line and the pixel's left and
+            // right edges respectively.
+            //
+            // There is some subtlety going on here: `y_slope` will usually be finite, but will
+            // be `inf` for purely vertical lines (`p0_x == p1_x`).
+            //
+            // In the case of `inf`, the resulting slope calculation will be `-inf` or `inf`
+            // depending on whether the pixel edge is left or right of the line, respectively
+            // (from the viewport's coordinate system perspective). The `min` and `max`
+            // y-clamping logic generalizes nicely, as a pixel edge to the left of the line is
+            // clamped to `ymin`, and a pixel edge to the right is clamped to `ymax`.
+            //
+            // In the special case where a vertical line and pixel edge are at the exact same
+            // x-position (collinear), the line belongs to the pixel on whose _left_ edge it is
+            // situated. The resulting slope calculation for the edge the line is situated on
+            // will be NaN, as `0 * inf` results in NaN. This is true for both the left and
+            // right edge. In both cases, the call to `f32::max` will set this to `ymin`.
+            let line_px_left_y = line_top_y.madd(px_left_x - line_top_x, y_slope)
+                .max_precise(ymin)
+                .min_precise(ymax);
+            let line_px_right_y = line_top_y.madd(px_right_x - line_top_x, y_slope)
+                .max_precise(ymin)
+                .min_precise(ymax);
+
+            // `x_slope` is always finite, as horizontal geometry is elided.
+            let line_px_left_yx = f32x4::splat(s, line_top_x).madd(line_px_left_y - line_top_y, x_slope);
+            let line_px_right_yx = f32x4::splat(s, line_top_x).madd(line_px_right_y - line_top_y, x_slope);
+            let h = (line_px_right_y - line_px_left_y).abs();
+
+            // The trapezoidal area enclosed between the line and the right edge of the pixel
+            // square.
+            let area = 0.5 * h * (2. * px_right_x - line_px_right_yx - line_px_left_yx);
+            location_winding[x_idx as usize] = location_winding[x_idx as usize] + acc.madd(sign, area);
+            acc = acc.madd(sign, h);
+        }
+
+        accumulated_winding = accumulated_winding + acc;
+    }
+}

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -25,7 +25,8 @@ use vello_common::peniko::{Font, ImageQuality};
 use vello_common::pixmap::Pixmap;
 use vello_common::strip::Strip;
 use vello_common::tile::Tiles;
-use vello_common::{flatten, peniko, strip};
+use vello_common::{flatten, peniko, strip, strip_simd};
+use vello_common::fearless_simd::Level;
 
 pub(crate) const DEFAULT_TOLERANCE: f64 = 0.1;
 /// A render context.
@@ -390,8 +391,11 @@ impl RenderContext {
         self.tiles
             .make_tiles(&self.line_buf, self.width, self.height);
         self.tiles.sort_tiles();
+        
+        let level = Level::new();
 
-        strip::render(
+        strip_simd::render(
+            level,
             &self.tiles,
             &mut self.strip_buf,
             &mut self.alphas,


### PR DESCRIPTION
Here are the changes I needed to make: https://github.com/raphlinus/fearless_simd/commit/7a999662e99bce6d7b16d2d128fe4bfc3a8eb141

And here are the benchmark results before vs. after:

```
render_strips/Ghostscript_Tiger
                        time:   [181.39 µs 182.40 µs 183.90 µs]
                        change: [-18.710% -18.391% -18.040%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 50 measurements (4.00%)
  1 (2.00%) high mild
  1 (2.00%) high severe
render_strips/paris_30k time:   [17.009 ms 17.160 ms 17.321 ms]
                        change: [-17.442% -16.607% -15.729%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 50 measurements (4.00%)
  2 (4.00%) high mild
render_strips/coat_of_arms
                        time:   [1.5429 ms 1.5453 ms 1.5481 ms]
                        change: [-15.918% -15.404% -14.926%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 50 measurements (6.00%)
  2 (4.00%) high mild
  1 (2.00%) high severe
```

This might not look like a lot, but the reason for this is that the previous implementation already auto-vectorized on ARM, so I would say this is still a very significant speed boost! Tests also pass, with some minor differences due to our usage of fused multiply-add. But it shows that `fearless_simd` works at least. :)

Currently this works with explicit f32x4, but it's also adaptable fo f32x8 and f32x16. In the end, we will probably want to choose f32x8 for now.

Just a draft PR because it's not intended to be merged (we will need to implement fallback in `fearless_simd` first), but only for showcase.