### PR TITLE
sparse_strips: fix strip generation on WASM +simd128

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,6 +359,10 @@ jobs:
         run: wasm-pack test --headless --chrome --features webgl
         working-directory: sparse_strips/vello_sparse_tests
 
+      - name: Run vello_sparse_tests (+simd128) on Chrome
+        run: RUSTFLAGS=-Ctarget-feature=+simd128 wasm-pack test --headless --chrome --features webgl
+        working-directory: sparse_strips/vello_sparse_tests
+
 
   check-stable-android:
     name: cargo check (aarch64-android)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,7 +919,7 @@ dependencies = [
 [[package]]
 name = "fearless_simd"
 version = "0.2.0"
-source = "git+https://github.com/raphlinus/fearless_simd?rev=1c658f7#1c658f79db9eb4014d5bb14ed08c5fb91c44a230"
+source = "git+https://github.com/raphlinus/fearless_simd?rev=8c22f7c#8c22f7c469633d94e10deb116ad0df005ed3d024"
 dependencies = [
  "bytemuck",
  "libm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ rayon = { version = "1.10.0" }
 thread_local = "1.1.8"
 crossbeam-channel = "0.5.15"
 ordered-channel = { version = "1.2.0", features = ["crossbeam-channel"] }
-fearless_simd = { git = "https://github.com/raphlinus/fearless_simd", rev = "1c658f7", default-features = false }
+fearless_simd = { git = "https://github.com/raphlinus/fearless_simd", rev = "8c22f7c", default-features = false }
 
 # The below crates are experimental!
 vello_api = { path = "sparse_strips/vello_api", default-features = false }

--- a/sparse_strips/vello_dev_macros/src/test.rs
+++ b/sparse_strips/vello_dev_macros/src/test.rs
@@ -189,7 +189,7 @@ pub(crate) fn vello_test_inner(attr: TokenStream, item: TokenStream) -> TokenStr
                        num_threads: u16,
                        // Need to pass as string, to avoid dependency on `fearless_simd` and also
                        // so that it works with proc_macros.
-                       level: &str,
+                       level: proc_macro2::TokenStream,
                        ignore: bool,
                        render_mode: proc_macro2::TokenStream| {
         // Use the name to infer if the test is running in the browser.
@@ -237,13 +237,20 @@ pub(crate) fn vello_test_inner(attr: TokenStream, item: TokenStream) -> TokenStr
     #[cfg(not(target_arch = "aarch64"))]
     let has_neon = false;
 
+    let wasm_simd_level = quote! {if cfg!(target_feature = "simd128") {
+            "wasm_simd128"
+        } else {
+            "fallback"
+        }
+    };
+
     let u8_snippet = cpu_snippet(
         u8_fn_name_scalar,
         u8_fn_name_str_scalar,
         cpu_u8_tolerance_scalar,
         false,
         0,
-        "fallback",
+        quote! {"fallback"},
         skip_cpu,
         quote! { RenderMode::OptimizeSpeed },
     );
@@ -253,7 +260,7 @@ pub(crate) fn vello_test_inner(attr: TokenStream, item: TokenStream) -> TokenStr
         cpu_f32_tolerance_scalar,
         true,
         0,
-        "fallback",
+        quote! {"fallback"},
         skip_cpu,
         quote! { RenderMode::OptimizeQuality },
     );
@@ -263,7 +270,7 @@ pub(crate) fn vello_test_inner(attr: TokenStream, item: TokenStream) -> TokenStr
         cpu_u8_tolerance_scalar,
         false,
         0,
-        "fallback",
+        wasm_simd_level.clone(),
         skip_cpu,
         quote! { RenderMode::OptimizeSpeed },
     );
@@ -273,7 +280,7 @@ pub(crate) fn vello_test_inner(attr: TokenStream, item: TokenStream) -> TokenStr
         cpu_f32_tolerance_scalar,
         true,
         0,
-        "fallback",
+        wasm_simd_level,
         skip_cpu,
         quote! { RenderMode::OptimizeQuality },
     );
@@ -283,7 +290,7 @@ pub(crate) fn vello_test_inner(attr: TokenStream, item: TokenStream) -> TokenStr
         cpu_f32_tolerance_scalar,
         false,
         3,
-        "fallback",
+        quote! {"fallback"},
         skip_cpu,
         quote! { RenderMode::OptimizeQuality },
     );
@@ -294,7 +301,7 @@ pub(crate) fn vello_test_inner(attr: TokenStream, item: TokenStream) -> TokenStr
         cpu_u8_tolerance_neon,
         false,
         0,
-        "neon",
+        quote! {"neon"},
         skip_cpu | !has_neon,
         quote! { RenderMode::OptimizeSpeed },
     );
