### PR TITLE
[vello_hybrid] update `set_paint` to conform with `vello_cpu`'s set_paint API

### DIFF
--- a/sparse_strips/vello_common/src/paint.rs
+++ b/sparse_strips/vello_common/src/paint.rs
@@ -153,11 +153,6 @@ impl PremulColor {
     pub fn is_opaque(&self) -> bool {
         self.premul_f32.components[3] == 1.0
     }
-
-    /// Return whether the color is transparent.
-    pub fn is_transparent(&self) -> bool {
-        self.premul_f32.components[3] == 0.0
-    }
 }
 
 /// A kind of paint that can be used for filling and stroking shapes.

--- a/sparse_strips/vello_hybrid/examples/render_to_file.rs
+++ b/sparse_strips/vello_hybrid/examples/render_to_file.rs
@@ -177,13 +177,13 @@ fn render_svg(ctx: &mut Scene, items: &[Item], transform: Affine) {
     for item in items {
         match item {
             Item::Fill(fill_item) => {
-                ctx.set_paint(fill_item.color.into());
+                ctx.set_paint(fill_item.color);
                 ctx.fill_path(&fill_item.path);
             }
             Item::Stroke(stroke_item) => {
                 let style = Stroke::new(stroke_item.width);
                 ctx.set_stroke(style);
-                ctx.set_paint(stroke_item.color.into());
+                ctx.set_paint(stroke_item.color);
                 ctx.stroke_path(&stroke_item.path);
             }
             Item::Group(group_item) => {

--- a/sparse_strips/vello_hybrid/examples/scenes/src/clip.rs
+++ b/sparse_strips/vello_hybrid/examples/scenes/src/clip.rs
@@ -42,7 +42,7 @@ impl Default for ClipScene {
 
 fn draw_clipping_outline(ctx: &mut Scene, path: &BezPath) {
     let stroke = Stroke::new(1.0);
-    ctx.set_paint(DARK_BLUE.into());
+    ctx.set_paint(DARK_BLUE);
     ctx.set_stroke(stroke);
     ctx.stroke_path(path);
 }
@@ -79,7 +79,7 @@ pub fn render(ctx: &mut Scene, root_transform: Affine) {
             draw_clipping_outline(ctx, &clip_circle);
             ctx.push_clip_layer(&clip_circle);
 
-            ctx.set_paint((*color).into());
+            ctx.set_paint(*color);
             ctx.fill_rect(&COVER_RECT);
 
             radius -= RADIUS_DECREMENT;

--- a/sparse_strips/vello_hybrid/examples/scenes/src/simple.rs
+++ b/sparse_strips/vello_hybrid/examples/scenes/src/simple.rs
@@ -44,10 +44,10 @@ pub fn render(ctx: &mut Scene, root_transform: Affine) {
     let scene_transform = Affine::scale(5.0);
     ctx.set_transform(root_transform * scene_transform);
 
-    ctx.set_paint(palette::css::REBECCA_PURPLE.into());
+    ctx.set_paint(palette::css::REBECCA_PURPLE);
     ctx.fill_path(&path);
     let stroke = Stroke::new(1.0);
-    ctx.set_paint(palette::css::DARK_BLUE.into());
+    ctx.set_paint(palette::css::DARK_BLUE);
     ctx.set_stroke(stroke);
     ctx.stroke_path(&path);
 }

--- a/sparse_strips/vello_hybrid/examples/scenes/src/svg.rs
+++ b/sparse_strips/vello_hybrid/examples/scenes/src/svg.rs
@@ -74,13 +74,13 @@ fn render_svg(ctx: &mut Scene, items: &[Item], transform: Affine) {
     for item in items {
         match item {
             Item::Fill(fill_item) => {
-                ctx.set_paint(fill_item.color.into());
+                ctx.set_paint(fill_item.color);
                 ctx.fill_path(&fill_item.path);
             }
             Item::Stroke(stroke_item) => {
                 let style = Stroke::new(stroke_item.width);
                 ctx.set_stroke(style);
-                ctx.set_paint(stroke_item.color.into());
+                ctx.set_paint(stroke_item.color);
                 ctx.stroke_path(&stroke_item.path);
             }
             Item::Group(group_item) => {

--- a/sparse_strips/vello_hybrid/examples/scenes/src/text.rs
+++ b/sparse_strips/vello_hybrid/examples/scenes/src/text.rs
@@ -120,7 +120,7 @@ fn render_glyph_run(ctx: &mut Scene, glyph_run: &GlyphRun<'_, ColorBrush>, paddi
     let normalized_coords = bytemuck::cast_slice(run.normalized_coords());
 
     let style = glyph_run.style();
-    ctx.set_paint(style.brush.color.into());
+    ctx.set_paint(style.brush.color);
     ctx.glyph_run(font)
         .font_size(font_size)
         .normalized_coords(normalized_coords)

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -10,7 +10,7 @@ use vello_common::flatten::Line;
 use vello_common::glyph::{GlyphRenderer, GlyphRunBuilder, GlyphType, PreparedGlyph};
 use vello_common::kurbo::{Affine, BezPath, Cap, Join, Rect, Shape, Stroke};
 use vello_common::mask::Mask;
-use vello_common::paint::Paint;
+use vello_common::paint::{Paint, PaintType};
 use vello_common::peniko::Font;
 use vello_common::peniko::color::palette::css::BLACK;
 use vello_common::peniko::{BlendMode, Compose, Fill, Mix};
@@ -25,7 +25,7 @@ pub(crate) const DEFAULT_TOLERANCE: f64 = 0.1;
 /// the current transform.
 #[derive(Debug)]
 struct RenderState {
-    pub(crate) paint: Paint,
+    pub(crate) paint: PaintType,
     pub(crate) stroke: Stroke,
     pub(crate) transform: Affine,
     pub(crate) fill_rule: Fill,
@@ -45,7 +45,7 @@ pub struct Scene {
     pub(crate) line_buf: Vec<Line>,
     pub(crate) tiles: Tiles,
     pub(crate) strip_buf: Vec<Strip>,
-    pub(crate) paint: Paint,
+    pub(crate) paint: PaintType,
     paint_visible: bool,
     pub(crate) stroke: Stroke,
     pub(crate) transform: Affine,
@@ -96,13 +96,26 @@ impl Scene {
         }
     }
 
+    fn encode_current_paint(&mut self) -> Paint {
+        match self.paint.clone() {
+            PaintType::Solid(s) => s.into(),
+            PaintType::Gradient(_) => {
+                unimplemented!("gradient not implemented")
+            }
+            PaintType::Image(_) => {
+                unimplemented!("images not implemented")
+            }
+        }
+    }
+
     /// Fill a path with the current paint and fill rule.
     pub fn fill_path(&mut self, path: &BezPath) {
         if !self.paint_visible {
             return;
         }
         flatten::fill(path, self.transform, &mut self.line_buf);
-        self.render_path(self.fill_rule, self.paint.clone());
+        let paint = self.encode_current_paint();
+        self.render_path(self.fill_rule, paint);
     }
 
     /// Stroke a path with the current paint and stroke settings.
@@ -111,7 +124,8 @@ impl Scene {
             return;
         }
         flatten::stroke(path, &self.stroke, self.transform, &mut self.line_buf);
-        self.render_path(Fill::NonZero, self.paint.clone());
+        let paint = self.encode_current_paint();
+        self.render_path(Fill::NonZero, paint);
     }
 
     /// Fill a rectangle with the current paint and fill rule.
@@ -187,12 +201,10 @@ impl Scene {
     }
 
     /// Set the paint for subsequent rendering operations.
-    pub fn set_paint(&mut self, paint: Paint) {
-        self.paint_visible = match &paint {
-            Paint::Solid(color) => !color.is_transparent(),
-            Paint::Indexed(_) => true,
-        };
-        self.paint = paint;
+    pub fn set_paint(&mut self, paint: impl Into<PaintType>) {
+        self.paint = paint.into();
+        self.paint_visible =
+            matches!(&self.paint, PaintType::Solid(color) if color.components[3] != 0.0);
     }
 
     /// Set the fill rule for subsequent fill operations.
@@ -262,7 +274,8 @@ impl GlyphRenderer for Scene {
         match prepared_glyph.glyph_type {
             GlyphType::Outline(glyph) => {
                 flatten::fill(glyph.path, prepared_glyph.transform, &mut self.line_buf);
-                self.render_path(Fill::NonZero, self.paint.clone());
+                let paint = self.encode_current_paint();
+                self.render_path(Fill::NonZero, paint);
             }
             GlyphType::Bitmap(_) => {}
             GlyphType::Colr(_) => {}
@@ -278,7 +291,8 @@ impl GlyphRenderer for Scene {
                     prepared_glyph.transform,
                     &mut self.line_buf,
                 );
-                self.render_path(Fill::NonZero, self.paint.clone());
+                let paint = self.encode_current_paint();
+                self.render_path(Fill::NonZero, paint);
             }
             GlyphType::Bitmap(_) => {}
             GlyphType::Colr(_) => {}

--- a/sparse_strips/vello_sparse_tests/tests/renderer.rs
+++ b/sparse_strips/vello_sparse_tests/tests/renderer.rs
@@ -198,7 +198,7 @@ impl Renderer for Scene {
     fn set_paint(&mut self, paint: impl Into<PaintType>) {
         let paint_type: PaintType = paint.into();
         match paint_type {
-            PaintType::Solid(s) => Self::set_paint(self, s.into()),
+            PaintType::Solid(s) => Self::set_paint(self, s),
             PaintType::Gradient(_) => {}
             PaintType::Image(_) => {}
         }


### PR DESCRIPTION
### Context

I am currently working on gradients, and Alex is working on Images. In both cases, being passed a `Paint` seems insufficient for expressing Images and Gradients.

While drafting gradients I noticed we had duplicated this API change, so I'm submitting it standalone. See the same change in the image draft PR: https://github.com/linebender/vello/pull/935/files#diff-cf782a179aa0fd954852f73458fb40f9a2e608c3b20eec0265acfc3e4dc284ccR201-R203

### Why

In order to enable image and gradient in vello_hybrid, I believe an API change is required.

A nice benefit of this change is that our API more closely resembles `vello_cpu`.


### Test plan

CI and existing unit tests.