### PR TITLE
feat: add parley in example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3095,6 +3095,7 @@ name = "simple"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "parley",
  "pollster",
  "vello",
  "winit",

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -16,3 +16,4 @@ vello = { version = "0.5.0", path = "../../vello" }
 anyhow = "1.0.98"
 pollster = "0.4.0"
 winit = "0.30.10"
+parley = "0.5.0"


### PR DESCRIPTION
Hi, I found that this repository was missing a good text rendering example with `parley` so I added it in the current `simple` example.

Please tell me if you prefer a separate example for this :)