### PR TITLE
[sparse strips] Support gradient interpolation in unpremultiplied alpha space

### DIFF
--- a/sparse_strips/vello_common/src/encode.rs
+++ b/sparse_strips/vello_common/src/encode.rs
@@ -17,8 +17,9 @@ use alloc::vec::Vec;
 #[cfg(not(feature = "multithreading"))]
 use core::cell::OnceCell;
 use core::hash::{Hash, Hasher};
-use fearless_simd::{Simd, SimdBase, SimdFloat, f32x4, f32x16};
+use fearless_simd::{Simd, SimdBase, SimdFloat, f32x4, f32x16, mask32x4, mask32x16};
 use peniko::color::cache_key::{BitEq, BitHash, CacheKey};
+use peniko::color::gradient_unpremultiplied;
 use peniko::{
     ImageSampler, InterpolationAlphaSpace, LinearGradientPosition, RadialGradientPosition,
     SweepGradientPosition,
@@ -62,12 +63,6 @@ impl EncodeExt for Gradient {
         // First make sure that the gradient is valid and not degenerate.
         if let Err(paint) = validate(self) {
             return paint;
-        }
-        if self.interpolation_alpha_space != InterpolationAlphaSpace::Premultiplied {
-            unimplemented!(
-                "We don't yet support gradient interpolation which isn't premultiplied, found {:?}.",
-                self.interpolation_alpha_space
-            )
         }
 
         let mut has_opacities = self.stops.iter().any(|s| s.color.components[3] != 1.0);
@@ -181,7 +176,12 @@ impl EncodeExt for Gradient {
             }
         };
 
-        let ranges = encode_stops(&stops, self.interpolation_cs, self.hue_direction);
+        let ranges = encode_stops(
+            &stops,
+            self.interpolation_cs,
+            self.hue_direction,
+            self.interpolation_alpha_space,
+        );
 
         // This represents the transform that needs to be applied to the starting point of a
         // command before starting with the rendering.
@@ -322,11 +322,12 @@ fn encode_stops(
     stops: &[ColorStop],
     cs: ColorSpaceTag,
     hue_dir: HueDirection,
+    interpolation_alpha_space: InterpolationAlphaSpace,
 ) -> Vec<GradientRange> {
     #[derive(Debug)]
     struct EncodedColorStop {
         offset: f32,
-        color: crate::color::PremulColor<Srgb>,
+        color: crate::color::AlphaColor<Srgb>,
     }
 
     let create_range = |left_stop: &EncodedColorStop, right_stop: &EncodedColorStop| {
@@ -342,8 +343,16 @@ fn encode_stops(
 
         let x0 = left_stop.offset;
         let x1 = right_stop.offset;
-        let c0 = clamp(left_stop.color.components);
-        let c1 = clamp(right_stop.color.components);
+        let c0 = if interpolation_alpha_space == InterpolationAlphaSpace::Unpremultiplied {
+            clamp(left_stop.color.components)
+        } else {
+            clamp(left_stop.color.premultiply().components)
+        };
+        let c1 = if interpolation_alpha_space == InterpolationAlphaSpace::Unpremultiplied {
+            clamp(right_stop.color.components)
+        } else {
+            clamp(right_stop.color.premultiply().components)
+        };
 
         // We calculate a bias and scale factor, such that we can simply calculate
         // bias + x * scale to get the interpolated color, where x is between x0 and x1,
@@ -359,27 +368,57 @@ fn encode_stops(
             bias[i] = c0[i] - x0 * scale[i];
         }
 
-        GradientRange { x1, bias, scale }
+        GradientRange {
+            x1,
+            bias,
+            scale,
+            interpolation_alpha_space,
+        }
     };
 
     // Create additional (SRGB-encoded) stops in-between to approximate the color space we want to
     // interpolate in.
     if cs != ColorSpaceTag::Srgb {
-        let interpolated_stops = stops
-            .windows(2)
-            .flat_map(|s| {
-                let left_stop = &s[0];
-                let right_stop = &s[1];
+        let interpolated_stops = if interpolation_alpha_space
+            == InterpolationAlphaSpace::Premultiplied
+        {
+            stops
+                .windows(2)
+                .flat_map(|s| {
+                    let left_stop = &s[0];
+                    let right_stop = &s[1];
 
-                let interpolated =
-                    gradient::<Srgb>(left_stop.color, right_stop.color, cs, hue_dir, 0.01);
+                    let interpolated =
+                        gradient::<Srgb>(left_stop.color, right_stop.color, cs, hue_dir, 0.01);
 
-                interpolated.map(|st| EncodedColorStop {
-                    offset: left_stop.offset + (right_stop.offset - left_stop.offset) * st.0,
-                    color: st.1,
+                    interpolated.map(|st| EncodedColorStop {
+                        offset: left_stop.offset + (right_stop.offset - left_stop.offset) * st.0,
+                        color: st.1.un_premultiply(),
+                    })
                 })
-            })
-            .collect::<Vec<_>>();
+                .collect::<Vec<_>>()
+        } else {
+            stops
+                .windows(2)
+                .flat_map(|s| {
+                    let left_stop = &s[0];
+                    let right_stop = &s[1];
+
+                    let interpolated = gradient_unpremultiplied::<Srgb>(
+                        left_stop.color,
+                        right_stop.color,
+                        cs,
+                        hue_dir,
+                        0.01,
+                    );
+
+                    interpolated.map(|st| EncodedColorStop {
+                        offset: left_stop.offset + (right_stop.offset - left_stop.offset) * st.0,
+                        color: st.1,
+                    })
+                })
+                .collect::<Vec<_>>()
+        };
 
         interpolated_stops
             .windows(2)
@@ -396,12 +435,12 @@ fn encode_stops(
             .map(|c| {
                 let c0 = EncodedColorStop {
                     offset: c[0].offset,
-                    color: c[0].color.to_alpha_color::<Srgb>().premultiply(),
+                    color: c[0].color.to_alpha_color::<Srgb>(),
                 };
 
                 let c1 = EncodedColorStop {
                     offset: c[1].offset,
-                    color: c[1].color.to_alpha_color::<Srgb>().premultiply(),
+                    color: c[1].color.to_alpha_color::<Srgb>(),
                 };
 
                 create_range(&c0, &c1)
@@ -732,7 +771,7 @@ impl BitEq for GradientCacheKey {
     }
 }
 
-/// An encoded ange between two color stops.
+/// An encoded range between two color stops.
 #[derive(Debug, Clone)]
 pub struct GradientRange {
     /// The end value of the range.
@@ -743,6 +782,8 @@ pub struct GradientRange {
     /// The scale factors of the range. By calculating bias + x * factors (where x is
     /// between 0.0 and 1.0), we can interpolate between start and end color of the gradient range.
     pub scale: [f32; 4],
+    /// The alpha space in which the interpolation was performed.
+    pub interpolation_alpha_space: InterpolationAlphaSpace,
 }
 
 /// An encoded blurred, rounded rectangle.
@@ -961,6 +1002,15 @@ impl<T: FromF32Color> GradientLut<T> {
 
                 let mut result = biases.madd(scales, t_vals);
                 let alphas = result.splat_4th();
+                // Premultiply colors, since we did interpolation in unpremultiplied space.
+                if range.interpolation_alpha_space == InterpolationAlphaSpace::Unpremultiplied {
+                    result = {
+                        let mask =
+                            mask32x16::block_splat(mask32x4::from_slice(simd, &[-1, -1, -1, 0]));
+                        simd.select_f32x16(mask, result * alphas, alphas)
+                    };
+                }
+
                 // Due to floating-point impreciseness, it can happen that
                 // values either become greater than 1 or the RGB channels
                 // become greater than the alpha channel. To prevent overflows

--- a/sparse_strips/vello_sparse_tests/snapshots/gradient_color_alpha_unmul.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/gradient_color_alpha_unmul.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:abdcde1d89e80b4b9f07e4834b6d1883e976404b95522e206595f4394c16815a
+size 299

--- a/sparse_strips/vello_sparse_tests/tests/issues.rs
+++ b/sparse_strips/vello_sparse_tests/tests/issues.rs
@@ -6,7 +6,7 @@
 use crate::renderer::Renderer;
 use vello_common::color::palette::css::{DARK_BLUE, LIME, REBECCA_PURPLE};
 use vello_common::kurbo::{Affine, BezPath, Rect, Shape, Stroke};
-use vello_common::peniko::{Color, ColorStop, Fill, Gradient};
+use vello_common::peniko::{Color, ColorStop, Fill, Gradient, InterpolationAlphaSpace};
 use vello_common::pixmap::Pixmap;
 use vello_cpu::color::palette::css::{BLACK, RED};
 use vello_cpu::peniko::Compose;
@@ -374,6 +374,30 @@ fn gradient_color_alpha(ctx: &mut impl Renderer) {
             color: Color::from_rgba8(0, 0, 255, 255).into(),
         },
     ]));
+    ctx.fill_rect(&viewport);
+}
+
+/// <https://github.com/web-platform-tests/wpt/blob/18c64a74b1/html/canvas/element/fill-and-stroke-styles/2d.gradient.interpolate.coloralpha.html>
+/// See <https://github.com/linebender/vello/issues/1056>.
+#[vello_test(width = 100, height = 50)]
+fn gradient_color_alpha_unmul(ctx: &mut impl Renderer) {
+    let viewport = Rect::new(0., 0., 100., 50.);
+    ctx.push_blend_layer(Compose::Clear.into());
+    ctx.pop_layer();
+    ctx.set_paint(
+        Gradient::new_linear((0., 0.), (100., 0.))
+            .with_stops([
+                ColorStop {
+                    offset: 0.,
+                    color: Color::from_rgba8(255, 255, 0, 0).into(),
+                },
+                ColorStop {
+                    offset: 1.,
+                    color: Color::from_rgba8(0, 0, 255, 255).into(),
+                },
+            ])
+            .with_interpolation_alpha_space(InterpolationAlphaSpace::Unpremultiplied),
+    );
     ctx.fill_rect(&viewport);
 }
 


### PR DESCRIPTION
Some SIMD stuff is from https://github.com/linebender/vello/pull/1140

Depends on https://github.com/linebender/peniko/pull/115

This currently includes only Vello CPU/Hybrid implementation, but I plan to do classic Vello too.

Fixes #1056 