### PR TITLE
[`vello_hybrid`]: Gradient rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3781,6 +3781,7 @@ version = "0.5.0"
 dependencies = [
  "bytemuck",
  "guillotiere",
+ "hashbrown 0.15.3",
  "js-sys",
  "log",
  "png",
@@ -3800,6 +3801,7 @@ dependencies = [
  "bytemuck",
  "image",
  "parley",
+ "smallvec",
  "vello_common",
  "vello_hybrid",
 ]

--- a/sparse_strips/vello_common/src/encode.rs
+++ b/sparse_strips/vello_common/src/encode.rs
@@ -9,7 +9,7 @@ use crate::color::{ColorSpaceTag, HueDirection, Srgb, gradient};
 use crate::kurbo::{Affine, Point, Vec2};
 use crate::math::{FloatExt, compute_erf7};
 use crate::paint::{Image, ImageSource, IndexedPaint, Paint, PremulColor};
-use crate::peniko::{ColorStop, Extend, Gradient, GradientKind, ImageQuality};
+use crate::peniko::{ColorStop, ColorStops, Extend, Gradient, GradientKind, ImageQuality};
 use alloc::borrow::Cow;
 use alloc::fmt::Debug;
 use alloc::vec;
@@ -235,6 +235,9 @@ impl EncodeExt for Gradient {
             x_advance,
             y_advance,
             ranges,
+            stops: ColorStops(stops.into_owned()),
+            interpolation_cs: self.interpolation_cs,
+            hue_direction: self.hue_direction,
             pad,
             has_opacities,
             u8_lut: OnceCell::new(),
@@ -709,6 +712,12 @@ pub struct EncodedGradient {
     pub y_advance: Vec2,
     /// The color ranges of the gradient.
     pub ranges: Vec<GradientRange>,
+    /// The original color stops.
+    pub stops: ColorStops,
+    /// The color space used for interpolation.
+    pub interpolation_cs: ColorSpaceTag,
+    /// The hue direction for cylindrical color space interpolation.
+    pub hue_direction: HueDirection,
     /// Whether the gradient should be padded.
     pub pad: bool,
     /// Whether the gradient requires `source_over` compositing.

--- a/sparse_strips/vello_common/src/math.rs
+++ b/sparse_strips/vello_common/src/math.rs
@@ -18,6 +18,8 @@ pub fn compute_erf7(x: f32) -> f32 {
 }
 
 // From <https://github.com/linebender/tiny-skia/blob/68b198a7210a6bbf752b43d6bc4db62445730313/path/src/scalar.rs#L12>
+// Note: If this value changes, also update NEARLY_ZERO_TOLERANCE in render_strips.wgsl
+// @see {@link https://github.com/linebender/vello/blob/58b80d660e2fc5aef3bd32b24af3f95e973aab95/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl#L63}
 const SCALAR_NEARLY_ZERO: f32 = 1.0 / (1 << 12) as f32;
 
 /// A number of useful methods for f32 numbers.

--- a/sparse_strips/vello_dev_macros/src/test.rs
+++ b/sparse_strips/vello_dev_macros/src/test.rs
@@ -185,10 +185,8 @@ pub(crate) fn vello_test_inner(attr: TokenStream, item: TokenStream) -> TokenStr
 
     // These tests currently don't work with `vello_hybrid`.
     skip_hybrid |= {
-        input_fn_name_str.contains("gradient")
-            || input_fn_name_str.contains("layer_multiple_properties")
+        input_fn_name_str.contains("layer_multiple_properties")
             || input_fn_name_str.contains("mask")
-            || input_fn_name_str.contains("mix")
             || input_fn_name_str.contains("blurred_rounded_rect")
             || input_fn_name_str.contains("clip_clear")
     };

--- a/sparse_strips/vello_dev_macros/src/test.rs
+++ b/sparse_strips/vello_dev_macros/src/test.rs
@@ -198,11 +198,6 @@ pub(crate) fn vello_test_inner(attr: TokenStream, item: TokenStream) -> TokenStr
         || input_fn_name_str.contains("compose")
         || input_fn_name_str.contains("clip_composite_opacity_nested_circles");
 
-    // Make an exception for mix tests that don't use gradients.
-    skip_hybrid = skip_hybrid
-        && !(input_fn_name_str == "mix_modes_non_gradient_test_matrix"
-            || input_fn_name_str == "mix_compose_combined_test_matrix");
-
     let empty_snippet = quote! {};
     let ignore_snippet = if let Some(reason) = ignore_reason {
         quote! {#[ignore = #reason]}

--- a/sparse_strips/vello_hybrid/Cargo.toml
+++ b/sparse_strips/vello_hybrid/Cargo.toml
@@ -22,6 +22,7 @@ wgpu = { workspace = true, optional = true }
 vello_sparse_shaders = { workspace = true, optional = true }
 log = { workspace = true }
 guillotiere = "0.6.2"
+hashbrown = "0.15"
 
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -51,5 +52,6 @@ roxmltree = "0.20.0"
 
 [features]
 default = ["wgpu"]
+std = ["wgpu", "vello_common/std"]
 wgpu = ["dep:wgpu", "dep:vello_sparse_shaders"]
 webgl = ["dep:js-sys", "dep:web-sys", "dep:vello_sparse_shaders", "vello_sparse_shaders/glsl"]

--- a/sparse_strips/vello_hybrid/examples/native_webgl/src/lib.rs
+++ b/sparse_strips/vello_hybrid/examples/native_webgl/src/lib.rs
@@ -280,9 +280,7 @@ pub async fn run_interactive(canvas_width: u16, canvas_height: u16) {
     body.append_child(&canvas).unwrap();
 
     let scenes = {
-        let mut v = vello_hybrid_scenes::get_example_scenes().into_vec();
-        // Remove the composite scene that currently doesn't work.
-        v.pop();
+        let v = vello_hybrid_scenes::get_example_scenes().into_vec();
         v.into_boxed_slice()
     };
 

--- a/sparse_strips/vello_hybrid/examples/scenes/Cargo.toml
+++ b/sparse_strips/vello_hybrid/examples/scenes/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 
 [dependencies]
 bytemuck = { workspace = true, features = [] }
+smallvec = { workspace = true }
 vello_hybrid = { workspace = true }
 vello_common = { workspace = true, features = ["pico_svg", "png"] }
 image = { workspace = true, features = ["jpeg"] }

--- a/sparse_strips/vello_hybrid/examples/scenes/src/gradient.rs
+++ b/sparse_strips/vello_hybrid/examples/scenes/src/gradient.rs
@@ -1,0 +1,337 @@
+// Copyright 2025 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Gradient rendering example scenes.
+//! Scenes demonstrating gradient rendering with different extend modes. Taken from Vello Classic
+//! test scenes:
+//! - `GradientExtendScene`:
+//!     - `gradient_extend` method from `https://github.com/linebender/vello/blob/0f3ef03a823eb10b0d7a60164e286cde77ffa222/examples/scenes/src/test_scenes.rs#L815`
+//! - `RadialScene`:
+//!     - `two_point_radial` method from `https://github.com/linebender/vello/blob/0f3ef03a823eb10b0d7a60164e286cde77ffa222/examples/scenes/src/test_scenes.rs#L882`
+
+use crate::ExampleScene;
+use smallvec::smallvec;
+use vello_common::color::palette::css::{BLACK, BLUE, LIME, RED, WHITE, YELLOW};
+use vello_common::kurbo::{Affine, Ellipse, Point, Rect, Shape, Stroke};
+use vello_common::peniko::{
+    Color, ColorStop, ColorStops, Extend, Gradient, GradientKind, color::DynamicColor,
+};
+use vello_hybrid::Scene;
+
+/// Gradient scene state
+#[derive(Debug, Default)]
+pub struct GradientExtendScene {}
+
+impl GradientExtendScene {
+    /// Create a new gradient extend scene
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl ExampleScene for GradientExtendScene {
+    fn render(&mut self, scene: &mut Scene, root_transform: Affine) {
+        enum Kind {
+            Linear,
+            Radial,
+            Sweep,
+        }
+
+        /// Helper function to create color stops
+        fn create_color_stops(colors: &[Color]) -> ColorStops {
+            ColorStops(smallvec![
+                ColorStop {
+                    offset: 0.0,
+                    color: DynamicColor::from_alpha_color(colors[0]),
+                },
+                ColorStop {
+                    offset: 0.5,
+                    color: DynamicColor::from_alpha_color(colors[1]),
+                },
+                ColorStop {
+                    offset: 1.0,
+                    color: DynamicColor::from_alpha_color(colors[2]),
+                },
+            ])
+        }
+
+        /// Helper function to create a square with a specific gradient type and extend mode
+        fn square(scene: &mut Scene, kind: Kind, transform: Affine, extend: Extend) {
+            let colors = [RED, LIME, BLUE];
+            let width = 300.0;
+            let height = 300.0;
+
+            let gradient = match kind {
+                Kind::Linear => {
+                    let start_x = width * 0.35;
+                    let start_y = height * 0.5;
+                    let end_x = width * 0.65;
+                    let end_y = height * 0.5;
+
+                    Gradient {
+                        kind: GradientKind::Linear {
+                            start: Point::new(start_x, start_y),
+                            end: Point::new(end_x, end_y),
+                        },
+                        stops: create_color_stops(&colors),
+                        extend,
+                        ..Default::default()
+                    }
+                }
+                Kind::Radial => {
+                    let center_x = width * 0.5;
+                    let center_y = height * 0.5;
+                    #[allow(
+                        clippy::cast_possible_truncation,
+                        reason = "Width is always positive and bounded"
+                    )]
+                    let radius = (width * 0.25) as f32;
+
+                    Gradient {
+                        kind: GradientKind::Radial {
+                            start_center: Point::new(center_x, center_y),
+                            start_radius: radius * 0.25,
+                            end_center: Point::new(center_x, center_y),
+                            end_radius: radius,
+                        },
+                        stops: create_color_stops(&colors),
+                        extend,
+                        ..Default::default()
+                    }
+                }
+                Kind::Sweep => {
+                    let center_x = width * 0.5;
+                    let center_y = height * 0.5;
+
+                    Gradient {
+                        kind: GradientKind::Sweep {
+                            center: Point::new(center_x, center_y),
+                            start_angle: 30.0,
+                            end_angle: 150.0,
+                        },
+                        stops: create_color_stops(&colors),
+                        extend,
+                        ..Default::default()
+                    }
+                }
+            };
+
+            scene.set_transform(transform);
+            scene.set_paint(gradient);
+            scene.fill_rect(&Rect::new(0.0, 0.0, width, height));
+        }
+
+        let extend_modes = [Extend::Pad, Extend::Repeat, Extend::Reflect];
+        for (x, extend) in extend_modes.iter().enumerate() {
+            for (y, kind) in [Kind::Linear, Kind::Radial, Kind::Sweep]
+                .into_iter()
+                .enumerate()
+            {
+                let transform = root_transform
+                    * Affine::translate((x as f64 * 350.0 + 50.0, y as f64 * 350.0 + 100.0));
+                square(scene, kind, transform, *extend);
+            }
+        }
+    }
+}
+
+/// Two-point radial gradient scene
+#[derive(Debug, Default)]
+pub struct RadialScene;
+
+impl RadialScene {
+    /// Create a new radial scene
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl ExampleScene for RadialScene {
+    fn render(&mut self, scene: &mut Scene, root_transform: Affine) {
+        /// Helper function to create color stops
+        fn create_color_stops(colors: &[Color]) -> ColorStops {
+            ColorStops(smallvec![
+                ColorStop {
+                    offset: 0.0,
+                    color: DynamicColor::from_alpha_color(colors[0]),
+                },
+                ColorStop {
+                    offset: 0.5,
+                    color: DynamicColor::from_alpha_color(colors[1]),
+                },
+                ColorStop {
+                    offset: 1.0,
+                    color: DynamicColor::from_alpha_color(colors[2]),
+                },
+            ])
+        }
+
+        /// Helper function to create a two-point radial gradient rectangle
+        fn make(
+            scene: &mut Scene,
+            x0: f64,
+            y0: f64,
+            r0: f32,
+            x1: f64,
+            y1: f64,
+            r1: f32,
+            transform: Affine,
+            extend: Extend,
+        ) {
+            let colors = [RED, YELLOW, Color::from_rgb8(6, 85, 186)];
+            let width = 400.0;
+            let height = 200.0;
+
+            scene.set_transform(transform);
+            scene.set_paint(WHITE);
+            scene.fill_rect(&Rect::new(0.0, 0.0, width, height));
+
+            let gradient = Gradient {
+                kind: GradientKind::Radial {
+                    start_center: Point::new(x0, y0),
+                    start_radius: r0,
+                    end_center: Point::new(x1, y1),
+                    end_radius: r1,
+                },
+                stops: create_color_stops(&colors),
+                extend,
+                ..Default::default()
+            };
+
+            scene.set_paint(gradient);
+            scene.fill_rect(&Rect::new(0.0, 0.0, width, height));
+
+            // Draw stroke circles showing the gradient extents
+            let r0 = r0 as f64 - 1.0;
+            let r1 = r1 as f64 - 1.0;
+            scene.set_paint(BLACK);
+            scene.set_stroke(Stroke::new(1.0));
+            scene.stroke_path(&Ellipse::new((x0, y0), (r0, r0), 0.0).to_path(0.1));
+            scene.stroke_path(&Ellipse::new((x1, y1), (r1, r1), 0.0).to_path(0.1));
+        }
+
+        // These demonstrate radial gradient patterns similar to the examples shown
+        // at <https://learn.microsoft.com/en-us/typography/opentype/spec/colr#radial-gradients>
+
+        // Row 1: Basic two-point radial gradient
+        for (i, mode) in [Extend::Pad, Extend::Repeat, Extend::Reflect]
+            .iter()
+            .enumerate()
+        {
+            let y = 100.0;
+            let x0 = 140.0;
+            let x1 = x0 + 140.0;
+            let r0 = 20.0;
+            let r1 = 50.0;
+            make(
+                scene,
+                x0,
+                y,
+                r0,
+                x1,
+                y,
+                r1,
+                root_transform * Affine::translate((i as f64 * 420.0 + 20.0, 20.0)),
+                *mode,
+            );
+        }
+
+        // Row 2: Reversed two-point radial gradient
+        for (i, mode) in [Extend::Pad, Extend::Repeat, Extend::Reflect]
+            .iter()
+            .enumerate()
+        {
+            let y = 100.0;
+            let x0: f64 = 140.0;
+            let x1 = x0 + 140.0;
+            let r0 = 20.0;
+            let r1 = 50.0;
+            make(
+                scene,
+                x1,
+                y,
+                r1,
+                x0,
+                y,
+                r0,
+                root_transform * Affine::translate((i as f64 * 420.0 + 20.0, 240.0)),
+                *mode,
+            );
+        }
+
+        // Row 3: Equal radii gradient
+        for (i, mode) in [Extend::Pad, Extend::Repeat, Extend::Reflect]
+            .iter()
+            .enumerate()
+        {
+            let y = 100.0;
+            let x0 = 140.0;
+            let x1 = x0 + 140.0;
+            let r0 = 50.0;
+            let r1 = 50.0;
+            make(
+                scene,
+                x0,
+                y,
+                r0,
+                x1,
+                y,
+                r1,
+                root_transform * Affine::translate((i as f64 * 420.0 + 20.0, 460.0)),
+                *mode,
+            );
+        }
+
+        // Row 4: Overlapping circles
+        for (i, mode) in [Extend::Pad, Extend::Repeat, Extend::Reflect]
+            .iter()
+            .enumerate()
+        {
+            let x0 = 140.0;
+            let y0 = 125.0;
+            let r0 = 20.0;
+            let x1 = 190.0;
+            let y1 = 100.0;
+            let r1 = 95.0;
+            make(
+                scene,
+                x0,
+                y0,
+                r0,
+                x1,
+                y1,
+                r1,
+                root_transform * Affine::translate((i as f64 * 420.0 + 20.0, 680.0)),
+                *mode,
+            );
+        }
+
+        // Row 5: Touching circles
+        for (i, mode) in [Extend::Pad, Extend::Repeat, Extend::Reflect]
+            .iter()
+            .enumerate()
+        {
+            let x0 = 140.0;
+            let y0 = 125.0;
+            let r0: f32 = 20.0;
+            let x1 = 190.0;
+            let y1 = 100.0;
+            let r1: f32 = 96.0;
+            // Shift p0 so the outer edges of both circles touch
+            let direction = Point::new(x0, y0) - Point::new(x1, y1);
+            let normalized_direction = direction.normalize();
+            let p0 = Point::new(x1, y1) + (normalized_direction * (r1 - r0) as f64);
+            make(
+                scene,
+                p0.x,
+                p0.y,
+                r0,
+                x1,
+                y1,
+                r1,
+                root_transform * Affine::translate((i as f64 * 420.0 + 20.0, 900.0)),
+                *mode,
+            );
+        }
+    }
+}

--- a/sparse_strips/vello_hybrid/examples/scenes/src/lib.rs
+++ b/sparse_strips/vello_hybrid/examples/scenes/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod blend;
 pub mod clip;
+pub mod gradient;
 pub mod image;
 pub mod simple;
 pub mod svg;
@@ -91,6 +92,8 @@ pub fn get_example_scenes(svg_paths: Option<Vec<&str>>) -> Box<[AnyScene]> {
     scenes.push(AnyScene::new(clip::ClipScene::new()));
     scenes.push(AnyScene::new(blend::BlendScene::new()));
     scenes.push(AnyScene::new(image::ImageScene::new()));
+    scenes.push(AnyScene::new(gradient::GradientExtendScene::new()));
+    scenes.push(AnyScene::new(gradient::RadialScene::new()));
 
     scenes.into_boxed_slice()
 }
@@ -104,7 +107,9 @@ pub fn get_example_scenes() -> Box<[AnyScene]> {
         AnyScene::new(simple::SimpleScene::new()),
         AnyScene::new(clip::ClipScene::new()),
         AnyScene::new(blend::BlendScene::new()),
-        AnyScene::new(image::ImageScene {}),
+        AnyScene::new(image::ImageScene::new()),
+        AnyScene::new(gradient::GradientExtendScene::new()),
+        AnyScene::new(gradient::RadialScene::new()),
     ]
     .into_boxed_slice()
 }

--- a/sparse_strips/vello_hybrid/src/gradient_cache.rs
+++ b/sparse_strips/vello_hybrid/src/gradient_cache.rs
@@ -1,0 +1,195 @@
+// Copyright 2025 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Gradient ramp cache for `vello_hybrid` renderer.
+
+use alloc::vec::Vec;
+use core::hash::{Hash, Hasher};
+use hashbrown::HashMap;
+use vello_common::color::{ColorSpaceTag, HueDirection};
+use vello_common::encode::EncodedGradient;
+use vello_common::fearless_simd::{Level, simd_dispatch};
+use vello_common::peniko::ColorStops;
+use vello_common::peniko::color::cache_key::{BitEq, BitHash, CacheKey};
+
+const RETAINED_COUNT: usize = 64;
+
+#[derive(Debug, Default)]
+pub(crate) struct GradientRampCache {
+    /// Current epoch for LRU tracking.
+    epoch: u64,
+    /// Cache mapping gradient signature to cached ramps and last access time.
+    cache: HashMap<CacheKey<GradientRampKey>, (CachedRamp, u64)>,
+    /// Packed gradient luts.
+    luts: Vec<u8>,
+    /// Whether the packed luts needs to be re-uploaded.
+    has_changed: bool,
+}
+
+// TODO: Rebuild the packed luts or allow to rewrite evicted gradient ramps after eviction.
+impl GradientRampCache {
+    /// Create a new gradient ramp cache.
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Get or generate a gradient ramp, returning its offset in the packed luts.
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "Conversion from usize to u32 is safe, used for texture coordinates"
+    )]
+    pub(crate) fn get_or_create_ramp(&mut self, gradient: &EncodedGradient) -> (u32, u32) {
+        self.epoch += 1;
+
+        // Create cache key from gradient color properties.
+        let cache_key = CacheKey(GradientRampKey {
+            stops: gradient.stops.clone(),
+            interpolation_cs: gradient.interpolation_cs,
+            hue_direction: gradient.hue_direction,
+        });
+
+        // Check if we already have this gradient cached.
+        if let Some((cached_ramp, last_used)) = self.cache.get_mut(&cache_key) {
+            *last_used = self.epoch;
+            return (cached_ramp.lut_start, cached_ramp.width);
+        }
+
+        // Generate new gradient LUT.
+        let lut_start = (self.luts.len() / 4) as u32;
+        generate_gradient_lut_dispatch(Level::new(), gradient, &mut self.luts);
+        let lut_end = (self.luts.len() / 4) as u32;
+        let width = lut_end - lut_start;
+        let cached_ramp = CachedRamp { width, lut_start };
+        self.has_changed = true;
+
+        if self.cache.len() >= RETAINED_COUNT {
+            self.evict_old_entries();
+        }
+
+        self.cache.insert(cache_key, (cached_ramp, self.epoch));
+
+        (lut_start, width)
+    }
+
+    /// Get the packed luts.
+    pub(crate) fn luts(&self) -> &[u8] {
+        &self.luts
+    }
+
+    /// Get the size of the packed luts.
+    pub(crate) fn size(&self) -> usize {
+        self.luts.len()
+    }
+
+    /// Check if the packed luts is empty.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.luts.is_empty()
+    }
+
+    /// Check if the luts data has changed.
+    pub(crate) fn has_changed(&self) -> bool {
+        self.has_changed
+    }
+
+    /// Mark the luts as synced.
+    pub(crate) fn mark_synced(&mut self) {
+        self.has_changed = false;
+    }
+
+    /// Periodic maintenance - call occasionally to prevent unbounded growth.
+    pub(crate) fn maintain(&mut self) {
+        self.epoch += 1;
+
+        if self.cache.len() > RETAINED_COUNT {
+            self.evict_old_entries();
+        }
+    }
+
+    /// Evict old cache entries using LRU policy.
+    fn evict_old_entries(&mut self) {
+        // Find entries that haven't been used in the last few epochs.
+        let cutoff_epoch = self.epoch.saturating_sub(3);
+
+        let entries_to_remove: Vec<_> = self
+            .cache
+            .iter()
+            .filter(|(_, (_, last_used))| *last_used < cutoff_epoch)
+            .map(|(key, _)| key.clone())
+            .collect();
+
+        // Remove old entries.
+        for key in entries_to_remove {
+            self.cache.remove(&key);
+        }
+
+        // If still too many entries, remove oldest ones.
+        if self.cache.len() > RETAINED_COUNT {
+            let mut entries: Vec<_> = self
+                .cache
+                .iter()
+                .map(|(k, (_, last_used))| (k.clone(), *last_used))
+                .collect();
+            entries.sort_by_key(|(_, last_used)| *last_used);
+
+            let to_remove = entries.len() - RETAINED_COUNT;
+            for (key, _) in entries.into_iter().take(to_remove) {
+                self.cache.remove(&key);
+            }
+        }
+    }
+}
+
+/// Cache key for gradient color ramps based on color-affecting properties.
+#[derive(Debug, Clone)]
+pub(crate) struct GradientRampKey {
+    /// The color stops (offsets + colors).
+    pub stops: ColorStops,
+    /// Color space used for interpolation.
+    pub interpolation_cs: ColorSpaceTag,
+    /// Hue direction used for interpolation.
+    pub hue_direction: HueDirection,
+}
+
+impl BitHash for GradientRampKey {
+    fn bit_hash<H: Hasher>(&self, state: &mut H) {
+        self.stops.bit_hash(state);
+        core::mem::discriminant(&self.interpolation_cs).hash(state);
+        core::mem::discriminant(&self.hue_direction).hash(state);
+    }
+}
+
+impl BitEq for GradientRampKey {
+    fn bit_eq(&self, other: &Self) -> bool {
+        self.stops.bit_eq(&other.stops)
+            && self.interpolation_cs == other.interpolation_cs
+            && self.hue_direction == other.hue_direction
+    }
+}
+
+/// Cached gradient ramp data with metadata.
+#[derive(Debug, Clone)]
+pub(crate) struct CachedRamp {
+    /// Width of this gradient's LUT.
+    pub width: u32,
+    /// Offset in luts where this ramp starts.
+    pub lut_start: u32,
+}
+
+simd_dispatch!(fn generate_gradient_lut_dispatch(
+    level,
+    gradient: &vello_common::encode::EncodedGradient,
+    output: &mut Vec<u8>
+) = generate_gradient_lut_impl);
+
+/// Generate the gradient LUT.
+#[inline(always)]
+fn generate_gradient_lut_impl<S: vello_common::fearless_simd::Simd>(
+    simd: S,
+    gradient: &vello_common::encode::EncodedGradient,
+    output: &mut Vec<u8>,
+) {
+    let lut = gradient.u8_lut(simd);
+    for color in lut.lut() {
+        output.extend_from_slice(&[color[0], color[1], color[2], color[3]]);
+    }
+}

--- a/sparse_strips/vello_hybrid/src/gradient_cache.rs
+++ b/sparse_strips/vello_hybrid/src/gradient_cache.rs
@@ -28,6 +28,27 @@ pub(crate) struct GradientRampCache {
     retained_count: u32,
     /// SIMD level used for gradient LUT generation.
     level: Level,
+    /// Scratch space for maintaining the cache.
+    scratch: ScratchSpace,
+}
+
+/// Reusable working memory for cache maintenance operations.
+///
+/// This struct implements a memory pool pattern to avoid repeated allocations
+/// during cache eviction and compaction. Each vector is borrowed during
+/// operations and returned with its capacity preserved for future reuse.
+#[derive(Debug, Default)]
+struct ScratchSpace {
+    /// Temporary storage for cache entries during LRU sorting.
+    /// Holds (`key_reference`, `last_used_timestamp`) pairs for all cache entries.
+    entries: Vec<(&'static CacheKey<GradientCacheKey>, u64)>,
+    /// Temporary storage for cache keys that need to be removed.
+    /// Collects the keys of the LRU entries before removal.
+    removed: Vec<CacheKey<GradientCacheKey>>,
+    /// Temporary storage for evicted cache entries and their ramp data.
+    /// Contains (`key`, `ramp`) pairs for entries that have been removed from the cache.
+    /// Used during LUT compaction to know which ramp data to remove from the packed LUTs.
+    lru_entries: Vec<(CacheKey<GradientCacheKey>, CachedRamp)>,
 }
 
 impl GradientRampCache {
@@ -40,6 +61,7 @@ impl GradientRampCache {
             has_changed: false,
             retained_count,
             level,
+            scratch: ScratchSpace::default(),
         }
     }
 
@@ -76,7 +98,7 @@ impl GradientRampCache {
             .cache
             .len()
             .saturating_sub(self.retained_count as usize);
-        self.remove_lru_entries(entries_to_remove_count);
+        self.evict(entries_to_remove_count);
     }
 
     /// Get the size of the packed luts.
@@ -109,25 +131,55 @@ impl GradientRampCache {
         self.luts = luts;
     }
 
-    /// Remove multiple least recently used cache entries and compact the luts vector efficiently.
-    fn remove_lru_entries(&mut self, count: usize) {
+    /// Remove multiple LRU entries and compact the LUTs vector.
+    fn evict(&mut self, count: usize) {
         if count == 0 {
             return;
         }
 
-        let entries_to_remove = self.get_lru_entries(count);
-        if entries_to_remove.is_empty() {
-            return;
-        }
-        for (key, _) in &entries_to_remove {
-            self.cache.remove(key);
-        }
-        self.compact_luts(entries_to_remove);
+        let mut lru_entries = core::mem::take(&mut self.scratch.lru_entries);
+        lru_entries.clear();
+        self.remove_lru_entries(count, &mut lru_entries);
+        self.compact_luts(&mut lru_entries);
+        self.scratch.lru_entries = lru_entries;
         self.has_changed = true;
     }
 
-    /// Compact the luts vector by removing multiple cached ramps
-    fn compact_luts(&mut self, mut ramps_to_remove: Vec<(CacheKey<GradientCacheKey>, CachedRamp)>) {
+    /// Identify and remove the LRU cache entries.
+    fn remove_lru_entries(
+        &mut self,
+        count: usize,
+        lru_entries: &mut Vec<(CacheKey<GradientCacheKey>, CachedRamp)>,
+    ) {
+        if count == 0 || self.cache.is_empty() {
+            return;
+        }
+
+        let mut entries = reuse_vec(core::mem::take(&mut self.scratch.entries));
+        entries.extend(
+            self.cache
+                .iter()
+                .map(|(key, (_, last_used))| (key, *last_used)),
+        );
+
+        // Sort by last_used (ascending) to get LRU entries first
+        entries.sort_by_key(|(_, last_used)| *last_used);
+
+        let mut removed = core::mem::take(&mut self.scratch.removed);
+        removed.clear();
+        removed.extend(entries.iter().take(count).map(|(key, _)| (*key).clone()));
+        self.scratch.entries = reuse_vec(entries);
+
+        for key in removed.drain(..) {
+            let ramp = self.cache.remove(&key).unwrap().0;
+            lru_entries.push((key, ramp));
+        }
+
+        self.scratch.removed = removed;
+    }
+
+    /// Remove LUT data for evicted entries with compacting the LUTs vector, and update remaining offsets.
+    fn compact_luts(&mut self, ramps_to_remove: &mut [(CacheKey<GradientCacheKey>, CachedRamp)]) {
         if ramps_to_remove.is_empty() {
             return;
         }
@@ -136,30 +188,27 @@ impl GradientRampCache {
         ramps_to_remove.sort_by_key(|(_, ramp)| ramp.lut_start);
 
         // Convert to byte ranges for easier processing
-        let ranges_to_remove: Vec<(usize, usize)> = ramps_to_remove
+        let mut ranges_to_remove = ramps_to_remove
             .iter()
             .map(|(_, ramp)| {
                 let start = (ramp.lut_start * BYTES_PER_TEXEL) as usize;
                 let end = start + (ramp.width * BYTES_PER_TEXEL) as usize;
                 (start, end)
             })
-            .collect();
+            .peekable();
 
         // Total bytes removed so far
         let mut write_offset = 0;
         // Current read position
         let mut read_pos = 0;
-        // Index into ranges_to_remove
-        let mut range_idx = 0;
 
         while read_pos < self.luts.len() {
             // Check if we're at the start of a range to remove
-            if range_idx < ranges_to_remove.len() && read_pos == ranges_to_remove[range_idx].0 {
-                let (start, end) = ranges_to_remove[range_idx];
+            if ranges_to_remove.peek().is_some() && read_pos == ranges_to_remove.peek().unwrap().0 {
+                let (start, end) = ranges_to_remove.next().unwrap();
                 // Skip over the range to remove
                 write_offset += end - start;
                 read_pos = end;
-                range_idx += 1;
             } else {
                 // Copy byte from read position to write position (read_pos - write_offset)
                 if write_offset > 0 {
@@ -176,7 +225,7 @@ impl GradientRampCache {
         // Calculate how much data was removed before each ramp's original position
         for (_, (ramp, _)) in self.cache.iter_mut() {
             let mut removed_before = 0;
-            for (_, removed_ramp) in &ramps_to_remove {
+            for (_, removed_ramp) in ramps_to_remove.iter() {
                 if removed_ramp.lut_start < ramp.lut_start {
                     removed_before += removed_ramp.width;
                 }
@@ -184,28 +233,24 @@ impl GradientRampCache {
             ramp.lut_start -= removed_before;
         }
     }
+}
 
-    /// Get multiple least recently used cache entries.
-    fn get_lru_entries(&self, count: usize) -> Vec<(CacheKey<GradientCacheKey>, CachedRamp)> {
-        if count == 0 || self.cache.is_empty() {
-            return Vec::new();
-        }
-
-        let mut entries: Vec<_> = self
-            .cache
-            .iter()
-            .map(|(key, (ramp, last_used))| (key.clone(), ramp.clone(), *last_used))
-            .collect();
-
-        // Sort by last_used (ascending) to get LRU entries first
-        entries.sort_by_key(|(_, _, last_used)| *last_used);
-
-        entries
-            .into_iter()
-            .take(count)
-            .map(|(key, ramp, _)| (key, ramp))
-            .collect()
+/// Used to reinterpret the lifetimes of a vector.
+// For how this works, see:
+// https://davidlattimore.github.io/posts/2025/09/02/rustforge-wild-performance-tricks.html
+fn reuse_vec<T, U>(mut v: Vec<T>) -> Vec<U> {
+    const {
+        assert!(
+            size_of::<T>() == size_of::<U>(),
+            "Types must have the same size for safe reinterpretation"
+        );
+        assert!(
+            align_of::<T>() == align_of::<U>(),
+            "Types must have the same alignment for safe reinterpretation"
+        );
     }
+    v.clear();
+    v.into_iter().map(|_x| unreachable!()).collect()
 }
 
 /// Cached gradient ramp data with metadata.

--- a/sparse_strips/vello_hybrid/src/lib.rs
+++ b/sparse_strips/vello_hybrid/src/lib.rs
@@ -29,7 +29,7 @@
 //!
 //! See the individual module documentation for more details on usage and implementation.
 
-#![no_std]
+// #![no_std]
 
 extern crate alloc;
 
@@ -45,7 +45,7 @@ pub use render::{AtlasWriter, RenderTargetConfig, Renderer};
 pub use render::{Config, GpuStrip, RenderSize};
 #[cfg(all(target_arch = "wasm32", feature = "webgl"))]
 pub use render::{WebGlAtlasWriter, WebGlRenderer, WebGlTextureWithDimensions};
-pub use scene::Scene;
+pub use scene::{RenderSettings, Scene};
 pub use util::DimensionConstraints;
 pub use vello_common::pixmap::Pixmap;
 

--- a/sparse_strips/vello_hybrid/src/lib.rs
+++ b/sparse_strips/vello_hybrid/src/lib.rs
@@ -33,6 +33,7 @@
 
 extern crate alloc;
 
+mod gradient_cache;
 mod image_cache;
 mod render;
 mod scene;

--- a/sparse_strips/vello_hybrid/src/render/common.rs
+++ b/sparse_strips/vello_hybrid/src/render/common.rs
@@ -93,7 +93,7 @@ impl GpuEncodedPaint {
     }
 
     /// Serialize paint enums directly into the provided buffer. Returns the number of bytes written.
-    pub(crate) fn serialize_to_buffer(paints: &[Self], buffer: &mut [u8]) -> usize {
+    pub(crate) fn serialize_to_buffer(paints: &[Self], buffer: &mut [u8]) {
         let mut offset = 0;
         for paint in paints {
             let paint_bytes = paint.as_bytes();
@@ -101,7 +101,6 @@ impl GpuEncodedPaint {
             buffer[offset..end_offset].copy_from_slice(paint_bytes);
             offset = end_offset;
         }
-        offset
     }
 }
 

--- a/sparse_strips/vello_hybrid/src/render/common.rs
+++ b/sparse_strips/vello_hybrid/src/render/common.rs
@@ -3,26 +3,41 @@
 
 //! Backend agnostic renderer module.
 
+#![allow(
+    clippy::cast_possible_truncation,
+    reason = "GPU paint structures have small, fixed sizes that fit in u32"
+)]
+
 use bytemuck::{Pod, Zeroable};
 
-/// Dimensions of the rendering target
+// GPU paint structure sizes in texels (1 texel = 16 bytes for RGBA32Uint texture format).
+pub(crate) const GPU_ENCODED_IMAGE_SIZE_TEXELS: u32 =
+    (core::mem::size_of::<GpuEncodedImage>() / 16) as u32;
+pub(crate) const GPU_LINEAR_GRADIENT_SIZE_TEXELS: u32 =
+    (core::mem::size_of::<GpuLinearGradient>() / 16) as u32;
+pub(crate) const GPU_RADIAL_GRADIENT_SIZE_TEXELS: u32 =
+    (core::mem::size_of::<GpuRadialGradient>() / 16) as u32;
+pub(crate) const GPU_SWEEP_GRADIENT_SIZE_TEXELS: u32 =
+    (core::mem::size_of::<GpuSweepGradient>() / 16) as u32;
+
+/// Dimensions of the rendering target.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct RenderSize {
-    /// Width of the rendering target
+    /// Width of the rendering target.
     pub width: u32,
-    /// Height of the rendering target
+    /// Height of the rendering target.
     pub height: u32,
 }
 
-/// Configuration for the GPU renderer
+/// Configuration for the GPU renderer.
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Pod, Zeroable)]
 pub struct Config {
-    /// Width of the rendering target
+    /// Width of the rendering target.
     pub width: u32,
-    /// Height of the rendering target
+    /// Height of the rendering target.
     pub height: u32,
-    /// Height of a strip in the rendering
+    /// Height of a strip in the rendering.
     pub strip_height: u32,
     /// Number of trailing zeros in `alphas_tex_width` (log2 of width).
     /// Pre-calculated on CPU since downlevel targets do not support `firstTrailingBit`.
@@ -52,26 +67,179 @@ pub struct GpuStrip {
     pub paint: u32,
 }
 
-/// Represents a GPU encoded image data for rendering
-// Align to 16 bytes for RGBA32Uint alignment
+/// Different types of GPU encoded paints.
+#[derive(Debug)]
+pub(crate) enum GpuEncodedPaint {
+    /// An encoded image.
+    Image(GpuEncodedImage),
+    /// An encoded linear gradient.
+    LinearGradient(GpuLinearGradient),
+    /// An encoded radial gradient.
+    RadialGradient(GpuRadialGradient),
+    /// An encoded sweep gradient.
+    SweepGradient(GpuSweepGradient),
+}
+
+impl GpuEncodedPaint {
+    /// Returns the byte representation of this paint.
+    #[inline]
+    pub(crate) fn as_bytes(&self) -> &[u8] {
+        match self {
+            Self::Image(paint) => bytemuck::bytes_of(paint),
+            Self::LinearGradient(paint) => bytemuck::bytes_of(paint),
+            Self::RadialGradient(paint) => bytemuck::bytes_of(paint),
+            Self::SweepGradient(paint) => bytemuck::bytes_of(paint),
+        }
+    }
+
+    /// Serialize paint enums directly into the provided buffer. Returns the number of bytes written.
+    pub(crate) fn serialize_to_buffer(paints: &[Self], buffer: &mut [u8]) -> usize {
+        let mut offset = 0;
+        for paint in paints {
+            let paint_bytes = paint.as_bytes();
+            let end_offset = offset + paint_bytes.len();
+            buffer[offset..end_offset].copy_from_slice(paint_bytes);
+            offset = end_offset;
+        }
+        offset
+    }
+}
+
+/// GPU encoded image data.
+/// Align to 16 bytes for `RGBA32Uint` alignment.
 #[repr(C, align(16))]
 #[derive(Debug, Clone, Copy, Zeroable, Pod)]
 #[allow(dead_code, reason = "Clippy fails when --no-default-features")]
 pub(crate) struct GpuEncodedImage {
-    // 1st 16 bytes
     /// The rendering quality of the image.
     pub quality_and_extend_modes: u32,
-    /// The extends in the horizontal and vertical direction.
-    /// The size of the image in pixels.
+    /// Packed image width and height.
     pub image_size: u32,
     /// The offset of the image in the atlas texture in pixels.
     pub image_offset: u32,
-    pub _padding1: u32,
-    // 2nd & 3rd 16 bytes
-    /// A transform to apply to the image.
+    /// Transform matrix [a, b, c, d, tx, ty].
     pub transform: [f32; 6],
-    /// Padding to align to 64 bytes (16-byte aligned)
-    pub _padding2: [u32; 2],
+    /// Padding for 16-byte alignment
+    pub _padding: [u32; 3],
+}
+
+/// GPU encoded linear gradient data.
+/// Align to 16 bytes for `RGBA32Uint` alignment.
+#[repr(C, align(16))]
+#[derive(Debug, Clone, Copy, Zeroable, Pod)]
+#[allow(dead_code, reason = "Clippy fails when --no-default-features")]
+pub(crate) struct GpuLinearGradient {
+    /// Packed texture width (bits 0-30) and extend mode (bit 31: 0=Pad, 1=Repeat).
+    pub texture_width_and_extend_mode: u32,
+    /// Start coordinate in the flat gradient texture.
+    pub gradient_start: u32,
+    /// Transform matrix [a, b, c, d, tx, ty].
+    pub transform: [f32; 6],
+}
+
+/// GPU encoded radial gradient data.
+/// Align to 16 bytes for `RGBA32Uint` alignment.
+#[repr(C, align(16))]
+#[derive(Debug, Clone, Copy, Zeroable, Pod)]
+#[allow(dead_code, reason = "Clippy fails when --no-default-features")]
+pub(crate) struct GpuRadialGradient {
+    /// Packed texture width (bits 0-30) and extend mode (bit 31: 0=Pad, 1=Repeat).
+    pub texture_width_and_extend_mode: u32,
+    /// Start coordinate in the flat gradient texture for dense packing.
+    pub gradient_start: u32,
+    /// Transform matrix [a, b, c, d, tx, ty].
+    pub transform: [f32; 6],
+    /// Packed kind (bits 0-1) and `f_is_swapped` (bit 2): 0=Radial, 1=Strip, 2=Focal; bit 2: swapped flag.
+    pub kind_and_f_is_swapped: u32,
+    /// Bias value for radial gradient calculation.
+    pub bias: f32,
+    /// Scale factor for radial gradient calculation.
+    pub scale: f32,
+    /// Focal point 0 parameter for radial gradient.
+    pub fp0: f32,
+    /// Focal point 1 parameter for radial gradient.
+    pub fp1: f32,
+    /// Focal radius 1 parameter for radial gradient.
+    pub fr1: f32,
+    /// Focal X coordinate for radial gradient.
+    pub f_focal_x: f32,
+    /// Scaled radius 0 squared parameter for radial gradient strip.
+    pub scaled_r0_squared: f32,
+}
+
+/// GPU encoded sweep gradient data.
+/// Align to 16 bytes for `RGBA32Uint` alignment.
+#[repr(C, align(16))]
+#[derive(Debug, Clone, Copy, Zeroable, Pod)]
+#[allow(dead_code, reason = "Clippy fails when --no-default-features")]
+pub(crate) struct GpuSweepGradient {
+    /// Packed texture width (bits 0-30) and extend mode (bit 31: 0=Pad, 1=Repeat).
+    pub texture_width_and_extend_mode: u32,
+    /// Start coordinate in the flat gradient texture for dense packing.
+    pub gradient_start: u32,
+    /// Transform matrix [a, b, c, d, tx, ty].
+    pub transform: [f32; 6],
+    /// Starting angle for sweep gradient.
+    pub start_angle: f32,
+    /// Inverse of angle delta for sweep gradient.
+    pub inv_angle_delta: f32,
+    /// Padding for 16-byte alignment.
+    pub _padding: [u32; 2],
+}
+
+// Constants for packing extend_mode and texture_width.
+const EXTEND_MODE_MASK: u32 = 1 << 31;
+const TEXTURE_WIDTH_MASK: u32 = !EXTEND_MODE_MASK;
+
+/// Pack `extend_mode` and `texture_width` into a single u32.
+/// `extend_mode`: 0=Pad, 1=Repeat (stored in bit 31)
+/// `texture_width`: stored in bits 0-30 (max value: 2^31-1)
+#[inline(always)]
+pub(crate) fn pack_texture_width_and_extend_mode(texture_width: u32, extend_mode: u32) -> u32 {
+    debug_assert!(extend_mode <= 1, "extend_mode must be 0 or 1");
+    debug_assert!(
+        texture_width <= TEXTURE_WIDTH_MASK,
+        "texture_width {texture_width} exceeds maximum value {TEXTURE_WIDTH_MASK}"
+    );
+    (extend_mode << 31) | (texture_width & TEXTURE_WIDTH_MASK)
+}
+
+/// Pack radial gradient `kind` and `f_is_swapped` into a single u32.
+/// `kind`: 0=Radial, 1=Strip, 2=Focal (stored in bits 0-1)
+/// `f_is_swapped`: 0=false, 1=true (stored in bit 2)
+#[inline(always)]
+pub(crate) fn pack_radial_kind_and_swapped(kind: u32, f_is_swapped: u32) -> u32 {
+    debug_assert!(kind <= 2, "kind must be 0, 1, or 2");
+    debug_assert!(f_is_swapped <= 1, "f_is_swapped must be 0 or 1");
+    (f_is_swapped << 2) | (kind & 0x3)
+}
+
+/// Pack image `width` and `height` into a single u32.
+/// `width`: stored in bits 16-31 (upper 16 bits)
+/// `height`: stored in bits 0-15 (lower 16 bits)
+#[inline(always)]
+pub(crate) fn pack_image_size(width: u16, height: u16) -> u32 {
+    ((width as u32) << 16) | (height as u32)
+}
+
+/// Pack image offset coordinates `x` and `y` into a single u32.
+/// `x`: stored in bits 16-31 (upper 16 bits)
+/// `y`: stored in bits 0-15 (lower 16 bits)
+#[inline(always)]
+pub(crate) fn pack_image_offset(x: u16, y: u16) -> u32 {
+    ((x as u32) << 16) | (y as u32)
+}
+
+/// Pack image `quality` and extend modes into a single u32.
+/// `extend_y`: stored in bits 4-7
+/// `extend_x`: stored in bits 2-3
+/// `quality`: stored in bits 0-1
+#[inline(always)]
+pub(crate) fn pack_quality_and_extend_modes(extend_x: u32, extend_y: u32, quality: u32) -> u32 {
+    debug_assert!(extend_x <= 3, "extend_x must be 0-3 (2 bits)");
+    debug_assert!(extend_y <= 15, "extend_y must be 0-15 (4 bits)");
+    debug_assert!(quality <= 3, "quality must be 0-3 (2 bits)");
+    (extend_y << 4) | (extend_x << 2) | quality
 }
 
 #[cfg(all(target_arch = "wasm32", feature = "webgl", feature = "wgpu"))]

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -44,7 +44,7 @@ use bytemuck::{Pod, Zeroable};
 use core::{fmt::Debug, mem};
 use vello_common::{
     coarse::WideTile,
-    encode::{EncodedKind, EncodedPaint, MAX_GRADIENT_LUT_SIZE, RadialKind},
+    encode::{EncodedGradient, EncodedKind, EncodedPaint, MAX_GRADIENT_LUT_SIZE, RadialKind},
     kurbo::Affine,
     paint::ImageSource,
     tile::Tile,
@@ -330,6 +330,8 @@ impl WebGlRenderer {
             .resize_with(encoded_paints.len(), || GPU_PAINT_PLACEHOLDER);
         self.paint_idxs.resize(encoded_paints.len() + 1, 0);
 
+        self.gradient_cache.maintain();
+
         let mut current_idx = 0;
         for (encoded_paint_idx, paint) in encoded_paints.iter().enumerate() {
             self.paint_idxs[encoded_paint_idx] = current_idx;
@@ -395,7 +397,7 @@ impl WebGlRenderer {
 
     fn encode_gradient_paint(
         &self,
-        gradient: &vello_common::encode::EncodedGradient,
+        gradient: &EncodedGradient,
         gradient_width: u32,
         gradient_start: u32,
     ) -> GpuEncodedPaint {

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -186,6 +186,7 @@ impl WebGlRenderer {
             gl: &self.gl,
         };
         self.scheduler.do_scene(&mut ctx, scene, &self.paint_idxs)?;
+        self.gradient_cache.maintain();
 
         // Blit the view framebuffer to the default framebuffer (canvas element), reflecting the
         // image along the Y axis to complete the WebGPU to WebGL2 coordinate transform.
@@ -329,8 +330,6 @@ impl WebGlRenderer {
         self.encoded_paints
             .resize_with(encoded_paints.len(), || GPU_PAINT_PLACEHOLDER);
         self.paint_idxs.resize(encoded_paints.len() + 1, 0);
-
-        self.gradient_cache.maintain();
 
         let mut current_idx = 0;
         for (encoded_paint_idx, paint) in encoded_paints.iter().enumerate() {

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -42,7 +42,7 @@ use crate::{
 use bytemuck::{Pod, Zeroable};
 use vello_common::{
     coarse::WideTile,
-    encode::{EncodedKind, EncodedPaint, MAX_GRADIENT_LUT_SIZE, RadialKind},
+    encode::{EncodedGradient, EncodedKind, EncodedPaint, MAX_GRADIENT_LUT_SIZE, RadialKind},
     kurbo::Affine,
     paint::ImageSource,
     pixmap::Pixmap,
@@ -264,6 +264,8 @@ impl Renderer {
             .resize_with(encoded_paints.len(), || GPU_PAINT_PLACEHOLDER);
         self.paint_idxs.resize(encoded_paints.len() + 1, 0);
 
+        self.gradient_cache.maintain();
+
         let mut current_idx = 0;
         for (encoded_paint_idx, paint) in encoded_paints.iter().enumerate() {
             self.paint_idxs[encoded_paint_idx] = current_idx;
@@ -329,7 +331,7 @@ impl Renderer {
 
     fn encode_gradient_paint(
         &self,
-        gradient: &vello_common::encode::EncodedGradient,
+        gradient: &EncodedGradient,
         gradient_width: u32,
         gradient_start: u32,
     ) -> GpuEncodedPaint {

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -22,9 +22,30 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::{fmt::Debug, mem, num::NonZeroU64};
 
+use crate::{
+    GpuStrip, RenderError, RenderSize,
+    gradient_cache::GradientRampCache,
+    image_cache::{ImageCache, ImageResource},
+    render::{
+        Config,
+        common::{
+            GPU_ENCODED_IMAGE_SIZE_TEXELS, GPU_LINEAR_GRADIENT_SIZE_TEXELS,
+            GPU_RADIAL_GRADIENT_SIZE_TEXELS, GPU_SWEEP_GRADIENT_SIZE_TEXELS, GpuEncodedImage,
+            GpuEncodedPaint, GpuLinearGradient, GpuRadialGradient, GpuSweepGradient,
+            pack_image_offset, pack_image_size, pack_quality_and_extend_modes,
+            pack_radial_kind_and_swapped, pack_texture_width_and_extend_mode,
+        },
+    },
+    scene::Scene,
+    schedule::{LoadOp, RendererBackend, Scheduler},
+};
 use bytemuck::{Pod, Zeroable};
 use vello_common::{
-    coarse::WideTile, encode::EncodedPaint, kurbo::Affine, paint::ImageSource, pixmap::Pixmap,
+    coarse::WideTile,
+    encode::{EncodedKind, EncodedPaint, RadialKind},
+    kurbo::Affine,
+    paint::ImageSource,
+    pixmap::Pixmap,
     tile::Tile,
 };
 use wgpu::{
@@ -33,13 +54,12 @@ use wgpu::{
     RenderPipeline, Texture, TextureView, util::DeviceExt,
 };
 
-use crate::{
-    GpuStrip, RenderError, RenderSize,
-    image_cache::{ImageCache, ImageResource},
-    render::{Config, common::GpuEncodedImage},
-    scene::Scene,
-    schedule::{LoadOp, RendererBackend, Scheduler},
-};
+/// Placeholder value for uninitialized GPU encoded paints.
+const GPU_PAINT_PLACEHOLDER: GpuEncodedPaint = GpuEncodedPaint::LinearGradient(GpuLinearGradient {
+    texture_width_and_extend_mode: 0,
+    gradient_start: 0,
+    transform: [0.0; 6],
+});
 
 /// Options for the renderer
 #[derive(Debug)]
@@ -55,9 +75,18 @@ pub struct RenderTargetConfig {
 /// Vello Hybrid's Renderer.
 #[derive(Debug)]
 pub struct Renderer {
+    /// Programs for rendering.
     programs: Programs,
+    /// Scheduler for scheduling draws.
     scheduler: Scheduler,
+    /// Image cache for storing images atlas allocations.
     image_cache: ImageCache,
+    /// Encoded paints for storing encoded paints.
+    encoded_paints: Vec<GpuEncodedPaint>,
+    /// Stores the index (offset) of the encoded paints in the encoded paints texture.
+    paint_idxs: Vec<u32>,
+    /// Gradient cache for storing gradient ramps.
+    gradient_cache: GradientRampCache,
 }
 
 impl Renderer {
@@ -68,11 +97,15 @@ impl Renderer {
         let max_texture_dimension_2d = device.limits().max_texture_dimension_2d;
         let total_slots = (max_texture_dimension_2d / u32::from(Tile::HEIGHT)) as usize;
         let image_cache = ImageCache::new(max_texture_dimension_2d, max_texture_dimension_2d);
+        let gradient_cache = GradientRampCache::new();
 
         Self {
             programs: Programs::new(device, render_target_config, total_slots),
             scheduler: Scheduler::new(total_slots),
             image_cache,
+            gradient_cache,
+            encoded_paints: Vec::new(),
+            paint_idxs: Vec::new(),
         }
     }
 
@@ -89,16 +122,18 @@ impl Renderer {
         render_size: &RenderSize,
         view: &TextureView,
     ) -> Result<(), RenderError> {
-        let encoded_paints = self.prepare_gpu_encoded_paints(&scene.encoded_paints);
+        self.prepare_gpu_encoded_paints(&scene.encoded_paints);
         // TODO: For the time being, we upload the entire alpha buffer as one big chunk. As a future
         // refinement, we could have a bounded alpha buffer, and break draws when the alpha
         // buffer fills.
         self.programs.prepare(
             device,
             queue,
+            &mut self.gradient_cache,
+            &self.encoded_paints,
             scene.strip_generator.alpha_buf(),
-            encoded_paints,
             render_size,
+            &self.paint_idxs,
         );
         let mut junk = RendererContext {
             programs: &mut self.programs,
@@ -108,7 +143,7 @@ impl Renderer {
             view,
         };
 
-        self.scheduler.do_scene(&mut junk, scene)
+        self.scheduler.do_scene(&mut junk, scene, &self.paint_idxs)
     }
 
     /// Upload image to cache and atlas in one step. Returns the `ImageId`.
@@ -211,41 +246,145 @@ impl Renderer {
         );
     }
 
-    fn prepare_gpu_encoded_paints(&self, encoded_paints: &[EncodedPaint]) -> Vec<GpuEncodedImage> {
-        let mut bytes: Vec<GpuEncodedImage> = Vec::new();
-        for paint in encoded_paints {
+    fn prepare_gpu_encoded_paints(&mut self, encoded_paints: &[EncodedPaint]) {
+        self.encoded_paints
+            .resize_with(encoded_paints.len(), || GPU_PAINT_PLACEHOLDER);
+        self.paint_idxs.resize(encoded_paints.len() + 1, 0);
+
+        self.gradient_cache.maintain();
+
+        let mut current_idx = 0;
+        for (encoded_paint_idx, paint) in encoded_paints.iter().enumerate() {
+            self.paint_idxs[encoded_paint_idx] = current_idx;
             match paint {
                 EncodedPaint::Image(img) => {
                     if let ImageSource::OpaqueId(image_id) = img.source {
                         let image_resource: Option<&ImageResource> = self.image_cache.get(image_id);
                         if let Some(image_resource) = image_resource {
-                            let transform = img.transform * Affine::translate((-0.5, -0.5));
-                            // pack two u16 as u32
-                            let image_size = ((image_resource.width as u32) << 16)
-                                | image_resource.height as u32;
-                            let image_offset = ((image_resource.offset[0] as u32) << 16)
-                                | image_resource.offset[1] as u32;
-                            let quality_and_extend_modes = ((img.extends.1 as u32) << 4)
-                                | ((img.extends.0 as u32) << 2)
-                                | img.quality as u32;
-
-                            bytes.push(GpuEncodedImage {
-                                quality_and_extend_modes,
-                                image_size,
-                                image_offset,
-                                _padding1: 0,
-                                transform: transform.as_coeffs().map(|x| x as f32),
-                                _padding2: [0, 0],
-                            });
+                            let image_paint = self.encode_image_paint(img, image_resource);
+                            self.encoded_paints[encoded_paint_idx] = image_paint;
+                            current_idx += GPU_ENCODED_IMAGE_SIZE_TEXELS;
                         }
                     }
                 }
-                _ => {
-                    unimplemented!("Gradient and rounded rectangle unsupported")
+                EncodedPaint::Gradient(gradient) => {
+                    let (gradient_start, gradient_width) =
+                        self.gradient_cache.get_or_create_ramp(gradient);
+                    let gradient_paint: GpuEncodedPaint =
+                        self.encode_gradient_paint(gradient, gradient_width, gradient_start);
+                    let gradient_size_texels = match &gradient_paint {
+                        GpuEncodedPaint::LinearGradient(_) => GPU_LINEAR_GRADIENT_SIZE_TEXELS,
+                        GpuEncodedPaint::RadialGradient(_) => GPU_RADIAL_GRADIENT_SIZE_TEXELS,
+                        GpuEncodedPaint::SweepGradient(_) => GPU_SWEEP_GRADIENT_SIZE_TEXELS,
+                        _ => unreachable!("encode_gradient_for_gpu only returns gradient types"),
+                    };
+                    self.encoded_paints[encoded_paint_idx] = gradient_paint;
+                    current_idx += gradient_size_texels;
+                }
+                EncodedPaint::BlurredRoundedRect(_blurred_rect) => {
+                    // TODO: Blurred rounded rectangles are not yet supported
+                    log::warn!(
+                        "Blurred rounded rectangles are not yet supported in sparse strips hybrid renderer"
+                    );
                 }
             }
         }
-        bytes
+        self.paint_idxs[encoded_paints.len()] = current_idx;
+    }
+
+    fn encode_image_paint(
+        &self,
+        image: &vello_common::encode::EncodedImage,
+        image_resource: &ImageResource,
+    ) -> GpuEncodedPaint {
+        let image_transform = image.transform * Affine::translate((-0.5, -0.5));
+        let transform = image_transform.as_coeffs().map(|x| x as f32);
+        let image_size = pack_image_size(image_resource.width, image_resource.height);
+        let image_offset = pack_image_offset(image_resource.offset[0], image_resource.offset[1]);
+        let quality_and_extend_modes = pack_quality_and_extend_modes(
+            image.extends.0 as u32,
+            image.extends.1 as u32,
+            image.quality as u32,
+        );
+
+        GpuEncodedPaint::Image(GpuEncodedImage {
+            quality_and_extend_modes,
+            image_size,
+            image_offset,
+            transform,
+            _padding: [0, 0, 0],
+        })
+    }
+
+    fn encode_gradient_paint(
+        &self,
+        gradient: &vello_common::encode::EncodedGradient,
+        gradient_width: u32,
+        gradient_start: u32,
+    ) -> GpuEncodedPaint {
+        let gradient_transform = gradient.transform * Affine::translate((-0.5, -0.5));
+        let transform = gradient_transform.as_coeffs().map(|x| x as f32);
+        let extend_mode = match gradient.pad {
+            true => 0,
+            false => 1,
+        };
+        let texture_width_and_extend_mode =
+            pack_texture_width_and_extend_mode(gradient_width, extend_mode);
+
+        match &gradient.kind {
+            EncodedKind::Linear(_) => GpuEncodedPaint::LinearGradient(GpuLinearGradient {
+                texture_width_and_extend_mode,
+                gradient_start,
+                transform,
+            }),
+            EncodedKind::Radial(radial) => {
+                let (kind, bias, scale, fp0, fp1, fr1, f_focal_x, f_is_swapped, scaled_r0_squared) =
+                    match radial {
+                        RadialKind::Radial { bias, scale } => {
+                            (0, *bias, *scale, 0.0, 0.0, 0.0, 0.0, 0, 0.0)
+                        }
+                        RadialKind::Strip { scaled_r0_squared } => {
+                            (1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0, *scaled_r0_squared)
+                        }
+                        RadialKind::Focal {
+                            focal_data,
+                            fp0,
+                            fp1,
+                        } => (
+                            2,
+                            *fp0,
+                            *fp1,
+                            *fp0,
+                            *fp1,
+                            focal_data.fr1,
+                            focal_data.f_focal_x,
+                            focal_data.f_is_swapped as u32,
+                            0.0,
+                        ),
+                    };
+                GpuEncodedPaint::RadialGradient(GpuRadialGradient {
+                    texture_width_and_extend_mode,
+                    gradient_start,
+                    transform,
+                    kind_and_f_is_swapped: pack_radial_kind_and_swapped(kind, f_is_swapped),
+                    bias,
+                    scale,
+                    fp0,
+                    fp1,
+                    fr1,
+                    f_focal_x,
+                    scaled_r0_squared,
+                })
+            }
+            EncodedKind::Sweep(sweep) => GpuEncodedPaint::SweepGradient(GpuSweepGradient {
+                texture_width_and_extend_mode,
+                gradient_start,
+                transform,
+                start_angle: sweep.start_angle,
+                inv_angle_delta: sweep.inv_angle_delta,
+                _padding: [0, 0],
+            }),
+        }
     }
 }
 
@@ -258,6 +397,8 @@ struct Programs {
     strip_bind_group_layout: BindGroupLayout,
     /// Bind group layout for encoded paints
     encoded_paints_bind_group_layout: BindGroupLayout,
+    /// Bind group layout for gradient texture
+    gradient_bind_group_layout: BindGroupLayout,
 
     /// Pipeline for clearing slots in slot textures.
     clear_pipeline: RenderPipeline,
@@ -270,6 +411,8 @@ struct Programs {
     alpha_data: Vec<u8>,
     /// Scratch buffer for staging encoded paints texture data.
     encoded_paints_data: Vec<u8>,
+    /// Scratch buffer for staging gradient texture data.
+    gradient_data: Vec<u8>,
 }
 
 /// Contains all GPU resources needed for rendering
@@ -288,6 +431,10 @@ struct GpuResources {
     encoded_paints_texture: Texture,
     /// Bind group for encoded paints
     encoded_paints_bind_group: BindGroup,
+    /// Texture for gradient lookup table
+    gradient_texture: Texture,
+    /// Bind group for gradient texture
+    gradient_bind_group: BindGroup,
 
     /// Config buffer for rendering wide tile commands into the view texture.
     view_config_buffer: Buffer,
@@ -403,6 +550,21 @@ impl Programs {
                 }],
             });
 
+        let gradient_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("Gradient Bind Group Layout"),
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                }],
+            });
+
         // Create bind group layout for clearing slots
         let clear_bind_group_layout =
             device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
@@ -436,6 +598,7 @@ impl Programs {
                     &strip_bind_group_layout,
                     &atlas_bind_group_layout,
                     &encoded_paints_bind_group_layout,
+                    &gradient_bind_group_layout,
                 ],
                 push_constant_ranges: &[],
             });
@@ -615,6 +778,19 @@ impl Programs {
             &encoded_paints_bind_group_layout,
             &encoded_paints_texture.create_view(&Default::default()),
         );
+        const INITIAL_GRADIENT_TEXTURE_HEIGHT: u32 = 1;
+        let gradient_data =
+            vec![0; ((max_texture_dimension_2d * INITIAL_GRADIENT_TEXTURE_HEIGHT) << 2) as usize];
+        let gradient_texture = Self::make_gradient_texture(
+            device,
+            max_texture_dimension_2d,
+            INITIAL_GRADIENT_TEXTURE_HEIGHT,
+        );
+        let gradient_bind_group = Self::make_gradient_bind_group(
+            device,
+            &gradient_bind_group_layout,
+            &gradient_texture.create_view(&Default::default()),
+        );
         let slot_bind_groups = Self::make_strip_bind_groups(
             device,
             &strip_bind_group_layout,
@@ -636,6 +812,8 @@ impl Programs {
             atlas_bind_group,
             encoded_paints_texture,
             encoded_paints_bind_group,
+            gradient_texture,
+            gradient_bind_group,
             view_config_buffer,
         };
 
@@ -643,9 +821,11 @@ impl Programs {
             strip_pipeline,
             strip_bind_group_layout,
             encoded_paints_bind_group_layout,
+            gradient_bind_group_layout,
             resources,
             alpha_data,
             encoded_paints_data,
+            gradient_data,
             render_size: RenderSize {
                 width: render_target_config.width,
                 height: render_target_config.height,
@@ -776,6 +956,38 @@ impl Programs {
         })
     }
 
+    fn make_gradient_texture(device: &Device, width: u32, height: u32) -> Texture {
+        device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("Gradient Texture"),
+            size: wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8Unorm,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[],
+        })
+    }
+
+    fn make_gradient_bind_group(
+        device: &Device,
+        gradient_bind_group_layout: &BindGroupLayout,
+        gradient_texture_view: &TextureView,
+    ) -> BindGroup {
+        device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Gradient Bind Group"),
+            layout: gradient_bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::TextureView(gradient_texture_view),
+            }],
+        })
+    }
+
     fn make_strip_bind_groups(
         device: &Device,
         strip_bind_group_layout: &BindGroupLayout,
@@ -844,100 +1056,33 @@ impl Programs {
         &mut self,
         device: &Device,
         queue: &Queue,
+        gradient_cache: &mut GradientRampCache,
+        encoded_paints: &[GpuEncodedPaint],
         alphas: &[u8],
-        encoded_paints: Vec<GpuEncodedImage>,
         new_render_size: &RenderSize,
+        paint_idxs: &[u32],
     ) {
         let max_texture_dimension_2d = device.limits().max_texture_dimension_2d;
-        // Update the alpha texture size if needed
-        self.maybe_resize_alphas_tex(device, alphas, max_texture_dimension_2d);
-        // Update the encoded paints texture size if needed
-        self.maybe_resize_encoded_paints_tex(device, &encoded_paints, max_texture_dimension_2d);
+        self.maybe_resize_alphas_tex(device, max_texture_dimension_2d, alphas);
+        self.maybe_resize_encoded_paints_tex(device, max_texture_dimension_2d, paint_idxs);
+        self.maybe_update_config_buffer(queue, max_texture_dimension_2d, new_render_size);
 
-        // Update config buffer if dimensions changed.
-        if self.render_size != *new_render_size {
-            let config = Config {
-                width: new_render_size.width,
-                height: new_render_size.height,
-                strip_height: Tile::HEIGHT.into(),
-                alphas_tex_width_bits: max_texture_dimension_2d.trailing_zeros(),
-            };
-            let mut buffer = queue
-                .write_buffer_with(&self.resources.view_config_buffer, 0, SIZE_OF_CONFIG)
-                .expect("Buffer only ever holds `Config`");
-            buffer.copy_from_slice(bytemuck::bytes_of(&config));
+        self.upload_alpha_texture(queue, alphas);
+        self.upload_encoded_paints_texture(queue, encoded_paints);
 
-            self.render_size = new_render_size.clone();
+        if gradient_cache.has_changed() {
+            self.maybe_resize_gradient_tex(device, max_texture_dimension_2d, gradient_cache);
+            self.upload_gradient_texture(queue, gradient_cache);
+            gradient_cache.mark_synced();
         }
-
-        // Prepare alpha data for the texture with 16 1-byte alpha values per texel (4 per channel)
-        let texture_width = self.resources.alphas_texture.width();
-        let texture_height = self.resources.alphas_texture.height();
-        debug_assert!(
-            alphas.len() <= (texture_width * texture_height * 16) as usize,
-            "Alpha texture dimensions are too small to fit the alpha data"
-        );
-
-        // After this copy to `self.alpha_data`, there may be stale trailing alpha values. These
-        // are not sampled, so can be left as-is.
-        self.alpha_data[0..alphas.len()].copy_from_slice(alphas);
-        queue.write_texture(
-            wgpu::TexelCopyTextureInfo {
-                texture: &self.resources.alphas_texture,
-                mip_level: 0,
-                origin: wgpu::Origin3d::ZERO,
-                aspect: wgpu::TextureAspect::All,
-            },
-            &self.alpha_data,
-            wgpu::TexelCopyBufferLayout {
-                offset: 0,
-                // 16 bytes per RGBA32Uint texel (4 u32s × 4 bytes each), which is equivalent to
-                // a bit shift of 4.
-                bytes_per_row: Some(texture_width << 4),
-                rows_per_image: Some(texture_height),
-            },
-            wgpu::Extent3d {
-                width: texture_width,
-                height: texture_height,
-                depth_or_array_layers: 1,
-            },
-        );
-
-        // Upload encoded paints to the texture
-        let encoded_paints_texture = &self.resources.encoded_paints_texture;
-        let encoded_paints_texture_width = encoded_paints_texture.width();
-        let encoded_paints_texture_height = encoded_paints_texture.height();
-
-        let encoded_paints_bytes = bytemuck::cast_slice(&encoded_paints);
-        self.encoded_paints_data[0..encoded_paints_bytes.len()]
-            .copy_from_slice(encoded_paints_bytes);
-        queue.write_texture(
-            wgpu::TexelCopyTextureInfo {
-                texture: encoded_paints_texture,
-                mip_level: 0,
-                origin: wgpu::Origin3d::ZERO,
-                aspect: wgpu::TextureAspect::All,
-            },
-            &self.encoded_paints_data,
-            wgpu::TexelCopyBufferLayout {
-                offset: 0,
-                // 16 bytes per RGBA32Uint texel (4 u32s × 4 bytes each), equivalent to bit shift of 4
-                bytes_per_row: Some(encoded_paints_texture_width << 4),
-                rows_per_image: Some(encoded_paints_texture_height),
-            },
-            wgpu::Extent3d {
-                width: encoded_paints_texture_width,
-                height: encoded_paints_texture_height,
-                depth_or_array_layers: 1,
-            },
-        );
     }
 
+    /// Update the alpha texture size if needed.
     fn maybe_resize_alphas_tex(
         &mut self,
         device: &Device,
-        alphas: &[u8],
         max_texture_dimension_2d: u32,
+        alphas: &[u8],
     ) {
         let required_alpha_height = u32::try_from(alphas.len())
             .unwrap()
@@ -978,15 +1123,15 @@ impl Programs {
         }
     }
 
+    /// Update the encoded paints texture size if needed.
     fn maybe_resize_encoded_paints_tex(
         &mut self,
         device: &Device,
-        encoded_paints: &[GpuEncodedImage],
         max_texture_dimension_2d: u32,
+        paint_idxs: &[u32],
     ) {
-        let required_encoded_paints_height = u32::try_from(size_of_val(encoded_paints))
-            .unwrap()
-            .div_ceil(max_texture_dimension_2d << 4);
+        let required_texels = paint_idxs.last().unwrap();
+        let required_encoded_paints_height = required_texels.div_ceil(max_texture_dimension_2d);
         debug_assert!(
             self.resources.encoded_paints_texture.width() == max_texture_dimension_2d,
             "Encoded paints texture width must match max texture dimensions"
@@ -1016,6 +1161,173 @@ impl Programs {
                     .resources
                     .encoded_paints_texture
                     .create_view(&Default::default()),
+            );
+        }
+    }
+
+    /// Update the gradient texture size if needed.
+    fn maybe_resize_gradient_tex(
+        &mut self,
+        device: &Device,
+        max_texture_dimension_2d: u32,
+        gradient_cache: &GradientRampCache,
+    ) {
+        let gradient_pixels = (gradient_cache.size() / 4) as u32; // 4 bytes per RGBA8 pixel
+        let required_gradient_height = gradient_pixels.div_ceil(max_texture_dimension_2d);
+        debug_assert!(
+            self.resources.gradient_texture.width() == max_texture_dimension_2d,
+            "Gradient texture width must match max texture dimensions"
+        );
+        let current_gradient_height = self.resources.gradient_texture.height();
+        if required_gradient_height > current_gradient_height {
+            assert!(
+                required_gradient_height <= max_texture_dimension_2d,
+                "Gradient texture height exceeds max texture dimensions"
+            );
+            let required_gradient_size = (max_texture_dimension_2d * required_gradient_height) << 2; // 4 bytes per RGBA8 pixel
+            self.gradient_data
+                .resize(required_gradient_size as usize, 0);
+            let gradient_texture = Self::make_gradient_texture(
+                device,
+                max_texture_dimension_2d,
+                required_gradient_height,
+            );
+            self.resources.gradient_texture = gradient_texture;
+
+            // Since the gradient texture has changed, we need to update the gradient bind group.
+            self.resources.gradient_bind_group = Self::make_gradient_bind_group(
+                device,
+                &self.gradient_bind_group_layout,
+                &self
+                    .resources
+                    .gradient_texture
+                    .create_view(&Default::default()),
+            );
+        }
+    }
+
+    /// Update config buffer if dimensions changed.
+    fn maybe_update_config_buffer(
+        &mut self,
+        queue: &Queue,
+        max_texture_dimension_2d: u32,
+        new_render_size: &RenderSize,
+    ) {
+        if self.render_size != *new_render_size {
+            let config = Config {
+                width: new_render_size.width,
+                height: new_render_size.height,
+                strip_height: Tile::HEIGHT.into(),
+                alphas_tex_width_bits: max_texture_dimension_2d.trailing_zeros(),
+            };
+            let mut buffer = queue
+                .write_buffer_with(&self.resources.view_config_buffer, 0, SIZE_OF_CONFIG)
+                .expect("Buffer only ever holds `Config`");
+            buffer.copy_from_slice(bytemuck::bytes_of(&config));
+
+            self.render_size = new_render_size.clone();
+        }
+    }
+
+    /// Upload alpha data to the texture.
+    fn upload_alpha_texture(&mut self, queue: &Queue, alphas: &[u8]) {
+        let texture_width = self.resources.alphas_texture.width();
+        let texture_height = self.resources.alphas_texture.height();
+        debug_assert!(
+            alphas.len() <= (texture_width * texture_height * 16) as usize,
+            "Alpha texture dimensions are too small to fit the alpha data"
+        );
+
+        // After this copy to `self.alpha_data`, there may be stale trailing alpha values. These
+        // are not sampled, so can be left as-is.
+        self.alpha_data[0..alphas.len()].copy_from_slice(alphas);
+        queue.write_texture(
+            wgpu::TexelCopyTextureInfo {
+                texture: &self.resources.alphas_texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            &self.alpha_data,
+            wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                // 16 bytes per RGBA32Uint texel (4 u32s × 4 bytes each), which is equivalent to
+                // a bit shift of 4.
+                bytes_per_row: Some(texture_width << 4),
+                rows_per_image: Some(texture_height),
+            },
+            wgpu::Extent3d {
+                width: texture_width,
+                height: texture_height,
+                depth_or_array_layers: 1,
+            },
+        );
+    }
+
+    /// Upload encoded paints to the texture.
+    fn upload_encoded_paints_texture(&mut self, queue: &Queue, encoded_paints: &[GpuEncodedPaint]) {
+        let encoded_paints_texture = &self.resources.encoded_paints_texture;
+        let encoded_paints_texture_width = encoded_paints_texture.width();
+        let encoded_paints_texture_height = encoded_paints_texture.height();
+
+        GpuEncodedPaint::serialize_to_buffer(encoded_paints, &mut self.encoded_paints_data);
+        queue.write_texture(
+            wgpu::TexelCopyTextureInfo {
+                texture: encoded_paints_texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            &self.encoded_paints_data,
+            wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                // 16 bytes per RGBA32Uint texel (4 u32s × 4 bytes each), equivalent to bit shift of 4
+                bytes_per_row: Some(encoded_paints_texture_width << 4),
+                rows_per_image: Some(encoded_paints_texture_height),
+            },
+            wgpu::Extent3d {
+                width: encoded_paints_texture_width,
+                height: encoded_paints_texture_height,
+                depth_or_array_layers: 1,
+            },
+        );
+    }
+
+    /// Upload gradient data to the texture.
+    fn upload_gradient_texture(&mut self, queue: &Queue, gradient_cache: &GradientRampCache) {
+        let gradient_texture = &self.resources.gradient_texture;
+        let gradient_texture_width = gradient_texture.width();
+        let gradient_texture_height = gradient_texture.height();
+
+        // Copy the flat gradient LUT data
+        if !gradient_cache.is_empty() {
+            let total_capacity = (gradient_texture_width * gradient_texture_height * 4) as usize;
+
+            self.gradient_data.clear();
+            self.gradient_data.resize(total_capacity, 0);
+
+            let copy_len = gradient_cache.size().min(self.gradient_data.len());
+            self.gradient_data[0..copy_len].copy_from_slice(&gradient_cache.luts()[0..copy_len]);
+
+            queue.write_texture(
+                wgpu::TexelCopyTextureInfo {
+                    texture: gradient_texture,
+                    mip_level: 0,
+                    origin: wgpu::Origin3d::ZERO,
+                    aspect: wgpu::TextureAspect::All,
+                },
+                &self.gradient_data,
+                wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    // 4 bytes per RGBA8 pixel
+                    bytes_per_row: Some(gradient_texture_width << 2),
+                    rows_per_image: Some(gradient_texture_height),
+                },
+                wgpu::Extent3d {
+                    width: gradient_texture_width,
+                    height: gradient_texture_height,
+                    depth_or_array_layers: 1,
+                },
             );
         }
     }
@@ -1085,6 +1397,7 @@ impl RendererContext<'_> {
         render_pass.set_bind_group(0, &self.programs.resources.slot_bind_groups[ix], &[]);
         render_pass.set_bind_group(1, &self.programs.resources.atlas_bind_group, &[]);
         render_pass.set_bind_group(2, &self.programs.resources.encoded_paints_bind_group, &[]);
+        render_pass.set_bind_group(3, &self.programs.resources.gradient_bind_group, &[]);
         render_pass.set_vertex_buffer(0, self.programs.resources.strips_buffer.slice(..));
         render_pass.draw(0..4, 0..u32::try_from(strips.len()).unwrap());
     }

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -156,7 +156,10 @@ impl Renderer {
             view,
         };
 
-        self.scheduler.do_scene(&mut junk, scene, &self.paint_idxs)
+        let result = self.scheduler.do_scene(&mut junk, scene, &self.paint_idxs);
+        self.gradient_cache.maintain();
+
+        result
     }
 
     /// Upload image to cache and atlas in one step. Returns the `ImageId`.
@@ -263,8 +266,6 @@ impl Renderer {
         self.encoded_paints
             .resize_with(encoded_paints.len(), || GPU_PAINT_PLACEHOLDER);
         self.paint_idxs.resize(encoded_paints.len() + 1, 0);
-
-        self.gradient_cache.maintain();
 
         let mut current_idx = 0;
         for (encoded_paint_idx, paint) in encoded_paints.iter().enumerate() {

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -109,9 +109,10 @@ impl Scene {
     fn encode_current_paint(&mut self) -> Paint {
         match self.paint.clone() {
             PaintType::Solid(s) => s.into(),
-            PaintType::Gradient(_) => {
-                unimplemented!("Gradient not implemented")
-            }
+            PaintType::Gradient(g) => g.encode_into(
+                &mut self.encoded_paints,
+                self.transform * self.paint_transform,
+            ),
             PaintType::Image(i) => i.encode_into(
                 &mut self.encoded_paints,
                 self.transform * self.paint_transform,

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -22,6 +22,21 @@ use vello_common::strip_generator::StripGenerator;
 /// Default tolerance for curve flattening
 pub(crate) const DEFAULT_TOLERANCE: f64 = 0.1;
 
+/// Settings to apply to the render context.
+#[derive(Copy, Clone, Debug)]
+pub struct RenderSettings {
+    /// The SIMD level that should be used for rendering operations.
+    pub level: Level,
+}
+
+impl Default for RenderSettings {
+    fn default() -> Self {
+        Self {
+            level: Level::try_detect().unwrap_or(Level::fallback()),
+        }
+    }
+}
+
 /// A render state which contains the style properties for path rendering and
 /// the current transform.
 #[derive(Debug)]
@@ -59,6 +74,11 @@ pub struct Scene {
 impl Scene {
     /// Create a new render context with the given width and height in pixels.
     pub fn new(width: u16, height: u16) -> Self {
+        Self::new_with(width, height, RenderSettings::default())
+    }
+
+    /// Create a new render context with specific settings.
+    pub fn new_with(width: u16, height: u16, settings: RenderSettings) -> Self {
         let render_state = Self::default_render_state();
         Self {
             width,
@@ -70,11 +90,7 @@ impl Scene {
             encoded_paints: vec![],
             paint_visible: true,
             stroke: render_state.stroke,
-            strip_generator: StripGenerator::new(
-                width,
-                height,
-                Level::try_detect().unwrap_or(Level::fallback()),
-            ),
+            strip_generator: StripGenerator::new(width, height, settings.level),
             transform: render_state.transform,
             fill_rule: render_state.fill_rule,
             blend_mode: render_state.blend_mode,

--- a/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
@@ -60,6 +60,8 @@ const RADIAL_GRADIENT_TYPE_FOCAL: u32 = 2u;
 const PI: f32 = 3.1415926535897932384626433832795028;
 const TWO_PI: f32 = 2.0 * PI;
 // Tolerance for nearly zero comparisons (matching vello_cpu implementation).
+// Note: This must match SCALAR_NEARLY_ZERO in vello_common/src/math.rs
+// @see {@link https://github.com/linebender/vello/blob/748ba4c7a8973f642f778591b09658d8ee6e1132/sparse_strips/vello_common/src/math.rs#L21}
 const NEARLY_ZERO_TOLERANCE: f32 = 1.0 / 4096.0;
 
 // Composite modes.

--- a/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
@@ -24,7 +24,7 @@
 // More details in the `StripInstance` documentation below.
 
 
-// Color source modes - where the fragment shader gets color data from
+// Color source modes - where the fragment shader gets color data from.
 // Use payload (color or image coordinates)
 const COLOR_SOURCE_PAYLOAD: u32 = 0u;
 // Sample from clip texture slot
@@ -33,14 +33,36 @@ const COLOR_SOURCE_BLEND: u32 = 2u;
 
 // Paint types
 const PAINT_TYPE_SOLID: u32 = 0u;  
-const PAINT_TYPE_IMAGE: u32 = 1u;  
+const PAINT_TYPE_IMAGE: u32 = 1u;
+const PAINT_TYPE_LINEAR_GRADIENT: u32 = 2u;
+const PAINT_TYPE_RADIAL_GRADIENT: u32 = 3u;
+const PAINT_TYPE_SWEEP_GRADIENT: u32 = 4u;
+
+// Paint texture index mask (extracts lower 27 bits from paint field).
+const PAINT_TEXTURE_INDEX_MASK: u32 = 0x07FFFFFFu; 
 
 // Image quality
 const IMAGE_QUALITY_LOW = 0u;
 const IMAGE_QUALITY_MEDIUM = 1u;
 const IMAGE_QUALITY_HIGH = 2u;
 
-// Composite modes
+// Gradient types.
+const GRADIENT_TYPE_LINEAR: u32 = 0u;
+const GRADIENT_TYPE_RADIAL: u32 = 1u;
+const GRADIENT_TYPE_SWEEP: u32 = 2u;
+
+// Radial gradient types.
+const RADIAL_GRADIENT_TYPE_STANDARD: u32 = 0u;
+const RADIAL_GRADIENT_TYPE_STRIP: u32 = 1u;
+const RADIAL_GRADIENT_TYPE_FOCAL: u32 = 2u;
+
+// Mathematical constants.
+const PI: f32 = 3.1415926535897932384626433832795028;
+const TWO_PI: f32 = 2.0 * PI;
+// Tolerance for nearly zero comparisons (matching vello_cpu implementation).
+const NEARLY_ZERO_TOLERANCE: f32 = 1.0 / 4096.0;
+
+// Composite modes.
 const COMPOSE_CLEAR: u32 = 0u;
 const COMPOSE_COPY: u32 = 1u;
 const COMPOSE_DEST: u32 = 2u;
@@ -93,10 +115,10 @@ struct Config {
 //   - Bits 0-29:  Usage depends on color_source:
 //
 //     When color_source = 0 (COLOR_SOURCE_PAYLOAD):
-//       - Bits 28-29: `paint_type` (0 = solid, 1 = image)
-//       - Bits 0-27: 
+//       - Bits 27-29: `paint_type` (0 = solid, 1 = image, 2 = linear_gradient, 3 = radial_gradient, 4 = sweep_gradient)
+//       - Bits 0-26: 
 //         - If paint_type = 0: unused
-//         - If paint_type = 1: `paint_texture_id`
+//         - If paint_type >= 1: `paint_texture_idx`
 //
 //     When color_source = 1 (COLOR_SOURCE_SLOT):
 //       - Bits 0-7: opacity (0-255)
@@ -113,9 +135,14 @@ struct Config {
 // ├── paint_type = 0 (PAINT_TYPE_SOLID) - Solid color rendering
 // │   └── payload = [r, g, b, a] RGBA (packed as u8s)
 // │
-// └── paint_type = 1 (PAINT_TYPE_IMAGE) - Image rendering
+// ├── paint_type = 1 (PAINT_TYPE_IMAGE) - Image rendering
+// │   └── payload = packed image parameters
+// │
+// ├── paint_type = 2 (PAINT_TYPE_LINEAR_GRADIENT) - Linear gradient rendering
+// ├── paint_type = 3 (PAINT_TYPE_RADIAL_GRADIENT) - Radial gradient (with kind discriminator)
+// └── paint_type = 4 (PAINT_TYPE_SWEEP_GRADIENT) - Sweep gradient rendering
 //     ├── payload = [x, y] scene coordinates (packed as u16s)
-//     └── bits 0-27 = paint_texture_id
+//     └── bits 0-27 = paint_texture_idx
 //
 // color_source = 1 (COLOR_SOURCE_SLOT) - Use slot texture
 // ├── payload = slot_index (u32)
@@ -171,6 +198,9 @@ var atlas_texture: texture_2d<f32>;
 @group(2) @binding(0)
 var encoded_paints_texture: texture_2d<u32>;
 
+@group(3) @binding(0)
+var gradient_texture: texture_2d<f32>;
+
 @vertex
 fn vs_main(
     @builtin(vertex_index) in_vertex_index: u32,
@@ -200,10 +230,10 @@ fn vs_main(
 
     let color_source = (instance.paint >> 30u) & 0x3u;
     if color_source == COLOR_SOURCE_PAYLOAD {
-        let paint_type = (instance.paint >> 28u) & 0x3u;
+        let paint_type = (instance.paint >> 27u) & 0x7u;
         if paint_type == PAINT_TYPE_IMAGE {
-            let paint_tex_id = instance.paint & 0x0FFFFFFF;
-            let encoded_image = unpack_encoded_image(paint_tex_id);
+            let paint_tex_idx = instance.paint & PAINT_TEXTURE_INDEX_MASK;
+            let encoded_image = unpack_encoded_image(paint_tex_idx);
             // Unpack view coordinates for image sampling
             let scene_strip_x = instance.payload & 0xffffu;
             let scene_strip_y = instance.payload >> 16u;
@@ -269,14 +299,14 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     var final_color: vec4<f32>;
 
     if color_source == COLOR_SOURCE_PAYLOAD {
-        let paint_type = (in.paint >> 28u) & 0x3u;
+        let paint_type = (in.paint >> 27u) & 0x7u;
 
         // in.payload encodes a color for PAINT_TYPE_SOLID or sample_xy for PAINT_TYPE_IMAGE
         if paint_type == PAINT_TYPE_SOLID {
             final_color = alpha * unpack4x8unorm(in.payload);
         } else if paint_type == PAINT_TYPE_IMAGE {
-            let paint_tex_id = in.paint & 0x0FFFFFFF;
-            let encoded_image = unpack_encoded_image(paint_tex_id);
+            let paint_tex_idx = in.paint & PAINT_TEXTURE_INDEX_MASK;
+            let encoded_image = unpack_encoded_image(paint_tex_idx);
             let image_offset = encoded_image.image_offset;
             let image_size = encoded_image.image_size;
             let local_xy = in.sample_xy - image_offset;
@@ -310,6 +340,87 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
                 let final_xy = image_offset + extended_xy;
                 final_color = alpha * textureLoad(atlas_texture, vec2<u32>(final_xy), 0);
             }
+        } else if paint_type == PAINT_TYPE_LINEAR_GRADIENT {
+            let paint_tex_idx = in.paint & PAINT_TEXTURE_INDEX_MASK;
+            let linear_gradient = unpack_linear_gradient(paint_tex_idx);
+            
+            // Calculate fragment position and apply transform
+            let fragment_pos = vec2<f32>(in.position.x, in.position.y);
+            let grad_pos = vec2<f32>(
+                linear_gradient.transform[0] * fragment_pos.x + 
+                linear_gradient.transform[2] * fragment_pos.y +
+                linear_gradient.transform[4],
+                linear_gradient.transform[1] * fragment_pos.x +
+                linear_gradient.transform[3] * fragment_pos.y + 
+                linear_gradient.transform[5]
+            );
+            
+            // For linear gradient, t-value is just the x coordinate in gradient space
+            let t_value = grad_pos.x + 0.00001;
+            let gradient_color = sample_gradient_lut(
+                t_value,
+                linear_gradient.extend_mode,
+                linear_gradient.gradient_start,
+                linear_gradient.texture_width
+            );
+            final_color = alpha * gradient_color;
+        } else if paint_type == PAINT_TYPE_RADIAL_GRADIENT {
+            let paint_tex_idx = in.paint & PAINT_TEXTURE_INDEX_MASK;
+            let radial_gradient = unpack_radial_gradient(paint_tex_idx);
+            
+            // Calculate fragment position and apply transform
+            let fragment_pos = vec2<f32>(in.position.x, in.position.y);
+            let grad_pos = vec2<f32>(
+                radial_gradient.transform[0] * fragment_pos.x + 
+                radial_gradient.transform[2] * fragment_pos.y + 
+                radial_gradient.transform[4],
+                radial_gradient.transform[1] * fragment_pos.x + 
+                radial_gradient.transform[3] * fragment_pos.y + 
+                radial_gradient.transform[5]
+            );
+            
+            // For radial gradient, calculate distance from center
+            let gradient_result = calculate_radial_gradient(grad_pos, radial_gradient);
+            if gradient_result.is_valid {
+                let gradient_color = sample_gradient_lut(
+                    gradient_result.t_value, 
+                    radial_gradient.extend_mode, 
+                    radial_gradient.gradient_start, 
+                    radial_gradient.texture_width
+                );
+                final_color = alpha * gradient_color;
+            } else {
+                // Invalid gradient region - render as transparent
+                final_color = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+            }
+        } else if paint_type == PAINT_TYPE_SWEEP_GRADIENT {
+            let paint_tex_idx = in.paint & PAINT_TEXTURE_INDEX_MASK;
+            let sweep_gradient = unpack_sweep_gradient(paint_tex_idx);
+            
+            // Calculate fragment position and apply transform
+            let fragment_pos = vec2<f32>(in.position.x, in.position.y);
+            let grad_pos = vec2<f32>(
+                sweep_gradient.transform[0] * fragment_pos.x + 
+                sweep_gradient.transform[2] * fragment_pos.y + 
+                sweep_gradient.transform[4],
+                sweep_gradient.transform[1] * fragment_pos.x + 
+                sweep_gradient.transform[3] * fragment_pos.y + 
+                sweep_gradient.transform[5]
+            );
+            
+            // For sweep gradient, calculate angle from center using fast polynomial approximation
+            // Flip Y coordinate for screen coordinate system (Y increases downward)
+            let unit_angle = xy_to_unit_angle(grad_pos.x, -grad_pos.y);
+            // Convert unit angle [0, 1) to radians [0, 2π)
+            let angle = unit_angle * TWO_PI;
+            let t_value = (angle - sweep_gradient.start_angle) * sweep_gradient.inv_angle_delta;
+            let gradient_color = sample_gradient_lut(
+                t_value,
+                sweep_gradient.extend_mode,
+                sweep_gradient.gradient_start,
+                sweep_gradient.texture_width
+            );
+            final_color = alpha * gradient_color;
         }
     } else if color_source == COLOR_SOURCE_SLOT {
         // in.payload encodes a slot in the source clip texture
@@ -634,21 +745,24 @@ struct EncodedImage {
     translate: vec2<f32>,
 }
 
-fn unpack_encoded_image(paint_tex_id: u32) -> EncodedImage {
-    let texel0 = textureLoad(encoded_paints_texture, vec2<u32>(paint_tex_id, 0), 0);
+// Unpack encoded image from the encoded paints texture.
+fn unpack_encoded_image(paint_tex_idx: u32) -> EncodedImage {
+    let texel0 = textureLoad(encoded_paints_texture, vec2<u32>(paint_tex_idx, 0), 0);
+    let texel1 = textureLoad(encoded_paints_texture, vec2<u32>(paint_tex_idx + 1u, 0), 0);
+    let texel2 = textureLoad(encoded_paints_texture, vec2<u32>(paint_tex_idx + 2u, 0), 0);
+    
     let quality = texel0.x & 0x3u;
     let extend_x = (texel0.x >> 2u) & 0x3u;
     let extend_y = (texel0.x >> 4u) & 0x3u;
+    // Unpack image_size from texel0.y (stored as u32, unpack to width/height)
     let image_size = vec2<f32>(f32(texel0.y >> 16u), f32(texel0.y & 0xFFFFu));
+    // Unpack image_offset from texel0.z (stored as u32, unpack to x/y)
     let image_offset = vec2<f32>(f32(texel0.z >> 16u), f32(texel0.z & 0xFFFFu));
-
-    let texel1 = textureLoad(encoded_paints_texture, vec2<u32>(paint_tex_id + 1u, 0), 0);
-    let texel2 = textureLoad(encoded_paints_texture, vec2<u32>(paint_tex_id + 2u, 0), 0);
     let transform = vec4<f32>(
-        bitcast<f32>(texel1.x), bitcast<f32>(texel1.y), 
-        bitcast<f32>(texel1.z), bitcast<f32>(texel1.w)
+        bitcast<f32>(texel0.w), bitcast<f32>(texel1.x), 
+        bitcast<f32>(texel1.y), bitcast<f32>(texel1.z)
     );
-    let translate = vec2<f32>(bitcast<f32>(texel2.x), bitcast<f32>(texel2.y));
+    let translate = vec2<f32>(bitcast<f32>(texel1.w), bitcast<f32>(texel2.x));
 
     return EncodedImage(
         quality, 
@@ -824,4 +938,289 @@ fn cubic_weights(fract: f32) -> vec4<f32> {
 // This matches the CPU implementation exactly
 fn single_weight(t: f32, a: f32, b: f32, c: f32, d: f32) -> f32 {
     return t * (t * (t * d + c) + b) + a;
+}
+
+// Fast polynomial approximation for xy_to_unit_angle from Skia
+// Returns angle in [0, 1) range representing [0, 2π)
+// See: https://github.com/google/skia/blob/30bba741989865c157c7a997a0caebe94921276b/src/opts/SkRasterPipeline_opts.h#L5859
+fn xy_to_unit_angle(x: f32, y: f32) -> f32 {
+    let xabs = abs(x);
+    let yabs = abs(y);
+    let slope = min(xabs, yabs) / max(xabs, yabs);
+    let s = slope * slope;
+    // Use a 7th degree polynomial to approximate atan.
+    // This was generated using sollya.gforge.inria.fr.
+    // A float optimized polynomial was generated using the following command.
+    // P1 = fpminimax((1/(2*Pi))*atan(x),[|1,3,5,7|],[|24...|],[2^(-40),1],relative);
+    var phi = slope * (0.15912117063999176025390625 + s * (-5.185396969318389892578125e-2 + s * (2.476101927459239959716796875e-2 + s * (-7.0547382347285747528076171875e-3))));
+    // Map from first octant to full circle using quadrant information
+    // Handle [0°, 90°] range
+    phi = select(phi, 0.25 - phi, xabs < yabs);
+    // Handle [90°, 180°] range
+    phi = select(phi, 0.5 - phi, x < 0.0);
+    // Handle [180°, 360°] range
+    phi = select(phi, 1.0 - phi, y < 0.0);
+    // Handle NaN cases (using property that NaN != NaN)
+    phi = select(phi, 0.0, phi != phi);
+    return phi;
+}
+
+// Sample from the gradient texture at calculated position.
+fn sample_gradient_lut(t_value: f32, extend_mode: u32, gradient_start: u32, texture_width: u32) -> vec4<f32> {
+    // Apply extend mode to t_value
+    let clamped_t = extend_mode_normalized(t_value, extend_mode);
+    // Convert t_value to texture coordinate
+    let t_offset = u32(clamped_t * f32(texture_width - 1u));
+    // Calculate absolute position in flat gradient texture
+    let flat_coord = gradient_start + t_offset;
+    // Convert flat coordinate to 2D texture coordinate
+    let gradient_tex_width = textureDimensions(gradient_texture).x;
+    let tex_x = flat_coord % gradient_tex_width;
+    let tex_y = flat_coord / gradient_tex_width;
+    // Sample from the gradient texture at calculated position
+    let gradient_color = textureLoad(gradient_texture, vec2<u32>(tex_x, tex_y), 0);
+    return gradient_color;
+}
+
+struct LinearGradient {
+    /// The extend mode for the gradient (0=Pad, 1=Repeat).
+    extend_mode: u32,
+    /// Start coordinate in the flat gradient texture.
+    gradient_start: u32,
+    /// Width of the gradient texture.
+    texture_width: u32,
+    /// Transform matrix [a, b, c, d, tx, ty].
+    transform: array<f32, 6>,
+}
+
+struct RadialGradient {
+    /// The extend mode for the gradient (0=Pad, 1=Repeat).
+    extend_mode: u32,
+    /// Start coordinate in the flat gradient texture.
+    gradient_start: u32,
+    /// Width of the gradient texture.
+    texture_width: u32,
+    /// Transform matrix [a, b, c, d, tx, ty].
+    transform: array<f32, 6>,
+    /// Bias value for radial gradient calculation.
+    bias: f32,
+    /// Scale factor for radial gradient calculation.
+    scale: f32,
+    /// Focal point 0 parameter for radial gradient.
+    fp0: f32,
+    /// Focal point 1 parameter for radial gradient.
+    fp1: f32,
+    /// Focal radius 1 parameter for radial gradient.
+    fr1: f32,
+    /// Focal X coordinate for radial gradient.
+    f_focal_x: f32,
+    /// Whether focal point is swapped for radial gradient (0=false, 1=true).
+    f_is_swapped: u32,
+    /// Scaled radius 0 squared parameter for radial gradient strip.
+    scaled_r0_squared: f32,
+    /// Kind of radial gradient (0=Radial, 1=Strip, 2=Focal).
+    kind: u32,
+}
+
+struct SweepGradient {
+    /// The extend mode for the gradient (0=Pad, 1=Repeat).
+    extend_mode: u32,
+    /// Start coordinate in the flat gradient texture.
+    gradient_start: u32,
+    /// Width of the gradient texture.
+    texture_width: u32,
+    /// Transform matrix [a, b, c, d, tx, ty].
+    transform: array<f32, 6>,
+    /// Starting angle for sweep gradient (in radians).
+    start_angle: f32,
+    /// Inverse of angle delta for sweep gradient.
+    inv_angle_delta: f32,
+}
+
+// Unpack linear gradient from the encoded paints texture.
+fn unpack_linear_gradient(paint_tex_idx: u32) -> LinearGradient {
+    let texel0 = textureLoad(encoded_paints_texture, vec2<u32>(paint_tex_idx, 0), 0);
+    let texel1 = textureLoad(encoded_paints_texture, vec2<u32>(paint_tex_idx + 1u, 0), 0);
+    
+    let texture_width_and_extend_mode = unpack_texture_width_and_extend_mode(texel0.x);
+    let texture_width = texture_width_and_extend_mode.x;
+    let extend_mode = texture_width_and_extend_mode.y;
+    let gradient_start = texel0.y;
+    
+    let transform = array<f32, 6>(
+        bitcast<f32>(texel0.z), bitcast<f32>(texel0.w), bitcast<f32>(texel1.x),
+        bitcast<f32>(texel1.y), bitcast<f32>(texel1.z), bitcast<f32>(texel1.w)
+    );
+    
+    return LinearGradient(
+        extend_mode, gradient_start, texture_width, transform
+    );
+}
+
+// Result of calculating a radial gradient.
+struct RadialGradientResult {
+    t_value: f32,
+    is_valid: bool,
+}
+
+// Calculate a radial gradient; matches vello_cpu implementation.
+fn calculate_radial_gradient(grad_pos: vec2<f32>, radial_gradient: RadialGradient) -> RadialGradientResult {
+    let x_pos = grad_pos.x;
+    let y_pos = grad_pos.y;
+    
+    var t_value: f32;
+    var is_valid: bool;
+    
+    switch radial_gradient.kind {
+        case RADIAL_GRADIENT_TYPE_STANDARD: {
+            // Standard radial gradient: bias + scale * sqrt(x^2 + y^2)
+            let radius = sqrt(x_pos * x_pos + y_pos * y_pos);
+            t_value = radial_gradient.bias + radial_gradient.scale * radius;
+            // Radial gradients are always valid
+            is_valid = true;
+        }
+        case RADIAL_GRADIENT_TYPE_STRIP: {
+            // Strip gradient: x + sqrt(scaled_r0_squared - y^2)
+            let p1 = radial_gradient.scaled_r0_squared - y_pos * y_pos;
+            // Invalid if negative under square root
+            is_valid = p1 >= 0.0;
+            if is_valid {
+                t_value = x_pos + sqrt(p1);
+            } else {
+                // Value doesn't matter when invalid
+                t_value = 0.0;
+            }
+        }
+        case RADIAL_GRADIENT_TYPE_FOCAL, default: {
+            // Focal gradient implementation
+            var t = 0.0;
+            let fp0 = radial_gradient.fp0;
+            let fp1 = radial_gradient.fp1;
+            let fr1 = radial_gradient.fr1;
+            let f_focal_x = radial_gradient.f_focal_x;
+            let is_swapped = radial_gradient.f_is_swapped;
+            
+            // Calculate focal flags directly from field values (matching FocalData implementation)
+            let is_focal_on_circle = abs(1.0 - fr1) <= NEARLY_ZERO_TOLERANCE;
+            let is_well_behaved = !is_focal_on_circle && fr1 > 1.0;
+            let is_natively_focal = abs(f_focal_x) <= NEARLY_ZERO_TOLERANCE;
+            
+            // Start with valid assumption
+            is_valid = true;
+            
+            if is_focal_on_circle {
+                t = x_pos + y_pos * y_pos / x_pos;
+                // Check for division by zero and negative t
+                is_valid = t >= 0.0 && x_pos != 0.0;
+            } else if is_well_behaved {
+                t = sqrt(x_pos * x_pos + y_pos * y_pos) - x_pos * fp0;
+            } else {
+                // For non-well-behaved gradients, check if calculation is valid
+                let xx = x_pos * x_pos;
+                let yy = y_pos * y_pos;
+                let discriminant = xx - yy;
+                
+                if is_swapped != 0u || (1.0 - f_focal_x < 0.0) {
+                    t = -sqrt(discriminant) - x_pos * fp0;
+                } else {
+                    t = sqrt(discriminant) - x_pos * fp0;
+                }
+                
+                // Invalid if discriminant is negative or t is negative
+                is_valid = discriminant >= 0.0 && t >= 0.0;
+            }
+            
+            // Apply additional focal transforms only if still valid
+            if is_valid {
+                if 1.0 - f_focal_x < 0.0 {
+                    t = -t;
+                }
+                
+                if !is_natively_focal {
+                    t = t + fp1;
+                }
+                
+                if is_swapped != 0u {
+                    t = 1.0 - t;
+                }
+            }
+            
+            t_value = t;
+        }
+    }
+    
+    return RadialGradientResult(t_value, is_valid);
+}
+
+// Unpack radial gradient from the encoded paints texture.
+fn unpack_radial_gradient(paint_tex_idx: u32) -> RadialGradient {
+    let texel0 = textureLoad(encoded_paints_texture, vec2<u32>(paint_tex_idx, 0), 0);
+    let texel1 = textureLoad(encoded_paints_texture, vec2<u32>(paint_tex_idx + 1u, 0), 0);
+    let texel2 = textureLoad(encoded_paints_texture, vec2<u32>(paint_tex_idx + 2u, 0), 0);
+    let texel3 = textureLoad(encoded_paints_texture, vec2<u32>(paint_tex_idx + 3u, 0), 0);
+    
+    let texture_width_and_extend_mode = unpack_texture_width_and_extend_mode(texel0.x);
+    let texture_width = texture_width_and_extend_mode.x;
+    let extend_mode = texture_width_and_extend_mode.y;
+    let gradient_start = texel0.y;
+    let transform = array<f32, 6>(
+        bitcast<f32>(texel0.z), bitcast<f32>(texel0.w), bitcast<f32>(texel1.x),
+        bitcast<f32>(texel1.y), bitcast<f32>(texel1.z), bitcast<f32>(texel1.w)
+    );
+    
+    let kind_and_swapped = unpack_radial_kind_and_swapped(texel2.x);
+    let kind = kind_and_swapped.x;
+    let f_is_swapped = kind_and_swapped.y;
+    
+    let bias = bitcast<f32>(texel2.y);
+    let scale = bitcast<f32>(texel2.z);
+    let fp0 = bitcast<f32>(texel2.w);
+    let fp1 = bitcast<f32>(texel3.x);
+    let fr1 = bitcast<f32>(texel3.y);
+    let f_focal_x = bitcast<f32>(texel3.z);
+    let scaled_r0_squared = bitcast<f32>(texel3.w);
+    
+    return RadialGradient(
+        extend_mode, gradient_start, texture_width, transform,
+        bias, scale, fp0, fp1, fr1, f_focal_x, f_is_swapped, scaled_r0_squared, kind
+    );
+}
+
+// Unpack sweep gradient from the encoded paints texture.
+fn unpack_sweep_gradient(paint_tex_idx: u32) -> SweepGradient {
+    let texel0 = textureLoad(encoded_paints_texture, vec2<u32>(paint_tex_idx, 0), 0);
+    let texel1 = textureLoad(encoded_paints_texture, vec2<u32>(paint_tex_idx + 1u, 0), 0);
+    let texel2 = textureLoad(encoded_paints_texture, vec2<u32>(paint_tex_idx + 2u, 0), 0);
+    
+    let texture_width_and_extend_mode = unpack_texture_width_and_extend_mode(texel0.x);
+    let texture_width = texture_width_and_extend_mode.x;
+    let extend_mode = texture_width_and_extend_mode.y;
+    let gradient_start = texel0.y;
+    let transform = array<f32, 6>(
+        bitcast<f32>(texel0.z), bitcast<f32>(texel0.w), bitcast<f32>(texel1.x),
+        bitcast<f32>(texel1.y), bitcast<f32>(texel1.z), bitcast<f32>(texel1.w)
+    );
+    
+    let start_angle = bitcast<f32>(texel2.x);
+    let inv_angle_delta = bitcast<f32>(texel2.y);
+
+    return SweepGradient(
+        extend_mode, gradient_start, texture_width, transform, start_angle, inv_angle_delta
+    );
+}
+
+// Unpack texture_width and extend_mode from packed field.
+// Returns (texture_width, extend_mode).
+fn unpack_texture_width_and_extend_mode(packed: u32) -> vec2<u32> {
+    let texture_width = packed & 0x7FFFFFFFu;  // Mask out bit 31
+    let extend_mode = (packed >> 31u) & 1u;    // Extract bit 31
+    return vec2<u32>(texture_width, extend_mode);
+}
+
+// Unpack radial gradient kind and f_is_swapped from packed field.
+// Returns (kind, f_is_swapped).
+fn unpack_radial_kind_and_swapped(packed: u32) -> vec2<u32> {
+    let kind = packed & 0x3u;           // Extract bits 0-1
+    let f_is_swapped = (packed >> 2u) & 1u;  // Extract bit 2
+    return vec2<u32>(kind, f_is_swapped);
 }

--- a/sparse_strips/vello_sparse_tests/tests/gradient.rs
+++ b/sparse_strips/vello_sparse_tests/tests/gradient.rs
@@ -298,7 +298,11 @@ mod linear {
         ctx.fill_path(&path);
     }
 
-    #[vello_test]
+    // vello_hybrid:
+    // - diff_pixels = 2: It’s likely that the issue comes from accumulated rounding errors.
+    // When the gradient’s t-value falls right on the edge of the texture ramp, it may yield
+    // a different result than in vello_cpu.
+    #[vello_test(diff_pixels = 2)]
     fn gradient_linear_with_y_repeat(ctx: &mut impl Renderer) {
         let rect = Rect::new(10.0, 10.0, 90.0, 90.0);
 
@@ -887,7 +891,8 @@ mod sweep {
         basic(ctx, stops_green_blue(), Point::new(30.0, 30.0));
     }
 
-    #[vello_test]
+    // A single pixel deviates from the reference image by at most 2 units per color channel.
+    #[vello_test(diff_pixels = 1)]
     fn gradient_sweep_complex_shape(ctx: &mut impl Renderer) {
         let path = crossed_line_star();
 

--- a/sparse_strips/vello_sparse_tests/tests/mix.rs
+++ b/sparse_strips/vello_sparse_tests/tests/mix.rs
@@ -14,6 +14,10 @@ use vello_common::peniko::{
 };
 use vello_dev_macros::vello_test;
 
+fn cowboy_img(ctx: &mut impl Renderer) -> ImageSource {
+    ctx.get_image_source(load_image!("cowboy"))
+}
+
 // The outputs have been compared visually with tiny-skia, and except for two cases (where tiny-skia
 // is wrong), the overall visual effect looks the same.
 fn mix(ctx: &mut impl Renderer, blend_mode: BlendMode) {
@@ -50,7 +54,7 @@ fn mix(ctx: &mut impl Renderer, blend_mode: BlendMode) {
     };
 
     let image = Image {
-        source: ImageSource::Pixmap(load_image!("cowboy")),
+        source: cowboy_img(ctx),
         x_extend: Extend::Pad,
         y_extend: Extend::Pad,
         quality: ImageQuality::Low,
@@ -65,12 +69,12 @@ fn mix(ctx: &mut impl Renderer, blend_mode: BlendMode) {
     ctx.pop_layer();
 }
 
-#[vello_test]
+#[vello_test(hybrid_tolerance = 1)]
 fn mix_normal(ctx: &mut impl Renderer) {
     mix(ctx, BlendMode::new(Mix::Normal, Compose::SrcOver));
 }
 
-#[vello_test(cpu_u8_tolerance = 1)]
+#[vello_test(cpu_u8_tolerance = 1, hybrid_tolerance = 1)]
 fn mix_multiply(ctx: &mut impl Renderer) {
     mix(ctx, BlendMode::new(Mix::Multiply, Compose::SrcOver));
 }
@@ -80,17 +84,17 @@ fn mix_screen(ctx: &mut impl Renderer) {
     mix(ctx, BlendMode::new(Mix::Screen, Compose::SrcOver));
 }
 
-#[vello_test(cpu_u8_tolerance = 1)]
+#[vello_test(cpu_u8_tolerance = 1, hybrid_tolerance = 1)]
 fn mix_darken(ctx: &mut impl Renderer) {
     mix(ctx, BlendMode::new(Mix::Darken, Compose::SrcOver));
 }
 
-#[vello_test(cpu_u8_tolerance = 1)]
+#[vello_test(cpu_u8_tolerance = 1, hybrid_tolerance = 1)]
 fn mix_lighten(ctx: &mut impl Renderer) {
     mix(ctx, BlendMode::new(Mix::Lighten, Compose::SrcOver));
 }
 
-#[vello_test(cpu_u8_tolerance = 4)]
+#[vello_test(cpu_u8_tolerance = 4, hybrid_tolerance = 5)]
 fn mix_color_dodge(ctx: &mut impl Renderer) {
     mix(ctx, BlendMode::new(Mix::ColorDodge, Compose::SrcOver));
 }
@@ -104,12 +108,12 @@ fn mix_color_dodge(ctx: &mut impl Renderer) {
 //  f32:  1.0 - ((1.0 - 0.8784314) / 0.125) = 0.027451038 (RGB value of around 7)
 //  u8/u16:  255 - (((255 - 224) * 255) / 31) = 0
 // And therefore a very large difference for that one component.
-#[vello_test(cpu_u8_tolerance = 5)]
+#[vello_test(cpu_u8_tolerance = 5, hybrid_tolerance = 1)]
 fn mix_color_burn(ctx: &mut impl Renderer) {
     mix(ctx, BlendMode::new(Mix::ColorBurn, Compose::SrcOver));
 }
 
-#[vello_test(cpu_u8_tolerance = 1)]
+#[vello_test(cpu_u8_tolerance = 1, hybrid_tolerance = 1)]
 fn mix_hard_light(ctx: &mut impl Renderer) {
     mix(ctx, BlendMode::new(Mix::HardLight, Compose::SrcOver));
 }
@@ -129,7 +133,7 @@ fn mix_exclusion(ctx: &mut impl Renderer) {
     mix(ctx, BlendMode::new(Mix::Exclusion, Compose::SrcOver));
 }
 
-#[vello_test(cpu_u8_tolerance = 1)]
+#[vello_test(cpu_u8_tolerance = 1, hybrid_tolerance = 1)]
 fn mix_overlay(ctx: &mut impl Renderer) {
     mix(ctx, BlendMode::new(Mix::Overlay, Compose::SrcOver));
 }
@@ -144,12 +148,12 @@ fn mix_saturation(ctx: &mut impl Renderer) {
     mix(ctx, BlendMode::new(Mix::Saturation, Compose::SrcOver));
 }
 
-#[vello_test(cpu_u8_tolerance = 2)]
+#[vello_test(cpu_u8_tolerance = 2, hybrid_tolerance = 1)]
 fn mix_color(ctx: &mut impl Renderer) {
     mix(ctx, BlendMode::new(Mix::Color, Compose::SrcOver));
 }
 
-#[vello_test(cpu_u8_tolerance = 1)]
+#[vello_test(cpu_u8_tolerance = 1, hybrid_tolerance = 1)]
 fn mix_luminosity(ctx: &mut impl Renderer) {
     mix(ctx, BlendMode::new(Mix::Luminosity, Compose::SrcOver));
 }


### PR DESCRIPTION
This PR implements a comprehensive gradient rendering system for `vello_hybrid` that combines CPU-side preprocessing with GPU-accelerated rendering. The implementation supports three gradient types (linear, radial, and sweep) with efficient caching and shader processing.

<img width="520" height="521" alt="image" src="https://github.com/user-attachments/assets/1b9d4386-5d9b-4524-8328-822d955de090" />&nbsp;

Gradient rendering in `vello_hybrid` uses a two-phase approach combining CPU preprocessing with GPU acceleration. On the CPU side, gradients are processed through a caching system (`GradientRampCache`) that generates lookup tables (LUTs) for color interpolation. When a gradient is encountered, the system creates a cache key based on color stops, interpolation color space, and hue direction. If not cached, it generates a SIMD-optimized LUT containing pre-computed colors and stores it in a flat byte buffer. All gradient LUTs are packed into a single buffer and uploaded to a 2d `Rgba8Unorm` GPU texture for efficient sampling.

During GPU rendering, the fragment shader handles three gradient types (linear, radial, sweep) through a unified pipeline. Each fragment calculates its position in gradient space using transform matrices, then computes a parameter t specific to the gradient type: linear gradients use the x-coordinate, radial gradients calculate distance-based values (with sub-types for standard, strip, and focal gradients), and sweep gradients use fast polynomial approximation for angle calculations (faster than trigonometric functions). The t value is then used to sample the appropriate position in the gradient LUT texture, with extend modes applied for values outside [0,1].

The system has several optimizations: LRU caching prevents redundant LUT generation, SIMD LUT generation accelerates color interpolation, packed texture storage minimizes GPU memory usage, and the unified sampling function reduces shader complexity.


