### PR TITLE
Remove unnecessary lifetime annotation

### DIFF
--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -22,7 +22,6 @@ use vello::wgpu;
 enum RenderState {
     /// `RenderSurface` and `Window` for active rendering.
     Active {
-        // The `RenderSurface` and the `Window` must be in this order, so that the surface is dropped first.
         surface: Box<RenderSurface<'static>>,
         window: Arc<Window>,
     },

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -19,18 +19,18 @@ use winit::window::Window;
 use vello::wgpu;
 
 #[derive(Debug)]
-enum RenderState<'s> {
+enum RenderState {
     /// `RenderSurface` and `Window` for active rendering.
     Active {
         // The `RenderSurface` and the `Window` must be in this order, so that the surface is dropped first.
-        surface: Box<RenderSurface<'s>>,
+        surface: Box<RenderSurface<'static>>,
         window: Arc<Window>,
     },
     /// Cache a window so that it can be reused when the app is resumed after being suspended.
     Suspended(Option<Arc<Window>>),
 }
 
-struct SimpleVelloApp<'s> {
+struct SimpleVelloApp {
     // The vello RenderContext which is a global context that lasts for the
     // lifetime of the application
     context: RenderContext,
@@ -39,7 +39,7 @@ struct SimpleVelloApp<'s> {
     renderers: Vec<Option<Renderer>>,
 
     // State for our example where we store the winit Window and the wgpu Surface
-    state: RenderState<'s>,
+    state: RenderState,
 
     // A vello Scene which is a data structure which allows one to build up a
     // description a scene to be drawn (with paths, fills, images, text, etc)
@@ -47,7 +47,7 @@ struct SimpleVelloApp<'s> {
     scene: Scene,
 }
 
-impl ApplicationHandler for SimpleVelloApp<'_> {
+impl ApplicationHandler for SimpleVelloApp {
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
         let RenderState::Suspended(cached_window) = &mut self.state else {
             return;

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -100,8 +100,8 @@ fn default_threads() -> usize {
     return 0;
 }
 
-struct RenderState<'s> {
-    surface: RenderSurface<'s>,
+struct RenderState {
+    surface: RenderSurface<'static>,
     window: Arc<Window>,
 }
 
@@ -114,10 +114,10 @@ const AA_CONFIGS: [AaConfig; 3] = [AaConfig::Area, AaConfig::Msaa8, AaConfig::Ms
 // Hard code to only one on Android whilst we are working on startup speed
 const AA_CONFIGS: [AaConfig; 1] = [AaConfig::Area];
 
-struct VelloApp<'s> {
+struct VelloApp {
     context: RenderContext,
     renderers: Vec<Option<Renderer>>,
-    state: Option<RenderState<'s>>,
+    state: Option<RenderState>,
     // Whilst suspended, we drop `render_state`, but need to keep the same window.
     #[cfg(not(target_arch = "wasm32"))]
     cached_window: Option<Arc<Window>>,
@@ -176,7 +176,7 @@ struct VelloApp<'s> {
     cache_data: Option<(PathBuf, std::sync::mpsc::Sender<(PipelineCache, PathBuf)>)>,
 }
 
-impl ApplicationHandler<UserEvent> for VelloApp<'_> {
+impl ApplicationHandler<UserEvent> for VelloApp {
     #[cfg(target_arch = "wasm32")]
     fn resumed(&mut self, _event_loop: &winit::event_loop::ActiveEventLoop) {}
 
@@ -702,12 +702,12 @@ fn run(
     args: Args,
     scenes: SceneSet,
     render_cx: RenderContext,
-    #[cfg(target_arch = "wasm32")] render_state: RenderState<'_>,
+    #[cfg(target_arch = "wasm32")] render_state: RenderState,
 ) {
     use winit::keyboard::ModifiersState;
 
     #[cfg(not(target_arch = "wasm32"))]
-    let (render_state, renderers) = (None::<RenderState<'_>>, vec![]);
+    let (render_state, renderers) = (None::<RenderState>, vec![]);
 
     let cache_directory = get_cache_directory(&event_loop).unwrap();
     // The design of `RenderContext` forces delayed renderer initialisation to


### PR DESCRIPTION
These lifetimes are `'static` because the wgpu `Surface` owns `Arc<Window>`.