### PR TITLE
[vello_hybrid]: add example for image destruction

### DIFF
--- a/sparse_strips/vello_hybrid/examples/scenes/src/clip.rs
+++ b/sparse_strips/vello_hybrid/examples/scenes/src/clip.rs
@@ -22,7 +22,12 @@ use vello_hybrid::Scene;
 pub struct ClipScene {}
 
 impl ExampleScene for ClipScene {
-    fn render(&mut self, ctx: &mut Scene, root_transform: Affine, _resources: &crate::SceneResources) {
+    fn render(
+        &mut self,
+        ctx: &mut Scene,
+        root_transform: Affine,
+        _resources: &crate::SceneResources,
+    ) {
         render(ctx, root_transform);
     }
 }

--- a/sparse_strips/vello_hybrid/examples/scenes/src/clip.rs
+++ b/sparse_strips/vello_hybrid/examples/scenes/src/clip.rs
@@ -22,7 +22,7 @@ use vello_hybrid::Scene;
 pub struct ClipScene {}
 
 impl ExampleScene for ClipScene {
-    fn render(&mut self, ctx: &mut Scene, root_transform: Affine) {
+    fn render(&mut self, ctx: &mut Scene, root_transform: Affine, _resources: &crate::SceneResources) {
         render(ctx, root_transform);
     }
 }

--- a/sparse_strips/vello_hybrid/examples/scenes/src/image.rs
+++ b/sparse_strips/vello_hybrid/examples/scenes/src/image.rs
@@ -10,28 +10,28 @@ use vello_common::peniko::ImageFormat;
 use vello_common::pixmap::Pixmap;
 use vello_common::{
     kurbo::{Affine, Rect},
-    paint::{Image, ImageId, ImageSource},
+    paint::{Image, ImageSource},
     peniko::{Extend, ImageQuality},
 };
 use vello_hybrid::Scene;
 
-use crate::ExampleScene;
+use crate::{ExampleScene, SceneResources};
 
-/// Image scene state
+/// Image scene shows how to use images in the scene.
 #[derive(Debug, Default)]
-pub struct ImageScene {}
+pub struct ImageScene;
 
 impl ImageScene {
     /// Create a new image scene
     pub fn new() -> Self {
-        Self {}
+        Self
     }
 }
 
 impl ExampleScene for ImageScene {
-    fn render(&mut self, scene: &mut Scene, root_transform: Affine) {
-        let splash_flower_id = ImageId::new(0);
-        let cowboy_id = ImageId::new(1);
+    fn render(&mut self, scene: &mut Scene, root_transform: Affine, resources: &SceneResources) {
+        let splash_flower_id = resources.images.first().copied().unwrap();
+        let cowboy_id = resources.images.get(1).copied().unwrap();
 
         scene.set_transform(
             root_transform
@@ -80,7 +80,7 @@ impl ExampleScene for ImageScene {
         );
         scene.set_paint_transform(Affine::scale(0.25));
         scene.set_paint(Image {
-            source: ImageSource::OpaqueId(ImageId::new(0)),
+            source: ImageSource::OpaqueId(splash_flower_id),
             x_extend: Extend::Repeat,
             y_extend: Extend::Repeat,
             quality: ImageQuality::Low,

--- a/sparse_strips/vello_hybrid/examples/scenes/src/simple.rs
+++ b/sparse_strips/vello_hybrid/examples/scenes/src/simple.rs
@@ -14,7 +14,7 @@ use crate::ExampleScene;
 pub struct SimpleScene {}
 
 impl ExampleScene for SimpleScene {
-    fn render(&mut self, ctx: &mut Scene, root_transform: Affine) {
+    fn render(&mut self, ctx: &mut Scene, root_transform: Affine, _resources: &crate::SceneResources) {
         render(ctx, root_transform);
     }
 }

--- a/sparse_strips/vello_hybrid/examples/scenes/src/simple.rs
+++ b/sparse_strips/vello_hybrid/examples/scenes/src/simple.rs
@@ -14,7 +14,12 @@ use crate::ExampleScene;
 pub struct SimpleScene {}
 
 impl ExampleScene for SimpleScene {
-    fn render(&mut self, ctx: &mut Scene, root_transform: Affine, _resources: &crate::SceneResources) {
+    fn render(
+        &mut self,
+        ctx: &mut Scene,
+        root_transform: Affine,
+        _resources: &crate::SceneResources,
+    ) {
         render(ctx, root_transform);
     }
 }

--- a/sparse_strips/vello_hybrid/examples/scenes/src/svg.rs
+++ b/sparse_strips/vello_hybrid/examples/scenes/src/svg.rs
@@ -26,7 +26,12 @@ impl fmt::Debug for SvgScene {
 }
 
 impl ExampleScene for SvgScene {
-    fn render(&mut self, scene: &mut Scene, root_transform: Affine, _resources: &crate::SceneResources) {
+    fn render(
+        &mut self,
+        scene: &mut Scene,
+        root_transform: Affine,
+        _resources: &crate::SceneResources,
+    ) {
         render_svg(scene, &self.svg.items, root_transform * self.transform);
     }
 }

--- a/sparse_strips/vello_hybrid/examples/scenes/src/svg.rs
+++ b/sparse_strips/vello_hybrid/examples/scenes/src/svg.rs
@@ -26,7 +26,7 @@ impl fmt::Debug for SvgScene {
 }
 
 impl ExampleScene for SvgScene {
-    fn render(&mut self, scene: &mut Scene, root_transform: Affine) {
+    fn render(&mut self, scene: &mut Scene, root_transform: Affine, _resources: &crate::SceneResources) {
         render_svg(scene, &self.svg.items, root_transform * self.transform);
     }
 }

--- a/sparse_strips/vello_hybrid/examples/scenes/src/text.rs
+++ b/sparse_strips/vello_hybrid/examples/scenes/src/text.rs
@@ -45,7 +45,7 @@ impl fmt::Debug for TextScene {
 }
 
 impl ExampleScene for TextScene {
-    fn render(&mut self, scene: &mut Scene, root_transform: Affine) {
+    fn render(&mut self, scene: &mut Scene, root_transform: Affine, _resources: &crate::SceneResources) {
         scene.set_transform(root_transform);
         render_text(self, scene);
     }

--- a/sparse_strips/vello_hybrid/examples/scenes/src/text.rs
+++ b/sparse_strips/vello_hybrid/examples/scenes/src/text.rs
@@ -45,7 +45,12 @@ impl fmt::Debug for TextScene {
 }
 
 impl ExampleScene for TextScene {
-    fn render(&mut self, scene: &mut Scene, root_transform: Affine, _resources: &crate::SceneResources) {
+    fn render(
+        &mut self,
+        scene: &mut Scene,
+        root_transform: Affine,
+        _resources: &crate::SceneResources,
+    ) {
         scene.set_transform(root_transform);
         render_text(self, scene);
     }

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -22,7 +22,7 @@ only break in edge cases, and some of them are also only related to conversions 
 
 use crate::{
     GpuStrip, RenderError, RenderSize,
-    image_cache::{ImageCache, ImageResource},
+    image_cache::ImageCache,
     render::Config,
     scene::Scene,
     schedule::{LoadOp, RendererBackend, Scheduler},
@@ -116,7 +116,8 @@ impl WebGlRenderer {
             programs: &mut self.programs,
             gl: &self.gl,
         };
-        self.scheduler.do_scene(&mut ctx, scene)?;
+        self.scheduler
+            .do_scene(&mut ctx, scene, &self.image_cache)?;
 
         // Blit the view framebuffer to the default framebuffer (canvas element), reflecting the
         // image along the Y axis to complete the WebGPU to WebGL2 coordinate transform.
@@ -257,32 +258,40 @@ impl WebGlRenderer {
     }
 
     fn prepare_gpu_encoded_paints(&self, encoded_paints: &[EncodedPaint]) -> Vec<GpuEncodedImage> {
-        let mut bytes: Vec<GpuEncodedImage> = Vec::new();
+        let mut gpu_encoded_images: Vec<GpuEncodedImage> = Vec::with_capacity(encoded_paints.len());
         for paint in encoded_paints {
             match paint {
                 EncodedPaint::Image(img) => {
                     if let ImageSource::OpaqueId(image_id) = img.source {
-                        let image_resource: Option<&ImageResource> = self.image_cache.get(image_id);
-                        if let Some(image_resource) = image_resource {
-                            let transform = img.transform * Affine::translate((-0.5, -0.5));
-                            // pack two u16 as u32
-                            let image_size = ((image_resource.width as u32) << 16)
-                                | image_resource.height as u32;
-                            let image_offset = ((image_resource.offset[0] as u32) << 16)
-                                | image_resource.offset[1] as u32;
-                            let quality_and_extend_modes = ((img.extends.1 as u32) << 4)
-                                | ((img.extends.0 as u32) << 2)
-                                | img.quality as u32;
+                        let (width, height, offset) =
+                            if let Some(image_resource) = self.image_cache.get(image_id) {
+                                (
+                                    image_resource.width,
+                                    image_resource.height,
+                                    image_resource.offset,
+                                )
+                            } else {
+                                (0, 0, [0, 0])
+                            };
+                        let transform = img.transform * Affine::translate((-0.5, -0.5));
+                        // Pack two u16 as u32 (width in high 16 bits, height in low 16 bits)
+                        let image_size = ((width as u32) << 16) | height as u32;
+                        // Pack offset similarly (x in high 16 bits, y in low 16 bits)
+                        let image_offset = ((offset[0] as u32) << 16) | offset[1] as u32;
+                        // Pack quality and extend modes:
+                        // first 2 bits for quality, next 4 bits for extend mode
+                        let quality_and_extend_modes = ((img.extends.1 as u32) << 4)
+                            | ((img.extends.0 as u32) << 2)
+                            | img.quality as u32;
 
-                            bytes.push(GpuEncodedImage {
-                                quality_and_extend_modes,
-                                image_size,
-                                image_offset,
-                                _padding1: 0,
-                                transform: transform.as_coeffs().map(|x| x as f32),
-                                _padding2: [0, 0],
-                            });
-                        }
+                        gpu_encoded_images.push(GpuEncodedImage {
+                            quality_and_extend_modes,
+                            image_size,
+                            image_offset,
+                            _padding1: 0,
+                            transform: transform.as_coeffs().map(|x| x as f32),
+                            _padding2: [0, 0],
+                        });
                     }
                 }
                 _ => {
@@ -290,7 +299,7 @@ impl WebGlRenderer {
                 }
             }
         }
-        bytes
+        gpu_encoded_images
     }
 }
 

--- a/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
@@ -112,8 +112,7 @@ fn vs_main(
     let paint_type = instance.paint >> 30u;
 
     if paint_type == PAINT_TYPE_IMAGE {
-        let paint_tex_id = instance.paint & 0x3FFFFFFF;
-        
+        let paint_tex_id = instance.paint & 0x1FFFFFFFu;
         let encoded_image = unpack_encoded_image(paint_tex_id);
         // Vertex position within the texture
         out.sample_xy = encoded_image.translate 
@@ -179,7 +178,12 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     let paint_type = in.paint >> 30u;
 
     if paint_type == PAINT_TYPE_IMAGE {
-        let paint_tex_id = in.paint & 0x3FFFFFFF;
+        let paint_tex_id = in.paint & 0x1FFFFFFFu;
+        let skip_paint = in.paint >> 29u & 1u;
+        if skip_paint == 1u {
+            discard;
+        }
+        
         let encoded_image = unpack_encoded_image(paint_tex_id);
         let image_offset = encoded_image.image_offset;
         let image_size = encoded_image.image_size;


### PR DESCRIPTION
This is a follow-up to [the comment](https://github.com/linebender/vello/pull/1064#discussion_r2178903924) in #1064.

Extended the examples to include support for destroying images:

https://github.com/user-attachments/assets/36a1ed37-dd08-4c1f-b83f-9528bf63c87b


