### PR TITLE
Add benchmarks for flattening and stroke expansion

### DIFF
--- a/sparse_strips/vello_bench/benches/main.rs
+++ b/sparse_strips/vello_bench/benches/main.rs
@@ -4,7 +4,7 @@
 #![allow(missing_docs, reason = "Not needed for benchmarks")]
 
 use criterion::{criterion_group, criterion_main};
-use vello_bench::{fine, strip, tile};
+use vello_bench::{fine, flatten, strip, tile};
 
 criterion_group!(fine_solid, fine::fill);
 criterion_group!(fine_strip, fine::strip);
@@ -14,10 +14,14 @@ criterion_group!(fine_rounded_blurred_rect, fine::rounded_blurred_rect);
 criterion_group!(fine_blend, fine::blend);
 criterion_group!(fine_image, fine::image);
 criterion_group!(tile, tile::tile);
+criterion_group!(flatten, flatten::flatten);
+criterion_group!(strokes, flatten::strokes);
 criterion_group!(render_strips, strip::render_strips);
 criterion_main!(
     tile,
     render_strips,
+    flatten,
+    strokes,
     fine_solid,
     fine_strip,
     fine_pack,

--- a/sparse_strips/vello_bench/src/data.rs
+++ b/sparse_strips/vello_bench/src/data.rs
@@ -42,8 +42,8 @@ pub fn get_data_items() -> &'static [DataItem] {
 #[derive(Clone, Debug)]
 pub struct DataItem {
     pub name: String,
-    pub fills: Vec<BezPath>,
-    pub strokes: Vec<BezPath>,
+    pub fills: Vec<FilledPath>,
+    pub strokes: Vec<StrokedPath>,
     pub width: u16,
     pub height: u16,
 }
@@ -75,30 +75,39 @@ impl DataItem {
     }
 
     /// Get the raw flattened lines of both fills and strokes.
-    ///
-    /// A stroke width of 2.0 is assumed.
     pub fn lines(&self) -> Vec<Line> {
         let mut line_buf = vec![];
         let mut temp_buf = vec![];
 
         for path in &self.fills {
-            flatten::fill(path, Affine::default(), &mut temp_buf);
+            flatten::fill(&path.path, path.transform, &mut temp_buf);
             line_buf.extend(&temp_buf);
         }
 
-        let stroke = Stroke {
-            // Obviously not all strokes have that width, but it should be good enough
-            // for benchmarking.
-            width: 2.0,
-            ..Default::default()
-        };
-
         for path in &self.strokes {
-            flatten::stroke(path, &stroke, Affine::default(), &mut temp_buf);
+            let stroke = Stroke {
+                width: path.stroke_width as f64,
+                ..Default::default()
+            };
+            flatten::stroke(&path.path, &stroke, path.transform, &mut temp_buf);
             line_buf.extend(&temp_buf);
         }
 
         line_buf
+    }
+
+    pub fn expanded_strokes(&self) -> Vec<BezPath> {
+        let mut paths = vec![];
+
+        for path in &self.strokes {
+            let stroke = Stroke {
+                width: path.stroke_width as f64,
+                ..Default::default()
+            };
+            paths.push(flatten::expand_stroke(path.path.iter(), &stroke, 0.25));
+        }
+
+        paths
     }
 
     /// Get the unsorted tiles.
@@ -153,8 +162,8 @@ fn convert(ctx: &mut ConversionContext, g: &Group) {
                     ctx.add_filled_path(converted.clone());
                 }
 
-                if p.stroke().is_some() {
-                    ctx.add_stroked_path(converted);
+                if let Some(stroke) = p.stroke() {
+                    ctx.add_stroked_path(converted, stroke.width().get());
                 }
             }
             Node::Image(_) | Node::Text(_) => {}
@@ -164,11 +173,24 @@ fn convert(ctx: &mut ConversionContext, g: &Group) {
     ctx.pop();
 }
 
+#[derive(Debug, Clone)]
+pub struct FilledPath {
+    pub path: BezPath,
+    pub transform: Affine,
+}
+
+#[derive(Debug, Clone)]
+pub struct StrokedPath {
+    pub path: BezPath,
+    pub transform: Affine,
+    pub stroke_width: f32,
+}
+
 #[derive(Debug)]
 struct ConversionContext {
     stack: Vec<Affine>,
-    fills: Vec<BezPath>,
-    strokes: Vec<BezPath>,
+    fills: Vec<FilledPath>,
+    strokes: Vec<StrokedPath>,
 }
 
 impl ConversionContext {
@@ -186,11 +208,18 @@ impl ConversionContext {
     }
 
     fn add_filled_path(&mut self, path: BezPath) {
-        self.fills.push(self.get() * path);
+        self.fills.push(FilledPath {
+            path,
+            transform: self.get(),
+        });
     }
 
-    fn add_stroked_path(&mut self, path: BezPath) {
-        self.strokes.push(self.get() * path);
+    fn add_stroked_path(&mut self, path: BezPath, stroke_width: f32) {
+        self.strokes.push(StrokedPath {
+            path,
+            transform: self.get(),
+            stroke_width,
+        });
     }
 
     fn get(&self) -> Affine {

--- a/sparse_strips/vello_bench/src/data.rs
+++ b/sparse_strips/vello_bench/src/data.rs
@@ -96,6 +96,7 @@ impl DataItem {
         line_buf
     }
 
+    /// Get the expanded strokes.
     pub fn expanded_strokes(&self) -> Vec<BezPath> {
         let mut paths = vec![];
 

--- a/sparse_strips/vello_bench/src/flatten.rs
+++ b/sparse_strips/vello_bench/src/flatten.rs
@@ -1,3 +1,6 @@
+// Copyright 2025 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use crate::data::get_data_items;
 use criterion::Criterion;
 use vello_common::flatten;

--- a/sparse_strips/vello_bench/src/flatten.rs
+++ b/sparse_strips/vello_bench/src/flatten.rs
@@ -1,0 +1,66 @@
+use crate::data::get_data_items;
+use criterion::Criterion;
+use vello_common::flatten;
+use vello_common::kurbo::Stroke;
+use vello_cpu::kurbo::Affine;
+
+pub fn flatten(c: &mut Criterion) {
+    let mut g = c.benchmark_group("flatten");
+
+    macro_rules! flatten_single {
+        ($item:expr) => {
+            let expanded_strokes = $item.expanded_strokes();
+
+            g.bench_function($item.name.clone(), |b| {
+                b.iter(|| {
+                    let mut line_buf: Vec<flatten::Line> = vec![];
+                    let mut temp_buf: Vec<flatten::Line> = vec![];
+
+                    for path in &$item.fills {
+                        flatten::fill(&path.path, path.transform, &mut temp_buf);
+                        line_buf.extend(&temp_buf);
+                    }
+
+                    for stroke in &expanded_strokes {
+                        flatten::fill(stroke, Affine::IDENTITY, &mut temp_buf);
+                        line_buf.extend(&temp_buf);
+                    }
+
+                    std::hint::black_box(&line_buf);
+                })
+            });
+        };
+    }
+
+    for item in get_data_items() {
+        flatten_single!(item);
+    }
+}
+
+pub fn strokes(c: &mut Criterion) {
+    let mut g = c.benchmark_group("strokes");
+
+    macro_rules! expand_single {
+        ($item:expr) => {
+            g.bench_function($item.name.clone(), |b| {
+                b.iter(|| {
+                    let mut paths = vec![];
+
+                    for path in &$item.strokes {
+                        let stroke = Stroke {
+                            width: path.stroke_width as f64,
+                            ..Default::default()
+                        };
+                        paths.push(flatten::expand_stroke(path.path.iter(), &stroke, 0.25));
+                    }
+
+                    std::hint::black_box(&paths);
+                })
+            });
+        };
+    }
+
+    for item in get_data_items() {
+        expand_single!(item);
+    }
+}

--- a/sparse_strips/vello_bench/src/lib.rs
+++ b/sparse_strips/vello_bench/src/lib.rs
@@ -8,6 +8,7 @@ use std::sync::LazyLock;
 
 pub mod data;
 pub mod fine;
+pub mod flatten;
 pub mod strip;
 pub mod tile;
 

--- a/sparse_strips/vello_common/src/flatten.rs
+++ b/sparse_strips/vello_common/src/flatten.rs
@@ -3,7 +3,7 @@
 
 //! Flattening filled and stroked paths.
 
-use crate::kurbo::{self, Affine, BezPath, Stroke, StrokeOpts};
+use crate::kurbo::{self, Affine, BezPath, PathEl, Stroke, StrokeOpts};
 use alloc::vec::Vec;
 
 /// The flattening tolerance.
@@ -113,8 +113,13 @@ pub fn stroke(path: &BezPath, style: &Stroke, affine: Affine, line_buf: &mut Vec
     // TODO: Temporary hack to ensure that strokes are scaled properly by the transform.
     let tolerance = TOL / affine.as_coeffs()[0].abs().max(affine.as_coeffs()[3].abs());
 
-    let expanded = kurbo::stroke(path.iter(), style, &StrokeOpts::default(), tolerance);
+    let expanded = expand_stroke(path.iter(), style, tolerance);
     fill(&expanded, affine, line_buf);
+}
+
+/// Expand a stroked path to a filled path.
+pub fn expand_stroke(path: impl IntoIterator<Item = PathEl>, style: &Stroke, tolerance: f64) -> BezPath {
+    kurbo::stroke(path, style, &StrokeOpts::default(), tolerance)
 }
 
 fn close_path(start: kurbo::Point, p0: kurbo::Point, line_buf: &mut Vec<Line>) {

--- a/sparse_strips/vello_common/src/flatten.rs
+++ b/sparse_strips/vello_common/src/flatten.rs
@@ -118,7 +118,11 @@ pub fn stroke(path: &BezPath, style: &Stroke, affine: Affine, line_buf: &mut Vec
 }
 
 /// Expand a stroked path to a filled path.
-pub fn expand_stroke(path: impl IntoIterator<Item = PathEl>, style: &Stroke, tolerance: f64) -> BezPath {
+pub fn expand_stroke(
+    path: impl IntoIterator<Item = PathEl>,
+    style: &Stroke,
+    tolerance: f64,
+) -> BezPath {
     kurbo::stroke(path, style, &StrokeOpts::default(), tolerance)
 }
 


### PR DESCRIPTION
So that we can more effectively measure the performance benefits of the new stroker, as well as measure the impact of SIMDifying the stroking/flattening stages.