### PR TITLE
[vello_dev_macros] enable vello_hybrid `clip` and `opacity` tests

### DIFF
--- a/sparse_strips/vello_dev_macros/src/test.rs
+++ b/sparse_strips/vello_dev_macros/src/test.rs
@@ -126,14 +126,12 @@ pub(crate) fn vello_test_inner(attr: TokenStream, item: TokenStream) -> TokenStr
 
     // These tests currently don't work with `vello_hybrid`.
     skip_hybrid |= {
-        input_fn_name_str.contains("clip")
-            || input_fn_name_str.contains("compose")
+        input_fn_name_str.contains("compose")
             || input_fn_name_str.contains("gradient")
             || input_fn_name_str.contains("image")
             || input_fn_name_str.contains("layer")
             || input_fn_name_str.contains("mask")
             || input_fn_name_str.contains("mix")
-            || input_fn_name_str.contains("opacity")
             || input_fn_name_str.contains("blurred_rounded_rect")
     };
 


### PR DESCRIPTION
This is a small test-only housekeeping PR enabling more tests for vello_hybrid.

Vello hybrid has landed clipping and opacity seems to pass tests. I also checked the other ignored tests but they still have failures.
