### PR TITLE
Fix examples crashing when resizing to zero.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ This release has an [MSRV][] of 1.85.
 
 - `register_texture`, a helper for using `wgpu` textures in a Vello `Renderer` ([#1161][] by [@DJMcNab][]).
 
+## Fixed
+
+- Examples crashing when window is resized to zero. ([#1182][] by [@xStrom][]).
+
 ## [0.5.1][] - 2025-08-22
 
 This release has an [MSRV][] of 1.85.
@@ -231,6 +235,7 @@ This release has an [MSRV][] of 1.75.
 [@tomcur]: https://github.com/tomcur
 [@TrueDoctor]: https://github.com/TrueDoctor
 [@waywardmonkeys]: https://github.com/waywardmonkeys
+[@xStrom]: https://github.com/xStrom
 [@yutannihilation]: https://github.com/yutannihilation
 
 [#416]: https://github.com/linebender/vello/pull/416
@@ -309,6 +314,7 @@ This release has an [MSRV][] of 1.75.
 [#841]: https://github.com/linebender/vello/pull/841
 [#1161]: https://github.com/linebender/vello/pull/1161
 [#1169]: https://github.com/linebender/vello/pull/1169
+[#1182]: https://github.com/linebender/vello/pull/1182
 
 <!-- Note that this still comparing against 0.5.0, because 0.5.1 is a cherry-picked patch -->
 [Unreleased]: https://github.com/linebender/vello/compare/v0.5.0...HEAD

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -23,6 +23,7 @@ enum RenderState {
     /// `RenderSurface` and `Window` for active rendering.
     Active {
         surface: Box<RenderSurface<'static>>,
+        valid_surface: bool,
         window: Arc<Window>,
     },
     /// Cache a window so that it can be reused when the app is resumed after being suspended.
@@ -30,19 +31,19 @@ enum RenderState {
 }
 
 struct SimpleVelloApp {
-    // The vello RenderContext which is a global context that lasts for the
-    // lifetime of the application
+    /// The Vello `RenderContext` which is a global context that lasts for the
+    /// lifetime of the application
     context: RenderContext,
 
-    // An array of renderers, one per wgpu device
+    /// An array of renderers, one per wgpu device
     renderers: Vec<Option<Renderer>>,
 
-    // State for our example where we store the winit Window and the wgpu Surface
+    /// State for our example where we store the winit Window and the wgpu Surface
     state: RenderState,
 
-    // A vello Scene which is a data structure which allows one to build up a
-    // description a scene to be drawn (with paths, fills, images, text, etc)
-    // which is then passed to a renderer for rendering
+    /// A vello Scene which is a data structure which allows one to build up a
+    /// description a scene to be drawn (with paths, fills, images, text, etc)
+    /// which is then passed to a renderer for rendering
     scene: Scene,
 }
 
@@ -76,6 +77,7 @@ impl ApplicationHandler for SimpleVelloApp {
         // Save the Window and Surface to a state variable
         self.state = RenderState::Active {
             surface: Box::new(surface),
+            valid_surface: true,
             window,
         };
     }
@@ -93,8 +95,12 @@ impl ApplicationHandler for SimpleVelloApp {
         event: WindowEvent,
     ) {
         // Only process events for our window, and only when we have a surface.
-        let surface = match &mut self.state {
-            RenderState::Active { surface, window } if window.id() == window_id => surface,
+        let (surface, valid_surface) = match &mut self.state {
+            RenderState::Active {
+                surface,
+                valid_surface,
+                window,
+            } if window.id() == window_id => (surface, valid_surface),
             _ => return,
         };
 
@@ -104,12 +110,21 @@ impl ApplicationHandler for SimpleVelloApp {
 
             // Resize the surface when the window is resized
             WindowEvent::Resized(size) => {
-                self.context
-                    .resize_surface(surface, size.width, size.height);
+                if size.width != 0 && size.height != 0 {
+                    self.context
+                        .resize_surface(surface, size.width, size.height);
+                    *valid_surface = true;
+                } else {
+                    *valid_surface = false;
+                }
             }
 
             // This is where all the rendering happens
             WindowEvent::RedrawRequested => {
+                if !*valid_surface {
+                    return;
+                }
+
                 // Empty the scene of objects to draw. You could create a new Scene each time, but in this case
                 // the same Scene is reused so that the underlying memory allocation can also be reused.
                 self.scene.reset();

--- a/vello/src/util.rs
+++ b/vello/src/util.rs
@@ -109,6 +109,10 @@ impl RenderContext {
     }
 
     /// Resizes the surface to the new dimensions.
+    ///
+    /// # Panics
+    ///
+    /// If `width` or `height` is zero.
     pub fn resize_surface(&self, surface: &mut RenderSurface<'_>, width: u32, height: u32) {
         let (texture, view) = create_targets(width, height, &self.devices[surface.dev_id].device);
         // TODO: Use clever resize semantics to avoid thrashing the memory allocator during a resize


### PR DESCRIPTION
When a window is resized such that one of its dimensions is zero, the examples will crash. That's because resizing a `wgpu` surface in such a way is an illegal operation.

This PR adds a new `valid_surface` flag to track whether the current surface can actually be drawn on. More serious applications should delete the surface for the duration, as seen in e.g. [xilem#1371](https://github.com/linebender/xilem/pull/1371), instead of tracking the legality with a flag. However, for the examples here, solving this with a flag was a path of lower resistance and good enough for examples.

Fixes #371