### PR TITLE
[vello_cpu]: add WASM vello_cpu examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4116,6 +4116,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm_cpu"
+version = "0.5.0"
+dependencies = [
+ "bytemuck",
+ "console_error_panic_hook",
+ "console_log",
+ "js-sys",
+ "log",
+ "parley",
+ "vello_common",
+ "vello_cpu",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test",
+ "web-sys",
+ "wgpu",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.214.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "sparse_strips/vello_bench",
     "sparse_strips/vello_common",
     "sparse_strips/vello_cpu",
+    "sparse_strips/vello_cpu/examples/wasm_cpu",
     "sparse_strips/vello_hybrid",
     "sparse_strips/vello_sparse_shaders",
     "sparse_strips/vello_hybrid/examples/native_webgl",

--- a/sparse_strips/vello_cpu/examples/wasm_cpu/Cargo.toml
+++ b/sparse_strips/vello_cpu/examples/wasm_cpu/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "wasm_cpu"
+version.workspace = true
+description = "An example showing Vello CPU in the browser."
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[lints]
+workspace = true
+
+[dependencies]
+bytemuck = { workspace = true, features = [] }
+console_error_panic_hook = "0.1.7"
+console_log = "1.0"
+js-sys = "0.3.77"
+log = { workspace = true }
+vello_common = { workspace = true, features = ["pico_svg"] }
+vello_cpu = { workspace = true }
+wasm-bindgen = "0.2.100"
+wasm-bindgen-futures = "0.4.50"
+web-sys = { version = "0.3.77", features = [
+    "Window",
+    "Document",
+    "Element",
+    "HtmlElement",
+    "HtmlCanvasElement",
+    "CssStyleDeclaration",
+    "MouseEvent",
+    "WheelEvent",
+    "KeyboardEvent",
+    "CanvasRenderingContext2d",
+] }
+wgpu = { workspace = true, features = ["webgl"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+parley = { version = "0.4.0", default-features = false, features = ["std"] }
+
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3.50"

--- a/sparse_strips/vello_cpu/examples/wasm_cpu/README.md
+++ b/sparse_strips/vello_cpu/examples/wasm_cpu/README.md
@@ -1,0 +1,9 @@
+## Vello CPU in the Browser Demo
+
+Run with `cargo run_wasm -p wasm_cpu --release` for scalar build.
+
+
+To run the demo with SIMD enabled use:
+
+`RUSTFLAGS=-Ctarget-feature=+simd128 cargo run_wasm -p wasm_cpu --release`
+

--- a/sparse_strips/vello_cpu/examples/wasm_cpu/src/lib.rs
+++ b/sparse_strips/vello_cpu/examples/wasm_cpu/src/lib.rs
@@ -15,7 +15,6 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use vello_common::kurbo::{Affine, Vec2};
 use vello_cpu::Level;
-// use vello_hybrid_scenes::AnyScene;
 use wasm_bindgen::prelude::*;
 use web_sys::{Event, HtmlCanvasElement, KeyboardEvent, MouseEvent, WheelEvent};
 

--- a/sparse_strips/vello_cpu/examples/wasm_cpu/src/lib.rs
+++ b/sparse_strips/vello_cpu/examples/wasm_cpu/src/lib.rs
@@ -1,0 +1,366 @@
+// Copyright 2025 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Demonstrates using Vello CPU in the browser.
+
+#![allow(
+    clippy::cast_possible_truncation,
+    reason = "truncation has no appreciable impact in this demo"
+)]
+#![cfg(target_arch = "wasm32")]
+
+mod scenes;
+
+use std::cell::RefCell;
+use std::rc::Rc;
+use vello_common::kurbo::{Affine, Vec2};
+use vello_cpu::Level;
+// use vello_hybrid_scenes::AnyScene;
+use wasm_bindgen::prelude::*;
+use web_sys::{Event, HtmlCanvasElement, KeyboardEvent, MouseEvent, WheelEvent};
+
+use crate::scenes::AnyScene;
+
+/// State that handles scene rendering and interactions
+struct AppState {
+    scenes: Box<[AnyScene]>,
+    current_scene: usize,
+    transform: Affine,
+    mouse_down: bool,
+    last_cursor_position: Option<Vec2>,
+    width: u32,
+    height: u32,
+    renderer: vello_cpu::RenderContext,
+    pixmap: vello_common::pixmap::Pixmap,
+    need_render: bool,
+    canvas: HtmlCanvasElement,
+}
+
+impl AppState {
+    fn new(canvas: HtmlCanvasElement, scenes: Box<[AnyScene]>) -> Self {
+        let width = canvas.width();
+        let height = canvas.height();
+
+        let renderer = vello_cpu::RenderContext::new_with(
+            width as u16,
+            height as u16,
+            &vello_cpu::RenderSettings {
+                num_threads: 0,
+                level: Level::new(),
+            },
+        );
+
+        let pixmap = vello_common::pixmap::Pixmap::new(width as u16, height as u16);
+
+        Self {
+            scenes,
+            current_scene: 0,
+            transform: Affine::IDENTITY,
+            mouse_down: false,
+            last_cursor_position: None,
+            width,
+            height,
+            renderer,
+            pixmap,
+            need_render: true,
+            canvas,
+        }
+    }
+
+    fn render(&mut self) {
+        if !self.need_render {
+            return;
+        }
+        self.renderer.reset();
+        self.scenes[self.current_scene].render(&mut self.renderer, self.transform);
+
+        // Render the current scene with transform
+        self.renderer
+            .render_to_pixmap(&mut self.pixmap, vello_cpu::RenderMode::default());
+        let rgba_bytes = self.pixmap.data_as_u8_slice();
+        let image_data = web_sys::ImageData::new_with_u8_clamped_array_and_sh(
+            wasm_bindgen::Clamped(rgba_bytes),
+            self.width,
+            self.height,
+        )
+        .expect("Failed to create ImageData");
+        let ctx_2d = self
+            .canvas
+            .get_context("2d")
+            .expect("2D context should be available")
+            .unwrap()
+            .dyn_into::<web_sys::CanvasRenderingContext2d>()
+            .unwrap();
+
+        ctx_2d
+            .put_image_data(&image_data, 0., 0.)
+            .expect("Failed to put image data");
+        self.need_render = false;
+    }
+
+    fn resize(&mut self, width: u32, height: u32) {
+        self.canvas.set_width(width);
+        self.canvas.set_height(height);
+        self.width = width;
+        self.height = height;
+
+        self.pixmap.resize(width as u16, height as u16);
+        self.renderer = vello_cpu::RenderContext::new_with(
+            width as u16,
+            height as u16,
+            &vello_cpu::RenderSettings {
+                num_threads: 0,
+                level: Level::new(),
+            },
+        );
+
+        self.need_render = true;
+    }
+
+    fn next_scene(&mut self) {
+        self.current_scene = (self.current_scene + 1) % self.scenes.len();
+        self.transform = Affine::IDENTITY;
+        self.need_render = true;
+    }
+
+    fn prev_scene(&mut self) {
+        self.current_scene = if self.current_scene == 0 {
+            self.scenes.len() - 1
+        } else {
+            self.current_scene - 1
+        };
+        self.transform = Affine::IDENTITY;
+        self.need_render = true;
+    }
+
+    fn reset_transform(&mut self) {
+        self.transform = Affine::IDENTITY;
+        self.need_render = true;
+    }
+
+    fn handle_mouse_down(&mut self, x: f64, y: f64) {
+        self.mouse_down = true;
+        self.last_cursor_position = Some(Vec2::new(x, y));
+    }
+
+    fn handle_mouse_up(&mut self) {
+        self.mouse_down = false;
+        self.last_cursor_position = None;
+    }
+
+    fn handle_mouse_move(&mut self, x: f64, y: f64) {
+        let current_pos = Vec2::new(x, y);
+
+        if self.mouse_down {
+            if let Some(last_pos) = self.last_cursor_position {
+                let delta = current_pos - last_pos;
+                self.transform = Affine::translate(delta) * self.transform;
+                self.need_render = true;
+            }
+        }
+
+        self.last_cursor_position = Some(current_pos);
+    }
+
+    fn handle_wheel(&mut self, delta_y: f64) {
+        const ZOOM_STEP: f64 = 0.1;
+
+        if let Some(cursor_pos) = self.last_cursor_position {
+            let zoom_factor = (1.0 + delta_y * ZOOM_STEP).max(0.1);
+
+            // Zoom centered at cursor position
+            self.transform = Affine::translate(cursor_pos)
+                * Affine::scale(zoom_factor)
+                * Affine::translate(-cursor_pos)
+                * self.transform;
+
+            self.need_render = true;
+        } else {
+            // If no cursor position is known, zoom centered on screen
+            let center = Vec2::new(self.width as f64 / 2.0, self.height as f64 / 2.0);
+
+            let zoom_factor = (1.0 + delta_y * ZOOM_STEP).max(0.1);
+
+            self.transform = Affine::translate(center)
+                * Affine::scale(zoom_factor)
+                * Affine::translate(-center)
+                * self.transform;
+
+            self.need_render = true;
+        }
+    }
+}
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_name = requestAnimationFrame)]
+    fn request_animation_frame(f: &Closure<dyn FnMut()>);
+}
+
+/// Creates a `HTMLCanvasElement` of the given dimensions and renders the given scenes into it,
+/// with interactive controls for panning, zooming, and switching between scenes.
+pub async fn run_interactive(canvas_width: u16, canvas_height: u16) {
+    let canvas = web_sys::Window::document(&web_sys::window().unwrap())
+        .unwrap()
+        .create_element("canvas")
+        .unwrap()
+        .dyn_into::<web_sys::HtmlCanvasElement>()
+        .unwrap();
+    canvas.set_width(canvas_width as u32);
+    canvas.set_height(canvas_height as u32);
+    canvas.style().set_property("width", "100%").unwrap();
+    canvas.style().set_property("height", "100%").unwrap();
+
+    let body = web_sys::Window::document(&web_sys::window().unwrap())
+        .unwrap()
+        .body()
+        .unwrap();
+    // Apply background color so white text can be seen.
+    body.style()
+        .set_property("background-color", "#111")
+        .unwrap();
+
+    // Add canvas to body
+    body.append_child(&canvas).unwrap();
+
+    let scenes = crate::scenes::get_example_scenes();
+
+    let app_state = Rc::new(RefCell::new(AppState::new(canvas.clone(), scenes)));
+
+    // Set up animation frame loop
+    {
+        let f = Rc::new(RefCell::new(None));
+        let g = f.clone();
+        let app_state = app_state.clone();
+
+        *g.borrow_mut() = Some(Closure::wrap(Box::new(move || {
+            app_state.borrow_mut().render();
+            request_animation_frame(f.borrow().as_ref().unwrap());
+        }) as Box<dyn FnMut()>));
+
+        request_animation_frame(g.borrow().as_ref().unwrap());
+    }
+
+    // Set up window resize event handler
+    {
+        let app_state = app_state.clone();
+        let closure = Closure::wrap(Box::new(move |_: Event| {
+            let window = web_sys::window().unwrap();
+            let dpr = window.device_pixel_ratio();
+
+            let width = window.inner_width().unwrap().as_f64().unwrap() as u32 * dpr as u32;
+            let height = window.inner_height().unwrap().as_f64().unwrap() as u32 * dpr as u32;
+
+            app_state.borrow_mut().resize(width, height);
+        }) as Box<dyn FnMut(_)>);
+
+        let window = web_sys::window().unwrap();
+        window
+            .add_event_listener_with_callback("resize", closure.as_ref().unchecked_ref())
+            .unwrap();
+        closure.forget();
+    }
+
+    // Set up event handlers
+
+    // Mouse down
+    {
+        let app_state = app_state.clone();
+        let closure = Closure::wrap(Box::new(move |event: MouseEvent| {
+            app_state
+                .borrow_mut()
+                .handle_mouse_down(event.client_x() as f64, event.client_y() as f64);
+        }) as Box<dyn FnMut(_)>);
+        canvas
+            .add_event_listener_with_callback("mousedown", closure.as_ref().unchecked_ref())
+            .unwrap();
+        closure.forget();
+    }
+
+    // Mouse up
+    {
+        let app_state = app_state.clone();
+        let closure = Closure::wrap(Box::new(move |_event: MouseEvent| {
+            app_state.borrow_mut().handle_mouse_up();
+        }) as Box<dyn FnMut(_)>);
+        canvas
+            .add_event_listener_with_callback("mouseup", closure.as_ref().unchecked_ref())
+            .unwrap();
+        closure.forget();
+    }
+
+    // Mouse move
+    {
+        let app_state = app_state.clone();
+        let closure = Closure::wrap(Box::new(move |event: MouseEvent| {
+            app_state
+                .borrow_mut()
+                .handle_mouse_move(event.client_x() as f64, event.client_y() as f64);
+        }) as Box<dyn FnMut(_)>);
+        canvas
+            .add_event_listener_with_callback("mousemove", closure.as_ref().unchecked_ref())
+            .unwrap();
+        closure.forget();
+    }
+
+    // Mouse wheel
+    {
+        let app_state = app_state.clone();
+        let closure = Closure::wrap(Box::new(move |event: WheelEvent| {
+            event.prevent_default();
+            let delta = -event.delta_y() / 100.0; // Normalize and invert
+            app_state.borrow_mut().handle_wheel(delta);
+        }) as Box<dyn FnMut(_)>);
+        canvas
+            .add_event_listener_with_callback("wheel", closure.as_ref().unchecked_ref())
+            .unwrap();
+        closure.forget();
+    }
+
+    // Keyboard events (document level)
+    {
+        let app_state = app_state.clone();
+        let document = web_sys::window().unwrap().document().unwrap();
+        let closure =
+            Closure::wrap(
+                Box::new(move |event: KeyboardEvent| match event.key().as_str() {
+                    "ArrowRight" => app_state.borrow_mut().next_scene(),
+                    "ArrowLeft" => app_state.borrow_mut().prev_scene(),
+                    " " => app_state.borrow_mut().reset_transform(),
+                    _ => {}
+                }) as Box<dyn FnMut(_)>,
+            );
+        document
+            .add_event_listener_with_callback("keydown", closure.as_ref().unchecked_ref())
+            .unwrap();
+        closure.forget();
+    }
+
+    // Create instructions element
+    let document = web_sys::window().unwrap().document().unwrap();
+    let instructions = document.create_element("div").unwrap();
+    instructions.set_inner_html(
+        "Left/Right Arrow: Change scene | Space: Reset view | Mouse Drag: Pan | Mouse Wheel: Zoom",
+    );
+    let style = instructions
+        .dyn_ref::<web_sys::HtmlElement>()
+        .unwrap()
+        .style();
+    style.set_property("position", "fixed").unwrap();
+    style.set_property("bottom", "10px").unwrap();
+    style.set_property("left", "10px").unwrap();
+    style
+        .set_property("background", "rgba(0, 0, 0, 0.5)")
+        .unwrap();
+    style.set_property("color", "white").unwrap();
+    style.set_property("padding", "5px 10px").unwrap();
+    style.set_property("border-radius", "5px").unwrap();
+    style.set_property("font-family", "sans-serif").unwrap();
+    style.set_property("pointer-events", "none").unwrap();
+
+    document
+        .body()
+        .unwrap()
+        .append_child(&instructions)
+        .unwrap();
+}

