### PR TITLE
Fix hybrid examples to not use `std::time` in Wasm

### DIFF
--- a/sparse_strips/vello_hybrid/examples/scenes/src/svg.rs
+++ b/sparse_strips/vello_hybrid/examples/scenes/src/svg.rs
@@ -47,13 +47,17 @@ impl ExampleScene for SvgScene {
             record_fresh(self, scene, current_transform);
         } else {
             // Direct rendering mode (no recording/caching)
+            #[cfg(not(target_arch = "wasm32"))]
             let start = std::time::Instant::now();
             render_svg(scene, &self.svg.items, current_transform);
-            let elapsed = start.elapsed();
-            println!(
-                "Direct    : {:.3}ms | No caching",
-                elapsed.as_secs_f64() * 1000.0
-            );
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                let elapsed = start.elapsed();
+                println!(
+                    "Direct    : {:.3}ms | No caching",
+                    elapsed.as_secs_f64() * 1000.0
+                );
+            }
         }
     }
 
@@ -78,11 +82,13 @@ fn try_reuse_recording(
     recording: &mut Recording,
     current_transform: Affine,
 ) -> RenderResult {
+    #[cfg(not(target_arch = "wasm32"))]
     let start = std::time::Instant::now();
 
     // Case 1: Identical transforms - can reuse directly
     if transforms_are_identical(recording.transform(), current_transform) {
         scene.execute_recording(recording);
+        #[cfg(not(target_arch = "wasm32"))]
         print_render_stats("Identical ", start.elapsed(), recording);
         return RenderResult { is_reused: true };
     }
@@ -95,6 +101,7 @@ fn try_reuse_recording(
 
 /// Record a fresh scene from scratch
 fn record_fresh(scene_obj: &mut SvgScene, scene: &mut Scene, current_transform: Affine) {
+    #[cfg(not(target_arch = "wasm32"))]
     let start = std::time::Instant::now();
     let mut new_recording = Recording::new();
     scene.record(&mut new_recording, |recorder| {
@@ -103,6 +110,7 @@ fn record_fresh(scene_obj: &mut SvgScene, scene: &mut Scene, current_transform: 
     scene.prepare_recording(&mut new_recording);
     scene.execute_recording(&new_recording);
     new_recording.set_transform(current_transform);
+    #[cfg(not(target_arch = "wasm32"))]
     print_render_stats("Fresh     ", start.elapsed(), &new_recording);
 
     scene_obj.recording = Some(new_recording);

--- a/sparse_strips/vello_hybrid/examples/scenes/src/svg.rs
+++ b/sparse_strips/vello_hybrid/examples/scenes/src/svg.rs
@@ -117,6 +117,7 @@ fn record_fresh(scene_obj: &mut SvgScene, scene: &mut Scene, current_transform: 
 }
 
 /// Print timing and statistics for a render operation
+#[cfg(not(target_arch = "wasm32"))]
 fn print_render_stats(render_type: &str, elapsed: std::time::Duration, recording: &Recording) {
     println!(
         "SVG  | {}: {:.3}ms | Strips: {} | Alphas: {}",

--- a/sparse_strips/vello_hybrid/examples/scenes/src/text.rs
+++ b/sparse_strips/vello_hybrid/examples/scenes/src/text.rs
@@ -64,14 +64,18 @@ impl ExampleScene for TextScene {
             record_fresh(self, scene, root_transform);
         } else {
             // Direct rendering mode (no recording/caching)
+            #[cfg(not(target_arch = "wasm32"))]
             let start = std::time::Instant::now();
             scene.set_transform(root_transform);
             render_text(self, scene);
-            let elapsed = start.elapsed();
-            println!(
-                "Direct    : {:.3}ms | No caching",
-                elapsed.as_secs_f64() * 1000.0
-            );
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                let elapsed = start.elapsed();
+                println!(
+                    "Direct    : {:.3}ms | No caching",
+                    elapsed.as_secs_f64() * 1000.0
+                );
+            }
         }
     }
 
@@ -140,11 +144,13 @@ fn try_reuse_recording(
     recording: &mut Recording,
     current_transform: Affine,
 ) -> RenderResult {
+    #[cfg(not(target_arch = "wasm32"))]
     let start = std::time::Instant::now();
 
     // Case 1: Identical transforms - can reuse directly
     if transforms_are_identical(recording.transform(), current_transform) {
         scene.execute_recording(recording);
+        #[cfg(not(target_arch = "wasm32"))]
         print_render_stats("Identical ", start.elapsed(), recording);
         return RenderResult { is_reused: true };
     }
@@ -157,6 +163,7 @@ fn try_reuse_recording(
 
 /// Record a fresh scene from scratch
 fn record_fresh(scene_obj: &mut TextScene, scene: &mut Scene, current_transform: Affine) {
+    #[cfg(not(target_arch = "wasm32"))]
     let start = std::time::Instant::now();
     let mut recording = Recording::new();
     scene.record(&mut recording, |recorder| {
@@ -165,6 +172,7 @@ fn record_fresh(scene_obj: &mut TextScene, scene: &mut Scene, current_transform:
     scene.prepare_recording(&mut recording);
     scene.execute_recording(&recording);
     recording.set_transform(current_transform);
+    #[cfg(not(target_arch = "wasm32"))]
     print_render_stats("Fresh     ", start.elapsed(), &recording);
 
     scene_obj.recording = Some(recording);

--- a/sparse_strips/vello_hybrid/examples/scenes/src/text.rs
+++ b/sparse_strips/vello_hybrid/examples/scenes/src/text.rs
@@ -179,6 +179,7 @@ fn record_fresh(scene_obj: &mut TextScene, scene: &mut Scene, current_transform:
 }
 
 /// Print timing and statistics for a render operation
+#[cfg(not(target_arch = "wasm32"))]
 fn print_render_stats(render_type: &str, elapsed: std::time::Duration, recording: &Recording) {
     println!(
         "Text | {}: {:.3}ms | Strips: {} | Alphas: {}",


### PR DESCRIPTION
std::time isn't implemented in wasm, so we cannot access `std::time::Instant` on these platforms:

<img width="765" height="300" alt="image" src="https://github.com/user-attachments/assets/f8500f3f-f2b5-48c6-ae3e-dd059413c538" />
