### PR TITLE
Make the aliasing threshold configurable

### DIFF
--- a/sparse_strips/vello_bench/src/data.rs
+++ b/sparse_strips/vello_bench/src/data.rs
@@ -154,7 +154,7 @@ impl DataItem {
             &mut strip_buf,
             &mut alpha_buf,
             Fill::NonZero,
-            true,
+            None,
             &lines,
         );
 

--- a/sparse_strips/vello_bench/src/strip.rs
+++ b/sparse_strips/vello_bench/src/strip.rs
@@ -29,7 +29,7 @@ pub fn render_strips(c: &mut Criterion) {
                         &mut strip_buf,
                         &mut alpha_buf,
                         Fill::NonZero,
-                        true,
+                        None,
                         &lines,
                     );
                     std::hint::black_box((&strip_buf, &alpha_buf));

--- a/sparse_strips/vello_common/src/strip.rs
+++ b/sparse_strips/vello_common/src/strip.rs
@@ -38,7 +38,7 @@ pub fn render(
     strip_buf: &mut Vec<Strip>,
     alpha_buf: &mut Vec<u8>,
     fill_rule: Fill,
-    anti_aliasing: bool,
+    alias_threshold: Option<u8>,
     lines: &[Line],
 ) {
     render_dispatch(
@@ -47,7 +47,7 @@ pub fn render(
         strip_buf,
         alpha_buf,
         fill_rule,
-        anti_aliasing,
+        alias_threshold,
         lines,
     );
 }
@@ -58,7 +58,7 @@ simd_dispatch!(fn render_dispatch(
     strip_buf: &mut Vec<Strip>,
     alpha_buf: &mut Vec<u8>,
     fill_rule: Fill,
-    anti_aliasing: bool,
+    alias_threshold: Option<u8>,
     lines: &[Line],
 ) = render_impl);
 
@@ -68,7 +68,7 @@ fn render_impl<S: Simd>(
     strip_buf: &mut Vec<Strip>,
     alpha_buf: &mut Vec<u8>,
     fill_rule: Fill,
-    anti_aliasing: bool,
+    alias_threshold: Option<u8>,
     lines: &[Line],
 ) {
     strip_buf.clear();
@@ -156,9 +156,9 @@ fn render_impl<S: Simd>(
 
             let mut u8_vals = f32_to_u8(s.combine_f32x8(p1, p2));
 
-            if !anti_aliasing {
+            if let Some(alias_threshold) = alias_threshold {
                 u8_vals = s.select_u8x16(
-                    u8_vals.simd_ge(u8x16::splat(s, 128)),
+                    u8_vals.simd_ge(u8x16::splat(s, alias_threshold)),
                     u8x16::splat(s, 255),
                     u8x16::splat(s, 0),
                 );

--- a/sparse_strips/vello_common/src/strip.rs
+++ b/sparse_strips/vello_common/src/strip.rs
@@ -38,7 +38,7 @@ pub fn render(
     strip_buf: &mut Vec<Strip>,
     alpha_buf: &mut Vec<u8>,
     fill_rule: Fill,
-    alias_threshold: Option<u8>,
+    aliasing_threshold: Option<u8>,
     lines: &[Line],
 ) {
     render_dispatch(
@@ -47,7 +47,7 @@ pub fn render(
         strip_buf,
         alpha_buf,
         fill_rule,
-        alias_threshold,
+        aliasing_threshold,
         lines,
     );
 }
@@ -58,7 +58,7 @@ simd_dispatch!(fn render_dispatch(
     strip_buf: &mut Vec<Strip>,
     alpha_buf: &mut Vec<u8>,
     fill_rule: Fill,
-    alias_threshold: Option<u8>,
+    aliasing_threshold: Option<u8>,
     lines: &[Line],
 ) = render_impl);
 
@@ -68,7 +68,7 @@ fn render_impl<S: Simd>(
     strip_buf: &mut Vec<Strip>,
     alpha_buf: &mut Vec<u8>,
     fill_rule: Fill,
-    alias_threshold: Option<u8>,
+    aliasing_threshold: Option<u8>,
     lines: &[Line],
 ) {
     strip_buf.clear();
@@ -156,9 +156,9 @@ fn render_impl<S: Simd>(
 
             let mut u8_vals = f32_to_u8(s.combine_f32x8(p1, p2));
 
-            if let Some(alias_threshold) = alias_threshold {
+            if let Some(aliasing_threshold) = aliasing_threshold {
                 u8_vals = s.select_u8x16(
-                    u8_vals.simd_ge(u8x16::splat(s, alias_threshold)),
+                    u8_vals.simd_ge(u8x16::splat(s, aliasing_threshold)),
                     u8x16::splat(s, 255),
                     u8x16::splat(s, 0),
                 );

--- a/sparse_strips/vello_common/src/strip_generator.rs
+++ b/sparse_strips/vello_common/src/strip_generator.rs
@@ -46,7 +46,7 @@ impl StripGenerator {
         path: impl IntoIterator<Item = PathEl>,
         fill_rule: Fill,
         transform: Affine,
-        alias_threshold: Option<u8>,
+        aliasing_threshold: Option<u8>,
         func: impl FnOnce(&'a [Strip]),
     ) {
         flatten::fill(
@@ -56,7 +56,7 @@ impl StripGenerator {
             &mut self.line_buf,
             &mut self.flatten_ctx,
         );
-        self.make_strips(fill_rule, alias_threshold);
+        self.make_strips(fill_rule, aliasing_threshold);
         func(&mut self.strip_buf);
     }
 
@@ -66,7 +66,7 @@ impl StripGenerator {
         path: impl IntoIterator<Item = PathEl>,
         stroke: &Stroke,
         transform: Affine,
-        alias_threshold: Option<u8>,
+        aliasing_threshold: Option<u8>,
         func: impl FnOnce(&'a [Strip]),
     ) {
         flatten::stroke(
@@ -77,7 +77,7 @@ impl StripGenerator {
             &mut self.line_buf,
             &mut self.flatten_ctx,
         );
-        self.make_strips(Fill::NonZero, alias_threshold);
+        self.make_strips(Fill::NonZero, aliasing_threshold);
         func(&mut self.strip_buf);
     }
 
@@ -114,7 +114,7 @@ impl StripGenerator {
         self.strip_buf.clear();
     }
 
-    fn make_strips(&mut self, fill_rule: Fill, alias_threshold: Option<u8>) {
+    fn make_strips(&mut self, fill_rule: Fill, aliasing_threshold: Option<u8>) {
         self.tiles
             .make_tiles(&self.line_buf, self.width, self.height);
         self.tiles.sort_tiles();
@@ -124,7 +124,7 @@ impl StripGenerator {
             &mut self.strip_buf,
             &mut self.alphas,
             fill_rule,
-            alias_threshold,
+            aliasing_threshold,
             &self.line_buf,
         );
     }

--- a/sparse_strips/vello_common/src/strip_generator.rs
+++ b/sparse_strips/vello_common/src/strip_generator.rs
@@ -146,7 +146,7 @@ mod tests {
             rect.to_path(0.1),
             Fill::NonZero,
             Affine::IDENTITY,
-            true,
+            None,
             |_| {},
         );
 

--- a/sparse_strips/vello_common/src/strip_generator.rs
+++ b/sparse_strips/vello_common/src/strip_generator.rs
@@ -46,7 +46,7 @@ impl StripGenerator {
         path: impl IntoIterator<Item = PathEl>,
         fill_rule: Fill,
         transform: Affine,
-        anti_alias: bool,
+        alias_threshold: Option<u8>,
         func: impl FnOnce(&'a [Strip]),
     ) {
         flatten::fill(
@@ -56,7 +56,7 @@ impl StripGenerator {
             &mut self.line_buf,
             &mut self.flatten_ctx,
         );
-        self.make_strips(fill_rule, anti_alias);
+        self.make_strips(fill_rule, alias_threshold);
         func(&mut self.strip_buf);
     }
 
@@ -66,7 +66,7 @@ impl StripGenerator {
         path: impl IntoIterator<Item = PathEl>,
         stroke: &Stroke,
         transform: Affine,
-        anti_alias: bool,
+        alias_threshold: Option<u8>,
         func: impl FnOnce(&'a [Strip]),
     ) {
         flatten::stroke(
@@ -77,7 +77,7 @@ impl StripGenerator {
             &mut self.line_buf,
             &mut self.flatten_ctx,
         );
-        self.make_strips(Fill::NonZero, anti_alias);
+        self.make_strips(Fill::NonZero, alias_threshold);
         func(&mut self.strip_buf);
     }
 
@@ -114,7 +114,7 @@ impl StripGenerator {
         self.strip_buf.clear();
     }
 
-    fn make_strips(&mut self, fill_rule: Fill, anti_alias: bool) {
+    fn make_strips(&mut self, fill_rule: Fill, alias_threshold: Option<u8>) {
         self.tiles
             .make_tiles(&self.line_buf, self.width, self.height);
         self.tiles.sort_tiles();
@@ -124,7 +124,7 @@ impl StripGenerator {
             &mut self.strip_buf,
             &mut self.alphas,
             fill_rule,
-            anti_alias,
+            alias_threshold,
             &self.line_buf,
         );
     }

--- a/sparse_strips/vello_cpu/src/dispatch/mod.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/mod.rs
@@ -24,7 +24,7 @@ pub(crate) trait Dispatcher: Debug + Send + Sync {
         fill_rule: Fill,
         transform: Affine,
         paint: Paint,
-        anti_alias: bool,
+        alias_threshold: Option<u8>,
     );
     fn stroke_path(
         &mut self,
@@ -32,7 +32,7 @@ pub(crate) trait Dispatcher: Debug + Send + Sync {
         stroke: &Stroke,
         transform: Affine,
         paint: Paint,
-        anti_alias: bool,
+        alias_threshold: Option<u8>,
     );
     fn push_layer(
         &mut self,
@@ -41,7 +41,7 @@ pub(crate) trait Dispatcher: Debug + Send + Sync {
         clip_transform: Affine,
         blend_mode: BlendMode,
         opacity: f32,
-        anti_alias: bool,
+        alias_threshold: Option<u8>,
         mask: Option<Mask>,
     );
     fn pop_layer(&mut self);

--- a/sparse_strips/vello_cpu/src/dispatch/mod.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/mod.rs
@@ -24,7 +24,7 @@ pub(crate) trait Dispatcher: Debug + Send + Sync {
         fill_rule: Fill,
         transform: Affine,
         paint: Paint,
-        alias_threshold: Option<u8>,
+        aliasing_threshold: Option<u8>,
     );
     fn stroke_path(
         &mut self,
@@ -32,7 +32,7 @@ pub(crate) trait Dispatcher: Debug + Send + Sync {
         stroke: &Stroke,
         transform: Affine,
         paint: Paint,
-        alias_threshold: Option<u8>,
+        aliasing_threshold: Option<u8>,
     );
     fn push_layer(
         &mut self,
@@ -41,7 +41,7 @@ pub(crate) trait Dispatcher: Debug + Send + Sync {
         clip_transform: Affine,
         blend_mode: BlendMode,
         opacity: f32,
-        alias_threshold: Option<u8>,
+        aliasing_threshold: Option<u8>,
         mask: Option<Mask>,
     );
     fn pop_layer(&mut self);

--- a/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
@@ -357,14 +357,14 @@ impl Dispatcher for MultiThreadedDispatcher {
         fill_rule: Fill,
         transform: Affine,
         paint: Paint,
-        alias_threshold: Option<u8>,
+        aliasing_threshold: Option<u8>,
     ) {
         self.register_task(RenderTask::FillPath {
             path: Path::new(path),
             transform,
             paint,
             fill_rule,
-            alias_threshold,
+            aliasing_threshold,
         });
     }
 
@@ -374,14 +374,14 @@ impl Dispatcher for MultiThreadedDispatcher {
         stroke: &Stroke,
         transform: Affine,
         paint: Paint,
-        alias_threshold: Option<u8>,
+        aliasing_threshold: Option<u8>,
     ) {
         self.register_task(RenderTask::StrokePath {
             path: Path::new(path),
             transform,
             paint,
             stroke: stroke.clone(),
-            alias_threshold,
+            aliasing_threshold,
         });
     }
 
@@ -408,7 +408,7 @@ impl Dispatcher for MultiThreadedDispatcher {
         clip_transform: Affine,
         blend_mode: BlendMode,
         opacity: f32,
-        alias_threshold: Option<u8>,
+        aliasing_threshold: Option<u8>,
         mask: Option<Mask>,
     ) {
         self.register_task(RenderTask::PushLayer {
@@ -417,7 +417,7 @@ impl Dispatcher for MultiThreadedDispatcher {
             opacity,
             mask,
             fill_rule,
-            alias_threshold,
+            aliasing_threshold,
         });
     }
 
@@ -547,14 +547,14 @@ pub(crate) enum RenderTask {
         transform: Affine,
         paint: Paint,
         fill_rule: Fill,
-        alias_threshold: Option<u8>,
+        aliasing_threshold: Option<u8>,
     },
     StrokePath {
         path: Path,
         transform: Affine,
         paint: Paint,
         stroke: Stroke,
-        alias_threshold: Option<u8>,
+        aliasing_threshold: Option<u8>,
     },
     PushLayer {
         clip_path: Option<(BezPath, Affine)>,
@@ -562,7 +562,7 @@ pub(crate) enum RenderTask {
         opacity: f32,
         mask: Option<Mask>,
         fill_rule: Fill,
-        alias_threshold: Option<u8>,
+        aliasing_threshold: Option<u8>,
     },
     PopLayer,
 }

--- a/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
@@ -357,14 +357,14 @@ impl Dispatcher for MultiThreadedDispatcher {
         fill_rule: Fill,
         transform: Affine,
         paint: Paint,
-        anti_alias: bool,
+        alias_threshold: Option<u8>,
     ) {
         self.register_task(RenderTask::FillPath {
             path: Path::new(path),
             transform,
             paint,
             fill_rule,
-            anti_alias,
+            alias_threshold,
         });
     }
 
@@ -374,14 +374,14 @@ impl Dispatcher for MultiThreadedDispatcher {
         stroke: &Stroke,
         transform: Affine,
         paint: Paint,
-        anti_alias: bool,
+        alias_threshold: Option<u8>,
     ) {
         self.register_task(RenderTask::StrokePath {
             path: Path::new(path),
             transform,
             paint,
             stroke: stroke.clone(),
-            anti_alias,
+            alias_threshold,
         });
     }
 
@@ -408,7 +408,7 @@ impl Dispatcher for MultiThreadedDispatcher {
         clip_transform: Affine,
         blend_mode: BlendMode,
         opacity: f32,
-        anti_alias: bool,
+        alias_threshold: Option<u8>,
         mask: Option<Mask>,
     ) {
         self.register_task(RenderTask::PushLayer {
@@ -417,7 +417,7 @@ impl Dispatcher for MultiThreadedDispatcher {
             opacity,
             mask,
             fill_rule,
-            anti_alias,
+            alias_threshold,
         });
     }
 
@@ -547,14 +547,14 @@ pub(crate) enum RenderTask {
         transform: Affine,
         paint: Paint,
         fill_rule: Fill,
-        anti_alias: bool,
+        alias_threshold: Option<u8>,
     },
     StrokePath {
         path: Path,
         transform: Affine,
         paint: Paint,
         stroke: Stroke,
-        anti_alias: bool,
+        alias_threshold: Option<u8>,
     },
     PushLayer {
         clip_path: Option<(BezPath, Affine)>,
@@ -562,7 +562,7 @@ pub(crate) enum RenderTask {
         opacity: f32,
         mask: Option<Mask>,
         fill_rule: Fill,
-        anti_alias: bool,
+        alias_threshold: Option<u8>,
     },
     PopLayer,
 }

--- a/sparse_strips/vello_cpu/src/dispatch/multi_threaded/worker.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/multi_threaded/worker.rs
@@ -51,7 +51,7 @@ impl Worker {
                     transform,
                     paint,
                     fill_rule,
-                    alias_threshold,
+                    aliasing_threshold,
                 } => {
                     let func = |strips: &[Strip]| {
                         let coarse_command = CoarseTask::Render {
@@ -70,7 +70,7 @@ impl Worker {
                                 &b,
                                 fill_rule,
                                 transform,
-                                alias_threshold,
+                                aliasing_threshold,
                                 func,
                             );
                         }
@@ -79,7 +79,7 @@ impl Worker {
                                 s.elements(),
                                 fill_rule,
                                 transform,
-                                alias_threshold,
+                                aliasing_threshold,
                                 func,
                             );
                         }
@@ -90,7 +90,7 @@ impl Worker {
                     transform,
                     paint,
                     stroke,
-                    alias_threshold,
+                    aliasing_threshold,
                 } => {
                     let func = |strips: &[Strip]| {
                         let coarse_command = CoarseTask::Render {
@@ -109,7 +109,7 @@ impl Worker {
                                 &b,
                                 &stroke,
                                 transform,
-                                alias_threshold,
+                                aliasing_threshold,
                                 func,
                             );
                         }
@@ -118,7 +118,7 @@ impl Worker {
                                 s.elements(),
                                 &stroke,
                                 transform,
-                                alias_threshold,
+                                aliasing_threshold,
                                 func,
                             );
                         }
@@ -130,7 +130,7 @@ impl Worker {
                     opacity,
                     mask,
                     fill_rule,
-                    alias_threshold,
+                    aliasing_threshold,
                 } => {
                     let clip = if let Some((c, transform)) = clip_path {
                         let mut strip_buf = &[][..];
@@ -138,7 +138,7 @@ impl Worker {
                             c,
                             fill_rule,
                             transform,
-                            alias_threshold,
+                            aliasing_threshold,
                             |strips| strip_buf = strips,
                         );
 

--- a/sparse_strips/vello_cpu/src/dispatch/multi_threaded/worker.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/multi_threaded/worker.rs
@@ -51,7 +51,7 @@ impl Worker {
                     transform,
                     paint,
                     fill_rule,
-                    anti_alias,
+                    alias_threshold,
                 } => {
                     let func = |strips: &[Strip]| {
                         let coarse_command = CoarseTask::Render {
@@ -66,15 +66,20 @@ impl Worker {
 
                     match path {
                         Path::Bez(b) => {
-                            self.strip_generator
-                                .generate_filled_path(&b, fill_rule, transform, anti_alias, func);
+                            self.strip_generator.generate_filled_path(
+                                &b,
+                                fill_rule,
+                                transform,
+                                alias_threshold,
+                                func,
+                            );
                         }
                         Path::Small(s) => {
                             self.strip_generator.generate_filled_path(
                                 s.elements(),
                                 fill_rule,
                                 transform,
-                                anti_alias,
+                                alias_threshold,
                                 func,
                             );
                         }
@@ -85,7 +90,7 @@ impl Worker {
                     transform,
                     paint,
                     stroke,
-                    anti_alias,
+                    alias_threshold,
                 } => {
                     let func = |strips: &[Strip]| {
                         let coarse_command = CoarseTask::Render {
@@ -100,15 +105,20 @@ impl Worker {
 
                     match path {
                         Path::Bez(b) => {
-                            self.strip_generator
-                                .generate_stroked_path(&b, &stroke, transform, anti_alias, func);
+                            self.strip_generator.generate_stroked_path(
+                                &b,
+                                &stroke,
+                                transform,
+                                alias_threshold,
+                                func,
+                            );
                         }
                         Path::Small(s) => {
                             self.strip_generator.generate_stroked_path(
                                 s.elements(),
                                 &stroke,
                                 transform,
-                                anti_alias,
+                                alias_threshold,
                                 func,
                             );
                         }
@@ -120,7 +130,7 @@ impl Worker {
                     opacity,
                     mask,
                     fill_rule,
-                    anti_alias,
+                    alias_threshold,
                 } => {
                     let clip = if let Some((c, transform)) = clip_path {
                         let mut strip_buf = &[][..];
@@ -128,7 +138,7 @@ impl Worker {
                             c,
                             fill_rule,
                             transform,
-                            anti_alias,
+                            alias_threshold,
                             |strips| strip_buf = strips,
                         );
 

--- a/sparse_strips/vello_cpu/src/dispatch/single_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/single_threaded.rs
@@ -97,13 +97,18 @@ impl Dispatcher for SingleThreadedDispatcher {
         fill_rule: Fill,
         transform: Affine,
         paint: Paint,
-        anti_alias: bool,
+        alias_threshold: Option<u8>,
     ) {
         let wide = &mut self.wide;
 
         let func = |strips| wide.generate(strips, fill_rule, paint, 0);
-        self.strip_generator
-            .generate_filled_path(path, fill_rule, transform, anti_alias, func);
+        self.strip_generator.generate_filled_path(
+            path,
+            fill_rule,
+            transform,
+            alias_threshold,
+            func,
+        );
     }
 
     fn stroke_path(
@@ -112,13 +117,13 @@ impl Dispatcher for SingleThreadedDispatcher {
         stroke: &Stroke,
         transform: Affine,
         paint: Paint,
-        anti_alias: bool,
+        alias_threshold: Option<u8>,
     ) {
         let wide = &mut self.wide;
 
         let func = |strips| wide.generate(strips, Fill::NonZero, paint, 0);
         self.strip_generator
-            .generate_stroked_path(path, stroke, transform, anti_alias, func);
+            .generate_stroked_path(path, stroke, transform, alias_threshold, func);
     }
 
     fn alpha_buf(&self) -> &[u8] {
@@ -144,7 +149,7 @@ impl Dispatcher for SingleThreadedDispatcher {
         clip_transform: Affine,
         blend_mode: BlendMode,
         opacity: f32,
-        anti_alias: bool,
+        alias_threshold: Option<u8>,
         mask: Option<Mask>,
     ) {
         let clip = if let Some(c) = clip_path {
@@ -156,7 +161,7 @@ impl Dispatcher for SingleThreadedDispatcher {
                 c,
                 fill_rule,
                 clip_transform,
-                anti_alias,
+                alias_threshold,
                 |strips| strip_buf = strips,
             );
 

--- a/sparse_strips/vello_cpu/src/dispatch/single_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/single_threaded.rs
@@ -97,7 +97,7 @@ impl Dispatcher for SingleThreadedDispatcher {
         fill_rule: Fill,
         transform: Affine,
         paint: Paint,
-        alias_threshold: Option<u8>,
+        aliasing_threshold: Option<u8>,
     ) {
         let wide = &mut self.wide;
 
@@ -106,7 +106,7 @@ impl Dispatcher for SingleThreadedDispatcher {
             path,
             fill_rule,
             transform,
-            alias_threshold,
+            aliasing_threshold,
             func,
         );
     }
@@ -117,13 +117,18 @@ impl Dispatcher for SingleThreadedDispatcher {
         stroke: &Stroke,
         transform: Affine,
         paint: Paint,
-        alias_threshold: Option<u8>,
+        aliasing_threshold: Option<u8>,
     ) {
         let wide = &mut self.wide;
 
         let func = |strips| wide.generate(strips, Fill::NonZero, paint, 0);
-        self.strip_generator
-            .generate_stroked_path(path, stroke, transform, alias_threshold, func);
+        self.strip_generator.generate_stroked_path(
+            path,
+            stroke,
+            transform,
+            aliasing_threshold,
+            func,
+        );
     }
 
     fn alpha_buf(&self) -> &[u8] {
@@ -149,7 +154,7 @@ impl Dispatcher for SingleThreadedDispatcher {
         clip_transform: Affine,
         blend_mode: BlendMode,
         opacity: f32,
-        alias_threshold: Option<u8>,
+        aliasing_threshold: Option<u8>,
         mask: Option<Mask>,
     ) {
         let clip = if let Some(c) = clip_path {
@@ -161,7 +166,7 @@ impl Dispatcher for SingleThreadedDispatcher {
                 c,
                 fill_rule,
                 clip_transform,
-                alias_threshold,
+                aliasing_threshold,
                 |strips| strip_buf = strips,
             );
 

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -49,7 +49,7 @@ pub struct RenderContext {
     pub(crate) fill_rule: Fill,
     pub(crate) temp_path: BezPath,
     // TODO: Consider taking a configurable threshold instead of just a boolean value here.
-    pub(crate) alias_threshold: Option<u8>,
+    pub(crate) aliasing_threshold: Option<u8>,
     pub(crate) encoded_paints: Vec<EncodedPaint>,
     #[cfg_attr(
         not(feature = "text"),
@@ -131,14 +131,14 @@ impl RenderContext {
         };
         let encoded_paints = vec![];
         let temp_path = BezPath::new();
-        let alias_threshold = None;
+        let aliasing_threshold = None;
 
         Self {
             width,
             height,
             dispatcher,
             transform,
-            alias_threshold,
+            aliasing_threshold,
             paint,
             render_settings: settings,
             paint_transform,
@@ -174,7 +174,7 @@ impl RenderContext {
             self.fill_rule,
             self.transform,
             paint,
-            self.alias_threshold,
+            self.aliasing_threshold,
         );
     }
 
@@ -186,7 +186,7 @@ impl RenderContext {
             &self.stroke,
             self.transform,
             paint,
-            self.alias_threshold,
+            self.aliasing_threshold,
         );
     }
 
@@ -213,7 +213,7 @@ impl RenderContext {
             self.fill_rule,
             self.transform,
             paint,
-            self.alias_threshold,
+            self.aliasing_threshold,
         );
     }
 
@@ -249,7 +249,7 @@ impl RenderContext {
             Fill::NonZero,
             self.transform,
             paint,
-            self.alias_threshold,
+            self.aliasing_threshold,
         );
     }
 
@@ -293,7 +293,7 @@ impl RenderContext {
             self.transform,
             blend_mode,
             opacity,
-            self.alias_threshold,
+            self.aliasing_threshold,
             mask,
         );
     }
@@ -324,8 +324,8 @@ impl RenderContext {
     ///
     /// Note that there is no performance benefit to disabling anti-aliasing and
     /// this functionality is simply provided for compatibility.
-    pub fn set_aliasing_threshold(&mut self, value: Option<u8>) {
-        self.alias_threshold = value;
+    pub fn set_aliasing_threshold(&mut self, aliasing_threshold: Option<u8>) {
+        self.aliasing_threshold = aliasing_threshold;
     }
 
     /// Push a new mask layer.
@@ -487,7 +487,7 @@ impl GlyphRenderer for RenderContext {
                     Fill::NonZero,
                     prepared_glyph.transform,
                     paint,
-                    self.alias_threshold,
+                    self.aliasing_threshold,
                 );
             }
             GlyphType::Bitmap(glyph) => {
@@ -582,7 +582,7 @@ impl GlyphRenderer for RenderContext {
                     &self.stroke,
                     prepared_glyph.transform,
                     paint,
-                    self.alias_threshold,
+                    self.aliasing_threshold,
                 );
             }
             GlyphType::Bitmap(_) | GlyphType::Colr(_) => {
@@ -893,7 +893,7 @@ impl RenderContext {
             path,
             self.fill_rule,
             transform,
-            self.alias_threshold,
+            self.aliasing_threshold,
             |generated_strips| {
                 strips.extend_from_slice(generated_strips);
             },
@@ -912,7 +912,7 @@ impl RenderContext {
             path,
             &self.stroke,
             transform,
-            self.alias_threshold,
+            self.aliasing_threshold,
             |generated_strips| {
                 strips.extend_from_slice(generated_strips);
             },

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -49,7 +49,7 @@ pub struct RenderContext {
     pub(crate) fill_rule: Fill,
     pub(crate) temp_path: BezPath,
     // TODO: Consider taking a configurable threshold instead of just a boolean value here.
-    pub(crate) anti_alias: bool,
+    pub(crate) alias_threshold: Option<u8>,
     pub(crate) encoded_paints: Vec<EncodedPaint>,
     #[cfg_attr(
         not(feature = "text"),
@@ -131,14 +131,14 @@ impl RenderContext {
         };
         let encoded_paints = vec![];
         let temp_path = BezPath::new();
-        let anti_alias = true;
+        let alias_threshold = None;
 
         Self {
             width,
             height,
             dispatcher,
             transform,
-            anti_alias,
+            alias_threshold,
             paint,
             render_settings: settings,
             paint_transform,
@@ -169,15 +169,25 @@ impl RenderContext {
     /// Fill a path.
     pub fn fill_path(&mut self, path: &BezPath) {
         let paint = self.encode_current_paint();
-        self.dispatcher
-            .fill_path(path, self.fill_rule, self.transform, paint, self.anti_alias);
+        self.dispatcher.fill_path(
+            path,
+            self.fill_rule,
+            self.transform,
+            paint,
+            self.alias_threshold,
+        );
     }
 
     /// Stroke a path.
     pub fn stroke_path(&mut self, path: &BezPath) {
         let paint = self.encode_current_paint();
-        self.dispatcher
-            .stroke_path(path, &self.stroke, self.transform, paint, self.anti_alias);
+        self.dispatcher.stroke_path(
+            path,
+            &self.stroke,
+            self.transform,
+            paint,
+            self.alias_threshold,
+        );
     }
 
     /// Fill a rectangle.
@@ -203,7 +213,7 @@ impl RenderContext {
             self.fill_rule,
             self.transform,
             paint,
-            self.anti_alias,
+            self.alias_threshold,
         );
     }
 
@@ -239,7 +249,7 @@ impl RenderContext {
             Fill::NonZero,
             self.transform,
             paint,
-            self.anti_alias,
+            self.alias_threshold,
         );
     }
 
@@ -283,7 +293,7 @@ impl RenderContext {
             self.transform,
             blend_mode,
             opacity,
-            self.anti_alias,
+            self.alias_threshold,
             mask,
         );
     }
@@ -303,9 +313,19 @@ impl RenderContext {
         self.push_layer(None, None, Some(opacity), None);
     }
 
-    /// Set whether to enable anti-aliasing.
-    pub fn set_anti_aliasing(&mut self, value: bool) {
-        self.anti_alias = value;
+    /// Set the aliasing threshold.
+    ///
+    /// If set to `None` (which is the recommended option in nearly all cases),
+    /// anti-aliasing will be applied.
+    ///
+    /// If instead set to some value, then a pixel will be fully painted if
+    /// the coverage is bigger than the threshold (between 0 and 255), otherwise
+    /// it will not be painted at all.
+    ///
+    /// Note that there is no performance benefit to disabling anti-aliasing and
+    /// this functionality is simply provided for compatibility.
+    pub fn set_aliasing_threshold(&mut self, value: Option<u8>) {
+        self.alias_threshold = value;
     }
 
     /// Push a new mask layer.
@@ -467,7 +487,7 @@ impl GlyphRenderer for RenderContext {
                     Fill::NonZero,
                     prepared_glyph.transform,
                     paint,
-                    self.anti_alias,
+                    self.alias_threshold,
                 );
             }
             GlyphType::Bitmap(glyph) => {
@@ -562,7 +582,7 @@ impl GlyphRenderer for RenderContext {
                     &self.stroke,
                     prepared_glyph.transform,
                     paint,
-                    self.anti_alias,
+                    self.alias_threshold,
                 );
             }
             GlyphType::Bitmap(_) | GlyphType::Colr(_) => {
@@ -873,7 +893,7 @@ impl RenderContext {
             path,
             self.fill_rule,
             transform,
-            self.anti_alias,
+            self.alias_threshold,
             |generated_strips| {
                 strips.extend_from_slice(generated_strips);
             },
@@ -892,7 +912,7 @@ impl RenderContext {
             path,
             &self.stroke,
             transform,
-            self.anti_alias,
+            self.alias_threshold,
             |generated_strips| {
                 strips.extend_from_slice(generated_strips);
             },

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -48,7 +48,6 @@ pub struct RenderContext {
     pub(crate) transform: Affine,
     pub(crate) fill_rule: Fill,
     pub(crate) temp_path: BezPath,
-    // TODO: Consider taking a configurable threshold instead of just a boolean value here.
     pub(crate) aliasing_threshold: Option<u8>,
     pub(crate) encoded_paints: Vec<EncodedPaint>,
     #[cfg_attr(

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -46,7 +46,7 @@ pub struct Scene {
     pub(crate) wide: Wide<MODE_HYBRID>,
     pub(crate) paint: PaintType,
     pub(crate) paint_transform: Affine,
-    pub(crate) anti_alias: bool,
+    pub(crate) alias_threshold: Option<u8>,
     pub(crate) encoded_paints: Vec<EncodedPaint>,
     paint_visible: bool,
     pub(crate) stroke: Stroke,
@@ -64,7 +64,7 @@ impl Scene {
             width,
             height,
             wide: Wide::<MODE_HYBRID>::new(width, height),
-            anti_alias: true,
+            alias_threshold: None,
             paint: render_state.paint,
             paint_transform: render_state.paint_transform,
             encoded_paints: vec![],
@@ -126,7 +126,13 @@ impl Scene {
         }
 
         let paint = self.encode_current_paint();
-        self.fill_path_with(path, self.transform, self.fill_rule, paint, self.anti_alias);
+        self.fill_path_with(
+            path,
+            self.transform,
+            self.fill_rule,
+            paint,
+            self.alias_threshold,
+        );
     }
 
     /// Build strips for a filled path with the given properties.
@@ -136,12 +142,17 @@ impl Scene {
         transform: Affine,
         fill_rule: Fill,
         paint: Paint,
-        anti_alias: bool,
+        alias_threshold: Option<u8>,
     ) {
         let wide = &mut self.wide;
         let func = |strips| wide.generate(strips, fill_rule, paint, 0);
-        self.strip_generator
-            .generate_filled_path(path, fill_rule, transform, anti_alias, func);
+        self.strip_generator.generate_filled_path(
+            path,
+            fill_rule,
+            transform,
+            alias_threshold,
+            func,
+        );
     }
 
     /// Stroke a path with the current paint and stroke settings.
@@ -151,7 +162,7 @@ impl Scene {
         }
 
         let paint = self.encode_current_paint();
-        self.stroke_path_with(path, self.transform, paint, self.anti_alias);
+        self.stroke_path_with(path, self.transform, paint, self.alias_threshold);
     }
 
     /// Build strips for a stroked path with the given properties.
@@ -160,17 +171,32 @@ impl Scene {
         path: &BezPath,
         transform: Affine,
         paint: Paint,
-        anti_alias: bool,
+        alias_threshold: Option<u8>,
     ) {
         let wide = &mut self.wide;
         let func = |strips| wide.generate(strips, Fill::NonZero, paint, 0);
-        self.strip_generator
-            .generate_stroked_path(path, &self.stroke, transform, anti_alias, func);
+        self.strip_generator.generate_stroked_path(
+            path,
+            &self.stroke,
+            transform,
+            alias_threshold,
+            func,
+        );
     }
 
-    /// Set whether to enable anti-aliasing.
-    pub fn set_anti_aliasing(&mut self, value: bool) {
-        self.anti_alias = value;
+    /// Set the aliasing threshold.
+    ///
+    /// If set to `None` (which is the recommended option in nearly all cases),
+    /// anti-aliasing will be applied.
+    ///
+    /// If instead set to some value, then a pixel will be fully painted if
+    /// the coverage is bigger than the threshold (between 0 and 255), otherwise
+    /// it will not be painted at all.
+    ///
+    /// Note that there is no performance benefit to disabling anti-aliasing and
+    /// this functionality is simply provided for compatibility.
+    pub fn set_aliasing_threshold(&mut self, value: Option<u8>) {
+        self.alias_threshold = value;
     }
 
     /// Fill a rectangle with the current paint and fill rule.
@@ -205,7 +231,7 @@ impl Scene {
                 c,
                 self.fill_rule,
                 self.transform,
-                self.anti_alias,
+                self.alias_threshold,
                 |strips| strip_buf = strips,
             );
 
@@ -325,7 +351,7 @@ impl GlyphRenderer for Scene {
                     prepared_glyph.transform,
                     Fill::NonZero,
                     paint,
-                    self.anti_alias,
+                    self.alias_threshold,
                 );
             }
             GlyphType::Bitmap(_) => {}
@@ -337,7 +363,12 @@ impl GlyphRenderer for Scene {
         match prepared_glyph.glyph_type {
             GlyphType::Outline(glyph) => {
                 let paint = self.encode_current_paint();
-                self.stroke_path_with(glyph.path, prepared_glyph.transform, paint, self.anti_alias);
+                self.stroke_path_with(
+                    glyph.path,
+                    prepared_glyph.transform,
+                    paint,
+                    self.alias_threshold,
+                );
             }
             GlyphType::Bitmap(_) => {}
             GlyphType::Colr(_) => {}
@@ -547,7 +578,7 @@ impl Scene {
             path,
             self.fill_rule,
             transform,
-            self.anti_alias,
+            self.alias_threshold,
             |generated_strips| {
                 strips.extend_from_slice(generated_strips);
             },
@@ -565,7 +596,7 @@ impl Scene {
             path,
             &self.stroke,
             transform,
-            self.anti_alias,
+            self.alias_threshold,
             |generated_strips| {
                 strips.extend_from_slice(generated_strips);
             },

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -46,7 +46,7 @@ pub struct Scene {
     pub(crate) wide: Wide<MODE_HYBRID>,
     pub(crate) paint: PaintType,
     pub(crate) paint_transform: Affine,
-    pub(crate) alias_threshold: Option<u8>,
+    pub(crate) aliasing_threshold: Option<u8>,
     pub(crate) encoded_paints: Vec<EncodedPaint>,
     paint_visible: bool,
     pub(crate) stroke: Stroke,
@@ -64,7 +64,7 @@ impl Scene {
             width,
             height,
             wide: Wide::<MODE_HYBRID>::new(width, height),
-            alias_threshold: None,
+            aliasing_threshold: None,
             paint: render_state.paint,
             paint_transform: render_state.paint_transform,
             encoded_paints: vec![],
@@ -131,7 +131,7 @@ impl Scene {
             self.transform,
             self.fill_rule,
             paint,
-            self.alias_threshold,
+            self.aliasing_threshold,
         );
     }
 
@@ -142,7 +142,7 @@ impl Scene {
         transform: Affine,
         fill_rule: Fill,
         paint: Paint,
-        alias_threshold: Option<u8>,
+        aliasing_threshold: Option<u8>,
     ) {
         let wide = &mut self.wide;
         let func = |strips| wide.generate(strips, fill_rule, paint, 0);
@@ -150,7 +150,7 @@ impl Scene {
             path,
             fill_rule,
             transform,
-            alias_threshold,
+            aliasing_threshold,
             func,
         );
     }
@@ -162,7 +162,7 @@ impl Scene {
         }
 
         let paint = self.encode_current_paint();
-        self.stroke_path_with(path, self.transform, paint, self.alias_threshold);
+        self.stroke_path_with(path, self.transform, paint, self.aliasing_threshold);
     }
 
     /// Build strips for a stroked path with the given properties.
@@ -171,7 +171,7 @@ impl Scene {
         path: &BezPath,
         transform: Affine,
         paint: Paint,
-        alias_threshold: Option<u8>,
+        aliasing_threshold: Option<u8>,
     ) {
         let wide = &mut self.wide;
         let func = |strips| wide.generate(strips, Fill::NonZero, paint, 0);
@@ -179,7 +179,7 @@ impl Scene {
             path,
             &self.stroke,
             transform,
-            alias_threshold,
+            aliasing_threshold,
             func,
         );
     }
@@ -195,8 +195,8 @@ impl Scene {
     ///
     /// Note that there is no performance benefit to disabling anti-aliasing and
     /// this functionality is simply provided for compatibility.
-    pub fn set_aliasing_threshold(&mut self, value: Option<u8>) {
-        self.alias_threshold = value;
+    pub fn set_aliasing_threshold(&mut self, aliasing_threshold: Option<u8>) {
+        self.aliasing_threshold = aliasing_threshold;
     }
 
     /// Fill a rectangle with the current paint and fill rule.
@@ -231,7 +231,7 @@ impl Scene {
                 c,
                 self.fill_rule,
                 self.transform,
-                self.alias_threshold,
+                self.aliasing_threshold,
                 |strips| strip_buf = strips,
             );
 
@@ -351,7 +351,7 @@ impl GlyphRenderer for Scene {
                     prepared_glyph.transform,
                     Fill::NonZero,
                     paint,
-                    self.alias_threshold,
+                    self.aliasing_threshold,
                 );
             }
             GlyphType::Bitmap(_) => {}
@@ -367,7 +367,7 @@ impl GlyphRenderer for Scene {
                     glyph.path,
                     prepared_glyph.transform,
                     paint,
-                    self.alias_threshold,
+                    self.aliasing_threshold,
                 );
             }
             GlyphType::Bitmap(_) => {}
@@ -578,7 +578,7 @@ impl Scene {
             path,
             self.fill_rule,
             transform,
-            self.alias_threshold,
+            self.aliasing_threshold,
             |generated_strips| {
                 strips.extend_from_slice(generated_strips);
             },
@@ -596,7 +596,7 @@ impl Scene {
             path,
             &self.stroke,
             transform,
-            self.alias_threshold,
+            self.aliasing_threshold,
             |generated_strips| {
                 strips.extend_from_slice(generated_strips);
             },

--- a/sparse_strips/vello_sparse_tests/tests/basic.rs
+++ b/sparse_strips/vello_sparse_tests/tests/basic.rs
@@ -392,7 +392,7 @@ fn oversized_star(ctx: &mut impl Renderer) {
 #[vello_test(width = 100, height = 100)]
 fn no_anti_aliasing(ctx: &mut impl Renderer) {
     let rect = Rect::new(30.0, 30.0, 70.0, 70.0);
-    ctx.set_anti_aliasing(false);
+    ctx.set_aliasing_threshold(Some(128));
 
     ctx.set_transform(Affine::rotate_about(
         45.0 * PI / 180.0,
@@ -404,7 +404,7 @@ fn no_anti_aliasing(ctx: &mut impl Renderer) {
 
 #[vello_test(width = 100, height = 100)]
 fn no_anti_aliasing_clip_path(ctx: &mut impl Renderer) {
-    ctx.set_anti_aliasing(false);
+    ctx.set_aliasing_threshold(Some(128));
     let rect = Rect::new(0.0, 0.0, 100.0, 100.0);
     let star_path = crossed_line_star();
 

--- a/sparse_strips/vello_sparse_tests/tests/renderer.rs
+++ b/sparse_strips/vello_sparse_tests/tests/renderer.rs
@@ -50,7 +50,7 @@ pub(crate) trait Renderer: Sized + GlyphRenderer {
     fn set_paint_transform(&mut self, affine: Affine);
     fn set_fill_rule(&mut self, fill_rule: Fill);
     fn set_transform(&mut self, transform: Affine);
-    fn set_aliasing_threshold(&mut self, value: Option<u8>);
+    fn set_aliasing_threshold(&mut self, aliasing_threshold: Option<u8>);
     fn render_to_pixmap(&self, pixmap: &mut Pixmap);
     fn width(&self) -> u16;
     fn height(&self) -> u16;
@@ -157,8 +157,8 @@ impl Renderer for RenderContext {
         Self::set_transform(self, transform);
     }
 
-    fn set_aliasing_threshold(&mut self, value: Option<u8>) {
-        Self::set_aliasing_threshold(self, value);
+    fn set_aliasing_threshold(&mut self, aliasing_threshold: Option<u8>) {
+        Self::set_aliasing_threshold(self, aliasing_threshold);
     }
 
     fn render_to_pixmap(&self, pixmap: &mut Pixmap) {
@@ -348,8 +348,8 @@ impl Renderer for HybridRenderer {
         self.scene.set_transform(transform);
     }
 
-    fn set_aliasing_threshold(&mut self, value: Option<u8>) {
-        self.scene.set_aliasing_threshold(value);
+    fn set_aliasing_threshold(&mut self, aliasing_threshold: Option<u8>) {
+        self.scene.set_aliasing_threshold(aliasing_threshold);
     }
 
     // This method creates device resources every time it is called. This does not matter much for

--- a/sparse_strips/vello_sparse_tests/tests/renderer.rs
+++ b/sparse_strips/vello_sparse_tests/tests/renderer.rs
@@ -632,8 +632,8 @@ impl Renderer for HybridRenderer {
         self.scene.set_transform(transform);
     }
 
-    fn set_aliasing_threshold(&mut self, value: bool) {
-        self.scene.set_aliasing_threshold(value);
+    fn set_aliasing_threshold(&mut self, aliasing_threshold: Option<u8>) {
+        self.scene.set_aliasing_threshold(aliasing_threshold);
     }
 
     // vello_hybrid WebGL renderer backend.

--- a/sparse_strips/vello_sparse_tests/tests/renderer.rs
+++ b/sparse_strips/vello_sparse_tests/tests/renderer.rs
@@ -50,7 +50,7 @@ pub(crate) trait Renderer: Sized + GlyphRenderer {
     fn set_paint_transform(&mut self, affine: Affine);
     fn set_fill_rule(&mut self, fill_rule: Fill);
     fn set_transform(&mut self, transform: Affine);
-    fn set_anti_aliasing(&mut self, value: bool);
+    fn set_aliasing_threshold(&mut self, value: Option<u8>);
     fn render_to_pixmap(&self, pixmap: &mut Pixmap);
     fn width(&self) -> u16;
     fn height(&self) -> u16;
@@ -157,8 +157,8 @@ impl Renderer for RenderContext {
         Self::set_transform(self, transform);
     }
 
-    fn set_anti_aliasing(&mut self, value: bool) {
-        Self::set_anti_aliasing(self, value);
+    fn set_aliasing_threshold(&mut self, value: Option<u8>) {
+        Self::set_aliasing_threshold(self, value);
     }
 
     fn render_to_pixmap(&self, pixmap: &mut Pixmap) {
@@ -348,8 +348,8 @@ impl Renderer for HybridRenderer {
         self.scene.set_transform(transform);
     }
 
-    fn set_anti_aliasing(&mut self, value: bool) {
-        self.scene.set_anti_aliasing(value);
+    fn set_aliasing_threshold(&mut self, value: Option<u8>) {
+        self.scene.set_aliasing_threshold(value);
     }
 
     // This method creates device resources every time it is called. This does not matter much for
@@ -632,8 +632,8 @@ impl Renderer for HybridRenderer {
         self.scene.set_transform(transform);
     }
 
-    fn set_anti_aliasing(&mut self, value: bool) {
-        self.scene.set_anti_aliasing(value);
+    fn set_aliasing_threshold(&mut self, value: bool) {
+        self.scene.set_aliasing_threshold(value);
     }
 
     // vello_hybrid WebGL renderer backend.

--- a/sparse_strips/vello_toy/src/debug.rs
+++ b/sparse_strips/vello_toy/src/debug.rs
@@ -80,7 +80,7 @@ fn main() {
             &mut strip_buf,
             &mut alpha_buf,
             args.fill_rule,
-            true,
+            None,
             &line_buf,
         );
     }


### PR DESCRIPTION
This changes the API so instead of taking a boolean flag, the user can now set a threshold for aliasing, as was previously suggested by @grebmeg. Unfortunately I realized too late that I need this to be configurable. :(