### PR TITLE
No shader runtime checks

### DIFF
--- a/vello/src/wgpu_engine.rs
+++ b/vello/src/wgpu_engine.rs
@@ -834,10 +834,15 @@ impl WgpuEngine {
         entries: Vec<wgpu::BindGroupLayoutEntry>,
         cache: Option<&PipelineCache>,
     ) -> WgpuShader {
-        let shader_module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some(label),
-            source: wgpu::ShaderSource::Wgsl(wgsl),
-        });
+        let shader_module = unsafe {
+            device.create_shader_module_trusted(
+                wgpu::ShaderModuleDescriptor {
+                    label: Some(label),
+                    source: wgpu::ShaderSource::Wgsl(wgsl),
+                },
+                wgpu::ShaderRuntimeChecks::unchecked(),
+            )
+        };
         let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             label: None,
             entries: &entries,

--- a/vello/src/wgpu_engine.rs
+++ b/vello/src/wgpu_engine.rs
@@ -834,6 +834,7 @@ impl WgpuEngine {
         entries: Vec<wgpu::BindGroupLayoutEntry>,
         cache: Option<&PipelineCache>,
     ) -> WgpuShader {
+        // SAFETY: We only call this with trusted shaders (written by Vello developers)
         let shader_module = unsafe {
             device.create_shader_module_trusted(
                 wgpu::ShaderModuleDescriptor {

--- a/vello_tests/tests/known_issues.rs
+++ b/vello_tests/tests/known_issues.rs
@@ -63,10 +63,8 @@ fn many_bins(use_cpu: bool) {
     assert!(black_count > 0);
 }
 
-// With wgpu 23, this started mysteriously working on macOS (and only on macOS).
 #[test]
 #[cfg_attr(skip_gpu_tests, ignore)]
-#[cfg_attr(target_os = "macos", should_panic)]
 fn many_bins_gpu() {
     many_bins(false);
 }


### PR DESCRIPTION
In servo I observed performance regression with #908: https://xi.zulipchat.com/#narrow/channel/197075-vello/topic/Servo.202D.20canvas.20backend/with/528398019

but disabling shader runtime checks gives it back on pre #908.