### PR TITLE
Fix panic in multi-threaded rendering

### DIFF
--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -555,8 +555,9 @@ impl ColrRenderer for RenderContext {
 
 #[cfg(test)]
 mod tests {
-    use crate::RenderContext;
+    use crate::{Level, RenderContext, RenderMode, RenderSettings};
     use vello_common::kurbo::{Rect, Shape};
+    use vello_common::pixmap::Pixmap;
     use vello_common::tile::Tile;
 
     #[test]
@@ -569,5 +570,21 @@ mod tests {
 
         ctx.push_clip_layer(&Rect::new(20.0, 20.0, 180.0, 180.0).to_path(0.1));
         ctx.pop_layer();
+    }
+    
+    #[cfg(feature = "multithreading")]
+    #[test]
+    fn multithreaded_crash_after_reset() {
+        let mut pixmap = Pixmap::new(200, 200);
+        let settings = RenderSettings {
+            level: Level::new(),
+            num_threads: 1,
+        };
+        
+        let mut ctx = RenderContext::new_with(200, 200, &settings);
+        ctx.reset();
+        ctx.fill_path(&Rect::new(0.0, 0.0, 100.0, 100.0).to_path(0.1));
+        ctx.flush();
+        ctx.render_to_pixmap(&mut pixmap, RenderMode::OptimizeQuality);
     }
 }


### PR DESCRIPTION
The problem is that when resetting the render context, we are creating a new alpha storage, but we are not adding the new alpha storage to the workers.