### PR TITLE
Alternative API for image overrides

### DIFF
--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -510,6 +510,9 @@ impl Renderer {
 
     /// Overwrite `image` with `texture`.
     ///
+    /// Most users should prefer [`register_texture`](Self::register_texture), which
+    /// ergonomically encapulates these requirements.
+    ///
     /// `texture` must have the [`wgpu::TextureFormat::Rgba8Unorm`] format and
     /// the [`wgpu::TextureUsages::COPY_SRC`] flag set. The `Rgba8UnormSrgb` format
     /// might also be supported, but this is not tested.
@@ -524,7 +527,6 @@ impl Renderer {
     /// dimensions would be rendered.
     ///
     /// [data]: peniko::Image::data
-    #[deprecated = "Use register_texture and unregister_texture methods instead"]
     pub fn override_image(
         &mut self,
         image: &Image,

--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -512,7 +512,7 @@ impl Renderer {
     ///
     /// `texture` must have the [`wgpu::TextureFormat::Rgba8Unorm`] format and
     /// the [`wgpu::TextureUsages::COPY_SRC`] flag set. The `Rgba8UnormSrgb` format
-    /// might also be supported.
+    /// might also be supported, but this is not tested.
     ///
     /// The given `Texture`'s data will be copied into the slot in Vello's image
     /// atlas where the image would be placed each frame.
@@ -536,8 +536,18 @@ impl Renderer {
         }
     }
 
-    /// Register a [`wgpu::Texture`] with Vello. You will receive a [`TextureHandle`] which
-    /// can be used to draw the registered texture using [`Scene::draw_texture`]
+    /// Register a [`wgpu::Texture`] with Vello, to allow drawing GPU-resident data.
+    ///
+    /// The returned `Image` can be used in [`Scene`]s (only those rendered with this `Renderer`)
+    /// Rendering Scenes which use this `Image` with other `Renderer`s will panic.
+    ///  
+    /// `texture` must have the [`wgpu::TextureFormat::Rgba8Unorm`] format and
+    /// the [`wgpu::TextureUsages::COPY_SRC`] flag set. This is because the data will
+    /// be copied into Vello's image atlas at the start of each frame.
+    /// The `Rgba8UnormSrgb` format might also be supported, but this is not tested.
+    ///
+    /// This is a utility wrapper around [`override_image`](Self::override_image).
+    /// For greater control, use that method.
     ///
     /// If the texture is no longer active then it should be unregistered using [`unregister_texture`](Self::unregister_texture)
     pub fn register_texture(&mut self, texture: wgpu::Texture) -> Image {
@@ -569,7 +579,7 @@ impl Renderer {
         image
     }
 
-    /// Unregister a [`wgpu::Texture`] that was registered with [`register_texture`](Self::register_texture)
+    /// Unregister a [`wgpu::Texture`] that was registered with [`register_texture`](Self::register_texture).
     pub fn unregister_texture(&mut self, handle: Image) {
         self.engine.image_overrides.remove(&handle.data.id());
     }

--- a/vello/src/scene.rs
+++ b/vello/src/scene.rs
@@ -23,8 +23,6 @@ use skrifa::{
 use vello_encoding::BumpAllocatorMemory;
 use vello_encoding::{Encoding, Glyph, GlyphRun, NormalizedCoord, Patch, Transform};
 
-use crate::TextureHandle;
-
 // TODO - Document invariants and edge cases (#470)
 // - What happens when we pass a transform matrix with NaN values to the Scene?
 // - What happens if a push_layer isn't matched by a pop_layer?
@@ -310,58 +308,6 @@ impl Scene {
             image,
             None,
             &Rect::new(0.0, 0.0, image.width as f64, image.height as f64),
-        );
-    }
-
-    /// Draws a texture at its natural size with the given transform
-    ///
-    /// To get a [`TextureHandle`] to use with this API, first register the texture with the renderer
-    /// using the [`Renderer::register_texture`](crate::Renderer::register_texture) method.
-    pub fn draw_texture(&mut self, handle: TextureHandle, transform: Affine) {
-        self.fill_texture(
-            Fill::NonZero,
-            transform,
-            1.0,
-            handle,
-            None,
-            &Rect::new(0.0, 0.0, handle.width as f64, handle.height as f64),
-            Extend::Pad,
-            Extend::Pad,
-        );
-    }
-
-    /// Fills a shape using the specified texture
-    ///
-    /// To get a [`TextureHandle`] to use with this API, first register the texture with the renderer
-    /// using the [`Renderer::register_texture`](crate::Renderer::register_texture) method.
-    pub fn fill_texture(
-        &mut self,
-        style: Fill,
-        transform: Affine,
-        alpha: f32,
-        handle: TextureHandle,
-        brush_transform: Option<Affine>,
-        shape: &impl Shape,
-        x_extend: Extend,
-        y_extend: Extend,
-    ) {
-        let dummy_image = Image {
-            data: Blob::from_raw_parts(Arc::new([]), handle.id),
-            width: handle.width,
-            height: handle.height,
-            format: peniko::ImageFormat::Rgba8,
-            quality: peniko::ImageQuality::High,
-            x_extend,
-            y_extend,
-            alpha,
-        };
-
-        self.fill(
-            style,
-            transform,
-            BrushRef::Image(&dummy_image),
-            brush_transform,
-            shape,
         );
     }
 

--- a/vello/src/scene.rs
+++ b/vello/src/scene.rs
@@ -23,6 +23,8 @@ use skrifa::{
 use vello_encoding::BumpAllocatorMemory;
 use vello_encoding::{Encoding, Glyph, GlyphRun, NormalizedCoord, Patch, Transform};
 
+use crate::TextureHandle;
+
 // TODO - Document invariants and edge cases (#470)
 // - What happens when we pass a transform matrix with NaN values to the Scene?
 // - What happens if a push_layer isn't matched by a pop_layer?
@@ -308,6 +310,58 @@ impl Scene {
             image,
             None,
             &Rect::new(0.0, 0.0, image.width as f64, image.height as f64),
+        );
+    }
+
+    /// Draws a texture at its natural size with the given transform
+    ///
+    /// To get a [`TextureHandle`] to use with this API, first register the texture with the renderer
+    /// using the [`Renderer::register_texture`](crate::Renderer::register_texture) method.
+    pub fn draw_texture(&mut self, handle: TextureHandle, transform: Affine) {
+        self.fill_texture(
+            Fill::NonZero,
+            transform,
+            1.0,
+            handle,
+            None,
+            &Rect::new(0.0, 0.0, handle.width as f64, handle.height as f64),
+            Extend::Pad,
+            Extend::Pad,
+        );
+    }
+
+    /// Fills a shape using the specified texture
+    ///
+    /// To get a [`TextureHandle`] to use with this API, first register the texture with the renderer
+    /// using the [`Renderer::register_texture`](crate::Renderer::register_texture) method.
+    pub fn fill_texture(
+        &mut self,
+        style: Fill,
+        transform: Affine,
+        alpha: f32,
+        handle: TextureHandle,
+        brush_transform: Option<Affine>,
+        shape: &impl Shape,
+        x_extend: Extend,
+        y_extend: Extend,
+    ) {
+        let dummy_image = Image {
+            data: Blob::from_raw_parts(Arc::new([]), handle.id),
+            width: handle.width,
+            height: handle.height,
+            format: peniko::ImageFormat::Rgba8,
+            quality: peniko::ImageQuality::High,
+            x_extend,
+            y_extend,
+            alpha,
+        };
+
+        self.fill(
+            style,
+            transform,
+            BrushRef::Image(&dummy_image),
+            brush_transform,
+            shape,
         );
     }
 

--- a/vello/src/wgpu_engine.rs
+++ b/vello/src/wgpu_engine.rs
@@ -504,6 +504,14 @@ impl WgpuEngine {
                             },
                         );
                     } else {
+                        if image.data.is_empty() && image.width != 0 && image.height != 0 {
+                            panic!(
+                                "Tried to draw an invalid empty image (id: {}). \
+                                Maybe it was registered to a different renderer, or \
+                                unregistered before this render was submitted.",
+                                image.data.id()
+                            );
+                        }
                         queue.write_texture(
                             wgpu::TexelCopyTextureInfo {
                                 texture,


### PR DESCRIPTION
Fixes #664

Supersedes (and integrates) #1052

The proposal in #1052 is an ergonomics improvement, but has several shortfalls. In particular, it required special case methods for every API which used an external texture. As these only had partial coverage, you couldn't use an external texture to render text (or any stroked path).

This is a much smaller proposal based on the core of that PR, to instead return a (fake) Peniko `Image`, which is then compatible with every Scene method which would draw an image.