### PR TITLE
Attempt to make `text` feature optional

### DIFF
--- a/sparse_strips/vello_common/Cargo.toml
+++ b/sparse_strips/vello_common/Cargo.toml
@@ -22,12 +22,12 @@ peniko = { workspace = true, features = ["bytemuck"] }
 fearless_simd = { workspace = true }
 png = { workspace = true, optional = true }
 roxmltree = { version = "0.20.0", optional = true }
-skrifa = { workspace = true }
+skrifa = { workspace = true, optional = true }
 smallvec = { workspace = true }
 libm = { version = "0.2.15", optional = true }
 
 [features]
-default = ["std", "png"]
+default = ["std", "png", "text"]
 # Enable using SIMD instructions for rendering
 simd = []
 # Get floating point functions from the standard library (likely using your target’s libc).
@@ -38,6 +38,8 @@ libm = ["peniko/libm", "skrifa/libm", "dep:libm", "fearless_simd/libm"]
 png = ["std", "dep:png"]
 # Enable multi-threaded rendering.
 multithreading = []
+# Add support for text rendering
+text = ["skrifa"]
 
 # Development only features
 

--- a/sparse_strips/vello_common/src/lib.rs
+++ b/sparse_strips/vello_common/src/lib.rs
@@ -61,10 +61,12 @@ extern crate alloc;
 
 pub mod blurred_rounded_rect;
 pub mod coarse;
+#[cfg(feature = "text")]
 pub mod colr;
 pub mod encode;
 pub mod execute;
 pub mod flatten;
+#[cfg(feature = "text")]
 pub mod glyph;
 pub mod mask;
 pub mod math;

--- a/sparse_strips/vello_cpu/Cargo.toml
+++ b/sparse_strips/vello_cpu/Cargo.toml
@@ -26,7 +26,7 @@ thread_local = { workspace = true, optional = true }
 
 
 [features]
-default = ["std", "png"]
+default = ["std", "png", "text"]
 # Get floating point functions from the standard library (likely using your target’s libc).
 std = ["vello_common/std"]
 # Use floating point implementations from libm.
@@ -42,6 +42,8 @@ multithreading = [
     "dep:crossbeam-channel",
     "vello_common/multithreading",
 ]
+# Add support for text rendering
+text = ["vello_common/text"]
 
 [lints]
 workspace = true

--- a/sparse_strips/vello_cpu/src/lib.rs
+++ b/sparse_strips/vello_cpu/src/lib.rs
@@ -124,6 +124,7 @@ mod util;
 
 pub use render::{RenderContext, RenderSettings};
 pub use vello_common::fearless_simd::Level;
+#[cfg(feature = "text")]
 pub use vello_common::glyph::Glyph;
 pub use vello_common::mask::Mask;
 pub use vello_common::paint::{Image, Paint, PaintType};

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -15,17 +15,17 @@ use alloc::vec;
 use alloc::vec::Vec;
 use vello_common::blurred_rounded_rect::BlurredRoundedRectangle;
 use vello_common::color::{AlphaColor, Srgb};
+#[cfg(feature = "text")]
 use vello_common::colr::{ColrPainter, ColrRenderer};
 use vello_common::encode::{EncodeExt, EncodedPaint};
 use vello_common::fearless_simd::Level;
+#[cfg(feature = "text")]
 use vello_common::glyph::{GlyphRenderer, GlyphRunBuilder, GlyphType, PreparedGlyph};
 use vello_common::kurbo::{Affine, BezPath, Cap, Join, Rect, Shape, Stroke};
 use vello_common::mask::Mask;
-use vello_common::paint::{Image, Paint, PaintType};
-use vello_common::peniko;
+use vello_common::paint::{Paint, PaintType};
 use vello_common::peniko::color::palette::css::BLACK;
-use vello_common::peniko::{BlendMode, Compose, Fill, Gradient, Mix};
-use vello_common::peniko::{Font, ImageQuality};
+use vello_common::peniko::{BlendMode, Compose, Fill, Mix};
 use vello_common::pixmap::Pixmap;
 
 pub(crate) const DEFAULT_TOLERANCE: f64 = 0.1;
