### PR TITLE
SIMDify the `u8_to_f32` method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,7 +920,7 @@ dependencies = [
 [[package]]
 name = "fearless_simd"
 version = "0.2.0"
-source = "git+https://github.com/linebender/fearless_simd?rev=8ca44c0#8ca44c04c186bedcde51de983bfaa54ae3a03e8d"
+source = "git+https://github.com/linebender/fearless_simd?rev=74ad51c#74ad51cae4f0a0a0631c1a2c82f50fcf83a8da51"
 dependencies = [
  "bytemuck",
  "libm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ rayon = { version = "1.10.0" }
 thread_local = "1.1.8"
 crossbeam-channel = "0.5.15"
 ordered-channel = { version = "1.2.0", features = ["crossbeam-channel"] }
-fearless_simd = { git = "https://github.com/linebender/fearless_simd", rev = "8ca44c0", default-features = false }
+fearless_simd = { git = "https://github.com/linebender/fearless_simd", rev = "74ad51c", default-features = false }
 
 # The below crates are experimental!
 vello_api = { path = "sparse_strips/vello_api", default-features = false }

--- a/sparse_strips/vello_cpu/src/fine/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/mod.rs
@@ -118,28 +118,25 @@ pub(crate) fn f32_to_u8<S: Simd>(val: f32x16<S>) -> u8x16<S> {
     .simd_into(val.simd)
 }
 
-#[inline(always)]
 pub(crate) fn u8_to_f32<S: Simd>(val: u8x16<S>) -> f32x16<S> {
-    // TODO: SIMDify
-    [
-        val.val[0] as f32,
-        val.val[1] as f32,
-        val.val[2] as f32,
-        val.val[3] as f32,
-        val.val[4] as f32,
-        val.val[5] as f32,
-        val.val[6] as f32,
-        val.val[7] as f32,
-        val.val[8] as f32,
-        val.val[9] as f32,
-        val.val[10] as f32,
-        val.val[11] as f32,
-        val.val[12] as f32,
-        val.val[13] as f32,
-        val.val[14] as f32,
-        val.val[15] as f32,
-    ]
-    .simd_into(val.simd)
+    let simd = val.simd;
+    let zeroes = u8x16::splat(simd, 0);
+
+    let zip1 = simd.zip_high_u8x16(val, zeroes);
+    let zip2 = simd.zip_low_u8x16(val, zeroes);
+
+    let p1 = simd.zip_low_u8x16(zip2, zeroes).reinterpret_u32().cvt_f32();
+    let p2 = simd
+        .zip_high_u8x16(zip2, zeroes)
+        .reinterpret_u32()
+        .cvt_f32();
+    let p3 = simd.zip_low_u8x16(zip1, zeroes).reinterpret_u32().cvt_f32();
+    let p4 = simd
+        .zip_high_u8x16(zip1, zeroes)
+        .reinterpret_u32()
+        .cvt_f32();
+
+    simd.combine_f32x8(simd.combine_f32x4(p1, p2), simd.combine_f32x4(p3, p4))
 }
 
 pub trait CompositeType<N: Numeric, S: Simd>: Copy + Clone + Send + Sync {


### PR DESCRIPTION
Gives me the following speed bump for bicubic image rendering:

```
fine/image/quality/high_u8_neon
                        time:   [11.801 µs 11.823 µs 11.847 µs]
                        change: [-21.157% -21.009% -20.868%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
```

Blocked by https://github.com/linebender/fearless_simd/pull/33