### PR TITLE
Add support for non-isolated blending in `vello_cpu`

### DIFF
--- a/sparse_strips/vello_common/src/coarse.rs
+++ b/sparse_strips/vello_common/src/coarse.rs
@@ -894,43 +894,6 @@ impl WideTile {
             // we can just pop it instead.
             self.cmds.pop();
         } else {
-            if self.cmds.len() >= 3 {
-                // If we have a non-destructive blend mode with just a single fill/strip,
-                // inline the blend mode instead.
-                let (_, tail) = self.cmds.split_at(self.cmds.len() - 3);
-
-                let updated = match tail {
-                    [Cmd::PushBuf, Cmd::AlphaFill(a), Cmd::Blend(b)] => {
-                        if !b.is_destructive() && a.blend_mode.is_none() {
-                            let mut blended = a.clone();
-                            blended.blend_mode = Some(*b);
-                            Some(Cmd::AlphaFill(blended))
-                        } else {
-                            None
-                        }
-                    }
-                    [Cmd::PushBuf, Cmd::Fill(a), Cmd::Blend(b)] => {
-                        if !b.is_destructive() && a.blend_mode.is_none() {
-                            let mut blended = a.clone();
-                            blended.blend_mode = Some(*b);
-                            Some(Cmd::Fill(blended))
-                        } else {
-                            None
-                        }
-                    }
-                    _ => None,
-                };
-
-                if let Some(updated) = updated {
-                    self.cmds.pop();
-                    self.cmds.pop();
-                    self.cmds.pop();
-                    self.cmds.push(updated);
-
-                    return;
-                }
-            }
-
             self.cmds.push(Cmd::PopBuf);
         }
 

