### PR TITLE
Fix(vello_hybrid): Exceeded WebGPU buffer size limit

### DIFF
--- a/sparse_strips/vello_hybrid/examples/scenes/src/image.rs
+++ b/sparse_strips/vello_hybrid/examples/scenes/src/image.rs
@@ -18,8 +18,15 @@ use vello_hybrid::Scene;
 use crate::ExampleScene;
 
 /// Image scene state
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ImageScene {}
+
+impl ImageScene {
+    /// Create a new image scene
+    pub fn new() -> Self {
+        Self {}
+    }
+}
 
 impl ExampleScene for ImageScene {
     fn render(&mut self, scene: &mut Scene, root_transform: Affine) {

--- a/sparse_strips/vello_hybrid/examples/scenes/src/lib.rs
+++ b/sparse_strips/vello_hybrid/examples/scenes/src/lib.rs
@@ -67,7 +67,7 @@ pub fn get_example_scenes(svg_paths: Option<Vec<&str>>) -> Box<[AnyScene]> {
     scenes.push(AnyScene::new(text::TextScene::new("Hello, Vello!")));
     scenes.push(AnyScene::new(simple::SimpleScene::new()));
     scenes.push(AnyScene::new(clip::ClipScene::new()));
-    scenes.push(AnyScene::new(image::ImageScene {}));
+    scenes.push(AnyScene::new(image::ImageScene::new()));
 
     scenes.into_boxed_slice()
 }

--- a/sparse_strips/vello_hybrid/examples/wgpu_webgl/src/lib.rs
+++ b/sparse_strips/vello_hybrid/examples/wgpu_webgl/src/lib.rs
@@ -54,6 +54,7 @@ impl RendererWrapper {
                         // (8). Some devices (including CI) support only up to 4.
                         max_color_attachments: 4,
                         max_texture_dimension_2d: adapter.limits().max_texture_dimension_2d,
+                        max_buffer_size: adapter.limits().max_buffer_size,
                         ..wgpu::Limits::downlevel_webgl2_defaults()
                     },
                     ..Default::default()


### PR DESCRIPTION
This is a WebGPU buffer size limit error. Here's what's happening:
- Current limit: WebGPU device is configured with a maximum buffer size of 256MB
- Attempted usage: The application is trying to use a buffer of 1GB
- Hardware capability: Graphics adapter actually supports up to 4GB