### PR TITLE
[vello_sparse_tests] Add vello_cpu scalar test coverage on WASM

### DIFF
--- a/sparse_strips/vello_sparse_tests/README.md
+++ b/sparse_strips/vello_sparse_tests/README.md
@@ -44,7 +44,7 @@ See all the attributes that can be passed to `vello_test` in `vello_dev_macros/t
 Requirements:
  - on MacOS, a minimum Clang major version of 20 is required.
 
-To run the `vello_sparse_tests` suite on WebGL headless:
+To run the `vello_sparse_tests` suite including the WebGL tests:
 
 ```sh
 wasm-pack test --headless --chrome --features webgl

--- a/sparse_strips/vello_sparse_tests/tests/image.rs
+++ b/sparse_strips/vello_sparse_tests/tests/image.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use crate::gradient::tan_45;
+use crate::load_image;
 use crate::renderer::Renderer;
 use crate::util::crossed_line_star;
 use std::f64::consts::PI;
-use std::path::Path;
 use std::sync::Arc;
 use vello_common::kurbo::{Affine, Point, Rect};
 use vello_common::paint::Image;
@@ -13,33 +13,28 @@ use vello_common::peniko::{Extend, ImageQuality};
 use vello_common::pixmap::Pixmap;
 use vello_dev_macros::vello_test;
 
-pub(crate) fn load_image(name: &str) -> Arc<Pixmap> {
-    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(format!("tests/assets/{name}.png"));
-    Arc::new(Pixmap::from_png(std::fs::File::open(path).unwrap()).unwrap())
-}
-
 fn rgb_img_10x10() -> Arc<Pixmap> {
-    load_image("rgb_image_10x10")
+    load_image!("rgb_image_10x10")
 }
 
 fn rgb_img_2x2() -> Arc<Pixmap> {
-    load_image("rgb_image_2x2")
+    load_image!("rgb_image_2x2")
 }
 
 fn rgb_img_2x3() -> Arc<Pixmap> {
-    load_image("rgb_image_2x3")
+    load_image!("rgb_image_2x3")
 }
 
 fn rgba_img_10x10() -> Arc<Pixmap> {
-    load_image("rgba_image_10x10")
+    load_image!("rgba_image_10x10")
 }
 
 fn luma_img_10x10() -> Arc<Pixmap> {
-    load_image("luma_image_10x10")
+    load_image!("luma_image_10x10")
 }
 
 fn lumaa_img_10x10() -> Arc<Pixmap> {
-    load_image("lumaa_image_10x10")
+    load_image!("lumaa_image_10x10")
 }
 
 fn repeat(ctx: &mut impl Renderer, x_extend: Extend, y_extend: Extend) {

--- a/sparse_strips/vello_sparse_tests/tests/mix.rs
+++ b/sparse_strips/vello_sparse_tests/tests/mix.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use crate::image::load_image;
+use crate::load_image;
 use crate::renderer::Renderer;
 use smallvec::smallvec;
 use vello_common::color::palette::css::{BLUE, LIME, MAGENTA, RED, YELLOW};
@@ -49,7 +49,7 @@ fn mix(ctx: &mut impl Renderer, blend_mode: BlendMode) {
     };
 
     let image = Image {
-        pixmap: load_image("cowboy"),
+        pixmap: load_image!("cowboy"),
         x_extend: Extend::Pad,
         y_extend: Extend::Pad,
         quality: ImageQuality::Low,

--- a/sparse_strips/vello_sparse_tests/tests/mod.rs
+++ b/sparse_strips/vello_sparse_tests/tests/mod.rs
@@ -37,4 +37,5 @@ mod mask;
 mod mix;
 mod opacity;
 mod renderer;
+#[macro_use]
 mod util;

--- a/sparse_strips/vello_sparse_tests/tests/util.rs
+++ b/sparse_strips/vello_sparse_tests/tests/util.rs
@@ -32,6 +32,27 @@ static DIFFS_PATH: std::sync::LazyLock<PathBuf> = std::sync::LazyLock::new(|| {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../vello_sparse_tests/diffs")
 });
 
+/// Helper for loading png images contained within "tests/assets/**".
+#[macro_export]
+macro_rules! load_image {
+    ($name:expr) => {{
+        #[cfg(target_arch = "wasm32")]
+        {
+            let bytes = include_bytes!(concat!("../tests/assets/", $name, ".png"));
+            std::sync::Arc::new(vello_common::pixmap::Pixmap::from_png(&bytes[..]).unwrap())
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join(format!("tests/assets/{}.png", $name));
+            std::sync::Arc::new(
+                vello_common::pixmap::Pixmap::from_png(std::fs::File::open(path).unwrap()).unwrap(),
+            )
+        }
+    }};
+}
+
 pub(crate) fn get_ctx<T: Renderer>(
     width: u16,
     height: u16,


### PR DESCRIPTION
### Context

This is a test only PR - adding additional test coverage for scalar vello_cpu tests running on the browser.

**Before this PR:**

```sh
$ wasm-pack test --firefox --headless --features=webgl
test result: ok. 85 passed; 0 failed; 165 ignored; 0 filtered out; finished in 7.49s
```

**After this PR:**

```sh
$ wasm-pack test --firefox --headless --features=webgl
test result: ok. 581 passed; 0 failed; 169 ignored; 0 filtered out; finished in 22.18s
```

This can also be seen [in CI](https://github.com/linebender/vello/actions/runs/15842375361/job/44657293874?pr=1065#step:11:790) of this PR.

### Changes 

 - `load_image` has been moved into `utils` and has become a macro. This is required such that WASM can embed the image assets into the compiled WASM binary (as wasm doesn't have access to filesystem).
 - Most changes are to the `vello_test` proc macro, which now generates two additional tests, a u8 and f32 scalar wasm cpu test.

### Test plan

This whole PR is the test.

