### PR TITLE
Towards interpolating gradients in non-premultiplied space

### DIFF
--- a/sparse_strips/vello_sparse_tests/snapshots/glyphs_colr_test_glyphs.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/glyphs_colr_test_glyphs.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b85cea2b293b7d34d80b1b626c47f989fa54ef2c4391fc90b29c4a4e64ed3176
-size 122982
+oid sha256:dfc556fb1ef4a6a2b4bc593e1bc8259b465565eae443e033b40eda53c5d1acdf
+size 124147

--- a/sparse_strips/vello_sparse_tests/snapshots/gradient_linear_2_stops_with_alpha.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/gradient_linear_2_stops_with_alpha.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d0a20abeb64430774244f2384bbc0ef30aeadc52ecf91e25d36e4a4911965f4c
-size 255
+oid sha256:9d3c8d0a5be60548ff8c009cc349a5b45a44458c95c04b77f7111fce52121992
+size 308

--- a/sparse_strips/vello_sparse_tests/snapshots/gradient_radial_2_stops_with_alpha.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/gradient_radial_2_stops_with_alpha.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c8ce095079f238deb79512589755461d6d2763500ccc4dfd6f0f9f03e39985bc
-size 1635
+oid sha256:ec51fb2c562e986d838041a8a0dcccf652c60324bba8605074ec88a1131ed344
+size 1950

--- a/sparse_strips/vello_sparse_tests/snapshots/gradient_sweep_2_stops_with_alpha.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/gradient_sweep_2_stops_with_alpha.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8836ebb45f02360caf527be748bc035ceaee542fc049714b336a8e74046301b4
-size 2209
+oid sha256:d18c30a7014fa5e42d4b6030130853df1fb39dd7e97c1ebb84fc243bd53f30ea
+size 2081

--- a/sparse_strips/vello_sparse_tests/snapshots/gradient_with_last_stop_0_opacity.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/gradient_with_last_stop_0_opacity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08cb0ea24999110fc65005970883d894ed13e6b9116f71894c32fe5d5802754f
+size 310

--- a/sparse_strips/vello_sparse_tests/snapshots/mask_luminance.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/mask_luminance.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fffe5139b6ad63b2b7251c97f19851607a9617d84c3ba733f991e8d5c94c2f32
-size 263
+oid sha256:c53643515bacb13cbf40f62d90c2b8a61c4eeae7ec125163e5ab98da058f776d
+size 271

--- a/sparse_strips/vello_sparse_tests/snapshots/mix_color.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/mix_color.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:de8d4f9ed15ae0f074021d21670eba70c9e8390ae1b5a4b44bc6c71521982685
+oid sha256:f3dc53d3f13cd0a08f1c682ce39326891624f7e7a9f86786a50d2d035efa5346
 size 4624


### PR DESCRIPTION
This doesn't solve the issue for gradients with non-SRGB color space because the `color` crate will always provide a linear approximation in premultiplied space, but at least we can resolve the issue for SRGB color spaces, which seems like a good first step.

Fixes #1129.