### PR TITLE
Improve tolerance calculation for stroke expansion

### DIFF
--- a/sparse_strips/vello_common/src/flatten.rs
+++ b/sparse_strips/vello_common/src/flatten.rs
@@ -133,8 +133,14 @@ pub fn stroke(
     line_buf: &mut Vec<Line>,
     flatten_ctx: &mut FlattenCtx,
 ) {
-    // TODO: Temporary hack to ensure that strokes are scaled properly by the transform.
-    let tolerance = TOL / affine.as_coeffs()[0].abs().max(affine.as_coeffs()[3].abs());
+    // A transform can be decomposed to a rotation, a scale along the x and y axes, and another
+    // rotation. We are interested in knowing the max scale along those axes. This is the same as
+    // finding the semi-major axis of the ellipse created by transforming the unit circle.
+    let max_scale = kurbo::Ellipse::from_affine(affine)
+        .radii()
+        .to_size()
+        .max_side();
+    let tolerance = TOL / max_scale;
 
     let expanded = expand_stroke(path, style, tolerance);
     fill(level, &expanded, affine, line_buf, flatten_ctx);


### PR DESCRIPTION
Motivated by the discussion in and around #977.

We'd want to mark the `Ellipse::radii` method as `#[inline(always)]` in Kurbo.