--- a/sparse_strips/vello_cpu/examples/wasm_cpu/src/main.rs
+++ b/sparse_strips/vello_cpu/examples/wasm_cpu/src/main.rs
@@ -1,0 +1,29 @@
+// Copyright 2025 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Demonstrates using Vello CPU in the browser.
+
+#![allow(
+    clippy::cast_possible_truncation,
+    reason = "truncation has no appreciable impact in this demo"
+)]
+
+fn main() {
+    #[cfg(target_arch = "wasm32")]
+    {
+        use wasm_cpu::run_interactive;
+
+        console_error_panic_hook::set_once();
+        console_log::init_with_level(log::Level::Debug).unwrap();
+
+        let window = web_sys::window().unwrap();
+        let dpr = window.device_pixel_ratio();
+
+        let width = window.inner_width().unwrap().as_f64().unwrap() as u16 * dpr as u16;
+        let height = window.inner_height().unwrap().as_f64().unwrap() as u16 * dpr as u16;
+
+        wasm_bindgen_futures::spawn_local(async move {
+            run_interactive(width, height).await;
+        });
+    }
+}

--- a/sparse_strips/vello_cpu/examples/wasm_cpu/src/scenes/clip.rs
+++ b/sparse_strips/vello_cpu/examples/wasm_cpu/src/scenes/clip.rs
@@ -1,0 +1,93 @@
+// Copyright 2025 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Clip example showing deeply nested clipping.
+
+#![expect(
+    clippy::cast_possible_truncation,
+    reason = "We temporarily ignore those because the casts\
+only break in edge cases, and some of them are also only related to conversions from f64 to f32."
+)]
+
+use crate::scenes::ExampleScene;
+use vello_common::color::palette::css::{
+    BLACK, BLUE, DARK_BLUE, DARK_GREEN, GREEN, REBECCA_PURPLE, RED,
+};
+use vello_common::kurbo::{Affine, BezPath, Circle, Point, Rect, Shape, Stroke};
+use vello_common::peniko::Color;
+use vello_cpu::RenderContext;
+
+/// Clip scene state
+#[derive(Debug)]
+pub struct ClipScene {}
+
+impl ExampleScene for ClipScene {
+    fn render(&mut self, ctx: &mut RenderContext, root_transform: Affine) {
+        render(ctx, root_transform);
+    }
+}
+
+impl ClipScene {
+    /// Create a new `ClipScene`
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Default for ClipScene {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn draw_clipping_outline(ctx: &mut RenderContext, path: &BezPath) {
+    let stroke = Stroke::new(1.0);
+    ctx.set_paint(DARK_BLUE);
+    ctx.set_stroke(stroke);
+    ctx.stroke_path(path);
+}
+
+/// Draws a deeply nested clip of circles.
+pub fn render(ctx: &mut RenderContext, root_transform: Affine) {
+    const INITIAL_RADIUS: f64 = 48.0;
+    const RADIUS_DECREMENT: f64 = 2.5;
+    const INNER_COUNT: usize = 10;
+    // `.ceil()` is not constant-evaluatable, so we have to do this at runtime.
+    let outer_count: usize =
+        (INITIAL_RADIUS / RADIUS_DECREMENT / INNER_COUNT as f64).ceil() as usize;
+    const COLORS: [Color; INNER_COUNT] = [
+        RED,
+        DARK_BLUE,
+        DARK_GREEN,
+        REBECCA_PURPLE,
+        BLACK,
+        BLUE,
+        GREEN,
+        RED,
+        DARK_BLUE,
+        DARK_GREEN,
+    ];
+
+    const COVER_RECT: Rect = Rect::new(0.0, 0.0, 100.0, 100.0);
+    const CENTER: Point = Point::new(50.0, 50.0);
+    let mut radius = INITIAL_RADIUS;
+
+    ctx.set_transform(root_transform);
+    for _ in 0..outer_count {
+        for color in COLORS.iter() {
+            let clip_circle = Circle::new(CENTER, radius).to_path(0.1);
+            draw_clipping_outline(ctx, &clip_circle);
+            ctx.push_clip_layer(&clip_circle);
+
+            ctx.set_paint(*color);
+            ctx.fill_rect(&COVER_RECT);
+
+            radius -= RADIUS_DECREMENT;
+        }
+    }
+    for _ in 0..outer_count {
+        for _ in COLORS.iter() {
+            ctx.pop_layer();
+        }
+    }
+}

--- a/sparse_strips/vello_cpu/examples/wasm_cpu/src/scenes/clip.rs
+++ b/sparse_strips/vello_cpu/examples/wasm_cpu/src/scenes/clip.rs
@@ -19,7 +19,7 @@ use vello_cpu::RenderContext;
 
 /// Clip scene state
 #[derive(Debug)]
-pub struct ClipScene {}
+pub(crate) struct ClipScene {}
 
 impl ExampleScene for ClipScene {
     fn render(&mut self, ctx: &mut RenderContext, root_transform: Affine) {
@@ -29,7 +29,7 @@ impl ExampleScene for ClipScene {
 
 impl ClipScene {
     /// Create a new `ClipScene`
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {}
     }
 }
@@ -48,7 +48,7 @@ fn draw_clipping_outline(ctx: &mut RenderContext, path: &BezPath) {
 }
 
 /// Draws a deeply nested clip of circles.
-pub fn render(ctx: &mut RenderContext, root_transform: Affine) {
+pub(crate) fn render(ctx: &mut RenderContext, root_transform: Affine) {
     const INITIAL_RADIUS: f64 = 48.0;
     const RADIUS_DECREMENT: f64 = 2.5;
     const INNER_COUNT: usize = 10;

--- a/sparse_strips/vello_cpu/examples/wasm_cpu/src/scenes/image.rs
+++ b/sparse_strips/vello_cpu/examples/wasm_cpu/src/scenes/image.rs
@@ -1,0 +1,58 @@
+// Copyright 2025 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Simple example scene with an image.
+
+use std::sync::Arc;
+use vello_common::kurbo::{Affine, Rect};
+use vello_common::paint::Image;
+use vello_common::peniko::{Extend, ImageQuality};
+use vello_common::pixmap::Pixmap;
+use vello_cpu::RenderContext;
+
+use crate::scenes::ExampleScene;
+
+/// Image scene state
+#[derive(Debug)]
+pub(crate) struct ImageScene {
+    cowboy_image: Image,
+}
+
+impl ExampleScene for ImageScene {
+    fn render(&mut self, ctx: &mut RenderContext, root_transform: Affine) {
+        render(ctx, root_transform, &self.cowboy_image);
+    }
+}
+
+impl ImageScene {
+    /// Create a new `ImageScene`
+    pub(crate) fn new() -> Self {
+        let data = include_bytes!("../../../../../vello_sparse_tests/tests/assets/cowboy.png");
+        let pixmap = Pixmap::from_png(&data[..]).unwrap();
+
+        Self {
+            cowboy_image: Image {
+                pixmap: Arc::new(pixmap),
+                quality: ImageQuality::Medium,
+                x_extend: Extend::Pad,
+                y_extend: Extend::Pad,
+            },
+        }
+    }
+}
+
+impl Default for ImageScene {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Draws a simple scene with shapes
+pub(crate) fn render(ctx: &mut RenderContext, root_transform: Affine, image: &Image) {
+    // Use a combined transform that includes the root transform
+    let scene_transform = Affine::scale(5.0);
+    ctx.set_transform(root_transform * scene_transform);
+
+    ctx.set_paint(image.clone());
+    ctx.fill_rect(&Rect::new(0., 0., 80., 80.));
+}

--- a/sparse_strips/vello_cpu/examples/wasm_cpu/src/scenes/image.rs
+++ b/sparse_strips/vello_cpu/examples/wasm_cpu/src/scenes/image.rs
@@ -5,7 +5,7 @@
 
 use std::sync::Arc;
 use vello_common::kurbo::{Affine, Rect};
-use vello_common::paint::Image;
+use vello_common::paint::{Image, ImageSource};
 use vello_common::peniko::{Extend, ImageQuality};
 use vello_common::pixmap::Pixmap;
 use vello_cpu::RenderContext;
@@ -32,7 +32,7 @@ impl ImageScene {
 
         Self {
             cowboy_image: Image {
-                pixmap: Arc::new(pixmap),
+                source: ImageSource::Pixmap(Arc::new(pixmap)),
                 quality: ImageQuality::Medium,
                 x_extend: Extend::Pad,
                 y_extend: Extend::Pad,

--- a/sparse_strips/vello_cpu/examples/wasm_cpu/src/scenes/mod.rs
+++ b/sparse_strips/vello_cpu/examples/wasm_cpu/src/scenes/mod.rs
@@ -13,13 +13,13 @@ use vello_common::kurbo::Affine;
 use vello_cpu::RenderContext;
 
 /// Example scene that can maintain state between renders
-pub trait ExampleScene {
+pub(crate) trait ExampleScene {
     /// Render the scene using the current render context
     fn render(&mut self, ctx: &mut RenderContext, root_transform: Affine);
 }
 
 /// A type-erased example scene
-pub struct AnyScene {
+pub(crate) struct AnyScene {
     /// The render function that calls the wrapped scene's render method
     render_fn: RenderFn,
 }
@@ -35,20 +35,20 @@ impl std::fmt::Debug for AnyScene {
 
 impl AnyScene {
     /// Create a new `AnyScene` from any type that implements `ExampleScene`
-    pub fn new<T: ExampleScene + 'static>(mut scene: T) -> Self {
+    pub(crate) fn new<T: ExampleScene + 'static>(mut scene: T) -> Self {
         Self {
             render_fn: Box::new(move |s, transform| scene.render(s, transform)),
         }
     }
 
     /// Render the scene
-    pub fn render(&mut self, scene: &mut RenderContext, root_transform: Affine) {
+    pub(crate) fn render(&mut self, scene: &mut RenderContext, root_transform: Affine) {
         (self.render_fn)(scene, root_transform);
     }
 }
 
 /// Get all available example scenes
-pub fn get_example_scenes() -> Box<[AnyScene]> {
+pub(crate) fn get_example_scenes() -> Box<[AnyScene]> {
     vec![
         AnyScene::new(svg::SvgScene::new()),
         AnyScene::new(simple::SimpleScene::new()),

--- a/sparse_strips/vello_cpu/examples/wasm_cpu/src/scenes/mod.rs
+++ b/sparse_strips/vello_cpu/examples/wasm_cpu/src/scenes/mod.rs
@@ -1,0 +1,60 @@
+// Copyright 2025 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Example scenes for Vello CPU.
+
+pub(crate) mod clip;
+pub(crate) mod image;
+pub(crate) mod simple;
+pub(crate) mod svg;
+pub(crate) mod text;
+
+use vello_common::kurbo::Affine;
+use vello_cpu::RenderContext;
+
+/// Example scene that can maintain state between renders
+pub trait ExampleScene {
+    /// Render the scene using the current render context
+    fn render(&mut self, ctx: &mut RenderContext, root_transform: Affine);
+}
+
+/// A type-erased example scene
+pub struct AnyScene {
+    /// The render function that calls the wrapped scene's render method
+    render_fn: RenderFn,
+}
+
+/// A type-erased render function
+type RenderFn = Box<dyn FnMut(&mut RenderContext, Affine)>;
+
+impl std::fmt::Debug for AnyScene {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AnyScene").finish()
+    }
+}
+
+impl AnyScene {
+    /// Create a new `AnyScene` from any type that implements `ExampleScene`
+    pub fn new<T: ExampleScene + 'static>(mut scene: T) -> Self {
+        Self {
+            render_fn: Box::new(move |s, transform| scene.render(s, transform)),
+        }
+    }
+
+    /// Render the scene
+    pub fn render(&mut self, scene: &mut RenderContext, root_transform: Affine) {
+        (self.render_fn)(scene, root_transform);
+    }
+}
+
+/// Get all available example scenes
+pub fn get_example_scenes() -> Box<[AnyScene]> {
+    vec![
+        AnyScene::new(svg::SvgScene::new()),
+        AnyScene::new(simple::SimpleScene::new()),
+        AnyScene::new(text::TextScene::new("Hello World from vello_cpu")),
+        AnyScene::new(clip::ClipScene::new()),
+        AnyScene::new(image::ImageScene::new()),
+    ]
+    .into_boxed_slice()
+}

--- a/sparse_strips/vello_cpu/examples/wasm_cpu/src/scenes/simple.rs
+++ b/sparse_strips/vello_cpu/examples/wasm_cpu/src/scenes/simple.rs
@@ -11,7 +11,7 @@ use crate::scenes::ExampleScene;
 
 /// Simple scene state
 #[derive(Debug)]
-pub struct SimpleScene {}
+pub(crate) struct SimpleScene {}
 
 impl ExampleScene for SimpleScene {
     fn render(&mut self, ctx: &mut RenderContext, root_transform: Affine) {
@@ -21,7 +21,7 @@ impl ExampleScene for SimpleScene {
 
 impl SimpleScene {
     /// Create a new `SimpleScene`
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {}
     }
 }
@@ -33,7 +33,7 @@ impl Default for SimpleScene {
 }
 
 /// Draws a simple scene with shapes
-pub fn render(ctx: &mut RenderContext, root_transform: Affine) {
+pub(crate) fn render(ctx: &mut RenderContext, root_transform: Affine) {
     let mut path = BezPath::new();
     path.move_to((10.0, 10.0));
     path.line_to((180.0, 20.0));

--- a/sparse_strips/vello_cpu/examples/wasm_cpu/src/scenes/simple.rs
+++ b/sparse_strips/vello_cpu/examples/wasm_cpu/src/scenes/simple.rs
@@ -1,0 +1,53 @@
+// Copyright 2025 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Simple example scene with basic shapes.
+
+use vello_common::kurbo::{Affine, BezPath, Stroke};
+use vello_common::peniko::color::palette;
+use vello_cpu::RenderContext;
+
+use crate::scenes::ExampleScene;
+
+/// Simple scene state
+#[derive(Debug)]
+pub struct SimpleScene {}
+
+impl ExampleScene for SimpleScene {
+    fn render(&mut self, ctx: &mut RenderContext, root_transform: Affine) {
+        render(ctx, root_transform);
+    }
+}
+
+impl SimpleScene {
+    /// Create a new `SimpleScene`
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Default for SimpleScene {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Draws a simple scene with shapes
+pub fn render(ctx: &mut RenderContext, root_transform: Affine) {
+    let mut path = BezPath::new();
+    path.move_to((10.0, 10.0));
+    path.line_to((180.0, 20.0));
+    path.line_to((30.0, 40.0));
+    path.close_path();
+
+    // Use a combined transform that includes the root transform
+    let scene_transform = Affine::scale(5.0);
+    ctx.set_transform(root_transform * scene_transform);
+
+    ctx.set_paint(palette::css::REBECCA_PURPLE);
+    ctx.fill_path(&path);
+    let stroke = Stroke::new(1.0);
+    ctx.set_paint(palette::css::DARK_BLUE);
+    ctx.set_stroke(stroke);
+    ctx.stroke_path(&path);
+}

--- a/sparse_strips/vello_cpu/examples/wasm_cpu/src/scenes/svg.rs
+++ b/sparse_strips/vello_cpu/examples/wasm_cpu/src/scenes/svg.rs
@@ -11,7 +11,7 @@ use vello_cpu::RenderContext;
 use crate::scenes::ExampleScene;
 
 /// SVG scene that renders an SVG file
-pub struct SvgScene {
+pub(crate) struct SvgScene {
     transform: Affine,
     svg: PicoSvg,
 }
@@ -30,7 +30,7 @@ impl ExampleScene for SvgScene {
 
 impl SvgScene {
     /// Create a new `SvgScene` with the Ghost Tiger SVG
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         // Load the ghost tiger SVG by default
         let svg_content = include_str!("../../../../../../examples/assets/Ghostscript_Tiger.svg");
 

--- a/sparse_strips/vello_cpu/examples/wasm_cpu/src/scenes/svg.rs
+++ b/sparse_strips/vello_cpu/examples/wasm_cpu/src/scenes/svg.rs
@@ -1,0 +1,66 @@
+// Copyright 2025 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! SVG rendering example scene.
+
+use std::fmt;
+use vello_common::kurbo::{Affine, Stroke};
+use vello_common::pico_svg::{Item, PicoSvg};
+use vello_cpu::RenderContext;
+
+use crate::scenes::ExampleScene;
+
+/// SVG scene that renders an SVG file
+pub struct SvgScene {
+    transform: Affine,
+    svg: PicoSvg,
+}
+
+impl fmt::Debug for SvgScene {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SvgScene")
+    }
+}
+
+impl ExampleScene for SvgScene {
+    fn render(&mut self, ctx: &mut RenderContext, root_transform: Affine) {
+        render_svg(ctx, &self.svg.items, root_transform * self.transform);
+    }
+}
+
+impl SvgScene {
+    /// Create a new `SvgScene` with the Ghost Tiger SVG
+    pub fn new() -> Self {
+        // Load the ghost tiger SVG by default
+        let svg_content = include_str!("../../../../../../examples/assets/Ghostscript_Tiger.svg");
+
+        let svg = PicoSvg::load(svg_content, 1.0).expect("Failed to parse Ghost Tiger SVG");
+
+        Self {
+            transform: Affine::scale(3.0),
+            svg,
+        }
+    }
+}
+
+fn render_svg(ctx: &mut RenderContext, items: &[Item], transform: Affine) {
+    ctx.set_transform(transform);
+    for item in items {
+        match item {
+            Item::Fill(fill_item) => {
+                ctx.set_paint(fill_item.color);
+                ctx.fill_path(&fill_item.path);
+            }
+            Item::Stroke(stroke_item) => {
+                let style = Stroke::new(stroke_item.width);
+                ctx.set_stroke(style);
+                ctx.set_paint(stroke_item.color);
+                ctx.stroke_path(&stroke_item.path);
+            }
+            Item::Group(group_item) => {
+                render_svg(ctx, &group_item.children, transform * group_item.affine);
+                ctx.set_transform(transform);
+            }
+        }
+    }
+}

--- a/sparse_strips/vello_cpu/examples/wasm_cpu/src/scenes/text.rs
+++ b/sparse_strips/vello_cpu/examples/wasm_cpu/src/scenes/text.rs
@@ -35,7 +35,7 @@ const ROBOTO_FONT: &[u8] =
     include_bytes!("../../../../../../examples/assets/roboto/Roboto-Regular.ttf");
 
 /// State for the text example.
-pub struct TextScene {
+pub(crate) struct TextScene {
     layout: Layout<ColorBrush>,
 }
 
@@ -54,7 +54,7 @@ impl ExampleScene for TextScene {
 
 impl TextScene {
     /// Create a new `TextScene` with the given text.
-    pub fn new(text: &str) -> Self {
+    pub(crate) fn new(text: &str) -> Self {
         // Typically, you'd want to store 1 `layout_cx` and `font_cx` for the
         // duration of the program (or have an instance per thread).
         let mut layout_cx = LayoutContext::new();

--- a/sparse_strips/vello_cpu/examples/wasm_cpu/src/scenes/text.rs
+++ b/sparse_strips/vello_cpu/examples/wasm_cpu/src/scenes/text.rs
@@ -1,0 +1,130 @@
+// Copyright 2025 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Text rendering example scene.
+
+use core::fmt;
+use parley::FontFamily;
+use parley::{
+    Alignment, AlignmentOptions, FontContext, GlyphRun, Layout, LayoutContext,
+    PositionedLayoutItem, StyleProperty,
+};
+use vello_common::color::palette::css::WHITE;
+use vello_common::color::{AlphaColor, Srgb};
+use vello_common::glyph::Glyph;
+use vello_common::kurbo::Affine;
+
+use vello_cpu::RenderContext;
+
+use crate::scenes::ExampleScene;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct ColorBrush {
+    color: AlphaColor<Srgb>,
+}
+
+impl Default for ColorBrush {
+    fn default() -> Self {
+        Self { color: WHITE }
+    }
+}
+
+// Wasm doesn't support system fonts, so we need to include the font data directly.
+#[cfg(target_arch = "wasm32")]
+const ROBOTO_FONT: &[u8] =
+    include_bytes!("../../../../../../examples/assets/roboto/Roboto-Regular.ttf");
+
+/// State for the text example.
+pub struct TextScene {
+    layout: Layout<ColorBrush>,
+}
+
+impl fmt::Debug for TextScene {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "TextScene")
+    }
+}
+
+impl ExampleScene for TextScene {
+    fn render(&mut self, ctx: &mut RenderContext, root_transform: Affine) {
+        ctx.set_transform(root_transform);
+        render_text(self, ctx);
+    }
+}
+
+impl TextScene {
+    /// Create a new `TextScene` with the given text.
+    pub fn new(text: &str) -> Self {
+        // Typically, you'd want to store 1 `layout_cx` and `font_cx` for the
+        // duration of the program (or have an instance per thread).
+        let mut layout_cx = LayoutContext::new();
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let mut font_cx = FontContext::new();
+        #[cfg(target_arch = "wasm32")]
+        let mut font_cx = {
+            let mut font_cx = FontContext::new();
+            font_cx
+                .collection
+                .register_fonts(ROBOTO_FONT.to_vec().into(), None);
+            font_cx
+        };
+
+        let mut builder = layout_cx.ranged_builder(&mut font_cx, text, 1.0, true);
+        builder.push_default(FontFamily::parse("Roboto").unwrap());
+        builder.push_default(StyleProperty::LineHeight(1.3));
+        builder.push_default(StyleProperty::FontSize(32.0));
+
+        let mut layout: Layout<ColorBrush> = builder.build(text);
+        let max_advance = Some(400.0);
+        layout.break_all_lines(max_advance);
+        layout.align(max_advance, Alignment::Middle, AlignmentOptions::default());
+
+        Self { layout }
+    }
+}
+
+impl Default for TextScene {
+    fn default() -> Self {
+        Self::new("Hello, Vello!")
+    }
+}
+
+fn render_text(state: &mut TextScene, ctx: &mut RenderContext) {
+    for line in state.layout.lines() {
+        for item in line.items() {
+            if let PositionedLayoutItem::GlyphRun(glyph_run) = item {
+                render_glyph_run(ctx, &glyph_run, 30);
+            }
+        }
+    }
+}
+
+fn render_glyph_run(ctx: &mut RenderContext, glyph_run: &GlyphRun<'_, ColorBrush>, padding: u32) {
+    let mut run_x = glyph_run.offset();
+    let run_y = glyph_run.baseline();
+    let glyphs = glyph_run.glyphs().map(|glyph| {
+        let glyph_x = run_x + glyph.x + padding as f32;
+        let glyph_y = run_y - glyph.y + padding as f32;
+        run_x += glyph.advance;
+
+        Glyph {
+            id: glyph.id as u32,
+            x: glyph_x,
+            y: glyph_y,
+        }
+    });
+
+    let run = glyph_run.run();
+    let font = run.font();
+    let font_size = run.font_size();
+    let normalized_coords = bytemuck::cast_slice(run.normalized_coords());
+
+    let style = glyph_run.style();
+    ctx.set_paint(style.brush.color);
+    ctx.glyph_run(font)
+        .font_size(font_size)
+        .normalized_coords(normalized_coords)
+        .hint(true)
+        .fill_glyphs(glyphs);
+}


### PR DESCRIPTION
### Context

To help with performance profiling and inspecting vello_cpu example renders on the browser, this PR adds a vello_cpu examples.

Run with `cargo run_wasm -p wasm_cpu --release`

### Scenes added

We don't yet have a rendering abstraction between `vello_cpu` and `vello_hybrid`, so the example scenes are pretty similar, but not quite identical. I simplified each one to use `RenderContext` instead of `Scene`, and also made them very specific to running on the browser.

I added:
 - simple
 - tiger svg
 - cowboy image
 - text
 - clipping

No new assets are added in this PR - only existing assets in the repo are used. See the screen recording to see the scenes added.

### Test plan


> [!Note]
> Passing the +simd128 rustc flags spams the console with `(ignoring feature)` logs. This is because the run-wasm tool is built for your system architecture with the same global flags – and because it's not wasm it doesn't recognize the feature. Everything still works.

Test it by running it with `cargo run_wasm -p wasm_cpu --release` and test explicit SIMD by running `RUSTFLAGS=-Ctarget-feature=+simd128 cargo run_wasm -p wasm_cpu --release`.


### Screen recording


https://github.com/user-attachments/assets/80867362-bce5-4a9e-b303-88b2c9233972



