### PR TITLE
Make Dispatchers Send + Sync

### DIFF
--- a/sparse_strips/vello_cpu/src/dispatch/mod.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/mod.rs
@@ -14,7 +14,7 @@ use vello_common::encode::EncodedPaint;
 use vello_common::mask::Mask;
 use vello_common::paint::Paint;
 
-pub(crate) trait Dispatcher: Debug {
+pub(crate) trait Dispatcher: Debug + Send + Sync {
     fn wide(&self) -> &Wide;
     fn fill_path(&mut self, path: &BezPath, fill_rule: Fill, transform: Affine, paint: Paint);
     fn stroke_path(&mut self, path: &BezPath, stroke: &Stroke, transform: Affine, paint: Paint);


### PR DESCRIPTION
This allows the entire `vello_cpu::RendererContext` to also be `Send` + `Sync` (needed for Blitz's test runner).