### PR TITLE
Enforce matching dimensions between render context and pixmap when rasterizing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3744,6 +3744,7 @@ version = "0.0.1"
 dependencies = [
  "bytemuck",
  "crossbeam-channel",
+ "log",
  "ordered-channel",
  "rayon",
  "smallvec",

--- a/sparse_strips/vello_cpu/Cargo.toml
+++ b/sparse_strips/vello_cpu/Cargo.toml
@@ -24,6 +24,7 @@ ordered-channel = { workspace = true, optional = true, features = ["crossbeam-ch
 rayon = { workspace = true, optional = true }
 smallvec = { workspace = true, optional = true }
 thread_local = { workspace = true, optional = true }
+log = { workspace = true }
 
 
 [features]


### PR DESCRIPTION
Fixes #1191.