### PR TITLE
Fix an bug with clipping of sparse fills

### DIFF
--- a/sparse_strips/vello_common/src/coarse.rs
+++ b/sparse_strips/vello_common/src/coarse.rs
@@ -719,7 +719,8 @@ impl<const MODE: u8> Wide<MODE> {
                 let width = clipped_x2.saturating_sub(clipped_x1);
 
                 // If there's a gap, fill it. Only do this if the fill wouldn't cover the
-                // whole tile, as such clips are skipped by the `push_clip` function.
+                // whole tile, as such clips are skipped by the `push_clip` function. See
+                // <https://github.com/linebender/vello/blob/de0659e4df9842c8857153841a2b4ba6f1020bb0/sparse_strips/vello_common/src/coarse.rs#L504-L516>
                 if width > 0 && width < WideTile::WIDTH {
                     let x_rel = u32::from(clipped_x1 % WideTile::WIDTH);
                     self.get_mut(cur_wtile_x, cur_wtile_y)

--- a/sparse_strips/vello_common/src/coarse.rs
+++ b/sparse_strips/vello_common/src/coarse.rs
@@ -718,8 +718,9 @@ impl<const MODE: u8> Wide<MODE> {
                 let clipped_x2 = x2.min((cur_wtile_x + 1) * WideTile::WIDTH);
                 let width = clipped_x2.saturating_sub(clipped_x1);
 
-                // If there's a gap, fill it
-                if width > 0 {
+                // If there's a gap, fill it. Only do this if the fill wouldn't cover the
+                // whole tile, as such clips are skipped by the `push_clip` function.
+                if width > 0 && width < WideTile::WIDTH {
                     let x_rel = u32::from(clipped_x1 % WideTile::WIDTH);
                     self.get_mut(cur_wtile_x, cur_wtile_y)
                         .clip_fill(x_rel, u32::from(width));

--- a/sparse_strips/vello_sparse_tests/snapshots/clip_wrong_command.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/clip_wrong_command.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d11640e163ed8ad96c865a5139112d26e43b5538753330a4d75580975fae39ca
+size 391

--- a/sparse_strips/vello_sparse_tests/tests/issues.rs
+++ b/sparse_strips/vello_sparse_tests/tests/issues.rs
@@ -5,7 +5,7 @@
 
 use crate::renderer::Renderer;
 use vello_common::color::palette::css::{DARK_BLUE, LIME, REBECCA_PURPLE};
-use vello_common::kurbo::{BezPath, Rect, Shape, Stroke};
+use vello_common::kurbo::{Affine, BezPath, Rect, Shape, Stroke};
 use vello_common::peniko::{Color, ColorStop, Fill, Gradient};
 use vello_common::pixmap::Pixmap;
 use vello_cpu::color::palette::css::{BLACK, RED};
@@ -404,4 +404,17 @@ fn tile_clamped_off_by_one(ctx: &mut impl Renderer) {
     ctx.push_layer(Some(&rect.to_path(0.1)), None, None, None);
     ctx.fill_path(&rect.to_path(0.1));
     ctx.pop_layer();
+}
+
+/// See <https://github.com/linebender/vello/issues/1186>.
+#[vello_test(width = 595, height = 20)]
+fn clip_wrong_command(ctx: &mut impl Renderer) {
+    ctx.set_paint(BLACK);
+    ctx.set_transform(Affine::translate((0.0, -700.0)));
+    ctx.push_clip_layer(&BezPath::from_svg("M551.704,721.115 C465.024,716.424 375.466,706.552 289.699,688.737 C290.316,688.60205 290.935,688.466 291.55,688.33 C377.059,705.978 466.259,715.75 552.629,720.39 C552.32,720.632 552.013,720.87305 551.704,721.115").unwrap());
+    ctx.push_clip_layer(&BezPath::from_svg("M-133.795,680.40704 C390.292,801.45905 763.166,503.67102 666.575,258.86005 C1031.16,797.18604 -452.803,1197.37 -133.795,680.40704").unwrap());
+    ctx.fill_path(&Rect::new(0.0, 0.0, 595.0, 808.0).to_path(0.1));
+    ctx.pop_layer();
+    ctx.pop_layer();
+    ctx.flush();
 }


### PR DESCRIPTION
The basic problem is that as an optimization the `push_clip` function does not create `push_buf` commands for any wide tiles that would be completely filled. However, in `pop_clip` it can happen that due to the clamping of `x1`, we end up pushing a `ClipFill` command across the whole wide tile width. I don't think that this is the cleanest solution, but unfortunately I haven't come up with a different method that doesn't cause regressions in other cases. This fix works and doesn't cause any regressions in my integration tests.

Fixes #1186.