### PR TITLE
Completely forbid unsafe code in `vello_common`

### DIFF
--- a/sparse_strips/vello_common/src/lib.rs
+++ b/sparse_strips/vello_common/src/lib.rs
@@ -45,7 +45,7 @@
 #![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
 // END LINEBENDER LINT SET
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![cfg_attr(not(feature = "simd"), forbid(unsafe_code))]
+#![forbid(unsafe_code)]
 #![expect(
     clippy::cast_possible_truncation,
     reason = "We temporarily ignore those because the casts\


### PR DESCRIPTION
A remnant from the initial import of `vello_common`, it seems.