### PR TITLE
Force the user to specify the render mode in the beginning

### DIFF
--- a/sparse_strips/vello_cpu/README.md
+++ b/sparse_strips/vello_cpu/README.md
@@ -64,7 +64,7 @@ context.fill_rect(&Rect::from_points((3., 1.), (7., 4.)));
 let mut target = Pixmap::new(width, height);
 // This is only necessary if you activated the `multithreading` feature.
 context.flush();
-context.render_to_pixmap(&mut target, RenderMode::default());
+context.render_to_pixmap(&mut target);
 
 let expected_render = b"\
     0000000000\

--- a/sparse_strips/vello_cpu/examples/wasm_cpu/src/lib.rs
+++ b/sparse_strips/vello_cpu/examples/wasm_cpu/src/lib.rs
@@ -73,8 +73,7 @@ impl AppState {
         self.scenes[self.current_scene].render(&mut self.renderer, self.transform);
 
         // Render the current scene with transform
-        self.renderer
-            .render_to_pixmap(&mut self.pixmap);
+        self.renderer.render_to_pixmap(&mut self.pixmap);
         let rgba_bytes = self.pixmap.data_as_u8_slice();
         let image_data = web_sys::ImageData::new_with_u8_clamped_array_and_sh(
             wasm_bindgen::Clamped(rgba_bytes),

--- a/sparse_strips/vello_cpu/examples/wasm_cpu/src/lib.rs
+++ b/sparse_strips/vello_cpu/examples/wasm_cpu/src/lib.rs
@@ -45,7 +45,7 @@ impl AppState {
             height as u16,
             vello_cpu::RenderSettings {
                 num_threads: 0,
-                level: Level::new(),
+                ..Default::default()
             },
         );
 
@@ -109,7 +109,7 @@ impl AppState {
             height as u16,
             vello_cpu::RenderSettings {
                 num_threads: 0,
-                level: Level::new(),
+                ..Default::default()
             },
         );
 

--- a/sparse_strips/vello_cpu/examples/wasm_cpu/src/lib.rs
+++ b/sparse_strips/vello_cpu/examples/wasm_cpu/src/lib.rs
@@ -14,7 +14,6 @@ mod scenes;
 use std::cell::RefCell;
 use std::rc::Rc;
 use vello_common::kurbo::{Affine, Vec2};
-use vello_cpu::Level;
 use wasm_bindgen::prelude::*;
 use web_sys::{Event, HtmlCanvasElement, KeyboardEvent, MouseEvent, WheelEvent};
 
@@ -75,7 +74,7 @@ impl AppState {
 
         // Render the current scene with transform
         self.renderer
-            .render_to_pixmap(&mut self.pixmap, vello_cpu::RenderMode::default());
+            .render_to_pixmap(&mut self.pixmap);
         let rgba_bytes = self.pixmap.data_as_u8_slice();
         let image_data = web_sys::ImageData::new_with_u8_clamped_array_and_sh(
             wasm_bindgen::Clamped(rgba_bytes),

--- a/sparse_strips/vello_cpu/src/lib.rs
+++ b/sparse_strips/vello_cpu/src/lib.rs
@@ -32,7 +32,7 @@
 //! let mut target = Pixmap::new(width, height);
 //! // This is only necessary if you activated the `multithreading` feature.
 //! context.flush();
-//! context.render_to_pixmap(&mut target, RenderMode::default());
+//! context.render_to_pixmap(&mut target);
 //!
 //! let expected_render = b"\
 //!     0000000000\

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -73,7 +73,7 @@ pub struct RenderSettings {
     /// this to `OptimizeSpeed`. If accuracy is a more significant concern (for example for visual
     /// regression testing), then you can set this to `OptimizeQuality`.
     ///
-    /// Currently, the only difference this makes is that when choosing `OptimizeSpeed`, rendering
+    /// Currently, the only difference this makes is that when choosing `OptimizeSpeed`, rasterization
     /// will happen using u8/u16, while `OptimizeQuality` will use a f32-based pipeline.
     ///
     pub render_mode: RenderMode,

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -72,6 +72,9 @@ pub struct RenderSettings {
     /// For most cases (especially for real-time rendering), it is highly recommented to set
     /// this to `OptimizeSpeed`. If accuracy is a more significant concern (for example for visual
     /// regression testing), then you can set this to `OptimizeQuality`.
+    /// 
+    /// Currently, the only difference this makes is that when choosing `OptimizeSpeed`, rendering
+    /// will happen using u8/u16, while `OptimizeQuality` will use a f32-based pipeline.
     ///
     pub render_mode: RenderMode,
 }

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -75,7 +75,6 @@ pub struct RenderSettings {
     ///
     /// Currently, the only difference this makes is that when choosing `OptimizeSpeed`, rasterization
     /// will happen using u8/u16, while `OptimizeQuality` will use a f32-based pipeline.
-    ///
     pub render_mode: RenderMode,
 }
 

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -434,7 +434,7 @@ impl RenderContext {
             pixmap.data_as_u8_slice_mut(),
             width,
             height,
-            self.settings.render_mode,
+            self.render_settings.render_mode,
         );
     }
 

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -69,7 +69,7 @@ pub struct RenderSettings {
     pub num_threads: u16,
     /// Whether to prioritize speed or quality when rendering.
     ///
-    /// For most cases (especially for real-time rendering), it is highly recommented to set
+    /// For most cases (especially for real-time rendering), it is highly recommended to set
     /// this to `OptimizeSpeed`. If accuracy is a more significant concern (for example for visual
     /// regression testing), then you can set this to `OptimizeQuality`.
     /// 

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -72,7 +72,7 @@ pub struct RenderSettings {
     /// For most cases (especially for real-time rendering), it is highly recommended to set
     /// this to `OptimizeSpeed`. If accuracy is a more significant concern (for example for visual
     /// regression testing), then you can set this to `OptimizeQuality`.
-    /// 
+    ///
     /// Currently, the only difference this makes is that when choosing `OptimizeSpeed`, rendering
     /// will happen using u8/u16, while `OptimizeQuality` will use a f32-based pipeline.
     ///

--- a/sparse_strips/vello_dev_macros/src/test.rs
+++ b/sparse_strips/vello_dev_macros/src/test.rs
@@ -234,11 +234,11 @@ pub(crate) fn vello_test_inner(attr: TokenStream, item: TokenStream) -> TokenStr
                 };
                 use vello_cpu::{RenderContext, RenderMode};
 
-                let mut ctx = get_ctx::<RenderContext>(#width, #height, #transparent, #num_threads, #level);
+                let mut ctx = get_ctx::<RenderContext>(#width, #height, #transparent, #num_threads, #level, #render_mode);
                 #input_fn_name(&mut ctx);
                 ctx.flush();
                 if !#no_ref {
-                    check_ref(&ctx, #input_fn_name_str, #fn_name_str, #tolerance, #diff_pixels, #is_reference, #render_mode, #reference_image_name);
+                    check_ref(&ctx, #input_fn_name_str, #fn_name_str, #tolerance, #diff_pixels, #is_reference, #reference_image_name);
                 }
             }
         }
@@ -357,11 +357,11 @@ pub(crate) fn vello_test_inner(attr: TokenStream, item: TokenStream) -> TokenStr
             use crate::renderer::HybridRenderer;
             use vello_cpu::RenderMode;
 
-            let mut ctx = get_ctx::<HybridRenderer>(#width, #height, #transparent, 0, "fallback");
+            let mut ctx = get_ctx::<HybridRenderer>(#width, #height, #transparent, 0, "fallback", RenderMode::OptimizeSpeed);
             #input_fn_name(&mut ctx);
             ctx.flush();
             if !#no_ref {
-                check_ref(&ctx, #input_fn_name_str, #hybrid_fn_name_str, #hybrid_tolerance, #diff_pixels, false, RenderMode::OptimizeSpeed, #reference_image_name);
+                check_ref(&ctx, #input_fn_name_str, #hybrid_fn_name_str, #hybrid_tolerance, #diff_pixels, false, #reference_image_name);
             }
         }
 
@@ -375,11 +375,11 @@ pub(crate) fn vello_test_inner(attr: TokenStream, item: TokenStream) -> TokenStr
             use crate::renderer::HybridRenderer;
             use vello_cpu::RenderMode;
 
-            let mut ctx = get_ctx::<HybridRenderer>(#width, #height, #transparent, 0, "fallback");
+            let mut ctx = get_ctx::<HybridRenderer>(#width, #height, #transparent, 0, "fallback", RenderMode::OptimizeSpeed);
             #input_fn_name(&mut ctx);
             ctx.flush();
             if !#no_ref {
-                check_ref(&ctx, #input_fn_name_str, #webgl_fn_name_str, #hybrid_tolerance, #diff_pixels, false, RenderMode::OptimizeSpeed, #reference_image_name);
+                check_ref(&ctx, #input_fn_name_str, #webgl_fn_name_str, #hybrid_tolerance, #diff_pixels, false, #reference_image_name);
             }
         }
     };

--- a/sparse_strips/vello_sparse_tests/tests/glyph.rs
+++ b/sparse_strips/vello_sparse_tests/tests/glyph.rs
@@ -254,7 +254,7 @@ fn glyphs_bitmap_noto(ctx: &mut impl Renderer) {
         .fill_glyphs(glyphs.into_iter());
 }
 
-#[vello_test(width = 250, height = 70, skip_hybrid)]
+#[vello_test(width = 250, height = 70, skip_hybrid, cpu_u8_tolerance = 1)]
 fn glyphs_colr_noto(ctx: &mut impl Renderer) {
     let font_size: f32 = 50_f32;
     let (font, glyphs) = layout_glyphs_noto_colr("✅👀🎉🤠", font_size);

--- a/sparse_strips/vello_sparse_tests/tests/issues.rs
+++ b/sparse_strips/vello_sparse_tests/tests/issues.rs
@@ -382,14 +382,15 @@ fn multi_threading_oob_access() {
     let settings = RenderSettings {
         level: Level::new(),
         num_threads: 4,
+        render_mode: RenderMode::OptimizeQuality,
     };
     let mut ctx = RenderContext::new_with(100, 100, settings);
     let mut pixmap = Pixmap::new(100, 100);
 
     ctx.fill_path(&Rect::new(0.0, 0.0, 50.0, 50.0).to_path(0.1));
     ctx.flush();
-    ctx.render_to_pixmap(&mut pixmap, RenderMode::OptimizeQuality);
+    ctx.render_to_pixmap(&mut pixmap);
     ctx.fill_path(&Rect::new(50.0, 50.0, 100.0, 100.0).to_path(0.1));
     ctx.flush();
-    ctx.render_to_pixmap(&mut pixmap, RenderMode::OptimizeQuality);
+    ctx.render_to_pixmap(&mut pixmap);
 }

--- a/sparse_strips/vello_sparse_tests/tests/mask.rs
+++ b/sparse_strips/vello_sparse_tests/tests/mask.rs
@@ -18,6 +18,7 @@ pub(crate) fn example_mask(alpha_mask: bool) -> Mask {
     let settings = RenderSettings {
         level: Level::fallback(),
         num_threads: 0,
+        render_mode: RenderMode::OptimizeSpeed,
     };
     let mut mask_ctx = RenderContext::new_with(100, 100, settings);
 
@@ -45,7 +46,7 @@ pub(crate) fn example_mask(alpha_mask: bool) -> Mask {
 
     mask_ctx.set_paint(grad);
     mask_ctx.fill_rect(&Rect::new(10.0, 10.0, 90.0, 90.0));
-    mask_ctx.render_to_pixmap(&mut mask_pix, RenderMode::OptimizeSpeed);
+    mask_ctx.render_to_pixmap(&mut mask_pix);
 
     if alpha_mask {
         Mask::new_alpha(&mask_pix)

--- a/sparse_strips/vello_sparse_tests/tests/renderer.rs
+++ b/sparse_strips/vello_sparse_tests/tests/renderer.rs
@@ -508,7 +508,7 @@ pub(crate) struct HybridRenderer {
 impl Renderer for HybridRenderer {
     type GlyphRenderer = Scene;
 
-    fn new(width: u16, height: u16, num_threads: u16, level: Level) -> Self {
+    fn new(width: u16, height: u16, num_threads: u16, level: Level, _: RenderMode) -> Self {
         use wasm_bindgen::JsCast;
         use web_sys::HtmlCanvasElement;
 
@@ -637,7 +637,7 @@ impl Renderer for HybridRenderer {
     }
 
     // vello_hybrid WebGL renderer backend.
-    fn render_to_pixmap(&self, pixmap: &mut Pixmap, _: RenderMode) {
+    fn render_to_pixmap(&self, pixmap: &mut Pixmap) {
         use web_sys::WebGl2RenderingContext;
 
         let width = self.scene.width();

--- a/sparse_strips/vello_sparse_tests/tests/renderer.rs
+++ b/sparse_strips/vello_sparse_tests/tests/renderer.rs
@@ -19,7 +19,13 @@ use web_sys::WebGl2RenderingContext;
 pub(crate) trait Renderer: Sized + GlyphRenderer {
     type GlyphRenderer: GlyphRenderer;
 
-    fn new(width: u16, height: u16, num_threads: u16, level: Level) -> Self;
+    fn new(
+        width: u16,
+        height: u16,
+        num_threads: u16,
+        level: Level,
+        render_mode: RenderMode,
+    ) -> Self;
     fn fill_path(&mut self, path: &BezPath);
     fn stroke_path(&mut self, path: &BezPath);
     fn fill_rect(&mut self, rect: &Rect);
@@ -45,7 +51,7 @@ pub(crate) trait Renderer: Sized + GlyphRenderer {
     fn set_fill_rule(&mut self, fill_rule: Fill);
     fn set_transform(&mut self, transform: Affine);
     fn set_anti_aliasing(&mut self, value: bool);
-    fn render_to_pixmap(&self, pixmap: &mut Pixmap, render_mode: RenderMode);
+    fn render_to_pixmap(&self, pixmap: &mut Pixmap);
     fn width(&self) -> u16;
     fn height(&self) -> u16;
     fn get_image_source(&mut self, pixmap: Arc<Pixmap>) -> ImageSource;
@@ -57,8 +63,18 @@ pub(crate) trait Renderer: Sized + GlyphRenderer {
 impl Renderer for RenderContext {
     type GlyphRenderer = Self;
 
-    fn new(width: u16, height: u16, num_threads: u16, level: Level) -> Self {
-        let settings = RenderSettings { level, num_threads };
+    fn new(
+        width: u16,
+        height: u16,
+        num_threads: u16,
+        level: Level,
+        render_mode: RenderMode,
+    ) -> Self {
+        let settings = RenderSettings {
+            level,
+            num_threads,
+            render_mode,
+        };
 
         Self::new_with(width, height, settings)
     }
@@ -145,8 +161,8 @@ impl Renderer for RenderContext {
         Self::set_anti_aliasing(self, value);
     }
 
-    fn render_to_pixmap(&self, pixmap: &mut Pixmap, render_mode: RenderMode) {
-        Self::render_to_pixmap(self, pixmap, render_mode);
+    fn render_to_pixmap(&self, pixmap: &mut Pixmap) {
+        Self::render_to_pixmap(self, pixmap);
     }
 
     fn width(&self) -> u16 {
@@ -188,7 +204,7 @@ pub(crate) struct HybridRenderer {
 impl Renderer for HybridRenderer {
     type GlyphRenderer = Scene;
 
-    fn new(width: u16, height: u16, num_threads: u16, level: Level) -> Self {
+    fn new(width: u16, height: u16, num_threads: u16, level: Level, _: RenderMode) -> Self {
         if num_threads != 0 {
             panic!("hybrid renderer doesn't support multi-threading");
         }
@@ -339,7 +355,7 @@ impl Renderer for HybridRenderer {
     // This method creates device resources every time it is called. This does not matter much for
     // testing, but should not be used as a basis for implementing something real. This would be a
     // very bad example for that.
-    fn render_to_pixmap(&self, pixmap: &mut Pixmap, _: RenderMode) {
+    fn render_to_pixmap(&self, pixmap: &mut Pixmap) {
         // On some platforms using `cargo test` triggers segmentation faults in wgpu when the GPU
         // tests are run in parallel (likely related to the number of device resources being
         // requested simultaneously). This is "fixed" by putting a mutex around this method,

--- a/sparse_strips/vello_sparse_tests/tests/util.rs
+++ b/sparse_strips/vello_sparse_tests/tests/util.rs
@@ -327,12 +327,11 @@ pub(crate) fn check_ref(
     diff_pixels: u16,
     // Must be `false` on `wasm32` as reference image cannot be written to filesystem.
     is_reference: bool,
-    render_mode: RenderMode,
     ref_data: &[u8],
 ) {
     assert!(!is_reference, "WASM cannot create new reference images");
 
-    let pixmap = render_pixmap(ctx, render_mode);
+    let pixmap = render_pixmap(ctx);
     let encoded_image = pixmap.into_png().unwrap();
     let actual = load_from_memory(&encoded_image).unwrap().into_rgba8();
 

--- a/sparse_strips/vello_sparse_tests/tests/util.rs
+++ b/sparse_strips/vello_sparse_tests/tests/util.rs
@@ -57,6 +57,7 @@ pub(crate) fn get_ctx<T: Renderer>(
     transparent: bool,
     num_threads: u16,
     level: &str,
+    render_mode: RenderMode,
 ) -> T {
     let level = match level {
         #[cfg(target_arch = "aarch64")]
@@ -71,7 +72,7 @@ pub(crate) fn get_ctx<T: Renderer>(
         _ => panic!("unknown level: {level}"),
     };
 
-    let mut ctx = T::new(width, height, num_threads, level);
+    let mut ctx = T::new(width, height, num_threads, level, render_mode);
 
     if !transparent {
         let path = Rect::new(0.0, 0.0, width as f64, height as f64).to_path(0.1);
@@ -83,9 +84,9 @@ pub(crate) fn get_ctx<T: Renderer>(
     ctx
 }
 
-pub(crate) fn render_pixmap(ctx: &impl Renderer, render_mode: RenderMode) -> Pixmap {
+pub(crate) fn render_pixmap(ctx: &impl Renderer) -> Pixmap {
     let mut pixmap = Pixmap::new(ctx.width(), ctx.height());
-    ctx.render_to_pixmap(&mut pixmap, render_mode);
+    ctx.render_to_pixmap(&mut pixmap);
     pixmap
 }
 
@@ -265,10 +266,9 @@ pub(crate) fn check_ref(
     // Whether the test instance is the "gold standard" and should be used
     // for creating reference images.
     is_reference: bool,
-    render_mode: RenderMode,
     _: &[u8],
 ) {
-    let pixmap = render_pixmap(ctx, render_mode);
+    let pixmap = render_pixmap(ctx);
 
     let encoded_image = pixmap.into_png().unwrap();
     let ref_path = REFS_PATH.join(format!("{test_name}.png"));

--- a/sparse_strips/vello_toy/src/svg.rs
+++ b/sparse_strips/vello_toy/src/svg.rs
@@ -36,7 +36,7 @@ fn main() {
     let settings = RenderSettings {
         level: Level::new(),
         num_threads: args.num_threads as u16,
-        render_mode: RenderMode::OptimizeSpeed
+        render_mode: RenderMode::OptimizeSpeed,
     };
     let mut ctx = RenderContext::new_with(width, height, settings);
     let mut pixmap = Pixmap::new(width, height);

--- a/sparse_strips/vello_toy/src/svg.rs
+++ b/sparse_strips/vello_toy/src/svg.rs
@@ -36,6 +36,7 @@ fn main() {
     let settings = RenderSettings {
         level: Level::new(),
         num_threads: args.num_threads as u16,
+        render_mode: RenderMode::OptimizeSpeed
     };
     let mut ctx = RenderContext::new_with(width, height, settings);
     let mut pixmap = Pixmap::new(width, height);
@@ -49,7 +50,7 @@ fn main() {
 
         render_tree(&mut ctx, &mut sctx, &tree);
         ctx.flush();
-        ctx.render_to_pixmap(&mut pixmap, RenderMode::OptimizeSpeed);
+        ctx.render_to_pixmap(&mut pixmap);
 
         runtime += start.elapsed();
         num_iters += 1;


### PR DESCRIPTION
I think that's reasonable to do, one the one hand it would allow us making decisions based on the render mode in earlier parts of the pipeline (though I'm unsure we will ever need it), but more importantly, it allows us to get the render mode while we are still processing commands. 

For example, up until now, when rendering COLR glyphs, we always used `OptimizeQuality`, but now we can use whatever mode the user selected. Another motivation is that for SVG rendering, there are various situations where we wil need to create sub pixmaps (for rendering patterns or masks), and it would be good if we can use the same rendering mode for those.