### PR TITLE
Introduce a new clipping algorithm for non-layer based clipping

### DIFF
--- a/sparse_strips/vello_common/src/coarse.rs
+++ b/sparse_strips/vello_common/src/coarse.rs
@@ -317,10 +317,7 @@ impl<const MODE: u8> Wide<MODE> {
 
             // Determine if the region between this strip and the next should be filled
             // based on the fill rule (NonZero or EvenOdd)
-            let active_fill = match fill_rule {
-                Fill::NonZero => next_strip.winding != 0,
-                Fill::EvenOdd => next_strip.winding % 2 != 0,
-            };
+            let active_fill = next_strip.fill_left_area(fill_rule);
 
             // If region should be filled and both strips are on the same row,
             // generate fill commands for the region between them
@@ -511,10 +508,7 @@ impl<const MODE: u8> Wide<MODE> {
             let wtile_x_clamped = (x / WideTile::WIDTH).min(clip_bbox.x1());
             if cur_wtile_x < wtile_x_clamped {
                 // If winding is zero or doesn't match fill rule, these wide tiles are outside the path
-                let is_inside = match fill_rule {
-                    Fill::NonZero => strip.winding != 0,
-                    Fill::EvenOdd => strip.winding % 2 != 0,
-                };
+                let is_inside = strip.fill_left_area(fill_rule);
                 if !is_inside {
                     for wtile_x in cur_wtile_x..wtile_x_clamped {
                         self.get_mut(wtile_x, cur_wtile_y).push_zero_clip();
@@ -642,10 +636,7 @@ impl<const MODE: u8> Wide<MODE> {
                 // Pop zero clips for tiles that had zero winding or didn't match fill rule
                 // TODO: The winding check is probably not needed; if there was a fill,
                 // the logic below should have advanced wtile_x.
-                let is_inside = match fill_rule {
-                    Fill::NonZero => strip.winding != 0,
-                    Fill::EvenOdd => strip.winding % 2 != 0,
-                };
+                let is_inside = strip.fill_left_area(fill_rule);
                 if !is_inside {
                     for wtile_x in cur_wtile_x..wtile_x_clamped {
                         self.get_mut(wtile_x, cur_wtile_y).pop_zero_clip();
@@ -705,10 +696,7 @@ impl<const MODE: u8> Wide<MODE> {
             }
 
             // Handle fill regions between strips based on fill rule
-            let is_inside = match fill_rule {
-                Fill::NonZero => next_strip.winding != 0,
-                Fill::EvenOdd => next_strip.winding % 2 != 0,
-            };
+            let is_inside = next_strip.fill_left_area(fill_rule);
             if is_inside && strip_y == next_strip.strip_y() {
                 if cur_wtile_x >= clip_bbox.x1() {
                     continue;

--- a/sparse_strips/vello_common/src/strip.rs
+++ b/sparse_strips/vello_common/src/strip.rs
@@ -466,11 +466,11 @@ fn intersect_impl<S: Simd>(
     path_2: IntersectInputRef<'_>,
     target: IntersectOutput<'_>,
 )  {
+    target.strips.clear();
+    
     if path_1.strips.is_empty() || path_2.strips.is_empty() {
         return;
     }
-    
-    target.strips.clear();
 
     let mut cur_y = path_1.strips[0].strip_y().min(path_2.strips[0].strip_y());
     let end_y = path_1.strips[path_1.strips.len() - 1].strip_y()

--- a/sparse_strips/vello_common/src/strip.rs
+++ b/sparse_strips/vello_common/src/strip.rs
@@ -28,6 +28,20 @@ impl Strip {
     pub fn strip_y(&self) -> u16 {
         self.y / Tile::HEIGHT
     }
+    
+    /// Return whether the strip is a sentinel strip.
+    pub fn is_sentinel(&self) -> bool {
+        self.x == u16::MAX
+    }
+    
+    /// Return whether the area to the left of this strip should be filled according to the
+    /// fill rule.
+    pub fn fill_left_area(&self, rule: Fill) -> bool {
+        match rule {
+            Fill::NonZero => self.winding != 0,
+            Fill::EvenOdd => self.winding % 2 != 0,
+        }
+    }
 }
 
 /// Render the tiles stored in `tiles` into the strip and alpha buffer.

--- a/sparse_strips/vello_common/src/util.rs
+++ b/sparse_strips/vello_common/src/util.rs
@@ -3,7 +3,7 @@
 
 //! Utility functions.
 
-use fearless_simd::{Simd, f32x16, u8x16};
+use fearless_simd::{Simd, f32x16, u8x16, u16x32, u16x16, u8x32, SimdBase};
 
 /// Convert f32x16 to u8x16.
 #[inline(always)]
@@ -18,4 +18,36 @@ pub fn f32_to_u8<S: Simd>(val: f32x16<S>) -> u8x16<S> {
     let uzp1 = simd.unzip_low_u8x16(p1, p2);
     let uzp2 = simd.unzip_low_u8x16(p3, p4);
     simd.unzip_low_u8x16(uzp1, uzp2)
+}
+
+pub trait Div255Ext {
+    fn div_255(self) -> Self;
+}
+
+impl<S: Simd> Div255Ext for u16x32<S> {
+    #[inline(always)]
+    fn div_255(self) -> Self {
+        let p1 = Self::splat(self.simd, 255);
+        let p2 = self + p1;
+        p2.shr(8)
+    }
+}
+
+impl<S: Simd> Div255Ext for u16x16<S> {
+    #[inline(always)]
+    fn div_255(self) -> Self {
+        let p1 = Self::splat(self.simd, 255);
+        let p2 = self + p1;
+        p2.shr(8)
+    }
+}
+
+#[inline(always)]
+pub fn normalized_mul_u8x32<S: Simd>(a: u8x32<S>, b: u8x32<S>) -> u16x32<S> {
+    (S::widen_u8x32(a.simd, a) * S::widen_u8x32(b.simd, b)).div_255()
+}
+
+#[inline(always)]
+pub fn normalized_mul_u8x16<S: Simd>(a: u8x16<S>, b: u8x16<S>) -> u16x16<S> {
+    (S::widen_u8x16(a.simd, a) * S::widen_u8x16(b.simd, b)).div_255()
 }

--- a/sparse_strips/vello_cpu/src/dispatch/mod.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/mod.rs
@@ -14,6 +14,7 @@ use vello_common::coarse::Wide;
 use vello_common::encode::EncodedPaint;
 use vello_common::mask::Mask;
 use vello_common::paint::Paint;
+use vello_common::strip::IntersectInputRef;
 
 pub(crate) trait Dispatcher: Debug + Send + Sync {
     fn wide(&self) -> &Wide;
@@ -25,6 +26,7 @@ pub(crate) trait Dispatcher: Debug + Send + Sync {
         transform: Affine,
         paint: Paint,
         aliasing_threshold: Option<u8>,
+        clip_path: Option<IntersectInputRef<'_>>,
     );
     fn stroke_path(
         &mut self,
@@ -33,6 +35,7 @@ pub(crate) trait Dispatcher: Debug + Send + Sync {
         transform: Affine,
         paint: Paint,
         aliasing_threshold: Option<u8>,
+        clip_path: Option<IntersectInputRef<'_>>,
     );
     fn push_layer(
         &mut self,

--- a/sparse_strips/vello_cpu/src/dispatch/multi_threaded/worker.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/multi_threaded/worker.rs
@@ -52,8 +52,9 @@ impl Worker {
                     paint,
                     fill_rule,
                     aliasing_threshold,
+                    clip_path,
                 } => {
-                    let func = |strips: &[Strip]| {
+                    let func = |strips: &[Strip], _| {
                         let coarse_command = CoarseTask::Render {
                             thread_id: self.thread_id,
                             strips: strips.into(),
@@ -71,6 +72,7 @@ impl Worker {
                                 fill_rule,
                                 transform,
                                 aliasing_threshold,
+                                clip_path.as_ref().map(|c| c.as_intersect_ref()),
                                 func,
                             );
                         }
@@ -80,6 +82,7 @@ impl Worker {
                                 fill_rule,
                                 transform,
                                 aliasing_threshold,
+                                clip_path.as_ref().map(|c| c.as_intersect_ref()),
                                 func,
                             );
                         }
@@ -91,6 +94,7 @@ impl Worker {
                     paint,
                     stroke,
                     aliasing_threshold,
+                    clip_path,
                 } => {
                     let func = |strips: &[Strip]| {
                         let coarse_command = CoarseTask::Render {
@@ -110,6 +114,7 @@ impl Worker {
                                 &stroke,
                                 transform,
                                 aliasing_threshold,
+                                clip_path.as_ref().map(|c| c.as_intersect_ref()),
                                 func,
                             );
                         }
@@ -119,6 +124,7 @@ impl Worker {
                                 &stroke,
                                 transform,
                                 aliasing_threshold,
+                                clip_path.as_ref().map(|c| c.as_intersect_ref()),
                                 func,
                             );
                         }
@@ -139,7 +145,8 @@ impl Worker {
                             fill_rule,
                             transform,
                             aliasing_threshold,
-                            |strips| strip_buf = strips,
+                            None,
+                            |strips, _| strip_buf = strips,
                         );
 
                         Some((strip_buf.into(), fill_rule))

--- a/sparse_strips/vello_cpu/src/dispatch/single_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/single_threaded.rs
@@ -13,6 +13,7 @@ use vello_common::encode::EncodedPaint;
 use vello_common::fearless_simd::{Level, Simd, simd_dispatch};
 use vello_common::mask::Mask;
 use vello_common::paint::Paint;
+use vello_common::strip::IntersectInputRef;
 use vello_common::strip_generator::StripGenerator;
 
 #[derive(Debug)]
@@ -98,15 +99,17 @@ impl Dispatcher for SingleThreadedDispatcher {
         transform: Affine,
         paint: Paint,
         aliasing_threshold: Option<u8>,
+        clip_path: Option<IntersectInputRef<'_>>,
     ) {
         let wide = &mut self.wide;
 
-        let func = |strips| wide.generate(strips, fill_rule, paint, 0);
+        let func = |strips, _| wide.generate(strips, fill_rule, paint, 0);
         self.strip_generator.generate_filled_path(
             path,
             fill_rule,
             transform,
             aliasing_threshold,
+            clip_path,
             func,
         );
     }
@@ -118,6 +121,7 @@ impl Dispatcher for SingleThreadedDispatcher {
         transform: Affine,
         paint: Paint,
         aliasing_threshold: Option<u8>,
+        clip_path: Option<IntersectInputRef<'_>>,
     ) {
         let wide = &mut self.wide;
 
@@ -127,6 +131,7 @@ impl Dispatcher for SingleThreadedDispatcher {
             stroke,
             transform,
             aliasing_threshold,
+            clip_path,
             func,
         );
     }
@@ -167,7 +172,8 @@ impl Dispatcher for SingleThreadedDispatcher {
                 fill_rule,
                 clip_transform,
                 aliasing_threshold,
-                |strips| strip_buf = strips,
+                None,
+                |strips, _| strip_buf = strips,
             );
 
             Some((strip_buf, fill_rule))

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -11,7 +11,6 @@ use crate::dispatch::multi_threaded::MultiThreadedDispatcher;
 use crate::dispatch::single_threaded::SingleThreadedDispatcher;
 use crate::kurbo::{PathEl, Point};
 use alloc::boxed::Box;
-#[cfg(feature = "text")]
 use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -169,13 +169,13 @@ impl RenderContext {
         }
     }
     
-    pub fn push_clip_path(&mut self, clip_path: &BezPath, fill_rule: Fill) {
+    pub fn push_clip_path(&mut self, clip_path: &BezPath) {
         let last_clip = self.clip_stack.last().map(|c| c.clone());
         let clip_input = last_clip.as_ref().map(|c| c.as_intersect_ref());
         
         self.strip_generator.generate_filled_path(
             clip_path,
-            fill_rule,
+            self.fill_rule,
             self.transform,
             self.aliasing_threshold,
             clip_input,
@@ -183,7 +183,7 @@ impl RenderContext {
                 let rendered_path = IntersectInputOwned {
                     alphas: alphas.into(),
                     strips: strips.into(),
-                    fill: fill_rule,
+                    fill: self.fill_rule,
                 };
                 
                 self.clip_stack.push(Arc::new(rendered_path));

--- a/sparse_strips/vello_cpu/src/util.rs
+++ b/sparse_strips/vello_cpu/src/util.rs
@@ -5,6 +5,7 @@ use crate::peniko::{BlendMode, Compose, ImageQuality, Mix};
 use vello_common::encode::EncodedImage;
 use vello_common::fearless_simd::{Simd, SimdBase, f32x4, u8x32, u16x16, u16x32};
 use vello_common::math::FloatExt;
+use vello_common::util::Div255Ext;
 
 #[allow(
     dead_code,
@@ -77,33 +78,6 @@ impl<S: Simd> NormalizedMulExt for u8x32<S> {
         let divided = (self.simd.widen_u8x32(self) * other.simd.widen_u8x32(other)).div_255();
         self.simd.narrow_u16x32(divided)
     }
-}
-
-pub(crate) trait Div255Ext {
-    fn div_255(self) -> Self;
-}
-
-impl<S: Simd> Div255Ext for u16x32<S> {
-    #[inline(always)]
-    fn div_255(self) -> Self {
-        let p1 = Self::splat(self.simd, 255);
-        let p2 = self + p1;
-        p2.shr(8)
-    }
-}
-
-impl<S: Simd> Div255Ext for u16x16<S> {
-    #[inline(always)]
-    fn div_255(self) -> Self {
-        let p1 = Self::splat(self.simd, 255);
-        let p2 = self + p1;
-        p2.shr(8)
-    }
-}
-
-#[inline(always)]
-pub(crate) fn normalized_mul<S: Simd>(a: u8x32<S>, b: u8x32<S>) -> u16x32<S> {
-    (S::widen_u8x32(a.simd, a) * S::widen_u8x32(b.simd, b)).div_255()
 }
 
 pub(crate) trait BlendModeExt {

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -145,12 +145,13 @@ impl Scene {
         aliasing_threshold: Option<u8>,
     ) {
         let wide = &mut self.wide;
-        let func = |strips| wide.generate(strips, fill_rule, paint, 0);
+        let func = |strips, _| wide.generate(strips, fill_rule, paint, 0);
         self.strip_generator.generate_filled_path(
             path,
             fill_rule,
             transform,
             aliasing_threshold,
+            None,
             func,
         );
     }
@@ -180,6 +181,7 @@ impl Scene {
             &self.stroke,
             transform,
             aliasing_threshold,
+            None,
             func,
         );
     }
@@ -232,7 +234,8 @@ impl Scene {
                 self.fill_rule,
                 self.transform,
                 self.aliasing_threshold,
-                |strips| strip_buf = strips,
+                None,
+                |strips, _| strip_buf = strips,
             );
 
             Some((strip_buf, self.fill_rule))
@@ -579,7 +582,8 @@ impl Scene {
             self.fill_rule,
             transform,
             self.aliasing_threshold,
-            |generated_strips| {
+            None,
+            |generated_strips, _| {
                 strips.extend_from_slice(generated_strips);
             },
         );
@@ -597,6 +601,7 @@ impl Scene {
             &self.stroke,
             transform,
             self.aliasing_threshold,
+            None,
             |generated_strips| {
                 strips.extend_from_slice(generated_strips);
             },

--- a/sparse_strips/vello_sparse_tests/snapshots/clip_non_isolated_outside_canvas.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/clip_non_isolated_outside_canvas.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:acc4f4602f91b71ca283af813d72694e7cca36b27690f0561e0be5f55638d746
+size 71

--- a/sparse_strips/vello_sparse_tests/tests/clip.rs
+++ b/sparse_strips/vello_sparse_tests/tests/clip.rs
@@ -326,3 +326,15 @@ fn clip_completely_in_out_of_bounds_wide_tile(ctx: &mut impl Renderer) {
     ctx.push_clip_layer(&Rect::new(300.0, 8.0, 350.0, 48.0).to_path(0.1));
     ctx.pop_layer();
 }
+
+#[vello_test(skip_hybrid, width = 16, height = 16)]
+fn clip_non_isolated_outside_canvas(ctx: &mut impl Renderer) {
+    // Should be completely clipped.
+    let clip_rect = Rect::new(0.0, 0.0, 16.0, 16.0);
+    ctx.push_clip_path(&clip_rect.to_path(0.1));
+    
+    let rect = Rect::new(16.0, -16.0, 32.0, 0.0);
+    ctx.set_paint(REBECCA_PURPLE);
+    ctx.fill_rect(&rect);
+    ctx.pop_clip_path();
+}

--- a/sparse_strips/vello_sparse_tests/tests/renderer.rs
+++ b/sparse_strips/vello_sparse_tests/tests/renderer.rs
@@ -41,10 +41,12 @@ pub(crate) trait Renderer: Sized + GlyphRenderer {
     );
     fn flush(&mut self);
     fn push_clip_layer(&mut self, path: &BezPath);
+    fn push_clip_path(&mut self, path: &BezPath);
     fn push_blend_layer(&mut self, blend_mode: BlendMode);
     fn push_opacity_layer(&mut self, opacity: f32);
     fn push_mask_layer(&mut self, mask: Mask);
     fn pop_layer(&mut self);
+    fn pop_clip_path(&mut self);
     fn set_stroke(&mut self, stroke: Stroke);
     fn set_paint(&mut self, paint: impl Into<PaintType>);
     fn set_paint_transform(&mut self, affine: Affine);
@@ -121,6 +123,10 @@ impl Renderer for RenderContext {
         Self::push_clip_layer(self, path);
     }
 
+    fn push_clip_path(&mut self, path: &BezPath) {
+        Self::push_clip_path(self, path);
+    }
+
     fn push_blend_layer(&mut self, blend_mode: BlendMode) {
         Self::push_blend_layer(self, blend_mode);
     }
@@ -135,6 +141,10 @@ impl Renderer for RenderContext {
 
     fn pop_layer(&mut self) {
         Self::pop_layer(self);
+    }
+
+    fn pop_clip_path(&mut self) {
+        Self::pop_clip_path(self)
     }
 
     fn set_stroke(&mut self, stroke: Stroke) {
@@ -307,6 +317,10 @@ impl Renderer for HybridRenderer {
         self.scene.push_clip_layer(path);
     }
 
+    fn push_clip_path(&mut self, path: &BezPath) {
+        todo!()
+    }
+
     fn push_blend_layer(&mut self, blend_mode: BlendMode) {
         self.scene.push_layer(None, Some(blend_mode), None, None);
     }
@@ -321,6 +335,10 @@ impl Renderer for HybridRenderer {
 
     fn pop_layer(&mut self) {
         self.scene.pop_layer();
+    }
+
+    fn pop_clip_path(&mut self) {
+        todo!()
     }
 
     fn set_stroke(&mut self, stroke: Stroke) {


### PR DESCRIPTION
Bear with me as this is still not done, lots of cleanup, more tests and documentation needed, just opening this for tracking. Mainly wanted to get a quick dirty version working first! :)

# Motivation
Currently, the only way to do efficient clipping in Vello Sparse is by pushing a new isolated layer and associating a clip path with that layer. This might be sufficient for cases like for example SVG, but the problem is that doing so forces the user to conflate layers and clipping, which is not what should be done in some imaging models. For example, clip paths in PDF have nothing to do with isolation, and it is therefore desirable to be able to separate the two. I believe the same is the case for HTML canvas, where the clip stack is not really related to layers, and the fact they are causes problems (see https://github.com/linebender/vello/issues/1117). In practice, this mostly doesn't cause issues as (to my understanding) source-over compositing with premultiplied alpha is associative and it therefore mostly doesn't matter whether you clip with isolation or not. However, problems start to occur once you add masks or blending to the mix, as the behavior with and without isolation is not identical.

It should be noted that above can be simulated by creating a new mask for each clip path, but this is obviously expensive, especially for deeply-nested clips.

# Solution
Because of this, I propose a second way to support clipping in Vello CPU (could be added to hybrid as well) that is based on an independent clip stack that can be pushed and popped to without actually having to create new layers. In particular, you do not need to clear the clip stack before rasterizing, which should adddress the issue in #1117.

I think how this works is very neat and demonstrates how useful sparse strips are! Fundamentally, this is based on a new algorithm that, given two paths in sparse strips representation, computes a new path in sparse strips representation that represents the intersection of the two. While the actual implementation is a bit finicky, conceptually it's very simple: We iterate over each stripped and fill region of the two paths in lock step and determine all of the overlaps between the two. In case we have two fill regions, the overlap region will also be filled. In case we have one strip and one fill region, the overlap will copy the alpha mask of the strip region. Finally, if we have two strip regions, we combine the alpha masks of both. That's it, this is enough to compute a new sparse strips path that when filled is equivalent to intersecting the two strips. The beauty of this is that this is incredibly fast because of the usual sparseness of paths and the result will also still be as sparse as possible as we preserve sparse fill regions whenever possible.

Given this, we introduce two new `push_clip_path` and `pop_clip_path` methods that operate on their own clip stack and completely independently from the push/pop layer commands. In case a clip path is currently active, once we draw a path we simply calculate the intersection after converting it into sparse strips, and then use that new path as the basis in coarse rasterization instead. In case we call `push_clip_path` multiple times, we can simply intersect the new clip path with the one in the previous stack position, to end up with one single new clip path that represents the intersection of all previous ones. Therefore, even for deeply nested clips we only need to perform one intersection per path drawn.

The disadvantage is that in multi-threading, it requires us to process new clip paths on the main thread, but the advantage is that (unlike the current clip algorithm) causes no additional overhead during rasterization (which is currently the only serial part), and the clipping calculation is done by each worker separately for the path they are currently processing, which means it scales very well!

# Testing
I will add more tests, but I confirmed the current version to cause no regressions in my PDF test suite.