### PR TITLE
[WIP] Spatiotemporal Blending for vello_hybrid

### DIFF
--- a/sparse_strips/vello_common/src/coarse.rs
+++ b/sparse_strips/vello_common/src/coarse.rs
@@ -900,24 +900,24 @@ impl WideTile {
                 let (_, tail) = self.cmds.split_at(self.cmds.len() - 3);
 
                 let updated = match tail {
-                    [Cmd::PushBuf, Cmd::AlphaFill(a), Cmd::Blend(b)] => {
-                        if !b.is_destructive() && a.blend_mode.is_none() {
-                            let mut blended = a.clone();
-                            blended.blend_mode = Some(*b);
-                            Some(Cmd::AlphaFill(blended))
-                        } else {
-                            None
-                        }
-                    }
-                    [Cmd::PushBuf, Cmd::Fill(a), Cmd::Blend(b)] => {
-                        if !b.is_destructive() && a.blend_mode.is_none() {
-                            let mut blended = a.clone();
-                            blended.blend_mode = Some(*b);
-                            Some(Cmd::Fill(blended))
-                        } else {
-                            None
-                        }
-                    }
+                    // [Cmd::PushBuf, Cmd::AlphaFill(a), Cmd::Blend(b)] => {
+                    //     if !b.is_destructive() && a.blend_mode.is_none() {
+                    //         let mut blended = a.clone();
+                    //         blended.blend_mode = Some(*b);
+                    //         Some(Cmd::AlphaFill(blended))
+                    //     } else {
+                    //         None
+                    //     }
+                    // }
+                    // [Cmd::PushBuf, Cmd::Fill(a), Cmd::Blend(b)] => {
+                    //     if !b.is_destructive() && a.blend_mode.is_none() {
+                    //         let mut blended = a.clone();
+                    //         blended.blend_mode = Some(*b);
+                    //         Some(Cmd::Fill(blended))
+                    //     } else {
+                    //         None
+                    //     }
+                    // }
                     _ => None,
                 };
 

--- a/sparse_strips/vello_dev_macros/src/test.rs
+++ b/sparse_strips/vello_dev_macros/src/test.rs
@@ -161,8 +161,7 @@ pub(crate) fn vello_test_inner(attr: TokenStream, item: TokenStream) -> TokenStr
 
     // These tests currently don't work with `vello_hybrid`.
     skip_hybrid |= {
-        input_fn_name_str.contains("compose")
-            || input_fn_name_str.contains("gradient")
+            input_fn_name_str.contains("gradient")
             || input_fn_name_str.contains("layer_multiple_properties")
             || input_fn_name_str.contains("mask")
             || input_fn_name_str.contains("mix")

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -202,16 +202,13 @@ impl Scene {
         };
 
         // Blend mode, opacity, and mask are not supported yet.
-        if blend_mode.is_some() {
-            unimplemented!()
-        }
         if mask.is_some() {
             unimplemented!()
         }
 
         self.wide.push_layer(
             clip,
-            BlendMode::new(Mix::Normal, Compose::SrcOver),
+            blend_mode.unwrap_or(BlendMode::new(Mix::Normal, Compose::SrcOver)),
             None,
             opacity.unwrap_or(1.),
             0,

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -181,7 +181,7 @@ use crate::{GpuStrip, RenderError, Scene};
 use alloc::collections::VecDeque;
 use alloc::vec::Vec;
 use core::mem;
-use vello_common::peniko::{BlendMode, Compose, Mix};
+use vello_common::peniko::Mix;
 use vello_common::{
     coarse::{Cmd, WideTile},
     encode::EncodedPaint,
@@ -885,6 +885,10 @@ impl Scheduler {
                             payload,
                             paint,
                         });
+                        // TODO(DO NOT SUBMIT): There is a problem with blend dependencies. Currently
+                        // the system has no problem parallelizing dependent blends. Instead, I
+                        // think we need to signal after a blend that we need a new round to
+                        // continue working on the tile. After flushing we can continue.
 
                         // Invalidate the temporary slot after use
                         let nos_ptr = state.stack.len() - 2;
@@ -893,6 +897,7 @@ impl Scheduler {
                         self.rounds_queue[round - self.round].free[temporary_slot.get_texture()]
                             .push(temporary_slot.get_idx());
                     } else {
+                        // TODO(DO NOT SUBMIT): This path is very obviously wrong - and needs to not exist.
                         let draw = self.draw_mut(round, tos.get_draw_texture(clip_depth - 1));
                         let (x, y) = if (clip_depth - 1) <= 2 {
                             (wide_tile_x, wide_tile_y)

--- a/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
@@ -29,6 +29,7 @@
 const COLOR_SOURCE_PAYLOAD: u32 = 0u;
 // Sample from clip texture slot
 const COLOR_SOURCE_SLOT: u32 = 1u;
+const COLOR_SOURCE_BLEND: u32 = 2u;
 
 // Paint types
 const PAINT_TYPE_SOLID: u32 = 0u;  
@@ -38,6 +39,25 @@ const PAINT_TYPE_IMAGE: u32 = 1u;
 const IMAGE_QUALITY_LOW = 0u;
 const IMAGE_QUALITY_MEDIUM = 1u;
 const IMAGE_QUALITY_HIGH = 2u;
+
+// Blend modes
+const MIX_NORMAL: u32 = 0u;
+
+// Composite modes
+const COMPOSE_CLEAR: u32 = 0u;
+const COMPOSE_COPY: u32 = 1u;
+const COMPOSE_DEST: u32 = 2u;
+const COMPOSE_SRC_OVER: u32 = 3u;
+const COMPOSE_DEST_OVER: u32 = 4u;
+const COMPOSE_SRC_IN: u32 = 5u;
+const COMPOSE_DEST_IN: u32 = 6u;
+const COMPOSE_SRC_OUT: u32 = 7u;
+const COMPOSE_DEST_OUT: u32 = 8u;
+const COMPOSE_SRC_ATOP: u32 = 9u;
+const COMPOSE_DEST_ATOP: u32 = 10u;
+const COMPOSE_XOR: u32 = 11u;
+const COMPOSE_PLUS: u32 = 12u;
+const COMPOSE_PLUS_LIGHTER: u32 = 13u;
 
 struct Config {
     // Width of the rendering target
@@ -53,16 +73,24 @@ struct Config {
     alphas_tex_width_bits: u32,
 }
 
-// Strip instance data
-//
-// The `paint` field is packed with metadata that controls how `payload` is interpreted:
-//
 // `paint` bit layout:
-//   - Bit 31:     `color_source`      0 = use payload, 1 = use slot texture
-//   - Bits 29-30: `paint_type`        0 = solid, 1 = image (only used when color_source = 0)
-//   - Bits 0-28:  Usage depends on color_source:
-//                 - When color_source = 0 and paint_type = 1: `paint_texture_id` (index of `EncodedImage`)
-//                 - When color_source = 1: bits 0-7 contain opacity (0-255)
+//   - Bits 30-31: `color_source`      0 = use payload, 1 = use slot texture, 2 = blend mode
+//   - Bits 0-29:  Usage depends on color_source:
+//
+//     When color_source = 0 (COLOR_SOURCE_PAYLOAD):
+//       - Bits 28-29: `paint_type` (0 = solid, 1 = image)
+//       - Bits 0-27: 
+//         - If paint_type = 0: unused
+//         - If paint_type = 1: `paint_texture_id`
+//
+//     When color_source = 1 (COLOR_SOURCE_SLOT):
+//       - Bits 0-7: opacity (0-255)
+//       - Bits 8-29: unused
+//
+//     When color_source = 2 (COLOR_SOURCE_BLEND):
+//       - Bits 16-29: `dest_slot` (14 bits)
+//       - Bits 8-15: `mix_mode` (8 bits)
+//       - Bits 0-7: `compose_mode` (8 bits)
 //
 // Decision tree for paint/payload interpretation:
 //
@@ -72,11 +100,17 @@ struct Config {
 // │
 // └── paint_type = 1 (PAINT_TYPE_IMAGE) - Image rendering
 //     ├── payload = [x, y] scene coordinates (packed as u16s)
-//     └── bits 0-28 = paint_texture_id
+//     └── bits 0-27 = paint_texture_id
 //
 // color_source = 1 (COLOR_SOURCE_SLOT) - Use slot texture
 // ├── payload = slot_index (u32)
 // └── bits 0-7 = opacity (0-255, where 255 = fully opaque)
+//
+// color_source = 2 (COLOR_SOURCE_BLEND) - Blend two slots
+// ├── payload = src_slot_index (u32) - source slot to blend
+// ├── bits 16-29 = dest_slot (14 bits) - destination slot to blend with
+// ├── bits 8-15 = mix_mode (8 bits) - currently only MIX_NORMAL (0) is used
+// └── bits 0-7 = compose_mode (8 bits) - compose operation (see COMPOSE_* constants)
 struct StripInstance {
     // [x, y] packed as u16's
     // x, y — coordinates of the strip
@@ -145,22 +179,24 @@ fn vs_main(
     // NDC ranges from -1 to 1, with (0,0) at the center of the viewport
     let ndc_x = pix_x * 2.0 / f32(config.width) - 1.0;
     let ndc_y = 1.0 - pix_y * 2.0 / f32(config.height);
-    let paint_type = (instance.paint >> 29u) & 0x3u;
 
-    if paint_type == PAINT_TYPE_IMAGE {
-        let paint_tex_id = instance.paint & 0x1FFFFFFF;
-        
-        let encoded_image = unpack_encoded_image(paint_tex_id);
-        // Unpack view coordinates for image sampling
-        let scene_strip_x = instance.payload & 0xffffu;
-        let scene_strip_y = instance.payload >> 16u;
-        // Use view coordinates for image sampling (always in global view space)
-        out.sample_xy = encoded_image.translate 
-            + encoded_image.image_offset
-            + encoded_image.transform.xy * f32(scene_strip_x) 
-            + encoded_image.transform.zw * f32(scene_strip_y)
-            + encoded_image.transform.xy * x * f32(width)
-            + encoded_image.transform.zw * y * f32(config.strip_height);
+    let color_source = (instance.paint >> 30u) & 0x3u;
+    if color_source == COLOR_SOURCE_PAYLOAD {
+        let paint_type = (instance.paint >> 28u) & 0x3u;
+        if paint_type == PAINT_TYPE_IMAGE {
+            let paint_tex_id = instance.paint & 0x0FFFFFFF;
+            let encoded_image = unpack_encoded_image(paint_tex_id);
+            // Unpack view coordinates for image sampling
+            let scene_strip_x = instance.payload & 0xffffu;
+            let scene_strip_y = instance.payload >> 16u;
+            // Use view coordinates for image sampling (always in global view space)
+            out.sample_xy = encoded_image.translate 
+                + encoded_image.image_offset
+                + encoded_image.transform.xy * f32(scene_strip_x) 
+                + encoded_image.transform.zw * f32(scene_strip_y)
+                + encoded_image.transform.xy * x * f32(width)
+                + encoded_image.transform.zw * y * f32(config.strip_height);
+        }
     }
 
     // Regular texture coordinates for other render types
@@ -211,17 +247,17 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
         alpha = f32((alphas_u32 >> (y * 8u)) & 0xffu) * (1.0 / 255.0);
     }
     // Apply the alpha value to the unpacked RGBA color or slot index
-    let color_source = (in.paint >> 31u) & 0x1u;
+    let color_source = (in.paint >> 30u) & 0x3u;
     var final_color: vec4<f32>;
 
     if color_source == COLOR_SOURCE_PAYLOAD {
-        let paint_type = (in.paint >> 29u) & 0x3u;
+        let paint_type = (in.paint >> 28u) & 0x3u;
 
         // in.payload encodes a color for PAINT_TYPE_SOLID or sample_xy for PAINT_TYPE_IMAGE
         if paint_type == PAINT_TYPE_SOLID {
             final_color = alpha * unpack4x8unorm(in.payload);
         } else if paint_type == PAINT_TYPE_IMAGE {
-            let paint_tex_id = in.paint & 0x1FFFFFFF;
+            let paint_tex_id = in.paint & 0x0FFFFFFF;
             let encoded_image = unpack_encoded_image(paint_tex_id);
             let image_offset = encoded_image.image_offset;
             let image_size = encoded_image.image_size;
@@ -257,7 +293,7 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
                 final_color = alpha * textureLoad(atlas_texture, vec2<u32>(final_xy), 0);
             }
         }
-    } else {
+    } else if color_source == COLOR_SOURCE_SLOT {
         // in.payload encodes a slot in the source clip texture
         let clip_x = u32(in.position.x) & 0xFFu;
         let clip_y = (u32(in.position.y) & 3) + in.payload * config.strip_height;
@@ -267,6 +303,85 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
         let opacity = f32(in.paint & 0xFFu) * (1.0 / 255.0);
 
         final_color = alpha * opacity * clip_in_color;
+    } else if color_source == COLOR_SOURCE_BLEND {
+        let dest_slot = (in.paint >> 16u) & 0x3FFFu;
+        let mix_mode = (in.paint >> 8u) & 0xFFu;
+        let compose_mode = in.paint & 0xFFu;
+        
+        // Read source color from slot
+        let src_slot = in.payload;
+        let clip_x = u32(in.position.x) & 0xFFu;
+        let src_y = (u32(in.position.y) & 3u) + src_slot * config.strip_height;
+        let src_color = textureLoad(clip_input_texture, vec2(clip_x, src_y), 0);
+        
+        // Read destination color from slot
+        let dest_y = (u32(in.position.y) & 3u) + dest_slot * config.strip_height;
+        let dest_color = textureLoad(clip_input_texture, vec2(clip_x, dest_y), 0);
+        
+        switch compose_mode {
+            case COMPOSE_CLEAR: {
+                // Clear: result = 0
+                final_color = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+            }
+            case COMPOSE_COPY: {
+                // Copy: result = src
+                final_color = src_color;
+            }
+            case COMPOSE_DEST: {
+                // Dest: result = dest
+                final_color = dest_color;
+            }
+            case COMPOSE_SRC_OVER: {
+                // SrcOver: result = src + dest * (1 - src.a)
+                final_color = src_color + dest_color * (1.0 - src_color.a);
+            }
+            case COMPOSE_DEST_OVER: {
+                // DestOver: result = dest + src * (1 - dest.a)
+                final_color = dest_color + src_color * (1.0 - dest_color.a);
+            }
+            case COMPOSE_SRC_IN: {
+                // SrcIn: result = src * dest.a
+                final_color = src_color * dest_color.a;
+            }
+            case COMPOSE_DEST_IN: {
+                // DestIn: result = dest * src.a
+                final_color = dest_color * src_color.a;
+            }
+            case COMPOSE_SRC_OUT: {
+                // SrcOut: result = src * (1 - dest.a)
+                final_color = src_color * (1.0 - dest_color.a);
+            }
+            case COMPOSE_DEST_OUT: {
+                // DestOut: result = dest * (1 - src.a)
+                final_color = dest_color * (1.0 - src_color.a);
+            }
+            case COMPOSE_SRC_ATOP: {
+                // SrcAtop: result = src * dest.a + dest * (1 - src.a)
+                final_color = src_color * dest_color.a + dest_color * (1.0 - src_color.a);
+            }
+            case COMPOSE_DEST_ATOP: {
+                // DestAtop: result = dest * src.a + src * (1 - dest.a)
+                final_color = dest_color * src_color.a + src_color * (1.0 - dest_color.a);
+            }
+            case COMPOSE_XOR: {
+                // Xor: result = src * (1 - dest.a) + dest * (1 - src.a)
+                final_color = src_color * (1.0 - dest_color.a) + dest_color * (1.0 - src_color.a);
+            }
+            case COMPOSE_PLUS: {
+                // Plus: result = min(src + dest, 1)
+                final_color = clamp(src_color + dest_color, vec4<f32>(0.0), vec4<f32>(1.0));
+            }
+            case COMPOSE_PLUS_LIGHTER: {
+                // PlusLighter: result = src + dest (unclamped)
+                final_color = src_color + dest_color;
+            }
+            default: {
+                // Fallback to SrcOver
+                final_color = src_color + dest_color * (1.0 - src_color.a);
+            }
+        }
+
+        final_color = alpha * final_color;
     }
 
     return final_color;

--- a/sparse_strips/vello_sparse_tests/snapshots/clip_composite_opacity_nested_circles.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/clip_composite_opacity_nested_circles.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2eb78c87a22193a0df4b91230c86ed583db0c7658cf2a50fe4f7b04c44df97b1
+size 3658

--- a/sparse_strips/vello_sparse_tests/snapshots/compose_wide_tile_nested.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/compose_wide_tile_nested.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1a1ce220e274058046d90d9b07d436417c891a44cc9577dd759ae9f8ce1a026
+size 92

--- a/sparse_strips/vello_sparse_tests/snapshots/composed_layers_nesting.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/composed_layers_nesting.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d58eeb695de4aa8d1e710cd47a555ac4e72479af4986af408b24de84e0894c77
+size 100

--- a/sparse_strips/vello_sparse_tests/tests/compose.rs
+++ b/sparse_strips/vello_sparse_tests/tests/compose.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use crate::renderer::Renderer;
-use vello_common::color::palette::css::{BLUE, YELLOW};
+use vello_common::color::palette::css::{BLACK, BLUE, PURPLE, RED, WHITE, YELLOW};
 use vello_common::kurbo::Rect;
 use vello_common::peniko::{BlendMode, Compose, Mix};
 use vello_dev_macros::vello_test;
@@ -85,4 +85,34 @@ fn compose_dest_atop(ctx: &mut impl Renderer) {
 #[vello_test]
 fn compose_plus(ctx: &mut impl Renderer) {
     compose(ctx, Compose::Plus);
+}
+
+#[vello_test(height = 8, width = 100)]
+fn composed_layers_nesting(ctx: &mut impl Renderer) {
+    ctx.set_paint(WHITE);
+    ctx.fill_rect(&Rect::new(0.0, 0.0, 100.0, 8.0));
+    ctx.push_blend_layer(BlendMode {
+        mix: Mix::Normal,
+        compose: Compose::SrcOver,
+    });
+    {
+        ctx.set_paint(RED);
+        ctx.fill_rect(&Rect::new(0.0, 0.0, 80.0, 4.0));
+
+        ctx.push_blend_layer(BlendMode::new(Mix::Normal, Compose::SrcOver));
+        {
+            ctx.set_paint(PURPLE);
+            ctx.fill_rect(&Rect::new(50.0, 0.0, 100.0, 4.0));
+        }
+        ctx.pop_layer();
+
+        // Basically cut...
+        ctx.push_blend_layer(BlendMode::new(Mix::Normal, Compose::DestOut));
+        {
+            ctx.set_paint(BLACK);
+            ctx.fill_rect(&Rect::new(40.0, 0.0, 60.0, 4.0));
+        }
+        ctx.pop_layer();
+    }
+    ctx.pop_layer();
 }

--- a/sparse_strips/vello_sparse_tests/tests/compose.rs
+++ b/sparse_strips/vello_sparse_tests/tests/compose.rs
@@ -5,7 +5,6 @@ use crate::renderer::Renderer;
 use vello_common::color::palette::css::{BLUE, YELLOW};
 use vello_common::kurbo::Rect;
 use vello_common::peniko::{BlendMode, Compose, Mix};
-use vello_cpu::peniko::Color;
 use vello_dev_macros::vello_test;
 
 fn compose(ctx: &mut impl Renderer, compose: Compose) {
@@ -21,30 +20,6 @@ fn compose(ctx: &mut impl Renderer, compose: Compose) {
     // Compose.
     ctx.pop_layer();
     ctx.pop_layer();
-}
-
-#[vello_test(height = 8)]
-fn wide_tile_nested_with_explicit_composition(ctx: &mut impl Renderer) {
-    const WIDTH: f64 = 100.0;
-    const HEIGHT: f64 = 8.0;
-    const OFFSET: f64 = 50.0;
-
-    let blue = Color::from_rgb8(0, 0, 255);
-    let green = Color::from_rgb8(0, 255, 0);
-
-    ctx.push_blend_layer(BlendMode::new(Mix::Normal, Compose::SrcOver));
-
-    // Draw base blue rectangle
-    ctx.set_paint(blue);
-    ctx.fill_rect(&Rect::new(0.0, 0.0, WIDTH, HEIGHT));
-
-    ctx.push_blend_layer(BlendMode::new(Mix::Normal, Compose::SrcOver));
-    ctx.set_paint(green);
-    ctx.fill_rect(&Rect::new(OFFSET, 0.0, OFFSET + WIDTH, HEIGHT));
-
-    ctx.pop_layer(); // green
-
-    ctx.pop_layer(); // base
 }
 
 #[vello_test]

--- a/sparse_strips/vello_sparse_tests/tests/compose.rs
+++ b/sparse_strips/vello_sparse_tests/tests/compose.rs
@@ -5,6 +5,7 @@ use crate::renderer::Renderer;
 use vello_common::color::palette::css::{BLUE, YELLOW};
 use vello_common::kurbo::Rect;
 use vello_common::peniko::{BlendMode, Compose, Mix};
+use vello_cpu::peniko::Color;
 use vello_dev_macros::vello_test;
 
 fn compose(ctx: &mut impl Renderer, compose: Compose) {
@@ -20,6 +21,31 @@ fn compose(ctx: &mut impl Renderer, compose: Compose) {
     // Compose.
     ctx.pop_layer();
     ctx.pop_layer();
+}
+
+#[vello_test(height = 8)]
+fn compose_wide_tile_nested(ctx: &mut impl Renderer) {
+    const WIDTH: f64 = 100.0;
+    const HEIGHT: f64 = 8.0;
+    const OFFSET: f64 = 50.0;
+
+    // Pure colors: max values only
+    let blue = Color::from_rgb8(0, 0, 255);
+    let green = Color::from_rgb8(0, 255, 0);
+
+    ctx.push_blend_layer(BlendMode::new(Mix::Normal, Compose::SrcOver));
+
+    // Draw base blue rectangle
+    ctx.set_paint(blue);
+    ctx.fill_rect(&Rect::new(0.0, 0.0, WIDTH, HEIGHT));
+
+    ctx.push_blend_layer(BlendMode::new(Mix::Normal, Compose::SrcOver));
+    ctx.set_paint(green);
+    ctx.fill_rect(&Rect::new(OFFSET, 0.0, OFFSET + WIDTH, HEIGHT));
+
+    ctx.pop_layer(); // green
+
+    ctx.pop_layer(); // base
 }
 
 #[vello_test]

--- a/sparse_strips/vello_sparse_tests/tests/compose.rs
+++ b/sparse_strips/vello_sparse_tests/tests/compose.rs
@@ -24,12 +24,11 @@ fn compose(ctx: &mut impl Renderer, compose: Compose) {
 }
 
 #[vello_test(height = 8)]
-fn compose_wide_tile_nested(ctx: &mut impl Renderer) {
+fn wide_tile_nested_with_explicit_composition(ctx: &mut impl Renderer) {
     const WIDTH: f64 = 100.0;
     const HEIGHT: f64 = 8.0;
     const OFFSET: f64 = 50.0;
 
-    // Pure colors: max values only
     let blue = Color::from_rgb8(0, 0, 255);
     let green = Color::from_rgb8(0, 255, 0);
 

--- a/sparse_strips/vello_sparse_tests/tests/kitchen_sink.rs
+++ b/sparse_strips/vello_sparse_tests/tests/kitchen_sink.rs
@@ -5,76 +5,76 @@ use crate::renderer::Renderer;
 use vello_common::kurbo::Shape;
 use vello_dev_macros::vello_test;
 
-#[vello_test(cpu_u8_tolerance = 2)]
-fn clip_composite_opacity_nested_circles(ctx: &mut impl Renderer) {
-    use vello_common::color::palette::css::{BLUE, GREEN, PURPLE, RED, YELLOW};
-    use vello_common::kurbo::{Circle, Point, Rect};
-    use vello_common::peniko::{BlendMode, Color, Compose, Mix};
+// #[vello_test(cpu_u8_tolerance = 2)]
+// fn clip_composite_opacity_nested_circles(ctx: &mut impl Renderer) {
+//     use vello_common::color::palette::css::{BLUE, GREEN, PURPLE, RED, YELLOW};
+//     use vello_common::kurbo::{Circle, Point, Rect};
+//     use vello_common::peniko::{BlendMode, Color, Compose, Mix};
 
-    ctx.set_paint(Color::from_rgb8(240, 240, 240));
-    ctx.fill_rect(&Rect::new(0.0, 0.0, 100.0, 100.0));
+//     ctx.set_paint(Color::from_rgb8(240, 240, 240));
+//     ctx.fill_rect(&Rect::new(0.0, 0.0, 100.0, 100.0));
 
-    // Base layer circles to shine through
-    ctx.set_paint(YELLOW);
-    ctx.fill_path(&Circle::new(Point::new(30.0, 30.0), 25.0).to_path(0.1));
-    ctx.set_paint(BLUE);
-    ctx.fill_path(&Circle::new(Point::new(70.0, 30.0), 25.0).to_path(0.1));
-    ctx.set_paint(RED);
-    ctx.fill_path(&Circle::new(Point::new(30.0, 70.0), 25.0).to_path(0.1));
-    ctx.set_paint(GREEN);
-    ctx.fill_path(&Circle::new(Point::new(70.0, 70.0), 25.0).to_path(0.1));
+//     // Base layer circles to shine through
+//     ctx.set_paint(YELLOW);
+//     ctx.fill_path(&Circle::new(Point::new(30.0, 30.0), 25.0).to_path(0.1));
+//     ctx.set_paint(BLUE);
+//     ctx.fill_path(&Circle::new(Point::new(70.0, 30.0), 25.0).to_path(0.1));
+//     ctx.set_paint(RED);
+//     ctx.fill_path(&Circle::new(Point::new(30.0, 70.0), 25.0).to_path(0.1));
+//     ctx.set_paint(GREEN);
+//     ctx.fill_path(&Circle::new(Point::new(70.0, 70.0), 25.0).to_path(0.1));
 
-    // Layer 1: Clip to center area
-    let clip1 = Circle::new(Point::new(50.0, 50.0), 40.0).to_path(0.1);
-    ctx.push_clip_layer(&clip1);
+//     // Layer 1: Clip to center area
+//     let clip1 = Circle::new(Point::new(50.0, 50.0), 40.0).to_path(0.1);
+//     ctx.push_clip_layer(&clip1);
 
-    // Layer 2: Semi-transparent purple overlay
-    ctx.push_opacity_layer(0.7);
-    ctx.set_paint(PURPLE);
-    ctx.fill_rect(&Rect::new(0.0, 0.0, 100.0, 100.0));
-    ctx.pop_layer();
+//     // Layer 2: Semi-transparent purple overlay
+//     ctx.push_opacity_layer(0.7);
+//     ctx.set_paint(PURPLE);
+//     ctx.fill_rect(&Rect::new(0.0, 0.0, 100.0, 100.0));
+//     ctx.pop_layer();
 
-    // Layer 3: XOR blend mode with smaller clip
-    let clip2 = Rect::new(25.0, 25.0, 75.0, 75.0).to_path(0.1);
-    ctx.push_clip_layer(&clip2);
-    ctx.push_blend_layer(BlendMode::new(Mix::Normal, Compose::Xor));
+//     // Layer 3: XOR blend mode with smaller clip
+//     let clip2 = Rect::new(25.0, 25.0, 75.0, 75.0).to_path(0.1);
+//     ctx.push_clip_layer(&clip2);
+//     ctx.push_blend_layer(BlendMode::new(Mix::Normal, Compose::Xor));
 
-    // Draw overlapping circles with XOR
-    ctx.set_paint(RED);
-    ctx.fill_path(&Circle::new(Point::new(40.0, 40.0), 20.0).to_path(0.1));
-    ctx.set_paint(BLUE);
-    ctx.fill_path(&Circle::new(Point::new(60.0, 40.0), 20.0).to_path(0.1));
+//     // Draw overlapping circles with XOR
+//     ctx.set_paint(RED);
+//     ctx.fill_path(&Circle::new(Point::new(40.0, 40.0), 20.0).to_path(0.1));
+//     ctx.set_paint(BLUE);
+//     ctx.fill_path(&Circle::new(Point::new(60.0, 40.0), 20.0).to_path(0.1));
 
-    ctx.pop_layer(); // pop XOR blend
+//     ctx.pop_layer(); // pop XOR blend
 
-    // Layer 4: Nested opacity with Plus blend
-    ctx.push_opacity_layer(0.5);
-    ctx.push_blend_layer(BlendMode::new(Mix::Normal, Compose::Plus));
+//     // Layer 4: Nested opacity with Plus blend
+//     ctx.push_opacity_layer(0.5);
+//     ctx.push_blend_layer(BlendMode::new(Mix::Normal, Compose::Plus));
 
-    ctx.set_paint(YELLOW);
-    ctx.fill_path(&Circle::new(Point::new(50.0, 60.0), 15.0).to_path(0.1));
+//     ctx.set_paint(YELLOW);
+//     ctx.fill_path(&Circle::new(Point::new(50.0, 60.0), 15.0).to_path(0.1));
 
-    // Layer 5: Another clip with SrcIn
-    let clip3 = Circle::new(Point::new(50.0, 50.0), 30.0).to_path(0.1);
-    ctx.push_clip_layer(&clip3);
-    ctx.push_blend_layer(BlendMode::new(Mix::Normal, Compose::SrcIn));
+//     // Layer 5: Another clip with SrcIn
+//     let clip3 = Circle::new(Point::new(50.0, 50.0), 30.0).to_path(0.1);
+//     ctx.push_clip_layer(&clip3);
+//     ctx.push_blend_layer(BlendMode::new(Mix::Normal, Compose::SrcIn));
 
-    ctx.set_paint(GREEN);
-    ctx.fill_rect(&Rect::new(35.0, 35.0, 65.0, 65.0));
+//     ctx.set_paint(GREEN);
+//     ctx.fill_rect(&Rect::new(35.0, 35.0, 65.0, 65.0));
 
-    ctx.pop_layer(); // pop SrcIn
-    ctx.pop_layer(); // pop clip3
+//     ctx.pop_layer(); // pop SrcIn
+//     ctx.pop_layer(); // pop clip3
 
-    ctx.pop_layer(); // pop Plus blend
-    ctx.pop_layer(); // pop opacity
+//     ctx.pop_layer(); // pop Plus blend
+//     ctx.pop_layer(); // pop opacity
 
-    ctx.pop_layer(); // pop clip2
+//     ctx.pop_layer(); // pop clip2
 
-    // Layer 6: Final overlay with DestOut to create a hole
-    ctx.push_blend_layer(BlendMode::new(Mix::Normal, Compose::DestOut));
-    ctx.set_paint(Color::BLACK);
-    ctx.fill_path(&Circle::new(Point::new(50.0, 50.0), 10.0).to_path(0.1));
-    ctx.pop_layer();
+//     // Layer 6: Final overlay with DestOut to create a hole
+//     ctx.push_blend_layer(BlendMode::new(Mix::Normal, Compose::DestOut));
+//     ctx.set_paint(Color::BLACK);
+//     ctx.fill_path(&Circle::new(Point::new(50.0, 50.0), 10.0).to_path(0.1));
+//     ctx.pop_layer();
 
-    ctx.pop_layer(); // pop clip1
-}
+//     ctx.pop_layer(); // pop clip1
+// }

--- a/sparse_strips/vello_sparse_tests/tests/kitchen_sink.rs
+++ b/sparse_strips/vello_sparse_tests/tests/kitchen_sink.rs
@@ -1,0 +1,80 @@
+// Copyright 2025 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::renderer::Renderer;
+use vello_common::kurbo::Shape;
+use vello_dev_macros::vello_test;
+
+#[vello_test(cpu_u8_tolerance = 2)]
+fn clip_composite_opacity_nested_circles(ctx: &mut impl Renderer) {
+    use vello_common::color::palette::css::{BLUE, GREEN, PURPLE, RED, YELLOW};
+    use vello_common::kurbo::{Circle, Point, Rect};
+    use vello_common::peniko::{BlendMode, Color, Compose, Mix};
+
+    ctx.set_paint(Color::from_rgb8(240, 240, 240));
+    ctx.fill_rect(&Rect::new(0.0, 0.0, 100.0, 100.0));
+
+    // Base layer circles to shine through
+    ctx.set_paint(YELLOW);
+    ctx.fill_path(&Circle::new(Point::new(30.0, 30.0), 25.0).to_path(0.1));
+    ctx.set_paint(BLUE);
+    ctx.fill_path(&Circle::new(Point::new(70.0, 30.0), 25.0).to_path(0.1));
+    ctx.set_paint(RED);
+    ctx.fill_path(&Circle::new(Point::new(30.0, 70.0), 25.0).to_path(0.1));
+    ctx.set_paint(GREEN);
+    ctx.fill_path(&Circle::new(Point::new(70.0, 70.0), 25.0).to_path(0.1));
+
+    // Layer 1: Clip to center area
+    let clip1 = Circle::new(Point::new(50.0, 50.0), 40.0).to_path(0.1);
+    ctx.push_clip_layer(&clip1);
+
+    // Layer 2: Semi-transparent purple overlay
+    ctx.push_opacity_layer(0.7);
+    ctx.set_paint(PURPLE);
+    ctx.fill_rect(&Rect::new(0.0, 0.0, 100.0, 100.0));
+    ctx.pop_layer();
+
+    // Layer 3: XOR blend mode with smaller clip
+    let clip2 = Rect::new(25.0, 25.0, 75.0, 75.0).to_path(0.1);
+    ctx.push_clip_layer(&clip2);
+    ctx.push_blend_layer(BlendMode::new(Mix::Normal, Compose::Xor));
+
+    // Draw overlapping circles with XOR
+    ctx.set_paint(RED);
+    ctx.fill_path(&Circle::new(Point::new(40.0, 40.0), 20.0).to_path(0.1));
+    ctx.set_paint(BLUE);
+    ctx.fill_path(&Circle::new(Point::new(60.0, 40.0), 20.0).to_path(0.1));
+
+    ctx.pop_layer(); // pop XOR blend
+
+    // Layer 4: Nested opacity with Plus blend
+    ctx.push_opacity_layer(0.5);
+    ctx.push_blend_layer(BlendMode::new(Mix::Normal, Compose::Plus));
+
+    ctx.set_paint(YELLOW);
+    ctx.fill_path(&Circle::new(Point::new(50.0, 60.0), 15.0).to_path(0.1));
+
+    // Layer 5: Another clip with SrcIn
+    let clip3 = Circle::new(Point::new(50.0, 50.0), 30.0).to_path(0.1);
+    ctx.push_clip_layer(&clip3);
+    ctx.push_blend_layer(BlendMode::new(Mix::Normal, Compose::SrcIn));
+
+    ctx.set_paint(GREEN);
+    ctx.fill_rect(&Rect::new(35.0, 35.0, 65.0, 65.0));
+
+    ctx.pop_layer(); // pop SrcIn
+    ctx.pop_layer(); // pop clip3
+
+    ctx.pop_layer(); // pop Plus blend
+    ctx.pop_layer(); // pop opacity
+
+    ctx.pop_layer(); // pop clip2
+
+    // Layer 6: Final overlay with DestOut to create a hole
+    ctx.push_blend_layer(BlendMode::new(Mix::Normal, Compose::DestOut));
+    ctx.set_paint(Color::BLACK);
+    ctx.fill_path(&Circle::new(Point::new(50.0, 50.0), 10.0).to_path(0.1));
+    ctx.pop_layer();
+
+    ctx.pop_layer(); // pop clip1
+}

--- a/sparse_strips/vello_sparse_tests/tests/mod.rs
+++ b/sparse_strips/vello_sparse_tests/tests/mod.rs
@@ -32,6 +32,7 @@ mod glyph;
 mod gradient;
 mod image;
 mod issues;
+mod kitchen_sink;
 mod layer;
 mod mask;
 mod mix;

--- a/sparse_strips/vello_sparse_tests/tests/mod.rs
+++ b/sparse_strips/vello_sparse_tests/tests/mod.rs
@@ -32,7 +32,7 @@ mod glyph;
 mod gradient;
 mod image;
 mod issues;
-mod kitchen_sink;
+// mod kitchen_sink;
 mod layer;
 mod mask;
 mod mix;

--- a/sparse_strips/vello_sparse_tests/tests/opacity.rs
+++ b/sparse_strips/vello_sparse_tests/tests/opacity.rs
@@ -19,20 +19,6 @@ fn opacity_on_layer(ctx: &mut impl Renderer) {
     ctx.pop_layer();
 }
 
-#[vello_test(width = 8, height = 4)]
-fn nested_opacity_single_wide(ctx: &mut impl Renderer) {
-    ctx.set_paint(REBECCA_PURPLE);
-    ctx.fill_rect(&Rect::new(0.0, 0.0, 4.0, 4.0));
-    ctx.push_opacity_layer(0.5);
-    ctx.set_paint(YELLOW);
-    ctx.fill_rect(&Rect::new(0.0, 0.0, 6.0, 4.0));
-    ctx.push_opacity_layer(0.5);
-    ctx.set_paint(GREEN);
-    ctx.fill_rect(&Rect::new(2.0, 0.0, 8.0, 4.0));
-    ctx.pop_layer();
-    ctx.pop_layer();
-}
-
 #[vello_test]
 fn opacity_nested_on_layer(ctx: &mut impl Renderer) {
     ctx.set_paint(REBECCA_PURPLE);

--- a/sparse_strips/vello_sparse_tests/tests/opacity.rs
+++ b/sparse_strips/vello_sparse_tests/tests/opacity.rs
@@ -19,6 +19,20 @@ fn opacity_on_layer(ctx: &mut impl Renderer) {
     ctx.pop_layer();
 }
 
+#[vello_test(width = 8, height = 4)]
+fn nested_opacity_single_wide(ctx: &mut impl Renderer) {
+    ctx.set_paint(REBECCA_PURPLE);
+    ctx.fill_rect(&Rect::new(0.0, 0.0, 4.0, 4.0));
+    ctx.push_opacity_layer(0.5);
+    ctx.set_paint(YELLOW);
+    ctx.fill_rect(&Rect::new(0.0, 0.0, 6.0, 4.0));
+    ctx.push_opacity_layer(0.5);
+    ctx.set_paint(GREEN);
+    ctx.fill_rect(&Rect::new(2.0, 0.0, 8.0, 4.0));
+    ctx.pop_layer();
+    ctx.pop_layer();
+}
+
 #[vello_test]
 fn opacity_nested_on_layer(ctx: &mut impl Renderer) {
     ctx.set_paint(REBECCA_PURPLE);

--- a/sparse_strips/vello_sparse_tests/tests/renderer.rs
+++ b/sparse_strips/vello_sparse_tests/tests/renderer.rs
@@ -275,8 +275,8 @@ impl Renderer for HybridRenderer {
         self.scene.push_clip_layer(path);
     }
 
-    fn push_blend_layer(&mut self, _: BlendMode) {
-        unimplemented!()
+    fn push_blend_layer(&mut self, blend_mode: BlendMode) {
+        self.scene.push_layer(None, Some(blend_mode), None, None);
     }
 
     fn push_opacity_layer(&mut self, opacity: f32) {


### PR DESCRIPTION
This is still very much a work in progress.

Technically this currently passes all the existing tests, but it currently has a serious limitation. It is too parallel, and will place dependent blends into the same draw call.


There is also a kitchen sink test that I am using to weed out bugs. I will probably end up removing that test once I've split it up into smaller test cases. A test fuzzer would be awesome.


Status:
 - All existing tests for compositing pass.
 - Clip tests pass with the new system.
 - I've left Mix out, because I want to focus on getting scheduler change rock solid before doing color math.

Feeling good with this draft. What is quite funny is I think the solution to my problem is to use Taj's design of pausing processing tiles for a given round at a Blend, flushing a round then iterating over the rest of the wide tiles, detailed in [#vello > Hybrid Blending @ 💬](https://xi.zulipchat.com/#narrow/channel/197075-vello/topic/Hybrid.20Blending/near/532618735)