### PR TITLE
vello_hybrid: add `mix` blend layer support

### DIFF
--- a/sparse_strips/vello_dev_macros/src/test.rs
+++ b/sparse_strips/vello_dev_macros/src/test.rs
@@ -200,6 +200,11 @@ pub(crate) fn vello_test_inner(attr: TokenStream, item: TokenStream) -> TokenStr
         || input_fn_name_str.contains("compose")
         || input_fn_name_str.contains("clip_composite_opacity_nested_circles");
 
+    // Make an exception for mix tests that don't use gradients.
+    skip_hybrid = skip_hybrid
+        && !(input_fn_name_str == "mix_modes_non_gradient_test_matrix"
+            || input_fn_name_str == "mix_compose_combined_test_matrix");
+
     let empty_snippet = quote! {};
     let ignore_snippet = if let Some(reason) = ignore_reason {
         quote! {#[ignore = #reason]}

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -832,6 +832,11 @@ impl Scheduler {
                         );
                         let opacity_u8 = (tos.opacity * 255.0) as u8;
                         let mix_mode = mode.mix as u8;
+                        debug_assert_ne!(
+                            mode.mix,
+                            Mix::Clip,
+                            "Mix::Clip unsupported, instead use Mix::Normal."
+                        );
                         let compose_mode = mode.compose as u8;
 
                         let gpu_strip_builder = if depth <= 2 {

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -815,11 +815,6 @@ impl Scheduler {
                     state.stack.last_mut().unwrap().opacity = *opacity;
                 }
                 Cmd::Blend(mode) => {
-                    assert!(
-                        matches!(mode.mix, Mix::Normal),
-                        "Only Mix::Normal is supported currently"
-                    );
-
                     let tos = state.stack.last().unwrap();
                     let nos = &state.stack[state.stack.len() - 2];
 

--- a/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
@@ -73,7 +73,6 @@ const MIX_HUE = 12u;
 const MIX_SATURATION = 13u;
 const MIX_COLOR = 14u;
 const MIX_LUMINOSITY = 15u;
-const MIX_CLIP = 128u;
 
 struct Config {
     // Width of the rendering target

--- a/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
@@ -56,6 +56,25 @@ const COMPOSE_XOR: u32 = 11u;
 const COMPOSE_PLUS: u32 = 12u;
 const COMPOSE_PLUS_LIGHTER: u32 = 13u;
 
+// Mix modes
+const MIX_NORMAL = 0u;
+const MIX_MULTIPLY = 1u;
+const MIX_SCREEN = 2u;
+const MIX_OVERLAY = 3u;
+const MIX_DARKEN = 4u;
+const MIX_LIGHTEN = 5u;
+const MIX_COLOR_DODGE = 6u;
+const MIX_COLOR_BURN = 7u;
+const MIX_HARD_LIGHT = 8u;
+const MIX_SOFT_LIGHT = 9u;
+const MIX_DIFFERENCE = 10u;
+const MIX_EXCLUSION = 11u;
+const MIX_HUE = 12u;
+const MIX_SATURATION = 13u;
+const MIX_COLOR = 14u;
+const MIX_LUMINOSITY = 15u;
+const MIX_CLIP = 128u;
+
 struct Config {
     // Width of the rendering target
     width: u32,
@@ -305,7 +324,6 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
         final_color = alpha * opacity * clip_in_color;
     } else if color_source == COLOR_SOURCE_BLEND {
         let opacity = f32((in.paint >> 16u) & 0xFFu) * (1.0 / 255.0);
-        // TODO: Use mix modes. Currently Mix::Normal is hardcoded and this value is discarded.
         let mix_mode = (in.paint >> 8u) & 0xFFu;
         let compose_mode = in.paint & 0xFFu;
         
@@ -320,28 +338,36 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
         let dest_y = (u32(in.position.y) & 3u) + dest_slot * config.strip_height;
         let dest_color = textureLoad(clip_input_texture, vec2(clip_x, dest_y), 0);
 
-        final_color = blend_mix_compose(dest_color, src_color * opacity * alpha, compose_mode);
+        final_color = blend_mix_compose(dest_color, src_color * opacity * alpha, compose_mode, mix_mode);
     }
     return final_color;
 }
 
-// Apply color mixing and composition. Both input and output colors are
-// premultiplied RGB. Referenced from:
+// Apply color mixing and composition. Both input and output colors are premultiplied RGB.
+// Referenced from:
 //   <https://github.com/linebender/vello/blob/b0e2e598ac62c7b3d04d8660e7b1b7659b596970/vello_shaders/shader/shared/blend.wgsl#L288-L310>
-// TODO: Add color mixing support.
-fn blend_mix_compose(backdrop: vec4<f32>, src: vec4<f32>, compose_mode: u32) -> vec4<f32> {
+fn blend_mix_compose(backdrop: vec4<f32>, src: vec4<f32>, compose_mode: u32, mix_mode: u32) -> vec4<f32> {
     // Fast path for src_over
-    if compose_mode == COMPOSE_SRC_OVER {
+    let BLEND_DEFAULT = ((MIX_NORMAL << 8u) | COMPOSE_SRC_OVER);
+    let mode = ((mix_mode << 8u) | compose_mode);
+    if mode == BLEND_DEFAULT {
         return backdrop * (1.0 - src.a) + src;
     }
     
     let EPSILON = 1e-15;
     let inv_src_a = 1.0 / max(src.a, EPSILON);
-    let cs = src.rgb * inv_src_a;
+    var cs = src.rgb * inv_src_a;
     let inv_backdrop_a = 1.0 / max(backdrop.a, EPSILON);
     let cb = backdrop.rgb * inv_backdrop_a;
-    
-    return blend_compose_unpremul(cb, cs, backdrop.a, src.a, compose_mode);
+    let mixed = blend_mix(cb, cs, mix_mode);
+    cs = mix(cs, mixed, backdrop.a);
+
+    if compose_mode == COMPOSE_SRC_OVER {
+        let co = mix(backdrop.rgb, cs, src.a);
+        return vec4(co, src.a + backdrop.a * (1.0 - src.a));
+    } else {
+        return blend_compose_unpremul(cb, cs, backdrop.a, src.a, compose_mode);
+    }
 }
 
 // Apply general compositing operation. Inputs are separated colors and alpha, output is
@@ -415,6 +441,179 @@ fn blend_compose_unpremul(
     let co = as_fa * cs + ab_fb * cb;
     // Modes like COMPOSE_PLUS can generate alpha > 1.0, so clamp.
     return vec4(co, min(as_fa + ab_fb, 1.0));
+}
+
+fn screen(cb: vec3<f32>, cs: vec3<f32>) -> vec3<f32> {
+    return cb + cs - (cb * cs);
+}
+
+fn color_dodge(cb: f32, cs: f32) -> f32 {
+    if cb == 0.0 {
+        return 0.0;
+    } else if cs == 1.0 {
+        return 1.0;
+    } else {
+        return min(1.0, cb / (1.0 - cs));
+    }
+}
+
+fn color_burn(cb: f32, cs: f32) -> f32 {
+    if cb == 1.0 {
+        return 1.0;
+    } else if cs == 0.0 {
+        return 0.0;
+    } else {
+        return 1.0 - min(1.0, (1.0 - cb) / cs);
+    }
+}
+
+fn hard_light(cb: vec3<f32>, cs: vec3<f32>) -> vec3<f32> {
+    return select(
+        screen(cb, 2.0 * cs - 1.0),
+        cb * 2.0 * cs,
+        cs <= vec3(0.5)
+    );
+}
+
+fn soft_light(cb: vec3<f32>, cs: vec3<f32>) -> vec3<f32> {
+    let d = select(
+        sqrt(cb),
+        ((16.0 * cb - 12.0) * cb + 4.0) * cb,
+        cb <= vec3(0.25)
+    );
+    return select(
+        cb + (2.0 * cs - 1.0) * (d - cb),
+        cb - (1.0 - 2.0 * cs) * cb * (1.0 - cb),
+        cs <= vec3(0.5)
+    );
+}
+
+fn sat(c: vec3<f32>) -> f32 {
+    return max(c.x, max(c.y, c.z)) - min(c.x, min(c.y, c.z));
+}
+
+fn lum(c: vec3<f32>) -> f32 {
+    let f = vec3(0.3, 0.59, 0.11);
+    return dot(c, f);
+}
+
+fn clip_color(c_in: vec3<f32>) -> vec3<f32> {
+    var c = c_in;
+    let l = lum(c);
+    let n = min(c.x, min(c.y, c.z));
+    let x = max(c.x, max(c.y, c.z));
+    if n < 0.0 {
+        c = l + (((c - l) * l) / (l - n));
+    }
+    if x > 1.0 {
+        c = l + (((c - l) * (1.0 - l)) / (x - l));
+    }
+    return c;
+}
+
+fn set_lum(c: vec3<f32>, l: f32) -> vec3<f32> {
+    return clip_color(c + (l - lum(c)));
+}
+
+fn set_sat_inner(
+    cmin: ptr<function, f32>,
+    cmid: ptr<function, f32>,
+    cmax: ptr<function, f32>,
+    s: f32
+) {
+    if *cmax > *cmin {
+        *cmid = ((*cmid - *cmin) * s) / (*cmax - *cmin);
+        *cmax = s;
+    } else {
+        *cmid = 0.0;
+        *cmax = 0.0;
+    }
+    *cmin = 0.0;
+}
+
+fn set_sat(c: vec3<f32>, s: f32) -> vec3<f32> {
+    var r = c.r;
+    var g = c.g;
+    var b = c.b;
+    if r <= g {
+        if g <= b {
+            set_sat_inner(&r, &g, &b, s);
+        } else {
+            if r <= b {
+                set_sat_inner(&r, &b, &g, s);
+            } else {
+                set_sat_inner(&b, &r, &g, s);
+            }
+        }
+    } else {
+        if r <= b {
+            set_sat_inner(&g, &r, &b, s);
+        } else {
+            if g <= b {
+                set_sat_inner(&g, &b, &r, s);
+            } else {
+                set_sat_inner(&b, &g, &r, s);
+            }
+        }
+    }
+    return vec3(r, g, b);
+}
+
+// Blends two RGB colors together. The colors are assumed to be in sRGB
+// color space, and this function does not take alpha into account.
+fn blend_mix(cb: vec3<f32>, cs: vec3<f32>, mode: u32) -> vec3<f32> {
+    var b = vec3(0.0);
+    switch mode {
+        case MIX_MULTIPLY: {
+            b = cb * cs;
+        }
+        case MIX_SCREEN: {
+            b = screen(cb, cs);
+        }
+        case MIX_OVERLAY: {
+            b = hard_light(cs, cb);
+        }
+        case MIX_DARKEN: {
+            b = min(cb, cs);
+        }
+        case MIX_LIGHTEN: {
+            b = max(cb, cs);
+        }
+        case MIX_COLOR_DODGE: {
+            b = vec3(color_dodge(cb.x, cs.x), color_dodge(cb.y, cs.y), color_dodge(cb.z, cs.z));
+        }
+        case MIX_COLOR_BURN: {
+            b = vec3(color_burn(cb.x, cs.x), color_burn(cb.y, cs.y), color_burn(cb.z, cs.z));
+        }
+        case MIX_HARD_LIGHT: {
+            b = hard_light(cb, cs);
+        }
+        case MIX_SOFT_LIGHT: {
+            b = soft_light(cb, cs);
+        }
+        case MIX_DIFFERENCE: {
+            b = abs(cb - cs);
+        }
+        case MIX_EXCLUSION: {
+            b = cb + cs - 2.0 * cb * cs;
+        }
+        case MIX_HUE: {
+            b = set_lum(set_sat(cs, sat(cb)), lum(cb));
+        }
+        case MIX_SATURATION: {
+            b = set_lum(set_sat(cb, sat(cs)), lum(cb));
+        }
+        case MIX_COLOR: {
+            b = set_lum(cs, lum(cb));
+        }
+        case MIX_LUMINOSITY: {
+            b = set_lum(cb, lum(cs));
+        }
+        default: {
+            b = cs;
+        }
+    }
+    return b;
 }
 
 

--- a/sparse_strips/vello_sparse_tests/snapshots/mix_compose_combined_test_matrix.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/mix_compose_combined_test_matrix.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2ee438b0f40c5126a5a3dd72a9a7b69cfa9b13f8bf4e04f9ae10ae1ba594b713
-size 1618
+oid sha256:e31cdc9c5cecc018212de3ec57f933dde6095f65d71b66dfc22a6c69688ab9cb
+size 1167

--- a/sparse_strips/vello_sparse_tests/snapshots/mix_compose_combined_test_matrix.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/mix_compose_combined_test_matrix.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ee438b0f40c5126a5a3dd72a9a7b69cfa9b13f8bf4e04f9ae10ae1ba594b713
+size 1618

--- a/sparse_strips/vello_sparse_tests/snapshots/mix_modes_non_gradient_test_matrix.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/mix_modes_non_gradient_test_matrix.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7fa6aafe204b71a08f0a296ba8b0bc5930da92d503d985d24155c3a67a40950
+size 1601

--- a/sparse_strips/vello_sparse_tests/tests/compose.rs
+++ b/sparse_strips/vello_sparse_tests/tests/compose.rs
@@ -332,7 +332,7 @@ fn deep_compose(ctx: &mut impl Renderer) {
 }
 
 // Ensure that compose and mix work together in the same blend layer.
-#[vello_test(width = 140, height = 160, cpu_u8_tolerance = 1, hybrid_tolerance = 15)]
+#[vello_test(width = 160, height = 160)]
 fn mix_compose_combined_test_matrix(ctx: &mut impl Renderer) {
     let mix_modes = [
         Mix::Normal,
@@ -353,7 +353,6 @@ fn mix_compose_combined_test_matrix(ctx: &mut impl Renderer) {
         Mix::Luminosity,
     ];
 
-    // Selected compose modes for combination testing
     let compose_modes = [
         Compose::Clear,
         Compose::Copy,
@@ -371,14 +370,11 @@ fn mix_compose_combined_test_matrix(ctx: &mut impl Renderer) {
         Compose::PlusLighter,
     ];
 
-    // Grid configuration
     let cell_size = 10.0;
 
-    // Draw background
     ctx.set_paint(Color::from_rgb8(30, 30, 30));
-    ctx.fill_rect(&Rect::new(0.0, 0.0, 160.0, 140.0));
+    ctx.fill_rect(&Rect::new(0.0, 0.0, 160.0, 160.0));
 
-    // Draw the grid: mix modes as rows, compose modes as columns
     for (row, mix_mode) in mix_modes.iter().enumerate() {
         for (col, compose_mode) in compose_modes.iter().enumerate() {
             let x = (col as f64) * cell_size;
@@ -386,14 +382,13 @@ fn mix_compose_combined_test_matrix(ctx: &mut impl Renderer) {
 
             ctx.set_transform(Affine::translate((x, y)));
 
-            // Create an isolated group
             ctx.push_blend_layer(BlendMode::new(Mix::Normal, Compose::SrcOver));
 
-            // Draw destination (magenta rectangle)
+            // Draw magenta rectangle for destination.
             ctx.set_paint(Color::from_rgb8(200, 0, 200).with_alpha(0.7));
             ctx.fill_rect(&Rect::new(0.0, 0.0, cell_size * 0.7, cell_size * 0.7));
 
-            // Apply combined blend mode (mix + compose) and draw source
+            // Push mix + compose blend layer with fill
             ctx.push_blend_layer(BlendMode::new(*mix_mode, *compose_mode));
             ctx.set_paint(Color::from_rgb8(10, 200, 200).with_alpha(0.7)); // Cyan
             ctx.fill_rect(&Rect::new(
@@ -407,40 +402,4 @@ fn mix_compose_combined_test_matrix(ctx: &mut impl Renderer) {
             ctx.pop_layer();
         }
     }
-
-    // Add a second pattern below with different colors
-    for (row, mix_mode) in mix_modes.iter().enumerate() {
-        for (col, compose_mode) in compose_modes.iter().take(6).enumerate() {
-            let x = (col as f64) * cell_size;
-            let y = (row as f64 + 8.0) * cell_size;
-
-            ctx.set_transform(Affine::translate((x, y)));
-
-            ctx.push_blend_layer(BlendMode::new(Mix::Normal, Compose::SrcOver));
-
-            // Draw destination (yellow circle-like pattern using rectangles)
-            ctx.set_paint(YELLOW.with_alpha(0.8));
-            ctx.fill_rect(&Rect::new(
-                cell_size * 0.2,
-                cell_size * 0.1,
-                cell_size * 0.6,
-                cell_size * 0.8,
-            ));
-
-            // Apply combined blend mode and draw source pattern
-            ctx.push_blend_layer(BlendMode::new(*mix_mode, *compose_mode));
-            ctx.set_paint(RED.with_alpha(0.8));
-            ctx.fill_rect(&Rect::new(
-                cell_size * 0.4,
-                cell_size * 0.4,
-                cell_size * 0.6,
-                cell_size * 0.6,
-            ));
-            ctx.pop_layer();
-
-            ctx.pop_layer();
-        }
-    }
-
-    ctx.set_transform(Affine::IDENTITY);
 }

--- a/sparse_strips/vello_sparse_tests/tests/compose.rs
+++ b/sparse_strips/vello_sparse_tests/tests/compose.rs
@@ -3,7 +3,7 @@
 
 use crate::renderer::Renderer;
 use vello_common::color::palette::css::{BLUE, GREEN, PURPLE, RED, YELLOW};
-use vello_common::kurbo::{Circle, Point, Rect, Shape};
+use vello_common::kurbo::{Affine, Circle, Point, Rect, Shape};
 use vello_common::peniko::{BlendMode, Color, Compose, Mix};
 use vello_dev_macros::vello_test;
 
@@ -329,4 +329,118 @@ fn deep_compose(ctx: &mut impl Renderer) {
     for _ in 0..=LAYER_COUNT {
         ctx.pop_layer();
     }
+}
+
+// Ensure that compose and mix work together in the same blend layer.
+#[vello_test(width = 140, height = 160, cpu_u8_tolerance = 1, hybrid_tolerance = 15)]
+fn mix_compose_combined_test_matrix(ctx: &mut impl Renderer) {
+    let mix_modes = [
+        Mix::Normal,
+        Mix::Multiply,
+        Mix::Screen,
+        Mix::Overlay,
+        Mix::Darken,
+        Mix::Lighten,
+        Mix::ColorDodge,
+        Mix::ColorBurn,
+        Mix::HardLight,
+        Mix::SoftLight,
+        Mix::Difference,
+        Mix::Exclusion,
+        Mix::Hue,
+        Mix::Saturation,
+        Mix::Color,
+        Mix::Luminosity,
+    ];
+
+    // Selected compose modes for combination testing
+    let compose_modes = [
+        Compose::Clear,
+        Compose::Copy,
+        Compose::Dest,
+        Compose::SrcOver,
+        Compose::DestOver,
+        Compose::SrcIn,
+        Compose::DestIn,
+        Compose::SrcOut,
+        Compose::DestOut,
+        Compose::SrcAtop,
+        Compose::DestAtop,
+        Compose::Xor,
+        Compose::Plus,
+        Compose::PlusLighter,
+    ];
+
+    // Grid configuration
+    let cell_size = 10.0;
+
+    // Draw background
+    ctx.set_paint(Color::from_rgb8(30, 30, 30));
+    ctx.fill_rect(&Rect::new(0.0, 0.0, 160.0, 140.0));
+
+    // Draw the grid: mix modes as rows, compose modes as columns
+    for (row, mix_mode) in mix_modes.iter().enumerate() {
+        for (col, compose_mode) in compose_modes.iter().enumerate() {
+            let x = (col as f64) * cell_size;
+            let y = (row as f64) * cell_size;
+
+            ctx.set_transform(Affine::translate((x, y)));
+
+            // Create an isolated group
+            ctx.push_blend_layer(BlendMode::new(Mix::Normal, Compose::SrcOver));
+
+            // Draw destination (magenta rectangle)
+            ctx.set_paint(Color::from_rgb8(200, 0, 200).with_alpha(0.7));
+            ctx.fill_rect(&Rect::new(0.0, 0.0, cell_size * 0.7, cell_size * 0.7));
+
+            // Apply combined blend mode (mix + compose) and draw source
+            ctx.push_blend_layer(BlendMode::new(*mix_mode, *compose_mode));
+            ctx.set_paint(Color::from_rgb8(10, 200, 200).with_alpha(0.7)); // Cyan
+            ctx.fill_rect(&Rect::new(
+                cell_size * 0.3,
+                cell_size * 0.3,
+                cell_size,
+                cell_size,
+            ));
+            ctx.pop_layer();
+
+            ctx.pop_layer();
+        }
+    }
+
+    // Add a second pattern below with different colors
+    for (row, mix_mode) in mix_modes.iter().enumerate() {
+        for (col, compose_mode) in compose_modes.iter().take(6).enumerate() {
+            let x = (col as f64) * cell_size;
+            let y = (row as f64 + 8.0) * cell_size;
+
+            ctx.set_transform(Affine::translate((x, y)));
+
+            ctx.push_blend_layer(BlendMode::new(Mix::Normal, Compose::SrcOver));
+
+            // Draw destination (yellow circle-like pattern using rectangles)
+            ctx.set_paint(YELLOW.with_alpha(0.8));
+            ctx.fill_rect(&Rect::new(
+                cell_size * 0.2,
+                cell_size * 0.1,
+                cell_size * 0.6,
+                cell_size * 0.8,
+            ));
+
+            // Apply combined blend mode and draw source pattern
+            ctx.push_blend_layer(BlendMode::new(*mix_mode, *compose_mode));
+            ctx.set_paint(RED.with_alpha(0.8));
+            ctx.fill_rect(&Rect::new(
+                cell_size * 0.4,
+                cell_size * 0.4,
+                cell_size * 0.6,
+                cell_size * 0.6,
+            ));
+            ctx.pop_layer();
+
+            ctx.pop_layer();
+        }
+    }
+
+    ctx.set_transform(Affine::IDENTITY);
 }

--- a/sparse_strips/vello_sparse_tests/tests/mix.rs
+++ b/sparse_strips/vello_sparse_tests/tests/mix.rs
@@ -4,12 +4,13 @@
 use crate::load_image;
 use crate::renderer::Renderer;
 use smallvec::smallvec;
-use vello_common::color::palette::css::{BLUE, LIME, MAGENTA, RED, YELLOW};
+use vello_common::color::palette::css::{BLUE, LIME, MAGENTA, ORANGE, RED, YELLOW};
 use vello_common::color::{AlphaColor, DynamicColor, Srgb};
 use vello_common::kurbo::{Affine, Point, Rect};
 use vello_common::paint::{Image, ImageSource};
 use vello_common::peniko::{
-    BlendMode, ColorStop, ColorStops, Compose, Extend, Gradient, GradientKind, ImageQuality, Mix,
+    BlendMode, Color, ColorStop, ColorStops, Compose, Extend, Gradient, GradientKind, ImageQuality,
+    Mix,
 };
 use vello_dev_macros::vello_test;
 
@@ -187,4 +188,82 @@ fn mix_color_with_solid(ctx: &mut impl Renderer) {
 #[vello_test]
 fn mix_saturation_with_solid(ctx: &mut impl Renderer) {
     mix_solid(ctx, Mix::Saturation);
+}
+
+// Currently `vello_hybrid` does not support gradients. This test ensure mix is tested in
+// `vello_hybrid` by using solid colors.
+#[vello_test(width = 80, height = 160, cpu_u8_tolerance = 1)]
+fn mix_modes_non_gradient_test_matrix(ctx: &mut impl Renderer) {
+    // All mix modes to test
+    let mix_modes = [
+        Mix::Normal,
+        Mix::Multiply,
+        Mix::Screen,
+        Mix::Overlay,
+        Mix::Darken,
+        Mix::Lighten,
+        Mix::ColorDodge,
+        Mix::ColorBurn,
+        Mix::HardLight,
+        Mix::SoftLight,
+        Mix::Difference,
+        Mix::Exclusion,
+        Mix::Hue,
+        Mix::Saturation,
+        Mix::Color,
+        Mix::Luminosity,
+    ];
+
+    // Base colors (destination rectangles)
+    let base_colors = [
+        RED,
+        Color::from_rgb8(10, 230, 10),
+        BLUE,
+        YELLOW,
+        MAGENTA,
+        Color::from_rgb8(10, 230, 230),  // Cyan
+        Color::from_rgb8(128, 128, 128), // Gray
+        Color::from_rgb8(64, 64, 64),    // Dark gray
+    ];
+
+    // Grid configuration
+    let cell_size = 10.0;
+
+    // Draw background
+    ctx.set_paint(Color::from_rgb8(30, 30, 30));
+    ctx.fill_rect(&Rect::new(0.0, 0.0, 800.0, 800.0));
+
+    // Draw the grid
+    for (row, mix_mode) in mix_modes.iter().enumerate() {
+        for (col, base_color) in base_colors.iter().enumerate() {
+            let x = (col as f64) * (cell_size);
+            let y = (row as f64) * (cell_size);
+
+            ctx.set_transform(Affine::translate((x, y)));
+
+            // Draw base rectangle (destination)
+            ctx.set_paint(*base_color);
+            ctx.fill_rect(&Rect::new(0.0, 0.0, cell_size, cell_size));
+
+            // Apply blend mode and draw overlay (source)
+            ctx.push_blend_layer(BlendMode::new(*mix_mode, Compose::SrcOver));
+
+            // Draw overlapping rectangles with semi-transparent orange
+            ctx.set_paint(ORANGE.with_alpha(0.7));
+            ctx.fill_rect(&Rect::new(0.0, 0.0, cell_size * 0.7, cell_size * 0.7));
+
+            // Draw another rectangle with semi-transparent white
+            ctx.set_paint(Color::WHITE.with_alpha(0.5));
+            ctx.fill_rect(&Rect::new(
+                cell_size * 0.3,
+                cell_size * 0.3,
+                cell_size,
+                cell_size,
+            ));
+
+            ctx.pop_layer();
+        }
+    }
+
+    ctx.set_transform(Affine::IDENTITY);
 }

--- a/sparse_strips/vello_sparse_tests/tests/mix.rs
+++ b/sparse_strips/vello_sparse_tests/tests/mix.rs
@@ -192,9 +192,8 @@ fn mix_saturation_with_solid(ctx: &mut impl Renderer) {
 
 // Currently `vello_hybrid` does not support gradients. This test ensure mix is tested in
 // `vello_hybrid` by using solid colors.
-#[vello_test(width = 80, height = 160, cpu_u8_tolerance = 1)]
+#[vello_test(width = 80, height = 160)]
 fn mix_modes_non_gradient_test_matrix(ctx: &mut impl Renderer) {
-    // All mix modes to test
     let mix_modes = [
         Mix::Normal,
         Mix::Multiply,
@@ -214,26 +213,23 @@ fn mix_modes_non_gradient_test_matrix(ctx: &mut impl Renderer) {
         Mix::Luminosity,
     ];
 
-    // Base colors (destination rectangles)
+    // Base colors for destination.
     let base_colors = [
         RED,
         Color::from_rgb8(10, 230, 10),
         BLUE,
         YELLOW,
         MAGENTA,
-        Color::from_rgb8(10, 230, 230),  // Cyan
-        Color::from_rgb8(128, 128, 128), // Gray
-        Color::from_rgb8(64, 64, 64),    // Dark gray
+        Color::from_rgb8(10, 230, 230),
+        Color::from_rgb8(128, 128, 128),
+        Color::from_rgb8(64, 64, 64),
     ];
 
-    // Grid configuration
     let cell_size = 10.0;
 
-    // Draw background
     ctx.set_paint(Color::from_rgb8(30, 30, 30));
-    ctx.fill_rect(&Rect::new(0.0, 0.0, 800.0, 800.0));
+    ctx.fill_rect(&Rect::new(0.0, 0.0, 80.0, 160.0));
 
-    // Draw the grid
     for (row, mix_mode) in mix_modes.iter().enumerate() {
         for (col, base_color) in base_colors.iter().enumerate() {
             let x = (col as f64) * (cell_size);
@@ -248,11 +244,9 @@ fn mix_modes_non_gradient_test_matrix(ctx: &mut impl Renderer) {
             // Apply blend mode and draw overlay (source)
             ctx.push_blend_layer(BlendMode::new(*mix_mode, Compose::SrcOver));
 
-            // Draw overlapping rectangles with semi-transparent orange
             ctx.set_paint(ORANGE.with_alpha(0.7));
             ctx.fill_rect(&Rect::new(0.0, 0.0, cell_size * 0.7, cell_size * 0.7));
 
-            // Draw another rectangle with semi-transparent white
             ctx.set_paint(Color::WHITE.with_alpha(0.5));
             ctx.fill_rect(&Rect::new(
                 cell_size * 0.3,
@@ -264,6 +258,4 @@ fn mix_modes_non_gradient_test_matrix(ctx: &mut impl Renderer) {
             ctx.pop_layer();
         }
     }
-
-    ctx.set_transform(Affine::IDENTITY);
 }


### PR DESCRIPTION
Part of: https://github.com/linebender/vello/issues/1165

### Context

This PR extends the `render_strips.wgsl` shader to also support `mix` with compositing.

### How

Functionally this is a very simple PR as we're leveraging the Vello classic shader math. The shaders are taken from [`blend.wgsl`](https://github.com/linebender/vello/blob/8acbf60b6d9271030a710b1075147bf842938c27/vello_shaders/shader/shared/blend.wgsl#L142).

### Test plan

All the existing `mix` tests currently depend on gradients (which `vello_hybrid` doesn't support). For this reason I've added two new "matrix" tests which cover all the cases in a single test without using gradient. This enables early test coverage for `vello_hybrid` without blocking on gradients.

Once gradients are supported we can enable all the rest of the `mix` tests.

