### PR TITLE
[vello_cpu] Empty destructive layers are nops too.

### DIFF
--- a/sparse_strips/vello_common/src/coarse.rs
+++ b/sparse_strips/vello_common/src/coarse.rs
@@ -951,9 +951,9 @@ impl WideTile {
 
     /// Blend the current buffer into the previous buffer in the stack.
     pub fn blend(&mut self, blend_mode: BlendMode) {
-        // Optimization: If no drawing happened since the last `PushBuf` and the blend mode
-        // is not destructive, we do not need to do any blending at all.
-        if !matches!(self.cmds.last(), Some(&Cmd::PushBuf)) || blend_mode.is_destructive() {
+        // Optimization: If no drawing happened since the last `PushBuf`,
+        // we do not need to do any blending at all.
+        if !matches!(self.cmds.last(), Some(&Cmd::PushBuf)) {
             self.cmds.push(Cmd::Blend(blend_mode));
         }
     }

--- a/sparse_strips/vello_sparse_tests/snapshots/empty_destructive_layer.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/empty_destructive_layer.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3949c58392237150a72e454c09125340cde817d3ca2a2d053fce6b89139a8361
+size 91

--- a/sparse_strips/vello_sparse_tests/tests/compose.rs
+++ b/sparse_strips/vello_sparse_tests/tests/compose.rs
@@ -86,3 +86,11 @@ fn compose_dest_atop(ctx: &mut impl Renderer) {
 fn compose_plus(ctx: &mut impl Renderer) {
     compose(ctx, Compose::Plus);
 }
+
+#[vello_test]
+fn empty_destructive_layer(ctx: &mut impl Renderer) {
+    ctx.set_paint(BLUE);
+    ctx.fill_rect(&Rect::new(0.0, 0.0, 100.0, 100.0));
+    ctx.push_blend_layer(Compose::Clear.into());
+    ctx.pop_layer();
+}


### PR DESCRIPTION
Discovered in https://github.com/linebender/vello/issues/1119#issuecomment-3112219014, I think blends layers without any draw insides are actually nop.