### PR TITLE
Add a dynamically calculated granularity when rasterizing with multi-threading

### DIFF
--- a/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
@@ -223,22 +223,22 @@ impl MultiThreadedDispatcher {
         let fines = ThreadLocal::new();
         let wide = &self.wide;
         let alpha_slots = self.alpha_storage.slots();
-        
+
         // Further below, we will use `rayon` to iterate over each region in parallel to run
         // all commands. There is a trade-off we need to carefully balance: On the one hand, we
         // want the granularity (i.e. how many regions are processed in a batch on one thread) to
         // be fine enough so in case the amount of work per region is very different, the work
         // can still be distributed in a way so that threads don't end up being idle waiting for
-        // other threads to finish. 
-        // 
+        // other threads to finish.
+        //
         // However, if the granularity is too small, we will end up with many
-        // context switches if our drawing area is large (for a screen size of 1920x1080, 
+        // context switches if our drawing area is large (for a screen size of 1920x1080,
         // we will end up with around ~2000 regions). We therefore aim to choose a granularity such
         // that no more than 50 chunks need to be processed by a single thread.
         let granularity = {
             const CHUNKS_PER_THREAD: u32 = 50;
             debug_assert_ne!(self.num_threads, 0);
-            
+
             let num_regions = buffer.len() as u32;
             let regions_per_thread = num_regions / self.num_threads as u32;
 

--- a/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
@@ -234,8 +234,10 @@ impl MultiThreadedDispatcher {
         // However, if the granularity is too small, we will end up with many
         // context switches if our drawing area is large (for a screen size of 1920x1080,
         // we will end up with around ~2000 regions). We therefore aim to choose a granularity such
-        // that no more than 50 chunks need to be processed by a single thread. However, we also
-        // don't want to put too many regions in a single group (in this case 8) to prevent
+        // that no more than 50 (more or less arbitrarily chosen) chunks need to be processed 
+        // by a single thread. However, we also don't want to put too many regions in a 
+        // single group (the currently chosen values i 8) to prevent stalls in case some of the
+        // later regions contain more work than the previous ones.
         let granularity = {
             const CHUNKS_PER_THREAD: u32 = 50;
             const MIN_GRANULARITY: u32 = 1;

--- a/sparse_strips/vello_cpu/src/region.rs
+++ b/sparse_strips/vello_cpu/src/region.rs
@@ -65,7 +65,7 @@ impl<'a> Regions<'a> {
 
         Self { regions }
     }
-    
+
     /// Return the number of regions.
     pub fn len(&self) -> usize {
         self.regions.len()
@@ -74,15 +74,21 @@ impl<'a> Regions<'a> {
     /// Apply the given function to each region. The functions will be applied
     /// in parallel in the current threadpool.
     #[cfg(feature = "multithreading")]
-    pub fn update_regions_par(&mut self, granularity: u32, func: impl Fn(&mut Region<'_>) + Send + Sync) {
+    pub fn update_regions_par(
+        &mut self,
+        granularity: u32,
+        func: impl Fn(&mut Region<'_>) + Send + Sync,
+    ) {
         use rayon::iter::ParallelIterator;
         use rayon::prelude::*;
 
-        self.regions.par_chunks_mut(granularity as usize).for_each(|r| {
-            for region in r {
-                func(region);           
-            }
-        });
+        self.regions
+            .par_chunks_mut(granularity as usize)
+            .for_each(|r| {
+                for region in r {
+                    func(region);
+                }
+            });
     }
 
     /// Apply the given function to each region.

--- a/sparse_strips/vello_cpu/src/region.rs
+++ b/sparse_strips/vello_cpu/src/region.rs
@@ -65,15 +65,24 @@ impl<'a> Regions<'a> {
 
         Self { regions }
     }
+    
+    /// Return the number of regions.
+    pub fn len(&self) -> usize {
+        self.regions.len()
+    }
 
     /// Apply the given function to each region. The functions will be applied
     /// in parallel in the current threadpool.
     #[cfg(feature = "multithreading")]
-    pub fn update_regions_par(&mut self, func: impl Fn(&mut Region<'_>) + Send + Sync) {
+    pub fn update_regions_par(&mut self, granularity: u32, func: impl Fn(&mut Region<'_>) + Send + Sync) {
         use rayon::iter::ParallelIterator;
-        use rayon::prelude::IntoParallelRefMutIterator;
+        use rayon::prelude::*;
 
-        self.regions.par_iter_mut().for_each(func);
+        self.regions.par_chunks_mut(granularity as usize).for_each(|r| {
+            for region in r {
+                func(region);           
+            }
+        });
     }
 
     /// Apply the given function to each region.


### PR DESCRIPTION
See the comments in the code for an explanation. I probably should note that this change is not based on some measurement. Unfortunately, the rendering times vary very wildly (I still need to investigate whether there is something I can do to alleviate that), which makes it close to impossible to make precise measurements. But I think that at least conceptually this is a reasonable thing, but I'm open for feedback! 