### PR TITLE
Reuse `FlattenCtx` for paths

### DIFF
--- a/sparse_strips/vello_bench/src/data.rs
+++ b/sparse_strips/vello_bench/src/data.rs
@@ -6,7 +6,7 @@ use std::sync::OnceLock;
 use usvg::tiny_skia_path::PathSegment;
 use usvg::{Group, Node};
 use vello_common::fearless_simd::Level;
-use vello_common::flatten::Line;
+use vello_common::flatten::{FlattenCtx, Line};
 use vello_common::kurbo::{Affine, BezPath, Stroke};
 use vello_common::peniko::Fill;
 use vello_common::strip::Strip;
@@ -80,7 +80,13 @@ impl DataItem {
         let mut temp_buf = vec![];
 
         for path in &self.fills {
-            flatten::fill(Level::new(), &path.path, path.transform, &mut temp_buf);
+            flatten::fill(
+                Level::new(),
+                &path.path,
+                path.transform,
+                &mut temp_buf,
+                &mut FlattenCtx::default(),
+            );
             line_buf.extend(&temp_buf);
         }
 
@@ -95,6 +101,7 @@ impl DataItem {
                 &stroke,
                 path.transform,
                 &mut temp_buf,
+                &mut FlattenCtx::default(),
             );
             line_buf.extend(&temp_buf);
         }

--- a/sparse_strips/vello_bench/src/flatten.rs
+++ b/sparse_strips/vello_bench/src/flatten.rs
@@ -4,6 +4,7 @@
 use crate::data::get_data_items;
 use criterion::Criterion;
 use vello_common::flatten;
+use vello_common::flatten::FlattenCtx;
 use vello_common::kurbo::Stroke;
 use vello_cpu::Level;
 use vello_cpu::kurbo::Affine;