@@ -41,6 +41,7 @@ pub struct RenderContext {
     pub(crate) fill_rule: Fill,
     pub(crate) temp_path: BezPath,
     pub(crate) encoded_paints: Vec<EncodedPaint>,
+    #[allow(dead_code, reason = "used when the `text` feature is enabled")]
     pub(crate) level: Level,
     dispatcher: Box<dyn Dispatcher>,
 }
@@ -224,7 +225,8 @@ impl RenderContext {
     }
 
     /// Creates a builder for drawing a run of glyphs that have the same attributes.
-    pub fn glyph_run(&mut self, font: &Font) -> GlyphRunBuilder<'_, Self> {
+    #[cfg(feature = "text")]
+    pub fn glyph_run(&mut self, font: &crate::peniko::Font) -> GlyphRunBuilder<'_, Self> {
         GlyphRunBuilder::new(font.clone(), self.transform, self)
     }
 
@@ -389,6 +391,7 @@ impl RenderContext {
     }
 }
 
+#[cfg(feature = "text")]
 impl GlyphRenderer for RenderContext {
     fn fill_glyph(&mut self, prepared_glyph: PreparedGlyph<'_>) {
         match prepared_glyph.glyph_type {
@@ -412,15 +415,15 @@ impl GlyphRenderer for RenderContext {
                 let quality = if prepared_glyph.transform.as_coeffs()[0] < 0.5
                     || prepared_glyph.transform.as_coeffs()[3] < 0.5
                 {
-                    ImageQuality::High
+                    crate::peniko::ImageQuality::High
                 } else {
-                    ImageQuality::Medium
+                    crate::peniko::ImageQuality::Medium
                 };
 
-                let image = Image {
+                let image = vello_common::paint::Image {
                     pixmap: Arc::new(glyph.pixmap),
-                    x_extend: peniko::Extend::Pad,
-                    y_extend: peniko::Extend::Pad,
+                    x_extend: crate::peniko::Extend::Pad,
+                    y_extend: crate::peniko::Extend::Pad,
                     quality,
                 };
 
@@ -463,13 +466,13 @@ impl GlyphRenderer for RenderContext {
                     pix
                 };
 
-                let image = Image {
+                let image = vello_common::paint::Image {
                     pixmap: Arc::new(glyph_pixmap),
-                    x_extend: peniko::Extend::Pad,
-                    y_extend: peniko::Extend::Pad,
+                    x_extend: crate::peniko::Extend::Pad,
+                    y_extend: crate::peniko::Extend::Pad,
                     // Since the pixmap will already have the correct size, no need to
                     // use a different image quality here.
-                    quality: ImageQuality::Low,
+                    quality: crate::peniko::ImageQuality::Low,
                 };
 
                 self.set_paint(image);
@@ -503,6 +506,7 @@ impl GlyphRenderer for RenderContext {
     }
 }
 
+#[cfg(feature = "text")]
 impl ColrRenderer for RenderContext {
     fn push_clip_layer(&mut self, clip: &BezPath) {
         Self::push_clip_layer(self, clip);
@@ -522,7 +526,7 @@ impl ColrRenderer for RenderContext {
         ));
     }
 
-    fn fill_gradient(&mut self, gradient: Gradient) {
+    fn fill_gradient(&mut self, gradient: crate::peniko::Gradient) {
         self.set_paint(gradient);
         self.fill_rect(&Rect::new(
             0.0,


### PR DESCRIPTION
Unfortunately I'm stuck because just enabling the "std" feature will also enable the "skrifa/std" feature, and because of this skrifa will be pulled in as a dependency even though the text feature is disabled. I'm not sure how to best solve this without adding two `skrifa-std`/`skrifa-libm` features that need to be enabled manually by the user. Suggestions are welcome.

The main motivation is that it would allow using the renderer in contexts where text rendering is already implemented with a different method, without having to pull in skrifa as a dependency (e.g. resvg).