### PR TITLE
[vello_hybrid] add debug assertion to enforce correct WebGl context attributes

### DIFF
--- a/sparse_strips/vello_hybrid/Cargo.toml
+++ b/sparse_strips/vello_hybrid/Cargo.toml
@@ -29,6 +29,7 @@ js-sys = { version = "0.3.77", optional = true }
 web-sys = { version = "0.3.77", features = [
     "HtmlCanvasElement",
     "WebGl2RenderingContext",
+    "WebGlContextAttributes",
     "WebGlProgram",
     "WebGlUniformLocation",
     "WebGlBuffer",


### PR DESCRIPTION
This PR adds an optional debug assertion to catch a configuration error (that cost me a couple hours of debugging).

**Context**

When using `vello_hybrid`, it's possible to accidentally create a WebGL context on the `HTMLCanvasElement` before passing it to `WebGlRenderer::new(canvas)`. [Per the WebGL specification](https://html.spec.whatwg.org/#dom-canvas-getcontext), if the canvas already has a context, that cached context is returned and any new context attributes are ignored.

This is a problem when the cached context has `antialias: true` (default), as `vello_hybrid` requires `antialias: false` to render anything.

**User impact**

Previously: `vello_hybrid` would fail silently, rendering nothing and optionally logging GL operation warnings to the console.

Now (debug mode only): The renderer throws on instantiation with a clear error message indicating that antialias must be false.