### PR TITLE
Fix `unused_mut` lint

### DIFF
--- a/vello/src/util.rs
+++ b/vello/src/util.rs
@@ -247,7 +247,7 @@ impl std::task::Wake for NullWake {
 ///
 /// This will deadlock if the future is awaiting anything other than GPU progress.
 #[cfg_attr(docsrs, doc(hidden))]
-pub fn block_on_wgpu<F: Future>(device: &Device, mut fut: F) -> F::Output {
+pub fn block_on_wgpu<F: Future>(device: &Device, fut: F) -> F::Output {
     if cfg!(target_arch = "wasm32") {
         panic!("Blocking can't work on WASM, so don't try");
     }


### PR DESCRIPTION
This starts showing up in Rust 1.88.