### PR TITLE
vello_hybrid: remove suspending work from scheduler

### DIFF
--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -461,9 +461,7 @@ impl Scheduler {
                     for (idx, &slot) in round.clear[i].iter().enumerate() {
                         assert!(
                             !round.clear[i][..idx].contains(&slot),
-                            "Duplicate slot {} found in round.clear[{}]",
-                            slot,
-                            i
+                            "Duplicate slot {slot} found in round.clear[{i}]",
                         );
                     }
                 }

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -399,10 +399,10 @@ impl Scheduler {
         }
     }
 
-    pub(crate) fn do_scene<'scene, R: RendererBackend>(
+    pub(crate) fn do_scene<R: RendererBackend>(
         &mut self,
         renderer: &mut R,
-        scene: &'scene Scene,
+        scene: &Scene,
     ) -> Result<(), RenderError> {
         let wide_tiles_per_row = scene.wide.width_tiles();
         let wide_tiles_per_col = scene.wide.height_tiles();

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -648,6 +648,8 @@ impl Scheduler {
                             );
 
                             tos.temporary_slot = TemporarySlot::Valid(temp_slot);
+                            // Signal when this tile will be ready to use for future blend/pop/clip
+                            // operations.
                             tos.round = el_round + 1;
 
                             // Make sure the destination slot and temporary slot are cleared
@@ -660,7 +662,7 @@ impl Scheduler {
                                 SENTINEL_SLOT_IDX,
                                 "surface cannot be read"
                             );
-                            let round1 = self.get_round(el_round + 1);
+                            let round1 = self.get_round(tos.round);
                             round1.clear[dest_slot.get_texture()].push(dest_slot.get_idx() as u32);
                         }
                     }

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -452,6 +452,22 @@ impl Scheduler {
     fn flush<R: RendererBackend>(&mut self, renderer: &mut R) {
         let round = self.rounds_queue.pop_front().unwrap();
         for (i, draw) in round.draws.iter().enumerate() {
+            #[cfg(debug_assertions)]
+            {
+                // This is an expensive O(n²) debug only check that enforces that there are no
+                // duplicate slots in the clear list. Duplicates signal an inefficiency in
+                // scheduling.
+                if i != 2 {
+                    for (idx, &slot) in round.clear[i].iter().enumerate() {
+                        assert!(
+                            !round.clear[i][..idx].contains(&slot),
+                            "Duplicate slot {} found in round.clear[{}]",
+                            slot,
+                            i
+                        );
+                    }
+                }
+            }
             let load = {
                 if i == 2 {
                     // We're rendering to the view, don't clear.

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -180,7 +180,6 @@ use crate::render::common::GpuEncodedImage;
 use crate::{GpuStrip, RenderError, Scene};
 use alloc::collections::VecDeque;
 use alloc::vec::Vec;
-use core::mem;
 use vello_common::coarse::MODE_HYBRID;
 use vello_common::peniko::{BlendMode, Compose, Mix};
 use vello_common::{
@@ -230,30 +229,6 @@ pub(crate) struct Scheduler {
     free: [Vec<usize>; 2],
     /// Rounds are enqueued on push clip commands and dequeued on flush.
     rounds_queue: VecDeque<Round>,
-    #[cfg(debug_assertions)]
-    /// Enforce clearing invariants across rounds.
-    clear: [Vec<u32>; 2],
-}
-
-/// The information required to resume a wide tile draw operation. Note that the suspended tile owns
-/// global slot resources, so must be resumed to free the owned slots. Tile work suspends where
-/// blends are repeatedly scheduled into the same layer providing time for the blended result to be
-/// copied back to the other texture because we need to ensure the two slots we are blending are in
-/// the same texture.
-#[derive(Debug)]
-struct PendingWideTileWork<'a> {
-    /// Used to reference the wide tile.
-    wide_tile_col: u16,
-    /// Used to reference the wide tile.
-    wide_tile_row: u16,
-    /// On resuming the cmd index to start processing draws from.
-    next_cmd_idx: usize,
-    /// The suspended tile state stack representing active layers.
-    stack: TileState,
-    /// Round at which this work was suspended. Used to calculate round offsets.
-    suspended_at_round: usize,
-    /// The draw commands being iterated to draw the wide tile.
-    annotated_cmds: Vec<AnnotatedCmd<'a>>,
 }
 
 /// A "round" is a coarse scheduling quantum.
@@ -400,8 +375,6 @@ impl Scheduler {
             total_slots,
             free,
             rounds_queue: Default::default(),
-            #[cfg(debug_assertions)]
-            clear: [Vec::new(), Vec::new()],
         }
     }
 
@@ -433,10 +406,6 @@ impl Scheduler {
     ) -> Result<(), RenderError> {
         let wide_tiles_per_row = scene.wide.width_tiles();
         let wide_tiles_per_col = scene.wide.height_tiles();
-        let mut pending_work: Vec<PendingWideTileWork<'scene>> =
-            Vec::with_capacity((wide_tiles_per_row as usize) * (wide_tiles_per_col as usize));
-        let mut pending_work_scratch: Vec<PendingWideTileWork<'scene>> =
-            Vec::with_capacity((wide_tiles_per_row as usize) * (wide_tiles_per_col as usize));
 
         // Left to right, top to bottom iteration over wide tiles.
         for wide_tile_row in 0..wide_tiles_per_col {
@@ -448,66 +417,14 @@ impl Scheduler {
                 let tile_state =
                     self.initialize_tile_state(wide_tile, wide_tile_x, wide_tile_y, scene);
                 let annotated_cmds = prepare_cmds(&wide_tile.cmds);
-                pending_work.push(PendingWideTileWork {
-                    wide_tile_col,
-                    wide_tile_row,
-                    next_cmd_idx: 0,
-                    stack: tile_state,
-                    suspended_at_round: self.round,
-                    annotated_cmds,
-                });
-            }
-        }
-
-        while !self.rounds_queue.is_empty() || !pending_work.is_empty() {
-            if !self.rounds_queue.is_empty() {
-                self.flush(renderer);
-            }
-
-            for work in pending_work.drain(..) {
-                let wide_tile_col = work.wide_tile_col;
-                let wide_tile_row = work.wide_tile_row;
-                let wide_tile_x = wide_tile_col * WideTile::WIDTH;
-                let wide_tile_y = wide_tile_row * Tile::HEIGHT;
-                let mut tile_state = work.stack;
-
-                let round_offset = self.round - (work.suspended_at_round);
-                for el in tile_state.stack.iter_mut() {
-                    el.round += round_offset;
-                }
-
-                if let Some(next_cmd_idx) = self.do_tile(
+                self.do_tile(
                     renderer,
                     scene,
                     wide_tile_x,
                     wide_tile_y,
-                    &work.annotated_cmds,
-                    &mut tile_state,
-                    work.next_cmd_idx,
-                )? {
-                    pending_work_scratch.push(PendingWideTileWork {
-                        wide_tile_col,
-                        wide_tile_row,
-                        next_cmd_idx,
-                        stack: tile_state,
-                        suspended_at_round: self.round,
-                        annotated_cmds: work.annotated_cmds,
-                    });
-                }
-            }
-
-            mem::swap(&mut pending_work, &mut pending_work_scratch);
-
-            if !pending_work.is_empty() {
-                // TODO: This can be tested by arbitrarily limiting the total slots that the
-                // Scheduler is instantiated with. For example, tests deadlock at a value of `20`.
-                // Ideally we improve this system such that it does not deadlock given a situation
-                // where a single tile can always be completed given all resources. This may require
-                // reserving the slots required for a wide tile to complete upfront.
-                assert!(
-                    !self.rounds_queue.is_empty(),
-                    "deadlock in scheduler detected"
-                );
+                    &annotated_cmds,
+                    tile_state,
+                )?;
             }
         }
 
@@ -519,8 +436,6 @@ impl Scheduler {
         self.round = 0;
         #[cfg(debug_assertions)]
         {
-            debug_assert!(self.clear[0].is_empty(), "clear has not reset");
-            debug_assert!(self.clear[1].is_empty(), "clear has not reset");
             for i in 0..self.total_slots {
                 debug_assert!(self.free[0].contains(&i), "free[0] is missing slot {i}");
                 debug_assert!(self.free[1].contains(&i), "free[1] is missing slot {i}");
@@ -542,31 +457,10 @@ impl Scheduler {
                     // We're rendering to the view, don't clear.
                     LoadOp::Load
                 } else if round.clear[i].len() + self.free[i].len() == self.total_slots {
-                    #[cfg(debug_assertions)]
-                    self.clear[i].clear();
                     // All slots are either unoccupied or need to be cleared. Simply clear the slots
                     // via a load operation.
                     LoadOp::Clear
                 } else {
-                    #[cfg(debug_assertions)]
-                    {
-                        // This debug_assertion is expensive, but it enforces that duplicates cannot
-                        // be cleared. This usually signals a bug in the scheduler.
-                        for (idx, &slot) in round.clear[i].iter().enumerate() {
-                            debug_assert!(
-                                !round.clear[i][..idx].contains(&slot),
-                                "Duplicate slot {slot} found in round.clear[{i}]",
-                            );
-
-                            // We can't use `retain` because `self.clear` tracks clearing globally
-                            // across rounds. This means that it _can_ contain duplicates if a slot
-                            // is scheduled to be cleared in two rounds simultaneously.
-                            if let Some(pos) = self.clear[i].iter().position(|&x| x == slot) {
-                                self.clear[i].swap_remove(pos);
-                            }
-                        }
-                    }
-
                     // Some slots need to be preserved, so only clear the dirty slots.
                     renderer.clear_slots(i, round.clear[i].as_slice());
                     LoadOp::Load
@@ -648,13 +542,10 @@ impl Scheduler {
         scene: &Scene,
         wide_tile_x: u16,
         wide_tile_y: u16,
-        cmds: &[AnnotatedCmd<'a>],
-        state: &mut TileState,
-        start_cmd_idx: usize,
-    ) -> Result<Option<usize>, RenderError> {
-        let mut has_blended = false;
-        for (offset_cmd_idx, annotated_cmd) in cmds[start_cmd_idx..].iter().enumerate() {
-            let cmd_idx = start_cmd_idx + offset_cmd_idx;
+        cmds: &'a [AnnotatedCmd<'a>],
+        mut state: TileState,
+    ) -> Result<(), RenderError> {
+        for annotated_cmd in cmds {
             // Note: this starts at 1 (for the final target)
             let depth = state.stack.len();
             let cmd = annotated_cmd.as_cmd();
@@ -734,42 +625,30 @@ impl Scheduler {
                     {
                         let tos: &mut TileEl = state.stack.last_mut().unwrap();
                         if let TemporarySlot::Invalid(temp_slot) = tos.temporary_slot {
-                            if has_blended {
-                                // There has been a popped blend in this run of `do_tile`. Suspend
-                                // to give the blend command a chance to flush.
-                                return Ok(Some(cmd_idx));
-                            }
-
-                            let draw = self.draw_mut(tos.round - 1, temp_slot.get_texture());
+                            let next_round = depth % 2 == 0;
+                            let el_round = tos.round.max(tos.round + usize::from(next_round));
+                            let draw = self.draw_mut(el_round, temp_slot.get_texture());
                             draw.push(
                                 GpuStripBuilder::at_slot(temp_slot.get_idx(), 0, WideTile::WIDTH)
                                     .copy_from_slot(tos.dest_slot.get_idx(), 0xFF),
                             );
 
                             tos.temporary_slot = TemporarySlot::Valid(temp_slot);
+                            tos.round = el_round + 1;
 
                             // Make sure the destination slot and temporary slot are cleared
                             // appropriately.
                             let dest_slot = tos.dest_slot;
-                            let round = self.get_round(tos.round - 1);
+                            let round = self.get_round(el_round);
                             round.clear[temp_slot.get_texture()].push(temp_slot.get_idx() as u32);
-                            #[cfg(debug_assertions)]
-                            self.clear[temp_slot.get_texture()].push(temp_slot.get_idx() as u32);
                             debug_assert_ne!(
                                 dest_slot.get_idx(),
                                 SENTINEL_SLOT_IDX,
                                 "surface cannot be read"
                             );
-                            let round1 = self.get_round(tos.round);
+                            let round1 = self.get_round(el_round + 1);
                             round1.clear[dest_slot.get_texture()].push(dest_slot.get_idx() as u32);
-                            #[cfg(debug_assertions)]
-                            self.clear[dest_slot.get_texture()].push(dest_slot.get_idx() as u32);
                         }
-                    }
-
-                    // Suspend if there are no free slots.
-                    if self.free[0].is_empty() || self.free[1].is_empty() {
-                        return Ok(Some(cmd_idx));
                     }
 
                     // Push a new tile.
@@ -778,16 +657,12 @@ impl Scheduler {
                     {
                         let round = self.get_round(self.round);
                         round.clear[slot.get_texture()].push(slot.get_idx() as u32);
-                        #[cfg(debug_assertions)]
-                        self.clear[slot.get_texture()].push(slot.get_idx() as u32);
                     }
                     let temporary_slot =
                         if matches!(annotated_cmd, AnnotatedCmd::PushBufWithTemporarySlot) {
                             let temp_slot = self.claim_free_slot((ix + 1) % 2, renderer)?;
                             let round = self.get_round(self.round);
                             round.clear[temp_slot.get_texture()].push(temp_slot.get_idx() as u32);
-                            #[cfg(debug_assertions)]
-                            self.clear[temp_slot.get_texture()].push(temp_slot.get_idx() as u32);
                             debug_assert_ne!(
                                 slot.get_texture(),
                                 temp_slot.get_texture(),
@@ -964,8 +839,6 @@ impl Scheduler {
                         // Invalidate the temporary slot after use
                         let nos_ptr = state.stack.len() - 2;
                         state.stack[nos_ptr].temporary_slot.invalidate();
-                        // Signal to suspend before pushing a new buffer.
-                        has_blended = true;
                     } else {
                         assert_eq!(
                             nos.dest_slot.get_idx(),
@@ -987,7 +860,7 @@ impl Scheduler {
             }
         }
 
-        Ok(None)
+        Ok(())
     }
 
     /// Process a paint and return (`payload`, `paint`)

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -640,7 +640,7 @@ impl Scheduler {
                         let tos: &mut TileEl = state.stack.last_mut().unwrap();
                         if let TemporarySlot::Invalid(temp_slot) = tos.temporary_slot {
                             let next_round = depth % 2 == 0;
-                            let el_round = tos.round.max(tos.round + usize::from(next_round));
+                            let el_round = tos.round + usize::from(next_round);
                             let draw = self.draw_mut(el_round, temp_slot.get_texture());
                             draw.push(
                                 GpuStripBuilder::at_slot(temp_slot.get_idx(), 0, WideTile::WIDTH)


### PR DESCRIPTION
This PR addresses multiple tasks tracked in https://github.com/linebender/vello/issues/1165

### Context

Recently we landed https://github.com/linebender/vello/pull/1155 but it had lots of caveats. It also utilised suspending wide tile commands in order to pack rounds. A large pain point is that the system **could deadlock itself**.

At renderer office hours we discussed pre-planning out wide tiles into rounds and whether suspending was necessary. It was agreed that suspending was used as it was lower cost – but I felt like I hadn't explored a non-suspending solution adequately.

Originally I was working towards solving the deadlock issue – which would require either removing the suspending concept, or making suspending smarter such that it wouldn't get into deadlocks as much. Adding another system on top of the scheduler to "guess" resources to prevent deadlocks was really thorny and complex, so I also explored simply removing the complexity of suspending wide tile commands, and it worked!
This PR removes the entire concept of suspending.

Removing suspending lets us:
 - Delete many of the allocations I added.
 - Makes deadlocks impossible as they are coupled to the removed system.
 - Simplifies the code, and improves performance.

### How

The most pertinent changes in this PR are the round calculations in `PushBuf`. I messed up the rounds where we copy the destination slot contents back to the temporary texture. By fixing these rounds, the whole system "just works" without suspending because work is scheduled into rounds correctly.


#### What is the insight and why could suspending be removed?

On `main` note that suspending _only_ happens when pushing a buffer. It happens when the current top of stack (`tos`) has an invalid temporary slot which needs to be copied to the alternate texture such that a future blend operation will work.

There was a bug such that rounds were calculated incorrectly in push buffer. Hence, by suspending we would force enough rounds to pass such that temporary slots are made valid.

The key insight is that `rounds` tracked on the tiles track the round in which that tile is doing work. You can do work in parallel on different tiles in the stack as long as they are mutually exclusive. It's only when blending or popping buffers that we `max(nos.round, tos.round)` to synchronize the rounds and ensure that all work is done before blending.

This insight is what lets us fix the round calculations for compositing and allows us to remove suspending as a _hack_ to get around the round calculation bug. This explains why we get better round utilization with this PR.


But, I also vigorously empirically proved that this change is extremely worthwhile.

### Empirical Tests

#### Round stats

With the following code in the `Scheduler::flush` method we can capture some insightful statistics:

```rs
#[cfg(debug_assertions)]
        {
            let strips = [
                round.draws[0].0.len(),
                round.draws[1].0.len(),
                round.draws[2].0.len(),
            ];
            let total_strips: usize = strips.iter().sum();
            let slots_cleared = round.clear[0].len() + round.clear[1].len();
            let slots_freed = round.free[0].len() + round.free[1].len();

            eprintln!(
                "Round {}: {} strips (tex0:{}, tex1:{}, target:{}), {} cleared, {} freed",
                self.round,
                total_strips,
                strips[0],
                strips[1],
                strips[2],
                slots_cleared,
                slots_freed
            );
        }
```

**Command**: `cargo nextest run complex_composed_layers_hybrid --locked --all-features --no-fail-fast  --no-capture`


**On `main`:**
```md
Round 0: 299 strips (tex0:59, tex1:240, target:0), 225 cleared, 0 freed
Round 1: 152 strips (tex0:60, tex1:92, target:0), 120 cleared, 40 freed
Round 2: 134 strips (tex0:66, tex1:68, target:0), 265 cleared, 60 freed
Round 3: 81 strips (tex0:35, tex1:46, target:0), 30 cleared, 95 freed
Round 4: 50 strips (tex0:25, tex1:25, target:0), 10 cleared, 100 freed
Round 5: 50 strips (tex0:25, tex1:25, target:0), 5 cleared, 90 freed
Round 6: 70 strips (tex0:25, tex1:25, target:20), 5 cleared, 135 freed
Round 7: 15 strips (tex0:5, tex1:5, target:5), 0 cleared, 30 freed
```

**This PR:**
```md
Round 0: 496 strips (tex0:135, tex1:361, target:0), 550 cleared, 15 freed
Round 1: 120 strips (tex0:60, tex1:60, target:0), 25 cleared, 130 freed
Round 2: 100 strips (tex0:50, tex1:50, target:0), 50 cleared, 150 freed
Round 3: 50 strips (tex0:25, tex1:25, target:0), 30 cleared, 90 freed
Round 4: 70 strips (tex0:25, tex1:25, target:20), 5 cleared, 135 freed
Round 5: 15 strips (tex0:5, tex1:5, target:5), 0 cleared, 30 freed
```

This PR results in fewer rounds for drawing the same complex blend scene.



#### Deadlock tests

This was tested with the following diff:

```diff
diff --git a/sparse_strips/vello_hybrid/src/render/wgpu.rs b/sparse_strips/vello_hybrid/src/render/wgpu.rs
index f6998c02..1e3e3aef 100644
--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -71,7 +71,7 @@ impl Renderer {
 
         Self {
             programs: Programs::new(device, render_target_config, total_slots),
-            scheduler: Scheduler::new(total_slots),
+            scheduler: Scheduler::new(12),
             image_cache,
         }
     }
```

The command: `cargo nextest run --locked --all-features --no-fail-fast --release` run on `sparse_strips` as working directory.

With the extremely limited slots, this PR passes all tests. On main, the tests fail with a deadlock.



#### `wgpu_webgl` example (scalar)
(this is very rough and measured while dragging and zooming)

On main each rAF for the blend example is ~6.5ms.
This PR makes the rAF ~5ms.


### Test plan

Tested manually with `cargo run_wasm -p wgpu_webgl --release`, `cargo run -p vello_hybrid_winit --release`, and by leaning on the existing test corpus of tests that include hybrid compositing tests.


### Risks

I don't think there are major risks introduced by this PR. This PR really polishes rough edges introduced by the initial blend layers PR and eliminates the deadlock hazard.
