### PR TITLE
Limit number of threads to 8 by default in multi-threaded rendering

### DIFF
--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -77,7 +77,8 @@ impl Default for RenderSettings {
             num_threads: (std::thread::available_parallelism()
                 .unwrap()
                 .get()
-                .saturating_sub(1) as u16).min(8),
+                .saturating_sub(1) as u16)
+                .min(8),
             #[cfg(not(feature = "multithreading"))]
             num_threads: 0,
         }


### PR DESCRIPTION
Still not sure what's going on, but when trying 16 threads on my Intel machine instead of 8 I'm seeing a sudden very heavy performance drop. Let's limit it to 8 by default for now until we have figured this out.