@@ -305,7 +312,7 @@ pub(crate) fn vello_test_inner(attr: TokenStream, item: TokenStream) -> TokenStr
         cpu_f32_tolerance_neon,
         false,
         0,
-        "neon",
+        quote! {"neon"},
         skip_cpu | !has_neon,
         quote! { RenderMode::OptimizeQuality },
     );

--- a/sparse_strips/vello_dev_macros/src/test.rs
+++ b/sparse_strips/vello_dev_macros/src/test.rs
@@ -80,12 +80,12 @@ pub(crate) fn vello_test_inner(attr: TokenStream, item: TokenStream) -> TokenStr
         &format!("{}_cpu_f32_neon", input_fn_name),
         input_fn_name.span(),
     );
-    let u8_fn_name_scalar_wasm = Ident::new(
-        &format!("{}_cpu_u8_scalar_wasm", input_fn_name),
+    let u8_fn_name_wasm = Ident::new(
+        &format!("{}_cpu_u8_wasm", input_fn_name),
         input_fn_name.span(),
     );
-    let f32_fn_name_scalar_wasm: Ident = Ident::new(
-        &format!("{}_cpu_f32_scalar_wasm", input_fn_name),
+    let f32_fn_name_wasm: Ident = Ident::new(
+        &format!("{}_cpu_f32_wasm", input_fn_name),
         input_fn_name.span(),
     );
     let multithreaded_fn_name = Ident::new(
@@ -107,8 +107,8 @@ pub(crate) fn vello_test_inner(attr: TokenStream, item: TokenStream) -> TokenStr
     let f32_fn_name_str_scalar = f32_fn_name_scalar.to_string();
     let u8_fn_name_str_neon = u8_fn_name_neon.to_string();
     let f32_fn_name_str_neon = f32_fn_name_neon.to_string();
-    let u8_fn_name_scalar_wasm_str = u8_fn_name_scalar_wasm.to_string();
-    let f32_fn_name_scalar_wasm_str = f32_fn_name_scalar_wasm.to_string();
+    let u8_fn_name_wasm_str = u8_fn_name_wasm.to_string();
+    let f32_fn_name_wasm_str = f32_fn_name_wasm.to_string();
     let multithreaded_fn_name_str = multithreaded_fn_name.to_string();
     let hybrid_fn_name_str = hybrid_fn_name.to_string();
     let webgl_fn_name_str = webgl_fn_name.to_string();
@@ -265,8 +265,8 @@ pub(crate) fn vello_test_inner(attr: TokenStream, item: TokenStream) -> TokenStr
         quote! { RenderMode::OptimizeQuality },
     );
     let u8_snippet_wasm = cpu_snippet(
-        u8_fn_name_scalar_wasm,
-        u8_fn_name_scalar_wasm_str,
+        u8_fn_name_wasm,
+        u8_fn_name_wasm_str,
         cpu_u8_tolerance_scalar,
         false,
         0,
@@ -275,8 +275,8 @@ pub(crate) fn vello_test_inner(attr: TokenStream, item: TokenStream) -> TokenStr
         quote! { RenderMode::OptimizeSpeed },
     );
     let f32_snippet_wasm = cpu_snippet(
-        f32_fn_name_scalar_wasm,
-        f32_fn_name_scalar_wasm_str,
+        f32_fn_name_wasm,
+        f32_fn_name_wasm_str,
         cpu_f32_tolerance_scalar,
         true,
         0,

--- a/sparse_strips/vello_sparse_tests/tests/util.rs
+++ b/sparse_strips/vello_sparse_tests/tests/util.rs
@@ -63,6 +63,12 @@ pub(crate) fn get_ctx<T: Renderer>(
     let level = match level {
         #[cfg(target_arch = "aarch64")]
         "neon" => Level::Neon(Level::new().as_neon().expect("neon should be available")),
+        #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+        "wasm_simd128" => Level::WasmSimd128(
+            Level::new()
+                .as_wasm_simd128()
+                .expect("wasm simd128 should be available"),
+        ),
         "fallback" => Level::fallback(),
         _ => panic!("unknown level: {}", level),
     };


### PR DESCRIPTION
### Context

This PR upstreams the fearless_simd PR https://github.com/raphlinus/fearless_simd/pull/23 which fixes strip generation on WASM.

This test also enables testing WASM under a SIMD environment.


### Before

<img width="1211" alt="Screenshot 2025-06-27 at 4 13 02 pm" src="https://github.com/user-attachments/assets/7096ba86-0045-463c-b67f-0a40106f3c71" />

### After

Everything passes 😄 


