### PR TITLE
Optimize blending with default blend mode

### DIFF
--- a/sparse_strips/vello_cpu/src/fine/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/mod.rs
@@ -587,15 +587,20 @@ impl<S: Simd, T: FineKernel<S>> Fine<S, T> {
         let (source_buffer, rest) = self.blend_buf.split_last_mut().unwrap();
         let target_buffer = rest.last_mut().unwrap();
 
-        T::blend(
-            self.simd,
-            target_buffer,
-            source_buffer
-                .chunks_exact(T::Composite::LENGTH)
-                .map(|s| T::Composite::from_slice(self.simd, s)),
-            blend_mode,
-            None,
-        );
+        if blend_mode.is_default() {
+            T::alpha_composite_buffer(self.simd, target_buffer, source_buffer, None);
+        }   else {
+            T::blend(
+                self.simd,
+                target_buffer,
+                source_buffer
+                    .chunks_exact(T::Composite::LENGTH)
+                    .map(|s| T::Composite::from_slice(self.simd, s)),
+                blend_mode,
+                None,
+            );
+        }
+        
     }
 
     fn clip(&mut self, x: usize, width: usize, alphas: Option<&[u8]>) {

--- a/sparse_strips/vello_cpu/src/fine/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/mod.rs
@@ -589,7 +589,7 @@ impl<S: Simd, T: FineKernel<S>> Fine<S, T> {
 
         if blend_mode.is_default() {
             T::alpha_composite_buffer(self.simd, target_buffer, source_buffer, None);
-        }   else {
+        } else {
             T::blend(
                 self.simd,
                 target_buffer,
@@ -600,7 +600,6 @@ impl<S: Simd, T: FineKernel<S>> Fine<S, T> {
                 None,
             );
         }
-        
     }
 
     fn clip(&mut self, x: usize, width: usize, alphas: Option<&[u8]>) {


### PR DESCRIPTION
While playing with a profiler and blitz, I noticed that a non-insignificant amount of time is going into compositing/blending, even though no special blend modes are used. For the default blend mode, we can simply use the fast path of doing alpha compositing instead of taking the slow route.