### PR TITLE
[vello_cpu] reset transforms when resetting the `RenderContext`

### DIFF
--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -333,6 +333,8 @@ impl RenderContext {
     pub fn reset(&mut self) {
         self.dispatcher.reset();
         self.encoded_paints.clear();
+        self.reset_transform();
+        self.reset_paint_transform();
     }
 
     /// Flush any pending operations.


### PR DESCRIPTION
Small change, but I think it's intended that all state resets when calling `.reset` on the RenderContext.