### PR TITLE
fix: sparse_strips scalar WASM build containing SIMD instructions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,8 +919,9 @@ dependencies = [
 [[package]]
 name = "fearless_simd"
 version = "0.2.0"
-source = "git+https://github.com/raphlinus/fearless_simd?rev=e46bcfd#e46bcfd622dbd7edd8538c836d9b100b6101aa15"
+source = "git+https://github.com/raphlinus/fearless_simd?rev=1c658f7#1c658f79db9eb4014d5bb14ed08c5fb91c44a230"
 dependencies = [
+ "bytemuck",
  "libm",
 ]
 
@@ -1302,6 +1303,7 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+ "serde",
 ]
 
 [[package]]
@@ -3837,7 +3839,9 @@ dependencies = [
  "vello_dev_macros",
  "vello_hybrid",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "wasm-bindgen-test",
+ "wasmparser 0.235.0",
  "web-sys",
  "wgpu",
 ]
@@ -3895,7 +3899,7 @@ dependencies = [
  "rayon",
  "walrus-macro",
  "wasm-encoder",
- "wasmparser",
+ "wasmparser 0.214.0",
 ]
 
 [[package]]
@@ -4085,7 +4089,7 @@ dependencies = [
  "leb128",
  "log",
  "walrus",
- "wasmparser",
+ "wasmparser 0.214.0",
 ]
 
 [[package]]
@@ -4118,6 +4122,19 @@ dependencies = [
  "ahash",
  "bitflags 2.9.1",
  "hashbrown 0.14.5",
+ "indexmap 2.9.0",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.235.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
+dependencies = [
+ "bitflags 2.9.1",
+ "hashbrown 0.15.3",
  "indexmap 2.9.0",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ rayon = { version = "1.10.0" }
 thread_local = "1.1.8"
 crossbeam-channel = "0.5.15"
 ordered-channel = { version = "1.2.0", features = ["crossbeam-channel"] }
-fearless_simd = { git = "https://github.com/raphlinus/fearless_simd", rev = "e46bcfd", default-features = false }
+fearless_simd = { git = "https://github.com/raphlinus/fearless_simd", rev = "1c658f7", default-features = false }
 
 # The below crates are experimental!
 vello_api = { path = "sparse_strips/vello_api", default-features = false }

--- a/sparse_strips/vello_sparse_tests/Cargo.toml
+++ b/sparse_strips/vello_sparse_tests/Cargo.toml
@@ -41,8 +41,12 @@ web-sys = { version = "0.3.77", features = [
     "Blob",
     "BlobPropertyBag",
     "Url",
+    "Response",
 ] }
 wasm-bindgen = "0.2.100"
+wasm-bindgen-futures = "0.4.50"
+# Required for introspecting the built WASM binary.
+wasmparser = "0.235.0"
 
 [features]
 webgl = ["vello_hybrid/webgl"]

--- a/sparse_strips/vello_sparse_tests/tests/mod.rs
+++ b/sparse_strips/vello_sparse_tests/tests/mod.rs
@@ -39,3 +39,5 @@ mod opacity;
 mod renderer;
 #[macro_use]
 mod util;
+#[cfg(target_arch = "wasm32")]
+mod wasm_binary_invariants;

--- a/sparse_strips/vello_sparse_tests/tests/wasm_binary_invariants.rs
+++ b/sparse_strips/vello_sparse_tests/tests/wasm_binary_invariants.rs
@@ -1,0 +1,38 @@
+// Copyright 2025 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use wasm_bindgen_test::*;
+
+#[cfg(not(target_feature = "simd128"))]
+#[wasm_bindgen_test]
+async fn no_simd_instruction_inclusion() {
+    // Unless the WASM binary is explicitly built with `RUSTFLAGS=-Ctarget-feature=+simd128` then it
+    // is imperative that there isn't a single SIMD instruction in the resulting binary. These can
+    // accidentally creep into the binary due to usage of `#![cfg(target_feature = "simd128")]`. Any
+    // inclusion of a SIMD instruction in a non-SIMD WASM binary can invalidate the whole binary for
+    // browsers that do not have SIMD support.
+    //
+    // This test runs when simd128 is not enabled, and self-introspects the binary to ensure no SIMD
+    // instructions are included.
+
+    use wasm_bindgen::JsCast;
+    use wasm_bindgen_futures::JsFuture;
+    use wasmparser::{Validator, WasmFeatures};
+
+    let window = web_sys::window().unwrap();
+    let url = "/wasm-bindgen-test_bg.wasm";
+    let response = JsFuture::from(window.fetch_with_str(&url)).await.unwrap();
+    let response: web_sys::Response = response.dyn_into().unwrap();
+    assert!(response.ok(), "binary could not be fetched");
+    let buffer = JsFuture::from(response.array_buffer().unwrap())
+        .await
+        .unwrap();
+    let bytes = web_sys::js_sys::Uint8Array::new(&buffer).to_vec();
+
+    // Create the default wasm featureset, and explicitly subtract SIMD.
+    let mut wasm_non_simd_validator =
+        Validator::new_with_features(WasmFeatures::default().difference(WasmFeatures::SIMD));
+
+    // If validation is ok then no simd128 instructions were encountered.
+    assert!(wasm_non_simd_validator.validate_all(&bytes).is_ok());
+}


### PR DESCRIPTION
### Context

This is a bit of a subtle fix that follows https://github.com/raphlinus/fearless_simd/pull/16

The important excerpts from the WebAssembly spec.

> "[Modules](https://www.w3.org/TR/wasm-core-2/index.html#syntax-module) are valid when all the components they contain are valid."
> ~[link](https://www.w3.org/TR/wasm-core-2/#modules%E2%91%A2)

Thus, for a browser (or WebAssembly runtime) that doesn't support SIMD, the module validation check would fail because:
 - `v128` type would be invalid and wouldn't exist in that WebAssembly context.
 - `expr` must also be valid, so instructions over f32x4 would fail validation.

###  Why

Prior to the fearless_simd fix, it was possible via `target_feature` to accidentally leak SIMD instructions into the binary. Even if these instructions are never executed, their mere presence would result in the WASM binary failing to validate.

### Changes

This PR was implemented in a test-driven style.

First I implemented the test:
 - The test only runs if the `simd128` target feature is not requested in the rustc flags.
 - The test self-introspects the test wasm binary and validates the binary against a validator that doesn't contain SIMD support.

This test failed (because of the leaking SIMD instructions). Hence, on a browser that didn't support SIMD we would crash. (Not good for consumers of vello using WASM asking for a scalar binary).

Example test failure:

<img width="1022" alt="Screenshot 2025-06-27 at 3 21 59 pm" src="https://github.com/user-attachments/assets/fe886294-5cb1-40ea-b97d-0f7b10ce62b5" />

Then I bumped up fearless_simd, and the test passes!

### Test plan

This PR is effectively a test to prevent regressions.