--- a/sparse_strips/vello_common/src/coarse.rs
+++ b/sparse_strips/vello_common/src/coarse.rs
@@ -1044,11 +1044,11 @@ impl BlendModeExt for BlendMode {
 
 #[cfg(test)]
 mod tests {
-    use crate::coarse::{Cmd, CmdFill, Wide, WideTile};
-    use crate::color::AlphaColor;
+    use crate::coarse::{Wide, WideTile};
+
     use crate::color::palette::css::TRANSPARENT;
     use crate::paint::{Paint, PremulColor};
-    use crate::peniko::{BlendMode, Compose, Fill, Mix};
+    use crate::peniko::{BlendMode, Fill};
     use crate::strip::Strip;
     use alloc::{boxed::Box, vec};
 

--- a/sparse_strips/vello_common/src/coarse.rs
+++ b/sparse_strips/vello_common/src/coarse.rs
@@ -213,7 +213,14 @@ impl Wide {
     ///    - Generate alpha fill commands for the intersected wide tiles
     /// 2. For active fill regions (determined by fill rule):
     ///    - Generate solid fill commands for the regions between strips
-    pub fn generate(&mut self, strip_buf: &[Strip], fill_rule: Fill, paint: Paint, thread_idx: u8) {
+    pub fn generate(
+        &mut self,
+        strip_buf: &[Strip],
+        fill_rule: Fill,
+        paint: Paint,
+        blend_mode: BlendMode,
+        thread_idx: u8,
+    ) {
         if strip_buf.is_empty() {
             return;
         }
@@ -284,7 +291,7 @@ impl Wide {
                     #[cfg(feature = "multithreading")]
                     thread_idx,
                     paint: paint.clone(),
-                    blend_mode: None,
+                    blend_mode,
                 };
                 x += width;
                 col += u32::from(width);
@@ -314,8 +321,12 @@ impl Wide {
                     let x_wtile_rel = x % WideTile::WIDTH;
                     let width = x2.min((wtile_x + 1) * WideTile::WIDTH) - x;
                     x += width;
-                    self.get_mut(wtile_x, strip_y)
-                        .fill(x_wtile_rel, width, paint.clone());
+                    self.get_mut(wtile_x, strip_y).fill(
+                        x_wtile_rel,
+                        width,
+                        blend_mode,
+                        paint.clone(),
+                    );
                 }
             }
         }
@@ -792,7 +803,7 @@ impl WideTile {
         }
     }
 
-    pub(crate) fn fill(&mut self, x: u16, width: u16, paint: Paint) {
+    pub(crate) fn fill(&mut self, x: u16, width: u16, blend_mode: BlendMode, paint: Paint) {
         if !self.is_zero_clip() {
             let bg = if let Paint::Solid(s) = &paint {
                 // Note that we could be more aggressive in optimizing a whole-tile opaque fill
@@ -824,7 +835,7 @@ impl WideTile {
                     x,
                     width,
                     paint,
-                    blend_mode: None,
+                    blend_mode,
                 }));
             }
         }
@@ -964,7 +975,7 @@ pub struct CmdFill {
     /// The paint that should be used to fill the area.
     pub paint: Paint,
     /// The blend mode to apply before drawing the contents.
-    pub blend_mode: Option<BlendMode>,
+    pub blend_mode: BlendMode,
 }
 
 /// Fill a consecutive region of a wide tile with an alpha mask.
@@ -983,7 +994,7 @@ pub struct CmdAlphaFill {
     /// The paint that should be used to fill the area.
     pub paint: Paint,
     /// A blend mode to apply before drawing the contents.
-    pub blend_mode: Option<BlendMode>,
+    pub blend_mode: BlendMode,
 }
 
 /// Same as fill, but copies top of clip stack to next on stack.
@@ -1057,71 +1068,15 @@ mod tests {
         wide.fill(
             0,
             10,
+            BlendMode::default(),
             Paint::Solid(PremulColor::from_alpha_color(TRANSPARENT)),
         );
         wide.fill(
             10,
             10,
+            BlendMode::default(),
             Paint::Solid(PremulColor::from_alpha_color(TRANSPARENT)),
         );
-        wide.pop_buf();
-
-        assert_eq!(wide.cmds.len(), 4);
-    }
-
-    #[test]
-    fn inline_blend_with_one_fill() {
-        let paint = Paint::Solid(PremulColor::from_alpha_color(AlphaColor::from_rgba8(
-            30, 30, 30, 255,
-        )));
-        let blend_mode = BlendMode::new(Mix::Lighten, Compose::SrcOver);
-
-        let mut wide = WideTile::new(0, 0);
-        wide.push_buf();
-        wide.fill(0, 10, paint.clone());
-        wide.blend(blend_mode);
-        wide.pop_buf();
-
-        assert_eq!(wide.cmds.len(), 1);
-
-        let expected = Cmd::Fill(CmdFill {
-            x: 0,
-            width: 10,
-            paint,
-            blend_mode: Some(blend_mode),
-        });
-
-        assert_eq!(wide.cmds[0], expected);
-    }
-
-    #[test]
-    fn dont_inline_blend_with_two_fills() {
-        let paint = Paint::Solid(PremulColor::from_alpha_color(AlphaColor::from_rgba8(
-            30, 30, 30, 255,
-        )));
-        let blend_mode = BlendMode::new(Mix::Lighten, Compose::SrcOver);
-
-        let mut wide = WideTile::new(0, 0);
-        wide.push_buf();
-        wide.fill(0, 10, paint.clone());
-        wide.fill(10, 10, paint.clone());
-        wide.blend(blend_mode);
-        wide.pop_buf();
-
-        assert_eq!(wide.cmds.len(), 5);
-    }
-
-    #[test]
-    fn dont_inline_destructive_blend() {
-        let paint = Paint::Solid(PremulColor::from_alpha_color(AlphaColor::from_rgba8(
-            30, 30, 30, 255,
-        )));
-        let blend_mode = BlendMode::new(Mix::Lighten, Compose::Clear);
-
-        let mut wide = WideTile::new(0, 0);
-        wide.push_buf();
-        wide.fill(0, 10, paint.clone());
-        wide.blend(blend_mode);
         wide.pop_buf();
 
         assert_eq!(wide.cmds.len(), 4);

--- a/sparse_strips/vello_cpu/src/dispatch/mod.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/mod.rs
@@ -24,6 +24,7 @@ pub(crate) trait Dispatcher: Debug + Send + Sync {
         fill_rule: Fill,
         transform: Affine,
         paint: Paint,
+        blend_mode: BlendMode,
         anti_alias: bool,
     );
     fn stroke_path(
@@ -32,6 +33,7 @@ pub(crate) trait Dispatcher: Debug + Send + Sync {
         stroke: &Stroke,
         transform: Affine,
         paint: Paint,
+        blend_mode: BlendMode,
         anti_alias: bool,
     );
     fn push_layer(

--- a/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
@@ -246,8 +246,11 @@ impl MultiThreadedDispatcher {
                                 thread_id,
                                 strips,
                                 fill_rule,
+                                blend_mode,
                                 paint,
-                            } => self.wide.generate(&strips, fill_rule, paint, thread_id),
+                            } => self
+                                .wide
+                                .generate(&strips, fill_rule, paint, blend_mode, thread_id),
                             CoarseTask::PushLayer {
                                 thread_id,
                                 clip_path,
@@ -337,6 +340,7 @@ impl Dispatcher for MultiThreadedDispatcher {
         fill_rule: Fill,
         transform: Affine,
         paint: Paint,
+        blend_mode: BlendMode,
         anti_alias: bool,
     ) {
         self.register_task(RenderTask::FillPath {
@@ -344,6 +348,7 @@ impl Dispatcher for MultiThreadedDispatcher {
             transform,
             paint,
             fill_rule,
+            blend_mode,
             anti_alias,
         });
     }
@@ -354,6 +359,7 @@ impl Dispatcher for MultiThreadedDispatcher {
         stroke: &Stroke,
         transform: Affine,
         paint: Paint,
+        blend_mode: BlendMode,
         anti_alias: bool,
     ) {
         self.register_task(RenderTask::StrokePath {
@@ -361,6 +367,7 @@ impl Dispatcher for MultiThreadedDispatcher {
             transform,
             paint,
             stroke: stroke.clone(),
+            blend_mode,
             anti_alias,
         });
     }
@@ -537,6 +544,7 @@ pub(crate) enum RenderTask {
         transform: Affine,
         paint: Paint,
         fill_rule: Fill,
+        blend_mode: BlendMode,
         anti_alias: bool,
     },
     StrokePath {
@@ -544,6 +552,7 @@ pub(crate) enum RenderTask {
         transform: Affine,
         paint: Paint,
         stroke: Stroke,
+        blend_mode: BlendMode,
         anti_alias: bool,
     },
     PushLayer {
@@ -562,6 +571,7 @@ pub(crate) enum CoarseTask {
         thread_id: u8,
         strips: Box<[Strip]>,
         fill_rule: Fill,
+        blend_mode: BlendMode,
         paint: Paint,
     },
     PushLayer {

--- a/sparse_strips/vello_cpu/src/dispatch/multi_threaded/worker.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/multi_threaded/worker.rs
@@ -51,6 +51,7 @@ impl Worker {
                     transform,
                     paint,
                     fill_rule,
+                    blend_mode,
                     anti_alias,
                 } => {
                     let func = |strips: &[Strip]| {
@@ -58,6 +59,7 @@ impl Worker {
                             thread_id: self.thread_id,
                             strips: strips.into(),
                             fill_rule,
+                            blend_mode,
                             paint,
                         };
 
@@ -84,6 +86,7 @@ impl Worker {
                     path,
                     transform,
                     paint,
+                    blend_mode,
                     stroke,
                     anti_alias,
                 } => {
@@ -92,6 +95,7 @@ impl Worker {
                             thread_id: self.thread_id,
                             strips: strips.into(),
                             fill_rule: Fill::NonZero,
+                            blend_mode,
                             paint,
                         };
 

--- a/sparse_strips/vello_cpu/src/dispatch/single_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/single_threaded.rs
@@ -77,11 +77,12 @@ impl Dispatcher for SingleThreadedDispatcher {
         fill_rule: Fill,
         transform: Affine,
         paint: Paint,
+        blend_mode: BlendMode,
         anti_alias: bool,
     ) {
         let wide = &mut self.wide;
 
-        let func = |strips| wide.generate(strips, fill_rule, paint, 0);
+        let func = |strips| wide.generate(strips, fill_rule, paint, blend_mode, 0);
         self.strip_generator
             .generate_filled_path(path, fill_rule, transform, anti_alias, func);
     }
@@ -92,11 +93,12 @@ impl Dispatcher for SingleThreadedDispatcher {
         stroke: &Stroke,
         transform: Affine,
         paint: Paint,
+        blend_mode: BlendMode,
         anti_alias: bool,
     ) {
         let wide = &mut self.wide;
 
-        let func = |strips| wide.generate(strips, Fill::NonZero, paint, 0);
+        let func = |strips| wide.generate(strips, Fill::NonZero, paint, blend_mode, 0);
         self.strip_generator
             .generate_stroked_path(path, stroke, transform, anti_alias, func);
     }

--- a/sparse_strips/vello_cpu/src/fine/highp/compose.rs
+++ b/sparse_strips/vello_cpu/src/fine/highp/compose.rs
@@ -23,6 +23,23 @@ impl ComposeExt for BlendMode {
         bg_c: f32x16<S>,
         alpha_mask: Option<f32x16<S>>,
     ) -> f32x16<S> {
+        // There some non-obvious subtleties worth highlighting here.
+        // We support two kinds of blending (in this case, we focus on compositing specifically):
+        // - Isolated blending, where layers as a whole are blended together with their backdrop.
+        //   If we are currently performing this kind of blending, `alpha_mask` will always be `None`.
+        //   After all, there is no concrete shape opacity associated with a layer. Instead, we are
+        //   just compositing the RGBA values at _all_ positions of the source layer with the backdrop
+        //   layer. For example, if the backdrop contains a green rectangle and source layer is just
+        //   empty, if we perform blending with `Compose::Clear`, then _everything_ will be cleared,
+        //   because we are compositing the whole source layer with the whole backdrop, and not
+        //   just the parts of the source layer that have actually be drawn on.
+        // - Non-isolated blending, where a single path is blended with the backdrop. In this case,
+        //   `alpha_mask` _might_ be `Some` and contain the alpha values of the strips we are currently
+        //   compositing. Remember that strips always have a fixed height of 4, because of this, the
+        //   strips might cover areas that aren't actually covered by the path (and just have an alpha
+        //   value of 0, or a value between 0-254 for anti-aliased parts). Because of this, for
+        //   non-isolated blending, we need to lerp the result with the backdrop using `alpha_mask`.
+
         let mut res = match self.compose {
             Compose::SrcOver => SrcOver::compose(simd, src_c, bg_c),
             Compose::Clear => Clear::compose(simd, src_c, bg_c),

--- a/sparse_strips/vello_cpu/src/fine/highp/compose.rs
+++ b/sparse_strips/vello_cpu/src/fine/highp/compose.rs
@@ -63,7 +63,7 @@ macro_rules! compose {
         impl $name {
             fn compose<S: Simd>(
                 simd: S,
-                mut src_c: f32x16<S>,
+                src_c: f32x16<S>,
                 bg_c: f32x16<S>,
             ) -> f32x16<S> {
                 let al_b = bg_c.splat_4th();

--- a/sparse_strips/vello_cpu/src/fine/highp/compose.rs
+++ b/sparse_strips/vello_cpu/src/fine/highp/compose.rs
@@ -11,8 +11,7 @@ pub(crate) trait ComposeExt {
         simd: S,
         src_c: f32x16<S>,
         bg_c: f32x16<S>,
-        is_layer: bool,
-        alpha_mask: f32x16<S>,
+        alpha_mask: Option<f32x16<S>>,
     ) -> f32x16<S>;
 }
 
@@ -20,15 +19,10 @@ impl ComposeExt for BlendMode {
     fn compose<S: Simd>(
         &self,
         simd: S,
-        mut src_c: f32x16<S>,
+        src_c: f32x16<S>,
         bg_c: f32x16<S>,
-        is_layer: bool,
-        alpha_mask: f32x16<S>,
+        alpha_mask: Option<f32x16<S>>,
     ) -> f32x16<S> {
-        if is_layer {
-            src_c = src_c * alpha_mask;
-        }
-        
         let mut res = match self.compose {
             Compose::SrcOver => SrcOver::compose(simd, src_c, bg_c),
             Compose::Clear => Clear::compose(simd, src_c, bg_c),
@@ -47,7 +41,7 @@ impl ComposeExt for BlendMode {
             Compose::PlusLighter => Plus::compose(simd, src_c, bg_c),
         };
 
-        if !is_layer {
+        if let Some(alpha_mask) = alpha_mask {
             let alpha_mask_inv = 1.0 - alpha_mask;
             res = alpha_mask * res + alpha_mask_inv * bg_c;
         }
@@ -61,11 +55,7 @@ macro_rules! compose {
         struct $name;
 
         impl $name {
-            fn compose<S: Simd>(
-                simd: S,
-                src_c: f32x16<S>,
-                bg_c: f32x16<S>,
-            ) -> f32x16<S> {
+            fn compose<S: Simd>(simd: S, src_c: f32x16<S>, bg_c: f32x16<S>) -> f32x16<S> {
                 let al_b = bg_c.splat_4th();
                 let al_s = src_c.splat_4th();
 

--- a/sparse_strips/vello_cpu/src/fine/highp/compose.rs
+++ b/sparse_strips/vello_cpu/src/fine/highp/compose.rs
@@ -25,22 +25,28 @@ impl ComposeExt for BlendMode {
         is_layer: bool,
         alpha_mask: f32x16<S>,
     ) -> f32x16<S> {
+        let compose_mask = if is_layer {
+            f32x16::splat(simd, 1.0)
+        }   else {
+            alpha_mask
+        };
+        
         let mut res = match self.compose {
-            Compose::SrcOver => SrcOver::compose(simd, src_c, bg_c, alpha_mask),
-            Compose::Clear => Clear::compose(simd, src_c, bg_c, alpha_mask),
-            Compose::Copy => Copy::compose(simd, src_c, bg_c, alpha_mask),
-            Compose::DestOver => DestOver::compose(simd, src_c, bg_c, alpha_mask),
-            Compose::Dest => Dest::compose(simd, src_c, bg_c, alpha_mask),
-            Compose::SrcIn => SrcIn::compose(simd, src_c, bg_c, alpha_mask),
-            Compose::DestIn => DestIn::compose(simd, src_c, bg_c, alpha_mask),
-            Compose::SrcOut => SrcOut::compose(simd, src_c, bg_c, alpha_mask),
-            Compose::DestOut => DestOut::compose(simd, src_c, bg_c, alpha_mask),
-            Compose::SrcAtop => SrcAtop::compose(simd, src_c, bg_c, alpha_mask),
-            Compose::DestAtop => DestAtop::compose(simd, src_c, bg_c, alpha_mask),
-            Compose::Xor => Xor::compose(simd, src_c, bg_c, alpha_mask),
-            Compose::Plus => Plus::compose(simd, src_c, bg_c, alpha_mask),
+            Compose::SrcOver => SrcOver::compose(simd, src_c, bg_c, compose_mask),
+            Compose::Clear => Clear::compose(simd, src_c, bg_c, compose_mask),
+            Compose::Copy => Copy::compose(simd, src_c, bg_c, compose_mask),
+            Compose::DestOver => DestOver::compose(simd, src_c, bg_c, compose_mask),
+            Compose::Dest => Dest::compose(simd, src_c, bg_c, compose_mask),
+            Compose::SrcIn => SrcIn::compose(simd, src_c, bg_c, compose_mask),
+            Compose::DestIn => DestIn::compose(simd, src_c, bg_c, compose_mask),
+            Compose::SrcOut => SrcOut::compose(simd, src_c, bg_c, compose_mask),
+            Compose::DestOut => DestOut::compose(simd, src_c, bg_c, compose_mask),
+            Compose::SrcAtop => SrcAtop::compose(simd, src_c, bg_c, compose_mask),
+            Compose::DestAtop => DestAtop::compose(simd, src_c, bg_c, compose_mask),
+            Compose::Xor => Xor::compose(simd, src_c, bg_c, compose_mask),
+            Compose::Plus => Plus::compose(simd, src_c, bg_c, compose_mask),
             // Have not been able to find a formula for this, so just fallback to Plus.
-            Compose::PlusLighter => Plus::compose(simd, src_c, bg_c, alpha_mask),
+            Compose::PlusLighter => Plus::compose(simd, src_c, bg_c, compose_mask),
         };
 
         if !is_layer {
@@ -64,12 +70,10 @@ macro_rules! compose {
                 mask: f32x16<S>,
             ) -> f32x16<S> {
                 let al_b = bg_c.splat_4th();
-                let al_s = src_c.splat_4th() * mask;
+                let al_s = src_c.splat_4th();
 
                 let fa = $fa(simd, al_s, al_b);
                 let fb = $fb(simd, al_s, al_b);
-
-                let src_c = src_c * mask;
 
                 if $sat {
                     (src_c * fa + fb * bg_c)

--- a/sparse_strips/vello_cpu/src/fine/highp/compose.rs
+++ b/sparse_strips/vello_cpu/src/fine/highp/compose.rs
@@ -11,6 +11,7 @@ pub(crate) trait ComposeExt {
         simd: S,
         src_c: f32x16<S>,
         bg_c: f32x16<S>,
+        is_layer: bool,
         alpha_mask: f32x16<S>,
     ) -> f32x16<S>;
 }
@@ -21,9 +22,10 @@ impl ComposeExt for BlendMode {
         simd: S,
         src_c: f32x16<S>,
         bg_c: f32x16<S>,
+        is_layer: bool,
         alpha_mask: f32x16<S>,
     ) -> f32x16<S> {
-        match self.compose {
+        let mut res = match self.compose {
             Compose::SrcOver => SrcOver::compose(simd, src_c, bg_c, alpha_mask),
             Compose::Clear => Clear::compose(simd, src_c, bg_c, alpha_mask),
             Compose::Copy => Copy::compose(simd, src_c, bg_c, alpha_mask),
@@ -39,7 +41,14 @@ impl ComposeExt for BlendMode {
             Compose::Plus => Plus::compose(simd, src_c, bg_c, alpha_mask),
             // Have not been able to find a formula for this, so just fallback to Plus.
             Compose::PlusLighter => Plus::compose(simd, src_c, bg_c, alpha_mask),
+        };
+
+        if !is_layer {
+            let alpha_mask_inv = 1.0 - alpha_mask;
+            res = alpha_mask * res + alpha_mask_inv * bg_c;
         }
+
+        res
     }
 }
 

--- a/sparse_strips/vello_cpu/src/fine/highp/compose.rs
+++ b/sparse_strips/vello_cpu/src/fine/highp/compose.rs
@@ -20,33 +20,31 @@ impl ComposeExt for BlendMode {
     fn compose<S: Simd>(
         &self,
         simd: S,
-        src_c: f32x16<S>,
+        mut src_c: f32x16<S>,
         bg_c: f32x16<S>,
         is_layer: bool,
         alpha_mask: f32x16<S>,
     ) -> f32x16<S> {
-        let compose_mask = if is_layer {
-            f32x16::splat(simd, 1.0)
-        }   else {
-            alpha_mask
-        };
+        if is_layer {
+            src_c = src_c * alpha_mask;
+        }
         
         let mut res = match self.compose {
-            Compose::SrcOver => SrcOver::compose(simd, src_c, bg_c, compose_mask),
-            Compose::Clear => Clear::compose(simd, src_c, bg_c, compose_mask),
-            Compose::Copy => Copy::compose(simd, src_c, bg_c, compose_mask),
-            Compose::DestOver => DestOver::compose(simd, src_c, bg_c, compose_mask),
-            Compose::Dest => Dest::compose(simd, src_c, bg_c, compose_mask),
-            Compose::SrcIn => SrcIn::compose(simd, src_c, bg_c, compose_mask),
-            Compose::DestIn => DestIn::compose(simd, src_c, bg_c, compose_mask),
-            Compose::SrcOut => SrcOut::compose(simd, src_c, bg_c, compose_mask),
-            Compose::DestOut => DestOut::compose(simd, src_c, bg_c, compose_mask),
-            Compose::SrcAtop => SrcAtop::compose(simd, src_c, bg_c, compose_mask),
-            Compose::DestAtop => DestAtop::compose(simd, src_c, bg_c, compose_mask),
-            Compose::Xor => Xor::compose(simd, src_c, bg_c, compose_mask),
-            Compose::Plus => Plus::compose(simd, src_c, bg_c, compose_mask),
+            Compose::SrcOver => SrcOver::compose(simd, src_c, bg_c),
+            Compose::Clear => Clear::compose(simd, src_c, bg_c),
+            Compose::Copy => Copy::compose(simd, src_c, bg_c),
+            Compose::DestOver => DestOver::compose(simd, src_c, bg_c),
+            Compose::Dest => Dest::compose(simd, src_c, bg_c),
+            Compose::SrcIn => SrcIn::compose(simd, src_c, bg_c),
+            Compose::DestIn => DestIn::compose(simd, src_c, bg_c),
+            Compose::SrcOut => SrcOut::compose(simd, src_c, bg_c),
+            Compose::DestOut => DestOut::compose(simd, src_c, bg_c),
+            Compose::SrcAtop => SrcAtop::compose(simd, src_c, bg_c),
+            Compose::DestAtop => DestAtop::compose(simd, src_c, bg_c),
+            Compose::Xor => Xor::compose(simd, src_c, bg_c),
+            Compose::Plus => Plus::compose(simd, src_c, bg_c),
             // Have not been able to find a formula for this, so just fallback to Plus.
-            Compose::PlusLighter => Plus::compose(simd, src_c, bg_c, compose_mask),
+            Compose::PlusLighter => Plus::compose(simd, src_c, bg_c),
         };
 
         if !is_layer {
@@ -65,9 +63,8 @@ macro_rules! compose {
         impl $name {
             fn compose<S: Simd>(
                 simd: S,
-                src_c: f32x16<S>,
+                mut src_c: f32x16<S>,
                 bg_c: f32x16<S>,
-                mask: f32x16<S>,
             ) -> f32x16<S> {
                 let al_b = bg_c.splat_4th();
                 let al_s = src_c.splat_4th();

--- a/sparse_strips/vello_cpu/src/fine/highp/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/highp/mod.rs
@@ -116,10 +116,11 @@ impl<S: Simd> FineKernel<S> for F32Kernel {
         dest: &mut [Self::Numeric],
         src: impl Iterator<Item = Self::Composite>,
         blend_mode: BlendMode,
+        is_layer: bool,
         alphas: Option<&[u8]>,
     ) {
         if let Some(alphas) = alphas {
-            alpha_fill::blend(simd, dest, src, alphas, blend_mode);
+            alpha_fill::blend(simd, dest, src, alphas, blend_mode, is_layer);
         } else {
             fill::blend(simd, dest, src, blend_mode);
         }
@@ -169,7 +170,7 @@ mod fill {
         for (next_dest, next_src) in dest.chunks_exact_mut(16).zip(src) {
             let bg_v = f32x16::from_slice(simd, next_dest);
             let src_c = blend::mix(next_src, bg_v, blend_mode);
-            let res = blend_mode.compose(simd, src_c, bg_v, mask);
+            let res = blend_mode.compose(simd, src_c, bg_v, false, mask);
             next_dest.copy_from_slice(&res.val);
         }
     }
@@ -235,6 +236,7 @@ mod alpha_fill {
         src: T,
         alphas: &[u8],
         blend_mode: BlendMode,
+        is_layer: bool,       
     ) {
         for ((next_dest, next_mask), next_src) in dest
             .chunks_exact_mut(16)
@@ -244,7 +246,7 @@ mod alpha_fill {
             let masks = extract_masks(simd, next_mask);
             let bg = f32x16::from_slice(simd, next_dest);
             let src_c = blend::mix(next_src, bg, blend_mode);
-            let res = blend_mode.compose(simd, src_c, bg, masks);
+            let res = blend_mode.compose(simd, src_c, bg, is_layer, masks);
             next_dest.copy_from_slice(&res.val);
         }
     }

--- a/sparse_strips/vello_cpu/src/fine/highp/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/highp/mod.rs
@@ -116,11 +116,10 @@ impl<S: Simd> FineKernel<S> for F32Kernel {
         dest: &mut [Self::Numeric],
         src: impl Iterator<Item = Self::Composite>,
         blend_mode: BlendMode,
-        is_layer: bool,
         alphas: Option<&[u8]>,
     ) {
         if let Some(alphas) = alphas {
-            alpha_fill::blend(simd, dest, src, alphas, blend_mode, is_layer);
+            alpha_fill::blend(simd, dest, src, alphas, blend_mode);
         } else {
             fill::blend(simd, dest, src, blend_mode);
         }
@@ -165,12 +164,10 @@ mod fill {
         src: T,
         blend_mode: BlendMode,
     ) {
-        let mask = f32x16::splat(simd, 1.0);
-
         for (next_dest, next_src) in dest.chunks_exact_mut(16).zip(src) {
             let bg_v = f32x16::from_slice(simd, next_dest);
             let src_c = blend::mix(next_src, bg_v, blend_mode);
-            let res = blend_mode.compose(simd, src_c, bg_v, false, mask);
+            let res = blend_mode.compose(simd, src_c, bg_v, None);
             next_dest.copy_from_slice(&res.val);
         }
     }
@@ -236,7 +233,6 @@ mod alpha_fill {
         src: T,
         alphas: &[u8],
         blend_mode: BlendMode,
-        is_layer: bool,       
     ) {
         for ((next_dest, next_mask), next_src) in dest
             .chunks_exact_mut(16)
@@ -246,7 +242,7 @@ mod alpha_fill {
             let masks = extract_masks(simd, next_mask);
             let bg = f32x16::from_slice(simd, next_dest);
             let src_c = blend::mix(next_src, bg, blend_mode);
-            let res = blend_mode.compose(simd, src_c, bg, is_layer, masks);
+            let res = blend_mode.compose(simd, src_c, bg, Some(masks));
             next_dest.copy_from_slice(&res.val);
         }
     }

--- a/sparse_strips/vello_cpu/src/fine/lowp/compose.rs
+++ b/sparse_strips/vello_cpu/src/fine/lowp/compose.rs
@@ -12,8 +12,7 @@ pub(crate) trait ComposeExt {
         simd: S,
         src_c: u8x32<S>,
         bg_c: u8x32<S>,
-        is_layer: bool,
-        alpha_mask: u8x32<S>,
+        alpha_mask: Option<u8x32<S>>,
     ) -> u8x32<S>;
 }
 
@@ -21,16 +20,11 @@ impl ComposeExt for BlendMode {
     fn compose<S: Simd>(
         &self,
         simd: S,
-        mut src_c: u8x32<S>,
+        src_c: u8x32<S>,
         bg_c: u8x32<S>,
-        is_layer: bool,
-        alpha_mask: u8x32<S>,
+        alpha_mask: Option<u8x32<S>>,
     ) -> u8x32<S> {
-        if is_layer {
-            src_c = src_c.normalized_mul(alpha_mask);
-        }
-        
-        let mut res =match self.compose {
+        let mut res = match self.compose {
             Compose::SrcOver => SrcOver::compose(simd, src_c, bg_c),
             Compose::Clear => Clear::compose(simd, src_c, bg_c),
             Compose::Copy => Copy::compose(simd, src_c, bg_c),
@@ -47,14 +41,14 @@ impl ComposeExt for BlendMode {
             // Have not been able to find a formula for this, so just fallback to Plus.
             Compose::PlusLighter => Plus::compose(simd, src_c, bg_c),
         };
-        
-        if !is_layer {
+
+        if let Some(alpha_mask) = alpha_mask {
             let alpha_mask_inv = 255 - alpha_mask;
             let p1 = simd.widen_u8x32(alpha_mask) * simd.widen_u8x32(res);
             let p2 = simd.widen_u8x32(alpha_mask_inv) * simd.widen_u8x32(bg_c);
             res = simd.narrow_u16x32((p1 + p2).div_255());
         }
-        
+
         res
     }
 }
@@ -64,11 +58,7 @@ macro_rules! compose {
         struct $name;
 
         impl $name {
-            fn compose<S: Simd>(
-                simd: S,
-                src_c: u8x32<S>,
-                bg_c: u8x32<S>,
-            ) -> u8x32<S> {
+            fn compose<S: Simd>(simd: S, src_c: u8x32<S>, bg_c: u8x32<S>) -> u8x32<S> {
                 let al_b = bg_c.splat_4th();
                 let al_s = src_c.splat_4th();
 

--- a/sparse_strips/vello_cpu/src/fine/lowp/compose.rs
+++ b/sparse_strips/vello_cpu/src/fine/lowp/compose.rs
@@ -3,7 +3,7 @@
 
 use crate::fine::Splat4thExt;
 use crate::peniko::{BlendMode, Compose};
-use crate::util::NormalizedMulExt;
+use crate::util::{Div255Ext, NormalizedMulExt};
 use vello_common::fearless_simd::*;
 
 pub(crate) trait ComposeExt {
@@ -12,6 +12,7 @@ pub(crate) trait ComposeExt {
         simd: S,
         src_c: u8x32<S>,
         bg_c: u8x32<S>,
+        is_layer: bool,
         alpha_mask: u8x32<S>,
     ) -> u8x32<S>;
 }
@@ -22,9 +23,10 @@ impl ComposeExt for BlendMode {
         simd: S,
         src_c: u8x32<S>,
         bg_c: u8x32<S>,
+        is_layer: bool,
         alpha_mask: u8x32<S>,
     ) -> u8x32<S> {
-        match self.compose {
+        let mut res =match self.compose {
             Compose::SrcOver => SrcOver::compose(simd, src_c, bg_c, alpha_mask),
             Compose::Clear => Clear::compose(simd, src_c, bg_c, alpha_mask),
             Compose::Copy => Copy::compose(simd, src_c, bg_c, alpha_mask),
@@ -40,7 +42,16 @@ impl ComposeExt for BlendMode {
             Compose::Plus => Plus::compose(simd, src_c, bg_c, alpha_mask),
             // Have not been able to find a formula for this, so just fallback to Plus.
             Compose::PlusLighter => Plus::compose(simd, src_c, bg_c, alpha_mask),
+        };
+        
+        if !is_layer {
+            let alpha_mask_inv = 255 - alpha_mask;
+            let p1 = simd.widen_u8x32(alpha_mask) * simd.widen_u8x32(res);
+            let p2 = simd.widen_u8x32(alpha_mask_inv) * simd.widen_u8x32(bg_c);
+            res = simd.narrow_u16x32((p1 + p2).div_255());
         }
+        
+        res
     }
 }
 

--- a/sparse_strips/vello_cpu/src/fine/lowp/compose.rs
+++ b/sparse_strips/vello_cpu/src/fine/lowp/compose.rs
@@ -21,27 +21,31 @@ impl ComposeExt for BlendMode {
     fn compose<S: Simd>(
         &self,
         simd: S,
-        src_c: u8x32<S>,
+        mut src_c: u8x32<S>,
         bg_c: u8x32<S>,
         is_layer: bool,
         alpha_mask: u8x32<S>,
     ) -> u8x32<S> {
+        if is_layer {
+            src_c = src_c.normalized_mul(alpha_mask);
+        }
+        
         let mut res =match self.compose {
-            Compose::SrcOver => SrcOver::compose(simd, src_c, bg_c, alpha_mask),
-            Compose::Clear => Clear::compose(simd, src_c, bg_c, alpha_mask),
-            Compose::Copy => Copy::compose(simd, src_c, bg_c, alpha_mask),
-            Compose::DestOver => DestOver::compose(simd, src_c, bg_c, alpha_mask),
-            Compose::Dest => Dest::compose(simd, src_c, bg_c, alpha_mask),
-            Compose::SrcIn => SrcIn::compose(simd, src_c, bg_c, alpha_mask),
-            Compose::DestIn => DestIn::compose(simd, src_c, bg_c, alpha_mask),
-            Compose::SrcOut => SrcOut::compose(simd, src_c, bg_c, alpha_mask),
-            Compose::DestOut => DestOut::compose(simd, src_c, bg_c, alpha_mask),
-            Compose::SrcAtop => SrcAtop::compose(simd, src_c, bg_c, alpha_mask),
-            Compose::DestAtop => DestAtop::compose(simd, src_c, bg_c, alpha_mask),
-            Compose::Xor => Xor::compose(simd, src_c, bg_c, alpha_mask),
-            Compose::Plus => Plus::compose(simd, src_c, bg_c, alpha_mask),
+            Compose::SrcOver => SrcOver::compose(simd, src_c, bg_c),
+            Compose::Clear => Clear::compose(simd, src_c, bg_c),
+            Compose::Copy => Copy::compose(simd, src_c, bg_c),
+            Compose::DestOver => DestOver::compose(simd, src_c, bg_c),
+            Compose::Dest => Dest::compose(simd, src_c, bg_c),
+            Compose::SrcIn => SrcIn::compose(simd, src_c, bg_c),
+            Compose::DestIn => DestIn::compose(simd, src_c, bg_c),
+            Compose::SrcOut => SrcOut::compose(simd, src_c, bg_c),
+            Compose::DestOut => DestOut::compose(simd, src_c, bg_c),
+            Compose::SrcAtop => SrcAtop::compose(simd, src_c, bg_c),
+            Compose::DestAtop => DestAtop::compose(simd, src_c, bg_c),
+            Compose::Xor => Xor::compose(simd, src_c, bg_c),
+            Compose::Plus => Plus::compose(simd, src_c, bg_c),
             // Have not been able to find a formula for this, so just fallback to Plus.
-            Compose::PlusLighter => Plus::compose(simd, src_c, bg_c, alpha_mask),
+            Compose::PlusLighter => Plus::compose(simd, src_c, bg_c),
         };
         
         if !is_layer {
@@ -64,15 +68,12 @@ macro_rules! compose {
                 simd: S,
                 src_c: u8x32<S>,
                 bg_c: u8x32<S>,
-                mask: u8x32<S>,
             ) -> u8x32<S> {
                 let al_b = bg_c.splat_4th();
-                let al_s = src_c.splat_4th().normalized_mul(mask);
+                let al_s = src_c.splat_4th();
 
                 let fa = $fa(simd, al_s, al_b);
                 let fb = $fb(simd, al_s, al_b);
-
-                let src_c = src_c.normalized_mul(mask);
 
                 if $sat {
                     simd.narrow_u16x32(

--- a/sparse_strips/vello_cpu/src/fine/lowp/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/lowp/mod.rs
@@ -123,11 +123,10 @@ impl<S: Simd> FineKernel<S> for U8Kernel {
         dest: &mut [Self::Numeric],
         src: impl Iterator<Item = Self::Composite>,
         blend_mode: BlendMode,
-        is_layer: bool,
         alphas: Option<&[u8]>,
     ) {
         if let Some(alphas) = alphas {
-            alpha_fill::blend(simd, dest, src, blend_mode, is_layer, alphas);
+            alpha_fill::blend(simd, dest, src, blend_mode, alphas);
         } else {
             fill::blend(simd, dest, src, blend_mode);
         }
@@ -149,7 +148,6 @@ mod fill {
         blend_mode: BlendMode,
     ) {
         let default_mix = matches!(blend_mode.mix, Mix::Normal | Mix::Clip);
-        let mask = u8x32::splat(simd, 255);
         for (next_dest, next_src) in dest.chunks_exact_mut(32).zip(src) {
             let bg_v = u8x32::from_slice(simd, next_dest);
             let src_v = if default_mix {
@@ -157,7 +155,7 @@ mod fill {
             } else {
                 mix(next_src, bg_v, blend_mode)
             };
-            let res = blend_mode.compose(simd, src_v, bg_v, false, mask);
+            let res = blend_mode.compose(simd, src_v, bg_v, None);
             next_dest.copy_from_slice(&res.val);
         }
     }
@@ -216,7 +214,6 @@ mod alpha_fill {
         dest: &mut [u8],
         src: T,
         blend_mode: BlendMode,
-        is_layer: bool, 
         alphas: &[u8],
     ) {
         let default_mix = matches!(blend_mode.mix, Mix::Normal | Mix::Clip);
@@ -233,7 +230,7 @@ mod alpha_fill {
                 mix(next_src, bg_v, blend_mode)
             };
             let masks = extract_masks(simd, next_mask);
-            let res = blend_mode.compose(simd, src_c, bg_v, is_layer, masks);
+            let res = blend_mode.compose(simd, src_c, bg_v, Some(masks));
 
             next_bg.copy_from_slice(&res.val);
         }

--- a/sparse_strips/vello_cpu/src/fine/lowp/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/lowp/mod.rs
@@ -123,10 +123,11 @@ impl<S: Simd> FineKernel<S> for U8Kernel {
         dest: &mut [Self::Numeric],
         src: impl Iterator<Item = Self::Composite>,
         blend_mode: BlendMode,
+        is_layer: bool,
         alphas: Option<&[u8]>,
     ) {
         if let Some(alphas) = alphas {
-            alpha_fill::blend(simd, dest, src, blend_mode, alphas);
+            alpha_fill::blend(simd, dest, src, blend_mode, is_layer, alphas);
         } else {
             fill::blend(simd, dest, src, blend_mode);
         }
@@ -156,7 +157,7 @@ mod fill {
             } else {
                 mix(next_src, bg_v, blend_mode)
             };
-            let res = blend_mode.compose(simd, src_v, bg_v, mask);
+            let res = blend_mode.compose(simd, src_v, bg_v, false, mask);
             next_dest.copy_from_slice(&res.val);
         }
     }
@@ -215,6 +216,7 @@ mod alpha_fill {
         dest: &mut [u8],
         src: T,
         blend_mode: BlendMode,
+        is_layer: bool, 
         alphas: &[u8],
     ) {
         let default_mix = matches!(blend_mode.mix, Mix::Normal | Mix::Clip);
@@ -231,7 +233,7 @@ mod alpha_fill {
                 mix(next_src, bg_v, blend_mode)
             };
             let masks = extract_masks(simd, next_mask);
-            let res = blend_mode.compose(simd, src_c, bg_v, masks);
+            let res = blend_mode.compose(simd, src_c, bg_v, is_layer, masks);
 
             next_bg.copy_from_slice(&res.val);
         }

--- a/sparse_strips/vello_cpu/src/fine/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/mod.rs
@@ -256,7 +256,6 @@ pub trait FineKernel<S: Simd>: Send + Sync + 'static {
         dest: &mut [Self::Numeric],
         src: impl Iterator<Item = Self::Composite>,
         blend_mode: BlendMode,
-        is_layer: bool,
         alphas: Option<&[u8]>,
     );
 }
@@ -433,7 +432,6 @@ impl<S: Simd, T: FineKernel<S>> Fine<S, T> {
                         blend_buf,
                         iter::repeat(T::Composite::from_color(self.simd, color)),
                         blend_mode,
-                        false,
                         alphas,
                     );
                 }
@@ -464,7 +462,6 @@ impl<S: Simd, T: FineKernel<S>> Fine<S, T> {
                                         .chunks_exact(T::Composite::LENGTH)
                                         .map(|s| T::Composite::from_slice(self.simd, s)),
                                     blend_mode,
-                                    false,
                                     alphas,
                                 );
                             }
@@ -604,7 +601,6 @@ impl<S: Simd, T: FineKernel<S>> Fine<S, T> {
                     .chunks_exact(T::Composite::LENGTH)
                     .map(|s| T::Composite::from_slice(self.simd, s)),
                 blend_mode,
-                true,
                 None,
             );
         }

--- a/sparse_strips/vello_cpu/src/fine/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/mod.rs
@@ -5,7 +5,7 @@ mod common;
 mod highp;
 mod lowp;
 
-use crate::peniko::{BlendMode, Compose, ImageQuality, Mix};
+use crate::peniko::{BlendMode, ImageQuality};
 use crate::region::Region;
 use alloc::vec;
 use alloc::vec::Vec;
@@ -309,8 +309,7 @@ impl<S: Simd, T: FineKernel<S>> Fine<S, T> {
                     usize::from(f.x),
                     usize::from(f.width),
                     &f.paint,
-                    f.blend_mode
-                        .unwrap_or(BlendMode::new(Mix::Normal, Compose::SrcOver)),
+                    f.blend_mode,
                     paints,
                     None,
                 );
@@ -320,8 +319,7 @@ impl<S: Simd, T: FineKernel<S>> Fine<S, T> {
                     usize::from(s.x),
                     usize::from(s.width),
                     &s.paint,
-                    s.blend_mode
-                        .unwrap_or(BlendMode::new(Mix::Normal, Compose::SrcOver)),
+                    s.blend_mode,
                     paints,
                     Some(&alphas[s.alpha_idx..]),
                 );

--- a/sparse_strips/vello_cpu/src/fine/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/mod.rs
@@ -256,6 +256,7 @@ pub trait FineKernel<S: Simd>: Send + Sync + 'static {
         dest: &mut [Self::Numeric],
         src: impl Iterator<Item = Self::Composite>,
         blend_mode: BlendMode,
+        is_layer: bool,
         alphas: Option<&[u8]>,
     );
 }
@@ -432,6 +433,7 @@ impl<S: Simd, T: FineKernel<S>> Fine<S, T> {
                         blend_buf,
                         iter::repeat(T::Composite::from_color(self.simd, color)),
                         blend_mode,
+                        false,
                         alphas,
                     );
                 }
@@ -462,6 +464,7 @@ impl<S: Simd, T: FineKernel<S>> Fine<S, T> {
                                         .chunks_exact(T::Composite::LENGTH)
                                         .map(|s| T::Composite::from_slice(self.simd, s)),
                                     blend_mode,
+                                    false,
                                     alphas,
                                 );
                             }
@@ -601,6 +604,7 @@ impl<S: Simd, T: FineKernel<S>> Fine<S, T> {
                     .chunks_exact(T::Composite::LENGTH)
                     .map(|s| T::Composite::from_slice(self.simd, s)),
                 blend_mode,
+                true,
                 None,
             );
         }

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -354,6 +354,11 @@ impl RenderContext {
     pub fn paint(&self) -> &PaintType {
         &self.paint
     }
+    
+    /// Set the blend mode that should be used when drawing objects.
+    pub fn set_blend_mode(&mut self, blend_mode: BlendMode) {
+        self.blend_mode = blend_mode;
+    } 
 
     /// Set the current paint transform.
     ///

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -47,6 +47,7 @@ pub struct RenderContext {
     pub(crate) stroke: Stroke,
     pub(crate) transform: Affine,
     pub(crate) fill_rule: Fill,
+    pub(crate) blend_mode: BlendMode,
     pub(crate) temp_path: BezPath,
     // TODO: Consider taking a configurable threshold instead of just a boolean value here.
     pub(crate) anti_alias: bool,
@@ -136,6 +137,7 @@ impl RenderContext {
             dispatcher,
             transform,
             anti_alias,
+            blend_mode: BlendMode::new(Mix::Normal, Compose::SrcOver),
             paint,
             paint_transform,
             fill_rule,
@@ -166,15 +168,27 @@ impl RenderContext {
     /// Fill a path.
     pub fn fill_path(&mut self, path: &BezPath) {
         let paint = self.encode_current_paint();
-        self.dispatcher
-            .fill_path(path, self.fill_rule, self.transform, paint, self.anti_alias);
+        self.dispatcher.fill_path(
+            path,
+            self.fill_rule,
+            self.transform,
+            paint,
+            self.blend_mode,
+            self.anti_alias,
+        );
     }
 
     /// Stroke a path.
     pub fn stroke_path(&mut self, path: &BezPath) {
         let paint = self.encode_current_paint();
-        self.dispatcher
-            .stroke_path(path, &self.stroke, self.transform, paint, self.anti_alias);
+        self.dispatcher.stroke_path(
+            path,
+            &self.stroke,
+            self.transform,
+            paint,
+            self.blend_mode,
+            self.anti_alias,
+        );
     }
 
     /// Fill a rectangle.
@@ -200,6 +214,7 @@ impl RenderContext {
             self.fill_rule,
             self.transform,
             paint,
+            self.blend_mode,
             self.anti_alias,
         );
     }
@@ -236,6 +251,7 @@ impl RenderContext {
             Fill::NonZero,
             self.transform,
             paint,
+            self.blend_mode,
             self.anti_alias,
         );
     }
@@ -454,6 +470,7 @@ impl GlyphRenderer for RenderContext {
                     Fill::NonZero,
                     prepared_glyph.transform,
                     paint,
+                    self.blend_mode,
                     self.anti_alias,
                 );
             }
@@ -548,6 +565,7 @@ impl GlyphRenderer for RenderContext {
                     &self.stroke,
                     prepared_glyph.transform,
                     paint,
+                    self.blend_mode,
                     self.anti_alias,
                 );
             }
@@ -648,6 +666,7 @@ impl Recordable for RenderContext {
                         &adjusted_strips[start..end],
                         fill_rule,
                         paint,
+                        self.blend_mode,
                         0,
                     );
                     range_index += 1;

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -354,11 +354,11 @@ impl RenderContext {
     pub fn paint(&self) -> &PaintType {
         &self.paint
     }
-    
+
     /// Set the blend mode that should be used when drawing objects.
     pub fn set_blend_mode(&mut self, blend_mode: BlendMode) {
         self.blend_mode = blend_mode;
-    } 
+    }
 
     /// Set the current paint transform.
     ///

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -315,7 +315,13 @@ impl Scene {
     // Assumes that `line_buf` contains the flattened path.
     fn render_path(&mut self, fill_rule: Fill, paint: Paint) {
         self.make_strips(fill_rule);
-        self.wide.generate(&self.strip_buf, fill_rule, paint, 0);
+        self.wide.generate(
+            &self.strip_buf,
+            fill_rule,
+            paint,
+            BlendMode::new(Mix::Normal, Compose::SrcOver),
+            0,
+        );
     }
 
     fn make_strips(&mut self, fill_rule: Fill) {
@@ -418,8 +424,13 @@ impl Recordable for Scene {
                         }
                         _ => Fill::NonZero,
                     };
-                    self.wide
-                        .generate(&adjusted_strips[start..end], fill_rule, paint, 0);
+                    self.wide.generate(
+                        &adjusted_strips[start..end],
+                        fill_rule,
+                        paint,
+                        BlendMode::new(Mix::Normal, Compose::SrcOver),
+                        0,
+                    );
                     range_index += 1;
                 }
                 RenderCommand::SetPaint(paint) => {

--- a/sparse_strips/vello_sparse_tests/snapshots/compose_non_isolated_clear.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/compose_non_isolated_clear.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1162cd4baa80c52c219771936b9f2bbc8f2eb4f4f6ee6b4cbadff39aa6df0401
+size 162

--- a/sparse_strips/vello_sparse_tests/snapshots/compose_non_isolated_copy.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/compose_non_isolated_copy.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1da340de40c66d16545be38bd3735bcf219c721c4a8a336af24792ec1abcb3d8
+size 193

--- a/sparse_strips/vello_sparse_tests/snapshots/compose_non_isolated_dest.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/compose_non_isolated_dest.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d71814329ebba6b5a2113cddfacf18cf4d5a84a4a5a9ec3c5849b5c9d389ffe
+size 126

--- a/sparse_strips/vello_sparse_tests/snapshots/compose_non_isolated_dest_atop.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/compose_non_isolated_dest_atop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:744a10a3cb8e461434c0e4b7ebc85b9a8013a52e692f1158f36fbe5e91a11661
+size 212

--- a/sparse_strips/vello_sparse_tests/snapshots/compose_non_isolated_dest_in.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/compose_non_isolated_dest_in.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98bb15711aba628fd58854ad1eecdb6c71d36cf11bf0bef4239f2a2e810c70e2
+size 174

--- a/sparse_strips/vello_sparse_tests/snapshots/compose_non_isolated_dest_out.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/compose_non_isolated_dest_out.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98bb15711aba628fd58854ad1eecdb6c71d36cf11bf0bef4239f2a2e810c70e2
+size 174

--- a/sparse_strips/vello_sparse_tests/snapshots/compose_non_isolated_dest_over.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/compose_non_isolated_dest_over.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41d2e13333b09dd0095f6d376f537aeba245e5f8b50be5ca3b9483ef064ad1fd
+size 209

--- a/sparse_strips/vello_sparse_tests/snapshots/compose_non_isolated_plus.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/compose_non_isolated_plus.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12df58a3e0d230eae0ea03356fef543d598bfe3ba20083fd1f36d760bd7e95a0
+size 209

--- a/sparse_strips/vello_sparse_tests/snapshots/compose_non_isolated_src_atop.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/compose_non_isolated_src_atop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1309a33c48e0d9f200996123bd150931fe6809dcd9ccf81654d8f6643c229576
+size 181

--- a/sparse_strips/vello_sparse_tests/snapshots/compose_non_isolated_src_in.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/compose_non_isolated_src_in.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dcdef3a315dd79ebab72bfb8d5838233f349b220ae59d73cf586d8c80eb8bda6
+size 181

--- a/sparse_strips/vello_sparse_tests/snapshots/compose_non_isolated_src_out.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/compose_non_isolated_src_out.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5cb255962113ffbca5e0f51de219c14318cd3b56ebbac4d54274a298d7790b3
+size 209

--- a/sparse_strips/vello_sparse_tests/snapshots/compose_non_isolated_src_over.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/compose_non_isolated_src_over.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d3f1709f9bf1ddf1cc532ff8a6ddb08990849615fe113f3413c6aac8031dfdc
+size 212

--- a/sparse_strips/vello_sparse_tests/snapshots/compose_non_isolated_xor.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/compose_non_isolated_xor.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:744a10a3cb8e461434c0e4b7ebc85b9a8013a52e692f1158f36fbe5e91a11661
+size 212

--- a/sparse_strips/vello_sparse_tests/snapshots/mix_non_isolated_color_dodge.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/mix_non_isolated_color_dodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41d2e13333b09dd0095f6d376f537aeba245e5f8b50be5ca3b9483ef064ad1fd
+size 209

--- a/sparse_strips/vello_sparse_tests/snapshots/mix_non_isolated_difference.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/mix_non_isolated_difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b4d29f0024407c30ea274268ad2d0455cec2a2cb30f9e65ae513d82537ab472
+size 212

--- a/sparse_strips/vello_sparse_tests/snapshots/mix_non_isolated_soft_light.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/mix_non_isolated_soft_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41d2e13333b09dd0095f6d376f537aeba245e5f8b50be5ca3b9483ef064ad1fd
+size 209

--- a/sparse_strips/vello_sparse_tests/tests/compose.rs
+++ b/sparse_strips/vello_sparse_tests/tests/compose.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use crate::renderer::Renderer;
-use vello_common::color::palette::css::{BLUE, YELLOW};
+use vello_common::color::palette::css::{BLUE, LIME, YELLOW};
 use vello_common::kurbo::Rect;
 use vello_common::peniko::{BlendMode, Compose, Mix};
 use vello_dev_macros::vello_test;
@@ -85,4 +85,84 @@ fn compose_dest_atop(ctx: &mut impl Renderer) {
 #[vello_test]
 fn compose_plus(ctx: &mut impl Renderer) {
     compose(ctx, Compose::Plus);
+}
+
+fn compose_non_isolated(ctx: &mut impl Renderer, compose: Compose) {
+    // Just to isolate from the white background.
+    ctx.push_blend_layer(BlendMode::new(Mix::Normal, Compose::SrcOver));
+
+    let rect = Rect::new(10.5, 10.5, 70.5, 70.5);
+    ctx.set_paint(BLUE.with_alpha(0.5));
+    ctx.fill_rect(&rect);
+    ctx.set_blend_mode(BlendMode::new(Mix::Normal, compose));
+    let rect = Rect::new(30.5, 30.5, 90.5, 90.5);
+    ctx.set_paint(LIME.with_alpha(0.5));
+    ctx.fill_rect(&rect);
+
+    ctx.pop_layer();
+}
+
+#[vello_test]
+fn compose_non_isolated_src_over(ctx: &mut impl Renderer) {
+    compose_non_isolated(ctx, Compose::SrcOver);
+}
+
+#[vello_test]
+fn compose_non_isolated_xor(ctx: &mut impl Renderer) {
+    compose_non_isolated(ctx, Compose::Xor);
+}
+
+#[vello_test]
+fn compose_non_isolated_clear(ctx: &mut impl Renderer) {
+    compose_non_isolated(ctx, Compose::Clear);
+}
+
+#[vello_test]
+fn compose_non_isolated_copy(ctx: &mut impl Renderer) {
+    compose_non_isolated(ctx, Compose::Copy);
+}
+
+#[vello_test]
+fn compose_non_isolated_dest(ctx: &mut impl Renderer) {
+    compose_non_isolated(ctx, Compose::Dest);
+}
+
+#[vello_test]
+fn compose_non_isolated_dest_over(ctx: &mut impl Renderer) {
+    compose_non_isolated(ctx, Compose::DestOver);
+}
+
+#[vello_test]
+fn compose_non_isolated_src_in(ctx: &mut impl Renderer) {
+    compose_non_isolated(ctx, Compose::SrcIn);
+}
+
+#[vello_test]
+fn compose_non_isolated_src_out(ctx: &mut impl Renderer) {
+    compose_non_isolated(ctx, Compose::SrcOut);
+}
+
+#[vello_test]
+fn compose_non_isolated_dest_in(ctx: &mut impl Renderer) {
+    compose_non_isolated(ctx, Compose::DestIn);
+}
+
+#[vello_test]
+fn compose_non_isolated_dest_out(ctx: &mut impl Renderer) {
+    compose_non_isolated(ctx, Compose::DestOut);
+}
+
+#[vello_test]
+fn compose_non_isolated_src_atop(ctx: &mut impl Renderer) {
+    compose_non_isolated(ctx, Compose::SrcAtop);
+}
+
+#[vello_test]
+fn compose_non_isolated_dest_atop(ctx: &mut impl Renderer) {
+    compose_non_isolated(ctx, Compose::DestAtop);
+}
+
+#[vello_test]
+fn compose_non_isolated_plus(ctx: &mut impl Renderer) {
+    compose_non_isolated(ctx, Compose::Plus);
 }

--- a/sparse_strips/vello_sparse_tests/tests/mix.rs
+++ b/sparse_strips/vello_sparse_tests/tests/mix.rs
@@ -193,13 +193,13 @@ fn mix_non_isolated(ctx: &mut impl Renderer, mix: Mix) {
     // Just to isolate from the white background.
     ctx.push_blend_layer(BlendMode::new(Mix::Normal, Compose::SrcOver));
 
-    let rect = Rect::new(10.5, 10.5, 70.5, 70.5);
+    let rect1 = Rect::new(10.5, 10.5, 70.5, 70.5);
     ctx.set_paint(BLUE.with_alpha(0.5));
-    ctx.fill_rect(&rect);
+    ctx.fill_rect(&rect1);
     ctx.set_blend_mode(BlendMode::new(mix, Compose::SrcOver));
-    let rect = Rect::new(30.5, 30.5, 90.5, 90.5);
+    let rect2 = Rect::new(30.5, 30.5, 90.5, 90.5);
     ctx.set_paint(LIME.with_alpha(0.5));
-    ctx.fill_rect(&rect);
+    ctx.fill_rect(&rect2);
 
     ctx.pop_layer();
 }

--- a/sparse_strips/vello_sparse_tests/tests/mix.rs
+++ b/sparse_strips/vello_sparse_tests/tests/mix.rs
@@ -192,7 +192,7 @@ fn mix_saturation_with_solid(ctx: &mut impl Renderer) {
 fn mix_non_isolated(ctx: &mut impl Renderer, mix: Mix) {
     // Just to isolate from the white background.
     ctx.push_blend_layer(BlendMode::new(Mix::Normal, Compose::SrcOver));
-    
+
     let rect = Rect::new(10.5, 10.5, 70.5, 70.5);
     ctx.set_paint(BLUE.with_alpha(0.5));
     ctx.fill_rect(&rect);
@@ -200,7 +200,7 @@ fn mix_non_isolated(ctx: &mut impl Renderer, mix: Mix) {
     let rect = Rect::new(30.5, 30.5, 90.5, 90.5);
     ctx.set_paint(LIME.with_alpha(0.5));
     ctx.fill_rect(&rect);
-    
+
     ctx.pop_layer();
 }
 

--- a/sparse_strips/vello_sparse_tests/tests/mix.rs
+++ b/sparse_strips/vello_sparse_tests/tests/mix.rs
@@ -188,3 +188,33 @@ fn mix_color_with_solid(ctx: &mut impl Renderer) {
 fn mix_saturation_with_solid(ctx: &mut impl Renderer) {
     mix_solid(ctx, Mix::Saturation);
 }
+
+fn mix_non_isolated(ctx: &mut impl Renderer, mix: Mix) {
+    // Just to isolate from the white background.
+    ctx.push_blend_layer(BlendMode::new(Mix::Normal, Compose::SrcOver));
+    
+    let rect = Rect::new(10.5, 10.5, 70.5, 70.5);
+    ctx.set_paint(BLUE.with_alpha(0.5));
+    ctx.fill_rect(&rect);
+    ctx.set_blend_mode(BlendMode::new(mix, Compose::SrcOver));
+    let rect = Rect::new(30.5, 30.5, 90.5, 90.5);
+    ctx.set_paint(LIME.with_alpha(0.5));
+    ctx.fill_rect(&rect);
+    
+    ctx.pop_layer();
+}
+
+#[vello_test]
+fn mix_non_isolated_difference(ctx: &mut impl Renderer) {
+    mix_non_isolated(ctx, Mix::Difference);
+}
+
+#[vello_test]
+fn mix_non_isolated_soft_light(ctx: &mut impl Renderer) {
+    mix_non_isolated(ctx, Mix::SoftLight);
+}
+
+#[vello_test]
+fn mix_non_isolated_color_dodge(ctx: &mut impl Renderer) {
+    mix_non_isolated(ctx, Mix::ColorDodge);
+}

--- a/sparse_strips/vello_sparse_tests/tests/renderer.rs
+++ b/sparse_strips/vello_sparse_tests/tests/renderer.rs
@@ -143,7 +143,7 @@ impl Renderer for RenderContext {
     }
 
     fn set_blend_mode(&mut self, blend_mode: BlendMode) {
-        Self::set_blend_mode(self, blend_mode);   
+        Self::set_blend_mode(self, blend_mode);
     }
 
     fn set_anti_aliasing(&mut self, value: bool) {

--- a/sparse_strips/vello_sparse_tests/tests/renderer.rs
+++ b/sparse_strips/vello_sparse_tests/tests/renderer.rs
@@ -44,6 +44,7 @@ pub(crate) trait Renderer: Sized + GlyphRenderer {
     fn set_paint_transform(&mut self, affine: Affine);
     fn set_fill_rule(&mut self, fill_rule: Fill);
     fn set_transform(&mut self, transform: Affine);
+    fn set_blend_mode(&mut self, blend_mode: BlendMode);
     fn set_anti_aliasing(&mut self, value: bool);
     fn render_to_pixmap(&self, pixmap: &mut Pixmap, render_mode: RenderMode);
     fn width(&self) -> u16;
@@ -139,6 +140,10 @@ impl Renderer for RenderContext {
 
     fn set_transform(&mut self, transform: Affine) {
         Self::set_transform(self, transform);
+    }
+
+    fn set_blend_mode(&mut self, blend_mode: BlendMode) {
+        Self::set_blend_mode(self, blend_mode);   
     }
 
     fn set_anti_aliasing(&mut self, value: bool) {
@@ -330,6 +335,10 @@ impl Renderer for HybridRenderer {
 
     fn set_transform(&mut self, transform: Affine) {
         self.scene.set_transform(transform);
+    }
+
+    fn set_blend_mode(&mut self, _: BlendMode) {
+        unimplemented!()
     }
 
     fn set_anti_aliasing(&mut self, value: bool) {

--- a/sparse_strips/vello_toy/src/debug.rs
+++ b/sparse_strips/vello_toy/src/debug.rs
@@ -87,7 +87,13 @@ fn main() {
     }
 
     if stages.iter().any(|s| s.requires_wide_tiles()) {
-        wide.generate(&strip_buf, args.fill_rule, BLACK.into(), BlendMode::new(Mix::Normal, Compose::SrcOver), 0);
+        wide.generate(
+            &strip_buf,
+            args.fill_rule,
+            BLACK.into(),
+            BlendMode::new(Mix::Normal, Compose::SrcOver),
+            0,
+        );
     }
 
     draw_grid(&mut document, args.width, args.height);

--- a/sparse_strips/vello_toy/src/debug.rs
+++ b/sparse_strips/vello_toy/src/debug.rs
@@ -23,6 +23,7 @@ use vello_common::peniko::Fill;
 use vello_common::strip::Strip;
 use vello_common::tile::{Tile, Tiles};
 use vello_common::{flatten, strip};
+use vello_cpu::peniko::{BlendMode, Compose, Mix};
 
 fn main() {
     let args = Args::parse();
@@ -86,7 +87,7 @@ fn main() {
     }
 
     if stages.iter().any(|s| s.requires_wide_tiles()) {
-        wide.generate(&strip_buf, args.fill_rule, BLACK.into(), 0);
+        wide.generate(&strip_buf, args.fill_rule, BLACK.into(), BlendMode::new(Mix::Normal, Compose::SrcOver), 0);
     }
 
     draw_grid(&mut document, args.width, args.height);


### PR DESCRIPTION
I also removed the blend optimization since IMO it causes more troubles than it brings benefits.

Reference images match the ones in `tiny-skia`.