@@ -21,12 +22,24 @@ pub fn flatten(c: &mut Criterion) {
                     let mut temp_buf: Vec<flatten::Line> = vec![];
 
                     for path in &$item.fills {
-                        flatten::fill(Level::new(), &path.path, path.transform, &mut temp_buf);
+                        flatten::fill(
+                            Level::new(),
+                            &path.path,
+                            path.transform,
+                            &mut temp_buf,
+                            &mut FlattenCtx::default(),
+                        );
                         line_buf.extend(&temp_buf);
                     }
 
                     for stroke in &expanded_strokes {
-                        flatten::fill(Level::new(), stroke, Affine::IDENTITY, &mut temp_buf);
+                        flatten::fill(
+                            Level::new(),
+                            stroke,
+                            Affine::IDENTITY,
+                            &mut temp_buf,
+                            &mut FlattenCtx::default(),
+                        );
                         line_buf.extend(&temp_buf);
                     }
 

--- a/sparse_strips/vello_common/src/flatten_simd.rs
+++ b/sparse_strips/vello_common/src/flatten_simd.rs
@@ -30,8 +30,8 @@ pub(crate) fn flatten<S: Simd>(
     path: impl IntoIterator<Item = PathEl>,
     tolerance: f64,
     callback: &mut impl Callback,
+    flatten_ctx: &mut FlattenCtx,
 ) {
-    let mut flatten_ctx = FlattenCtx::default();
     let mut flattened_cubics = vec![];
 
     let sqrt_tol = tolerance.sqrt();
@@ -69,7 +69,7 @@ pub(crate) fn flatten<S: Simd>(
                     let max = flatten_cubic_simd(
                         simd,
                         c,
-                        &mut flatten_ctx,
+                        flatten_ctx,
                         tolerance as f32,
                         &mut flattened_cubics,
                     );
@@ -182,8 +182,9 @@ struct FlattenParams {
 /// transforms.
 const MAX_QUADS: usize = 16;
 
+/// The context needed for flattening curves.
 #[derive(Default, Debug)]
-struct FlattenCtx {
+pub struct FlattenCtx {
     // The +4 is to encourage alignment; might be better to be explicit
     even_pts: [Point32; MAX_QUADS + 4],
     odd_pts: [Point32; MAX_QUADS],

--- a/sparse_strips/vello_cpu/src/strip_generator.rs
+++ b/sparse_strips/vello_cpu/src/strip_generator.rs
@@ -5,7 +5,7 @@ use crate::kurbo::{Affine, BezPath, Stroke};
 use crate::peniko::Fill;
 use alloc::vec::Vec;
 use vello_common::fearless_simd::Level;
-use vello_common::flatten::Line;
+use vello_common::flatten::{FlattenCtx, Line};
 use vello_common::strip::Strip;
 use vello_common::tile::Tiles;
 use vello_common::{flatten, strip};
@@ -15,6 +15,7 @@ pub(crate) struct StripGenerator {
     level: Level,
     alphas: Vec<u8>,
     line_buf: Vec<Line>,
+    flatten_ctx: FlattenCtx,
     tiles: Tiles,
     strip_buf: Vec<Strip>,
     width: u16,
@@ -29,6 +30,7 @@ impl StripGenerator {
             line_buf: Vec::new(),
             tiles: Tiles::new(),
             strip_buf: Vec::new(),
+            flatten_ctx: FlattenCtx::default(),
             width,
             height,
         }
@@ -41,7 +43,13 @@ impl StripGenerator {
         transform: Affine,
         func: impl FnOnce(&'a [Strip]),
     ) {
-        flatten::fill(self.level, path, transform, &mut self.line_buf);
+        flatten::fill(
+            self.level,
+            path,
+            transform,
+            &mut self.line_buf,
+            &mut self.flatten_ctx,
+        );
         self.make_strips(fill_rule);
         func(&mut self.strip_buf);
     }
@@ -53,7 +61,14 @@ impl StripGenerator {
         transform: Affine,
         func: impl FnOnce(&'a [Strip]),
     ) {
-        flatten::stroke(self.level, path, stroke, transform, &mut self.line_buf);
+        flatten::stroke(
+            self.level,
+            path,
+            stroke,
+            transform,
+            &mut self.line_buf,
+            &mut self.flatten_ctx,
+        );
         self.make_strips(Fill::NonZero);
         func(&mut self.strip_buf);
     }

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -8,7 +8,7 @@ use alloc::vec::Vec;
 use vello_common::coarse::Wide;
 use vello_common::encode::{EncodeExt, EncodedPaint};
 use vello_common::fearless_simd::Level;
-use vello_common::flatten::Line;
+use vello_common::flatten::{FlattenCtx, Line};
 use vello_common::glyph::{GlyphRenderer, GlyphRunBuilder, GlyphType, PreparedGlyph};
 use vello_common::kurbo::{Affine, BezPath, Cap, Join, Rect, Shape, Stroke};
 use vello_common::mask::Mask;
@@ -53,6 +53,7 @@ pub struct Scene {
     pub(crate) encoded_paints: Vec<EncodedPaint>,
     paint_visible: bool,
     level: Level,
+    flatten_ctx: FlattenCtx,
     pub(crate) stroke: Stroke,
     pub(crate) transform: Affine,
     pub(crate) fill_rule: Fill,
@@ -77,6 +78,7 @@ impl Scene {
             encoded_paints: vec![],
             paint_visible: true,
             stroke: render_state.stroke,
+            flatten_ctx: FlattenCtx::default(),
             transform: render_state.transform,
             fill_rule: render_state.fill_rule,
             blend_mode: render_state.blend_mode,
@@ -125,7 +127,13 @@ impl Scene {
         if !self.paint_visible {
             return;
         }
-        flatten::fill(self.level, path, self.transform, &mut self.line_buf);
+        flatten::fill(
+            self.level,
+            path,
+            self.transform,
+            &mut self.line_buf,
+            &mut self.flatten_ctx,
+        );
         let paint = self.encode_current_paint();
         self.render_path(self.fill_rule, paint);
     }
@@ -141,6 +149,7 @@ impl Scene {
             &self.stroke,
             self.transform,
             &mut self.line_buf,
+            &mut self.flatten_ctx,
         );
         let paint = self.encode_current_paint();
         self.render_path(Fill::NonZero, paint);
@@ -172,7 +181,13 @@ impl Scene {
         mask: Option<Mask>,
     ) {
         let clip = if let Some(c) = clip_path {
-            flatten::fill(self.level, c, self.transform, &mut self.line_buf);
+            flatten::fill(
+                self.level,
+                c,
+                self.transform,
+                &mut self.line_buf,
+                &mut self.flatten_ctx,
+            );
             self.make_strips(self.fill_rule);
             Some((self.strip_buf.as_slice(), self.fill_rule))
         } else {
@@ -316,6 +331,7 @@ impl GlyphRenderer for Scene {
                     glyph.path,
                     prepared_glyph.transform,
                     &mut self.line_buf,
+                    &mut self.flatten_ctx,
                 );
                 let paint = self.encode_current_paint();
                 self.render_path(Fill::NonZero, paint);
@@ -334,6 +350,7 @@ impl GlyphRenderer for Scene {
                     &self.stroke,
                     prepared_glyph.transform,
                     &mut self.line_buf,
+                    &mut self.flatten_ctx,
                 );
                 let paint = self.encode_current_paint();
                 self.render_path(Fill::NonZero, paint);

--- a/sparse_strips/vello_toy/src/debug.rs
+++ b/sparse_strips/vello_toy/src/debug.rs
@@ -17,7 +17,7 @@ use svg::{Document, Node};
 use vello_common::coarse::{Cmd, Wide, WideTile};
 use vello_common::color::palette::css::BLACK;
 use vello_common::fearless_simd::Level;
-use vello_common::flatten::Line;
+use vello_common::flatten::{FlattenCtx, Line};
 use vello_common::kurbo::{Affine, BezPath, Cap, Join, Stroke};
 use vello_common::peniko::Fill;
 use vello_common::strip::Strip;
@@ -42,7 +42,13 @@ fn main() {
 
     if stages.iter().any(|s| s.requires_flatten()) {
         if !args.stroke {
-            flatten::fill(Level::new(), &args.path, Affine::IDENTITY, &mut line_buf);
+            flatten::fill(
+                Level::new(),
+                &args.path,
+                Affine::IDENTITY,
+                &mut line_buf,
+                &mut FlattenCtx::default(),
+            );
         } else {
             let stroke = Stroke {
                 width: args.stroke_width as f64,
@@ -57,6 +63,7 @@ fn main() {
                 &stroke,
                 Affine::IDENTITY,
                 &mut line_buf,
+                &mut FlattenCtx::default(),
             );
         }
     }


### PR DESCRIPTION
While not a huge bottleneck, there were some `memset` operations that showed up in a few profiles and disappeared after this change.