### PR TITLE
Fix `clippy::uninlined_format_args` lints

### DIFF
--- a/sparse_strips/vello_sparse_tests/tests/util.rs
+++ b/sparse_strips/vello_sparse_tests/tests/util.rs
@@ -70,7 +70,7 @@ pub(crate) fn get_ctx<T: Renderer>(
                 .expect("wasm simd128 should be available"),
         ),
         "fallback" => Level::fallback(),
-        _ => panic!("unknown level: {}", level),
+        _ => panic!("unknown level: {level}"),
     };
 
     let mut ctx = T::new(width, height, num_threads, level);
@@ -290,7 +290,7 @@ pub(crate) fn check_ref(
     let pixmap = render_pixmap(ctx, render_mode);
 
     let encoded_image = pixmap_to_png(pixmap, ctx.width() as u32, ctx.height() as u32);
-    let ref_path = REFS_PATH.join(format!("{}.png", test_name));
+    let ref_path = REFS_PATH.join(format!("{test_name}.png"));
 
     let write_ref_image = || {
         let optimized =
@@ -325,7 +325,7 @@ pub(crate) fn check_ref(
             let _ = std::fs::create_dir_all(DIFFS_PATH.as_path());
         }
 
-        let diff_path = DIFFS_PATH.join(format!("{}.png", specific_name));
+        let diff_path = DIFFS_PATH.join(format!("{specific_name}.png"));
         diff_image
             .save_with_format(&diff_path, image::ImageFormat::Png)
             .unwrap();
@@ -387,7 +387,7 @@ fn append_diff_image_to_browser_document(specific_name: &str, diff_image: &RgbaI
         .unwrap();
 
     let title = document.create_element("h3").unwrap();
-    title.set_text_content(Some(&format!("Test Failed: {}", specific_name)));
+    title.set_text_content(Some(&format!("Test Failed: {specific_name}")));
     title
         .set_attribute("style", "color: red; margin-top: 0;")
         .unwrap();

--- a/vello_shaders/build.rs
+++ b/vello_shaders/build.rs
@@ -128,8 +128,7 @@ fn write_msl(buf: &mut String, info: &ShaderInfo) -> Result<(), fmt::Error> {
     )?;
     writeln!(
         buf,
-        "                binding_indices : Cow::Borrowed(&{:?}),",
-        indices
+        "                binding_indices : Cow::Borrowed(&{indices:?}),",
     )?;
     writeln!(buf, "            }},")?;
     Ok(())

--- a/vello_shaders/src/types.rs
+++ b/vello_shaders/src/types.rs
@@ -52,8 +52,8 @@ pub mod msl {
     impl fmt::Debug for BindingIndex {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             match *self {
-                Self::Buffer(i) => write!(f, "msl::BindingIndex::Buffer({})", i),
-                Self::Texture(i) => write!(f, "msl::BindingIndex::Texture({})", i),
+                Self::Buffer(i) => write!(f, "msl::BindingIndex::Buffer({i})"),
+                Self::Texture(i) => write!(f, "msl::BindingIndex::Texture({i})"),
             }
         }
     }


### PR DESCRIPTION
These were missed in the last pass as they are in other targets or behind feature gates.