### PR TITLE
Separate storage of strips and alphas from strip generator

### DIFF
--- a/sparse_strips/vello_common/src/recording.rs
+++ b/sparse_strips/vello_common/src/recording.rs
@@ -41,9 +41,7 @@ impl CachedStrips {
 
     /// Check if this cached strips is empty.
     pub fn is_empty(&self) -> bool {
-        self.strip_storage.strips.is_empty()
-            && self.strip_storage.alphas.is_empty()
-            && self.strip_start_indices.is_empty()
+        self.strip_storage.is_empty() && self.strip_start_indices.is_empty()
     }
 
     /// Get the number of strips.

--- a/sparse_strips/vello_common/src/recording.rs
+++ b/sparse_strips/vello_common/src/recording.rs
@@ -12,59 +12,58 @@ use crate::paint::PaintType;
 use crate::peniko::Font;
 use crate::peniko::{BlendMode, Fill};
 use crate::strip::Strip;
+use crate::strip_generator::StripStorage;
 use alloc::vec::Vec;
 
 /// Cached sparse strip data.
 #[derive(Debug, Default)]
 pub struct CachedStrips {
-    /// The cached sparse strips.
-    strips: Vec<Strip>,
-    /// The alpha buffer data.
-    alphas: Vec<u8>,
+    /// The strip storage.
+    strip_storage: StripStorage,
     /// Strip start indices for each geometry command.
     strip_start_indices: Vec<usize>,
 }
 
 impl CachedStrips {
     /// Create a new cached strips instance.
-    pub fn new(strips: Vec<Strip>, alphas: Vec<u8>, strip_start_indices: Vec<usize>) -> Self {
+    pub fn new(strip_storage: StripStorage, strip_start_indices: Vec<usize>) -> Self {
         Self {
-            strips,
-            alphas,
+            strip_storage,
             strip_start_indices,
         }
     }
 
     /// Clear the contents.
     pub fn clear(&mut self) {
-        self.strips.clear();
-        self.alphas.clear();
+        self.strip_storage.reset();
         self.strip_start_indices.clear();
     }
 
     /// Check if this cached strips is empty.
     pub fn is_empty(&self) -> bool {
-        self.strips.is_empty() && self.alphas.is_empty() && self.strip_start_indices.is_empty()
+        self.strip_storage.strips.is_empty()
+            && self.strip_storage.alphas.is_empty()
+            && self.strip_start_indices.is_empty()
     }
 
     /// Get the number of strips.
     pub fn strip_count(&self) -> usize {
-        self.strips.len()
+        self.strip_storage.strips.len()
     }
 
     /// Get the number of alpha bytes.
     pub fn alpha_count(&self) -> usize {
-        self.alphas.len()
+        self.strip_storage.alphas.len()
     }
 
     /// Get strips as slice.
     pub fn strips(&self) -> &[Strip] {
-        &self.strips
+        &self.strip_storage.strips
     }
 
     /// Get alphas as slice
     pub fn alphas(&self) -> &[u8] {
-        &self.alphas
+        &self.strip_storage.alphas
     }
 
     /// Get strip start indices.
@@ -73,11 +72,10 @@ impl CachedStrips {
     }
 
     /// Takes ownership of all buffers.
-    pub fn take(&mut self) -> (Vec<Strip>, Vec<u8>, Vec<usize>) {
-        let strips = core::mem::take(&mut self.strips);
-        let alphas = core::mem::take(&mut self.alphas);
+    pub fn take(&mut self) -> (StripStorage, Vec<usize>) {
+        let strip_storage = core::mem::take(&mut self.strip_storage);
         let strip_start_indices = core::mem::take(&mut self.strip_start_indices);
-        (strips, alphas, strip_start_indices)
+        (strip_storage, strip_start_indices)
     }
 }
 
@@ -191,7 +189,7 @@ impl Recording {
     }
 
     /// Takes cached strip buffers.
-    pub fn take_cached_strips(&mut self) -> (Vec<Strip>, Vec<u8>, Vec<usize>) {
+    pub fn take_cached_strips(&mut self) -> (StripStorage, Vec<usize>) {
         self.cached_strips.take()
     }
 
@@ -215,11 +213,10 @@ impl Recording {
     /// Set cached strips.
     pub fn set_cached_strips(
         &mut self,
-        strips: Vec<Strip>,
-        alphas: Vec<u8>,
+        strip_storage: StripStorage,
         strip_start_indices: Vec<usize>,
     ) {
-        self.cached_strips = CachedStrips::new(strips, alphas, strip_start_indices);
+        self.cached_strips = CachedStrips::new(strip_storage, strip_start_indices);
     }
 }
 

--- a/sparse_strips/vello_common/src/recording.rs
+++ b/sparse_strips/vello_common/src/recording.rs
@@ -35,7 +35,7 @@ impl CachedStrips {
 
     /// Clear the contents.
     pub fn clear(&mut self) {
-        self.strip_storage.reset();
+        self.strip_storage.clear();
         self.strip_start_indices.clear();
     }
 

--- a/sparse_strips/vello_common/src/strip.rs
+++ b/sparse_strips/vello_common/src/strip.rs
@@ -32,7 +32,6 @@ impl Strip {
 }
 
 /// Render the tiles stored in `tiles` into the strip and alpha buffer.
-/// The strip buffer will be cleared in the beginning.
 pub fn render(
     level: Level,
     tiles: &Tiles,
@@ -72,8 +71,6 @@ fn render_impl<S: Simd>(
     aliasing_threshold: Option<u8>,
     lines: &[Line],
 ) {
-    strip_buf.clear();
-
     if tiles.is_empty() {
         return;
     }

--- a/sparse_strips/vello_common/src/strip_generator.rs
+++ b/sparse_strips/vello_common/src/strip_generator.rs
@@ -27,6 +27,11 @@ impl StripStorage {
         self.strips.clear();
         self.alphas.clear();
     }
+
+    /// Whether the strip storage is empty.
+    pub fn is_empty(&self) -> bool {
+        self.strips.is_empty() && self.alphas.is_empty()
+    }
 }
 
 /// An object for easily generating strips for a filled/stroked path.
@@ -155,14 +160,12 @@ mod tests {
         );
 
         assert!(!generator.line_buf.is_empty());
-        assert!(!storage.strips.is_empty());
-        assert!(!storage.alphas.is_empty());
+        assert!(!storage.is_empty());
 
         generator.reset();
         storage.clear();
 
         assert!(generator.line_buf.is_empty());
-        assert!(storage.strips.is_empty());
-        assert!(storage.alphas.is_empty());
+        assert!(storage.is_empty());
     }
 }

--- a/sparse_strips/vello_common/src/strip_generator.rs
+++ b/sparse_strips/vello_common/src/strip_generator.rs
@@ -19,6 +19,17 @@ pub struct StripStorage {
     pub strips: Vec<Strip>,
     /// The alphas in the storage.
     pub alphas: Vec<u8>,
+    generation_mode: GenerationMode,
+}
+
+/// The generation mode of the strip storage.
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub enum GenerationMode {
+    #[default]
+    /// Clear strips before generating the new ones.
+    Replace,
+    /// Don't clear strips, append to the existing buffer.
+    Append,
 }
 
 impl StripStorage {
@@ -26,6 +37,11 @@ impl StripStorage {
     pub fn clear(&mut self) {
         self.strips.clear();
         self.alphas.clear();
+    }
+
+    /// Set the generation mode of the storage.
+    pub fn set_generation_mode(&mut self, mode: GenerationMode) {
+        self.generation_mode = mode;
     }
 
     /// Whether the strip storage is empty.
@@ -66,7 +82,6 @@ impl StripGenerator {
         transform: Affine,
         aliasing_threshold: Option<u8>,
         strip_storage: &mut StripStorage,
-        clear_strips: bool,
     ) {
         flatten::fill(
             self.level,
@@ -75,7 +90,7 @@ impl StripGenerator {
             &mut self.line_buf,
             &mut self.flatten_ctx,
         );
-        self.make_strips(strip_storage, fill_rule, aliasing_threshold, clear_strips);
+        self.make_strips(strip_storage, fill_rule, aliasing_threshold);
     }
 
     /// Generate the strips for a stroked path.
@@ -86,7 +101,6 @@ impl StripGenerator {
         transform: Affine,
         aliasing_threshold: Option<u8>,
         strip_storage: &mut StripStorage,
-        clear_strips: bool,
     ) {
         flatten::stroke(
             self.level,
@@ -96,12 +110,7 @@ impl StripGenerator {
             &mut self.line_buf,
             &mut self.flatten_ctx,
         );
-        self.make_strips(
-            strip_storage,
-            Fill::NonZero,
-            aliasing_threshold,
-            clear_strips,
-        );
+        self.make_strips(strip_storage, Fill::NonZero, aliasing_threshold);
     }
 
     /// Reset the strip generator.
@@ -115,13 +124,12 @@ impl StripGenerator {
         strip_storage: &mut StripStorage,
         fill_rule: Fill,
         aliasing_threshold: Option<u8>,
-        clear_strips: bool,
     ) {
         self.tiles
             .make_tiles(&self.line_buf, self.width, self.height);
         self.tiles.sort_tiles();
 
-        if clear_strips {
+        if strip_storage.generation_mode == GenerationMode::Replace {
             strip_storage.strips.clear();
         }
 
@@ -156,7 +164,6 @@ mod tests {
             Affine::IDENTITY,
             None,
             &mut storage,
-            true,
         );
 
         assert!(!generator.line_buf.is_empty());

--- a/sparse_strips/vello_common/src/strip_generator.rs
+++ b/sparse_strips/vello_common/src/strip_generator.rs
@@ -23,7 +23,7 @@ pub struct StripStorage {
 
 impl StripStorage {
     /// Reset the storage.
-    pub fn reset(&mut self) {
+    pub fn clear(&mut self) {
         self.strips.clear();
         self.alphas.clear();
     }
@@ -159,7 +159,7 @@ mod tests {
         assert!(!storage.alphas.is_empty());
 
         generator.reset();
-        storage.reset();
+        storage.clear();
 
         assert!(generator.line_buf.is_empty());
         assert!(storage.strips.is_empty());

--- a/sparse_strips/vello_cpu/src/dispatch/mod.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/mod.rs
@@ -8,13 +8,13 @@ pub(crate) mod single_threaded;
 use crate::RenderMode;
 use crate::kurbo::{Affine, BezPath, Stroke};
 use crate::peniko::{BlendMode, Fill};
-use alloc::vec::Vec;
 use core::fmt::Debug;
 use vello_common::coarse::Wide;
 use vello_common::encode::EncodedPaint;
 use vello_common::mask::Mask;
 use vello_common::paint::Paint;
 use vello_common::strip::Strip;
+use vello_common::strip_generator::StripStorage;
 
 pub(crate) trait Dispatcher: Debug + Send + Sync {
     fn wide(&self) -> &Wide;
@@ -56,8 +56,5 @@ pub(crate) trait Dispatcher: Debug + Send + Sync {
         height: u16,
         encoded_paints: &[EncodedPaint],
     );
-    fn alpha_buf(&self) -> &[u8];
-    fn extend_alpha_buf(&mut self, alphas: &[u8]);
-    fn replace_alpha_buf(&mut self, alphas: Vec<u8>) -> Vec<u8>;
-    fn set_alpha_buf(&mut self, alphas: Vec<u8>);
+    fn strip_storage_mut(&mut self) -> &mut StripStorage;
 }

--- a/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
@@ -421,7 +421,7 @@ impl Dispatcher for MultiThreadedDispatcher {
         self.task_sender = None;
         self.coarse_task_receiver = None;
         self.strip_generator.reset();
-        self.strip_storage.reset();
+        self.strip_storage.clear();
         self.alpha_storage.with_inner(|alphas| {
             for alpha in alphas {
                 alpha.clear();

--- a/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
@@ -27,7 +27,7 @@ use vello_common::fearless_simd::{Level, Simd, simd_dispatch};
 use vello_common::mask::Mask;
 use vello_common::paint::Paint;
 use vello_common::strip::Strip;
-use vello_common::strip_generator::StripGenerator;
+use vello_common::strip_generator::{StripGenerator, StripStorage};
 
 mod cost;
 mod small_path;
@@ -98,6 +98,7 @@ pub(crate) struct MultiThreadedDispatcher {
     num_threads: u16,
     /// The strip generator for the main thread, only used for recordings.
     strip_generator: StripGenerator,
+    strip_storage: StripStorage,
     level: Level,
     flushed: bool,
 }
@@ -143,6 +144,7 @@ impl MultiThreadedDispatcher {
             task_sender: None,
             coarse_task_receiver: None,
             strip_generator: StripGenerator::new(width, height, level),
+            strip_storage: StripStorage::default(),
             level,
             alpha_storage,
             num_threads,
@@ -386,22 +388,6 @@ impl Dispatcher for MultiThreadedDispatcher {
         });
     }
 
-    fn alpha_buf(&self) -> &[u8] {
-        self.strip_generator.alpha_buf()
-    }
-
-    fn extend_alpha_buf(&mut self, alphas: &[u8]) {
-        self.strip_generator.extend_alpha_buf(alphas);
-    }
-
-    fn replace_alpha_buf(&mut self, alphas: Vec<u8>) -> Vec<u8> {
-        self.strip_generator.replace_alpha_buf(alphas)
-    }
-
-    fn set_alpha_buf(&mut self, alphas: Vec<u8>) {
-        self.strip_generator.set_alpha_buf(alphas);
-    }
-
     fn push_layer(
         &mut self,
         clip_path: Option<&BezPath>,
@@ -435,6 +421,7 @@ impl Dispatcher for MultiThreadedDispatcher {
         self.task_sender = None;
         self.coarse_task_receiver = None;
         self.strip_generator.reset();
+        self.strip_storage.reset();
         self.alpha_storage.with_inner(|alphas| {
             for alpha in alphas {
                 alpha.clear();
@@ -474,7 +461,7 @@ impl Dispatcher for MultiThreadedDispatcher {
             // The main thread stores the alphas that are produced by playing a recording.
             // It is important we reserve the thread id 0 for this as the implementation for
             // `Recordable` uses this thread ID when generating the commands for coarse rasterization.
-            alphas[0] = self.strip_generator.replace_alpha_buf(Vec::new());
+            alphas[0] = std::mem::take(&mut self.strip_storage.alphas);
         });
 
         self.flushed = true;
@@ -513,6 +500,10 @@ impl Dispatcher for MultiThreadedDispatcher {
             thread_idx: 0,
             paint,
         });
+    }
+
+    fn strip_storage_mut(&mut self) -> &mut StripStorage {
+        &mut self.strip_storage
     }
 }
 

--- a/sparse_strips/vello_cpu/src/dispatch/multi_threaded/worker.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/multi_threaded/worker.rs
@@ -63,7 +63,6 @@ impl Worker {
                                 transform,
                                 aliasing_threshold,
                                 &mut self.strip_storage,
-                                true,
                             );
                         }
                         Path::Small(s) => {
@@ -73,7 +72,6 @@ impl Worker {
                                 transform,
                                 aliasing_threshold,
                                 &mut self.strip_storage,
-                                true,
                             );
                         }
                     }
@@ -103,7 +101,6 @@ impl Worker {
                                 transform,
                                 aliasing_threshold,
                                 &mut self.strip_storage,
-                                true,
                             );
                         }
                         Path::Small(s) => {
@@ -113,7 +110,6 @@ impl Worker {
                                 transform,
                                 aliasing_threshold,
                                 &mut self.strip_storage,
-                                true,
                             );
                         }
                     }
@@ -143,7 +139,6 @@ impl Worker {
                             transform,
                             aliasing_threshold,
                             &mut self.strip_storage,
-                            true,
                         );
 
                         let strips: &[Strip] = &self.strip_storage.strips;

--- a/sparse_strips/vello_cpu/src/dispatch/multi_threaded/worker.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/multi_threaded/worker.rs
@@ -5,26 +5,29 @@ use crate::Level;
 use crate::dispatch::multi_threaded::{CoarseTask, CoarseTaskSender, Path, RenderTask};
 use std::vec::Vec;
 use vello_common::strip::Strip;
-use vello_common::strip_generator::StripGenerator;
+use vello_common::strip_generator::{StripGenerator, StripStorage};
 
 #[derive(Debug)]
 pub(crate) struct Worker {
     strip_generator: StripGenerator,
+    strip_storage: StripStorage,
     thread_id: u8,
 }
 
 impl Worker {
     pub(crate) fn new(width: u16, height: u16, thread_id: u8, level: Level) -> Self {
         let strip_generator = StripGenerator::new(width, height, level);
+        let strip_storage = StripStorage::default();
 
         Self {
             strip_generator,
+            strip_storage,
             thread_id,
         }
     }
 
     pub(crate) fn init(&mut self, alphas: Vec<u8>) {
-        self.strip_generator.set_alpha_buf(alphas);
+        self.strip_storage.alphas = alphas;
     }
 
     pub(crate) fn thread_id(&self) -> u8 {
@@ -52,16 +55,6 @@ impl Worker {
                     fill_rule,
                     aliasing_threshold,
                 } => {
-                    let func = |strips: &[Strip]| {
-                        let coarse_command = CoarseTask::Render {
-                            thread_id: self.thread_id,
-                            strips: strips.into(),
-                            paint,
-                        };
-
-                        task_buf.push(coarse_command);
-                    };
-
                     match path {
                         Path::Bez(b) => {
                             self.strip_generator.generate_filled_path(
@@ -69,7 +62,8 @@ impl Worker {
                                 fill_rule,
                                 transform,
                                 aliasing_threshold,
-                                func,
+                                &mut self.strip_storage,
+                                true,
                             );
                         }
                         Path::Small(s) => {
@@ -78,10 +72,21 @@ impl Worker {
                                 fill_rule,
                                 transform,
                                 aliasing_threshold,
-                                func,
+                                &mut self.strip_storage,
+                                true,
                             );
                         }
                     }
+
+                    let strips: &[Strip] = &self.strip_storage.strips;
+
+                    let coarse_command = CoarseTask::Render {
+                        thread_id: self.thread_id,
+                        strips: strips.into(),
+                        paint,
+                    };
+
+                    task_buf.push(coarse_command);
                 }
                 RenderTask::StrokePath {
                     path,
@@ -90,16 +95,6 @@ impl Worker {
                     stroke,
                     aliasing_threshold,
                 } => {
-                    let func = |strips: &[Strip]| {
-                        let coarse_command = CoarseTask::Render {
-                            thread_id: self.thread_id,
-                            strips: strips.into(),
-                            paint,
-                        };
-
-                        task_buf.push(coarse_command);
-                    };
-
                     match path {
                         Path::Bez(b) => {
                             self.strip_generator.generate_stroked_path(
@@ -107,7 +102,8 @@ impl Worker {
                                 &stroke,
                                 transform,
                                 aliasing_threshold,
-                                func,
+                                &mut self.strip_storage,
+                                true,
                             );
                         }
                         Path::Small(s) => {
@@ -116,10 +112,21 @@ impl Worker {
                                 &stroke,
                                 transform,
                                 aliasing_threshold,
-                                func,
+                                &mut self.strip_storage,
+                                true,
                             );
                         }
                     }
+
+                    let strips: &[Strip] = &self.strip_storage.strips;
+
+                    let coarse_command = CoarseTask::Render {
+                        thread_id: self.thread_id,
+                        strips: strips.into(),
+                        paint,
+                    };
+
+                    task_buf.push(coarse_command);
                 }
                 RenderTask::PushLayer {
                     clip_path,
@@ -130,16 +137,18 @@ impl Worker {
                     aliasing_threshold,
                 } => {
                     let clip = if let Some((c, transform)) = clip_path {
-                        let mut strip_buf = &[][..];
                         self.strip_generator.generate_filled_path(
                             c,
                             fill_rule,
                             transform,
                             aliasing_threshold,
-                            |strips| strip_buf = strips,
+                            &mut self.strip_storage,
+                            true,
                         );
 
-                        Some(strip_buf.into())
+                        let strips: &[Strip] = &self.strip_storage.strips;
+
+                        Some(strips.into())
                     } else {
                         None
                     };
@@ -177,6 +186,6 @@ impl Worker {
     }
 
     pub(crate) fn finalize(&mut self) -> Vec<u8> {
-        self.strip_generator.replace_alpha_buf(Vec::new())
+        std::mem::take(&mut self.strip_storage.alphas)
     }
 }

--- a/sparse_strips/vello_cpu/src/dispatch/single_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/single_threaded.rs
@@ -106,7 +106,6 @@ impl Dispatcher for SingleThreadedDispatcher {
             transform,
             aliasing_threshold,
             &mut self.strip_storage,
-            true,
         );
 
         wide.generate(&self.strip_storage.strips, paint, 0);
@@ -128,7 +127,6 @@ impl Dispatcher for SingleThreadedDispatcher {
             transform,
             aliasing_threshold,
             &mut self.strip_storage,
-            true,
         );
 
         wide.generate(&self.strip_storage.strips, paint, 0);
@@ -151,7 +149,6 @@ impl Dispatcher for SingleThreadedDispatcher {
                 clip_transform,
                 aliasing_threshold,
                 &mut self.strip_storage,
-                true,
             );
 
             Some(self.strip_storage.strips.as_slice())

--- a/sparse_strips/vello_cpu/src/dispatch/single_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/single_threaded.rs
@@ -7,19 +7,19 @@ use crate::fine::{F32Kernel, Fine, FineKernel, U8Kernel};
 use crate::kurbo::{Affine, BezPath, Stroke};
 use crate::peniko::{BlendMode, Fill};
 use crate::region::Regions;
-use alloc::vec::Vec;
 use vello_common::coarse::{MODE_CPU, Wide};
 use vello_common::encode::EncodedPaint;
 use vello_common::fearless_simd::{Level, Simd, simd_dispatch};
 use vello_common::mask::Mask;
 use vello_common::paint::Paint;
 use vello_common::strip::Strip;
-use vello_common::strip_generator::StripGenerator;
+use vello_common::strip_generator::{StripGenerator, StripStorage};
 
 #[derive(Debug)]
 pub(crate) struct SingleThreadedDispatcher {
     wide: Wide,
     strip_generator: StripGenerator,
+    strip_storage: StripStorage,
     level: Level,
 }
 
@@ -27,10 +27,12 @@ impl SingleThreadedDispatcher {
     pub(crate) fn new(width: u16, height: u16, level: Level) -> Self {
         let wide = Wide::<MODE_CPU>::new(width, height);
         let strip_generator = StripGenerator::new(width, height, level);
+        let strip_storage = StripStorage::default();
 
         Self {
             wide,
             strip_generator,
+            strip_storage,
             level,
         }
     }
@@ -75,7 +77,7 @@ impl SingleThreadedDispatcher {
 
             fine.clear(wtile.bg);
             for cmd in &wtile.cmds {
-                fine.run_cmd(cmd, self.strip_generator.alpha_buf(), encoded_paints);
+                fine.run_cmd(cmd, &self.strip_storage.alphas, encoded_paints);
             }
 
             fine.pack(region);
@@ -98,14 +100,16 @@ impl Dispatcher for SingleThreadedDispatcher {
     ) {
         let wide = &mut self.wide;
 
-        let func = |strips| wide.generate(strips, paint, 0);
         self.strip_generator.generate_filled_path(
             path,
             fill_rule,
             transform,
             aliasing_threshold,
-            func,
+            &mut self.strip_storage,
+            true,
         );
+
+        wide.generate(&self.strip_storage.strips, paint, 0);
     }
 
     fn stroke_path(
@@ -118,30 +122,16 @@ impl Dispatcher for SingleThreadedDispatcher {
     ) {
         let wide = &mut self.wide;
 
-        let func = |strips| wide.generate(strips, paint, 0);
         self.strip_generator.generate_stroked_path(
             path,
             stroke,
             transform,
             aliasing_threshold,
-            func,
+            &mut self.strip_storage,
+            true,
         );
-    }
 
-    fn alpha_buf(&self) -> &[u8] {
-        self.strip_generator.alpha_buf()
-    }
-
-    fn extend_alpha_buf(&mut self, alphas: &[u8]) {
-        self.strip_generator.extend_alpha_buf(alphas);
-    }
-
-    fn replace_alpha_buf(&mut self, alphas: Vec<u8>) -> Vec<u8> {
-        self.strip_generator.replace_alpha_buf(alphas)
-    }
-
-    fn set_alpha_buf(&mut self, alphas: Vec<u8>) {
-        self.strip_generator.set_alpha_buf(alphas);
+        wide.generate(&self.strip_storage.strips, paint, 0);
     }
 
     fn push_layer(
@@ -155,19 +145,16 @@ impl Dispatcher for SingleThreadedDispatcher {
         mask: Option<Mask>,
     ) {
         let clip = if let Some(c) = clip_path {
-            // This variable will always be assigned to in the closure, but the compiler can't recognize that.
-            // So just assign a dummy value here.
-            let mut strip_buf = &[][..];
-
             self.strip_generator.generate_filled_path(
                 c,
                 fill_rule,
                 clip_transform,
                 aliasing_threshold,
-                |strips| strip_buf = strips,
+                &mut self.strip_storage,
+                true,
             );
 
-            Some(strip_buf)
+            Some(self.strip_storage.strips.as_slice())
         } else {
             None
         };
@@ -204,6 +191,10 @@ impl Dispatcher for SingleThreadedDispatcher {
 
     fn generate_wide_cmd(&mut self, strip_buf: &[Strip], paint: Paint) {
         self.wide.generate(strip_buf, paint, 0);
+    }
+
+    fn strip_storage_mut(&mut self) -> &mut StripStorage {
+        &mut self.strip_storage
     }
 }
 

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -28,7 +28,7 @@ use vello_common::peniko::{BlendMode, Compose, Fill, Mix};
 use vello_common::pixmap::Pixmap;
 use vello_common::recording::{PushLayerCommand, Recordable, Recording, RenderCommand};
 use vello_common::strip::Strip;
-use vello_common::strip_generator::{StripGenerator, StripStorage};
+use vello_common::strip_generator::{GenerationMode, StripGenerator, StripStorage};
 #[cfg(feature = "text")]
 use vello_common::{
     color::{AlphaColor, Srgb},
@@ -738,6 +738,7 @@ impl RenderContext {
     ) -> (StripStorage, Vec<usize>) {
         let (mut strip_storage, mut strip_start_indices) = buffers;
         strip_storage.clear();
+        strip_storage.set_generation_mode(GenerationMode::Append);
         strip_start_indices.clear();
 
         let saved_state = self.take_current_state();
@@ -755,7 +756,6 @@ impl RenderContext {
                         self.transform,
                         self.aliasing_threshold,
                         &mut strip_storage,
-                        false,
                     );
                     strip_start_indices.push(start_index);
                 }
@@ -766,7 +766,6 @@ impl RenderContext {
                         self.transform,
                         self.aliasing_threshold,
                         &mut strip_storage,
-                        false,
                     );
                     strip_start_indices.push(start_index);
                 }
@@ -778,7 +777,6 @@ impl RenderContext {
                         self.transform,
                         self.aliasing_threshold,
                         &mut strip_storage,
-                        false,
                     );
                     strip_start_indices.push(start_index);
                 }
@@ -790,7 +788,6 @@ impl RenderContext {
                         self.transform,
                         self.aliasing_threshold,
                         &mut strip_storage,
-                        false,
                     );
                     strip_start_indices.push(start_index);
                 }
@@ -803,7 +800,6 @@ impl RenderContext {
                         glyph_transform,
                         self.aliasing_threshold,
                         &mut strip_storage,
-                        false,
                     );
                     strip_start_indices.push(start_index);
                 }
@@ -816,7 +812,6 @@ impl RenderContext {
                         glyph_transform,
                         self.aliasing_threshold,
                         &mut strip_storage,
-                        false,
                     );
                     strip_start_indices.push(start_index);
                 }

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -737,7 +737,7 @@ impl RenderContext {
         buffers: (StripStorage, Vec<usize>),
     ) -> (StripStorage, Vec<usize>) {
         let (mut strip_storage, mut strip_start_indices) = buffers;
-        strip_storage.reset();
+        strip_storage.clear();
         strip_start_indices.clear();
 
         let saved_state = self.take_current_state();

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -18,7 +18,7 @@ use alloc::vec::Vec;
 use vello_common::blurred_rounded_rect::BlurredRoundedRectangle;
 use vello_common::encode::{EncodeExt, EncodedPaint};
 use vello_common::fearless_simd::Level;
-use vello_common::kurbo::{Affine, BezPath, Cap, Join, Rect, Shape, Stroke};
+use vello_common::kurbo::{Affine, BezPath, Cap, Join, Rect, Stroke};
 use vello_common::mask::Mask;
 #[cfg(feature = "text")]
 use vello_common::paint::ImageSource;
@@ -28,7 +28,7 @@ use vello_common::peniko::{BlendMode, Compose, Fill, Mix};
 use vello_common::pixmap::Pixmap;
 use vello_common::recording::{PushLayerCommand, Recordable, Recording, RenderCommand};
 use vello_common::strip::Strip;
-use vello_common::strip_generator::StripGenerator;
+use vello_common::strip_generator::{StripGenerator, StripStorage};
 #[cfg(feature = "text")]
 use vello_common::{
     color::{AlphaColor, Srgb},
@@ -36,7 +36,6 @@ use vello_common::{
     glyph::{GlyphRenderer, GlyphRunBuilder, GlyphType, PreparedGlyph},
 };
 
-pub(crate) const DEFAULT_TOLERANCE: f64 = 0.1;
 /// A render context.
 #[derive(Debug)]
 pub struct RenderContext {
@@ -191,10 +190,18 @@ impl RenderContext {
 
     /// Fill a rectangle.
     pub fn fill_rect(&mut self, rect: &Rect) {
-        // Don't use `rect.to_path` here, because it will perform a new allocation, which
-        // profiling showed can become a bottleneck for many small rectangles.
-        // TODO: Generalize this so that for example `blurred_rectangle` and other places
-        // can also profit from this.
+        self.rect_to_temp_path(rect);
+        let paint = self.encode_current_paint();
+        self.dispatcher.fill_path(
+            &self.temp_path,
+            self.fill_rule,
+            self.transform,
+            paint,
+            self.aliasing_threshold,
+        );
+    }
+
+    fn rect_to_temp_path(&mut self, rect: &Rect) {
         self.temp_path.truncate(0);
         self.temp_path
             .push(PathEl::MoveTo(Point::new(rect.x0, rect.y0)));
@@ -205,15 +212,6 @@ impl RenderContext {
         self.temp_path
             .push(PathEl::LineTo(Point::new(rect.x0, rect.y1)));
         self.temp_path.push(PathEl::ClosePath);
-
-        let paint = self.encode_current_paint();
-        self.dispatcher.fill_path(
-            &self.temp_path,
-            self.fill_rule,
-            self.transform,
-            paint,
-            self.aliasing_threshold,
-        );
     }
 
     /// Fill a blurred rectangle with the given radius and standard deviation.
@@ -242,9 +240,11 @@ impl RenderContext {
         let inflated_rect = rect.inflate(f64::from(kernel_size), f64::from(kernel_size));
         let transform = self.transform * self.paint_transform;
 
+        self.rect_to_temp_path(&inflated_rect);
+
         let paint = blurred_rect.encode_into(&mut self.encoded_paints, transform);
         self.dispatcher.fill_path(
-            &inflated_rect.to_path(0.1),
+            &self.temp_path,
             Fill::NonZero,
             self.transform,
             paint,
@@ -254,7 +254,15 @@ impl RenderContext {
 
     /// Stroke a rectangle.
     pub fn stroke_rect(&mut self, rect: &Rect) {
-        self.stroke_path(&rect.to_path(DEFAULT_TOLERANCE));
+        self.rect_to_temp_path(rect);
+        let paint = self.encode_current_paint();
+        self.dispatcher.stroke_path(
+            &self.temp_path,
+            &self.stroke,
+            self.transform,
+            paint,
+            self.aliasing_threshold,
+        );
     }
 
     /// Creates a builder for drawing a run of glyphs that have the same attributes.
@@ -635,9 +643,9 @@ impl ColrRenderer for RenderContext {
 impl Recordable for RenderContext {
     fn prepare_recording(&mut self, recording: &mut Recording) {
         let buffers = recording.take_cached_strips();
-        let (strips, alphas, strip_start_indices) =
+        let (strip_storage, strip_start_indices) =
             self.generate_strips_from_commands(recording.commands(), buffers);
-        recording.set_cached_strips(strips, alphas, strip_start_indices);
+        recording.set_cached_strips(strip_storage, strip_start_indices);
     }
 
     fn execute_recording(&mut self, recording: &Recording) {
@@ -713,7 +721,6 @@ struct RenderState {
     stroke: Stroke,
     paint: PaintType,
     paint_transform: Affine,
-    alphas: Vec<u8>,
 }
 
 /// Recording management implementation.
@@ -727,78 +734,89 @@ impl RenderContext {
     fn generate_strips_from_commands(
         &mut self,
         commands: &[RenderCommand],
-        buffers: (Vec<Strip>, Vec<u8>, Vec<usize>),
-    ) -> (Vec<Strip>, Vec<u8>, Vec<usize>) {
-        let (mut collected_strips, mut cached_alphas, mut strip_start_indices) = buffers;
-        collected_strips.clear();
-        cached_alphas.clear();
+        buffers: (StripStorage, Vec<usize>),
+    ) -> (StripStorage, Vec<usize>) {
+        let (mut strip_storage, mut strip_start_indices) = buffers;
+        strip_storage.reset();
         strip_start_indices.clear();
 
-        let saved_state = self.take_current_state(cached_alphas);
+        let saved_state = self.take_current_state();
         let mut strip_generator =
             StripGenerator::new(self.width, self.height, self.render_settings.level);
 
         for command in commands {
-            let start_index = collected_strips.len();
+            let start_index = strip_storage.strips.len();
 
             match command {
                 RenderCommand::FillPath(path) => {
-                    self.generate_fill_strips(
+                    strip_generator.generate_filled_path(
                         path,
-                        &mut collected_strips,
+                        self.fill_rule,
                         self.transform,
-                        &mut strip_generator,
+                        self.aliasing_threshold,
+                        &mut strip_storage,
+                        false,
                     );
                     strip_start_indices.push(start_index);
                 }
                 RenderCommand::StrokePath(path) => {
-                    self.generate_stroke_strips(
+                    strip_generator.generate_stroked_path(
                         path,
-                        &mut collected_strips,
+                        &self.stroke,
                         self.transform,
-                        &mut strip_generator,
+                        self.aliasing_threshold,
+                        &mut strip_storage,
+                        false,
                     );
                     strip_start_indices.push(start_index);
                 }
                 RenderCommand::FillRect(rect) => {
-                    let path = rect.to_path(DEFAULT_TOLERANCE);
-                    self.generate_fill_strips(
-                        &path,
-                        &mut collected_strips,
+                    self.rect_to_temp_path(rect);
+                    strip_generator.generate_filled_path(
+                        &self.temp_path,
+                        self.fill_rule,
                         self.transform,
-                        &mut strip_generator,
+                        self.aliasing_threshold,
+                        &mut strip_storage,
+                        false,
                     );
                     strip_start_indices.push(start_index);
                 }
                 RenderCommand::StrokeRect(rect) => {
-                    let path = rect.to_path(DEFAULT_TOLERANCE);
-                    self.generate_stroke_strips(
-                        &path,
-                        &mut collected_strips,
+                    self.rect_to_temp_path(rect);
+                    strip_generator.generate_stroked_path(
+                        &self.temp_path,
+                        &self.stroke,
                         self.transform,
-                        &mut strip_generator,
+                        self.aliasing_threshold,
+                        &mut strip_storage,
+                        false,
                     );
                     strip_start_indices.push(start_index);
                 }
                 #[cfg(feature = "text")]
                 RenderCommand::FillOutlineGlyph((path, transform)) => {
                     let glyph_transform = self.transform * *transform;
-                    self.generate_fill_strips(
+                    strip_generator.generate_filled_path(
                         path,
-                        &mut collected_strips,
+                        self.fill_rule,
                         glyph_transform,
-                        &mut strip_generator,
+                        self.aliasing_threshold,
+                        &mut strip_storage,
+                        false,
                     );
                     strip_start_indices.push(start_index);
                 }
                 #[cfg(feature = "text")]
                 RenderCommand::StrokeOutlineGlyph((path, transform)) => {
                     let glyph_transform = self.transform * *transform;
-                    self.generate_stroke_strips(
+                    strip_generator.generate_stroked_path(
                         path,
-                        &mut collected_strips,
+                        &self.stroke,
                         glyph_transform,
-                        &mut strip_generator,
+                        self.aliasing_threshold,
+                        &mut strip_storage,
+                        false,
                     );
                     strip_start_indices.push(start_index);
                 }
@@ -816,10 +834,9 @@ impl RenderContext {
             }
         }
 
-        let collected_alphas = strip_generator.take_alpha_buf();
         self.restore_state(saved_state);
 
-        (collected_strips, collected_alphas, strip_start_indices)
+        (strip_storage, strip_start_indices)
     }
 }
 
@@ -857,9 +874,14 @@ impl RenderContext {
         cached_alphas: &[u8],
     ) -> Vec<Strip> {
         // Calculate offset for alpha indices based on current dispatcher's alpha buffer size.
-        let alpha_offset = self.dispatcher.alpha_buf().len() as u32;
-        // Extend the dispatcher's alpha buffer with cached alphas.
-        self.dispatcher.extend_alpha_buf(cached_alphas);
+        let alpha_offset = {
+            let storage = self.dispatcher.strip_storage_mut();
+            let offset = storage.alphas.len() as u32;
+            // Extend the dispatcher's alpha buffer with cached alphas.
+            storage.alphas.extend(cached_alphas);
+
+            offset
+        };
         // Create adjusted strips with corrected alpha indices.
         cached_strips
             .iter()
@@ -871,53 +893,14 @@ impl RenderContext {
             .collect()
     }
 
-    /// Generate strips for a filled path.
-    fn generate_fill_strips(
-        &mut self,
-        path: &BezPath,
-        strips: &mut Vec<Strip>,
-        transform: Affine,
-        strip_generator: &mut StripGenerator,
-    ) {
-        strip_generator.generate_filled_path(
-            path,
-            self.fill_rule,
-            transform,
-            self.aliasing_threshold,
-            |generated_strips| {
-                strips.extend_from_slice(generated_strips);
-            },
-        );
-    }
-
-    /// Generate strips for a stroked path.
-    fn generate_stroke_strips(
-        &mut self,
-        path: &BezPath,
-        strips: &mut Vec<Strip>,
-        transform: Affine,
-        strip_generator: &mut StripGenerator,
-    ) {
-        strip_generator.generate_stroked_path(
-            path,
-            &self.stroke,
-            transform,
-            self.aliasing_threshold,
-            |generated_strips| {
-                strips.extend_from_slice(generated_strips);
-            },
-        );
-    }
-
     /// Save the current rendering state.
-    fn take_current_state(&mut self, alphas: Vec<u8>) -> RenderState {
+    fn take_current_state(&mut self) -> RenderState {
         RenderState {
             paint: self.paint.clone(),
             paint_transform: self.paint_transform,
             transform: self.transform,
             fill_rule: self.fill_rule,
             stroke: core::mem::take(&mut self.stroke),
-            alphas: self.dispatcher.replace_alpha_buf(alphas),
         }
     }
 
@@ -928,7 +911,6 @@ impl RenderContext {
         self.stroke = state.stroke;
         self.paint = state.paint;
         self.paint_transform = state.paint_transform;
-        self.dispatcher.set_alpha_buf(state.alphas);
     }
 }
 

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -129,7 +129,7 @@ impl WebGlRenderer {
         let encoded_paints = self.prepare_gpu_encoded_paints(&scene.encoded_paints);
         self.programs.prepare(
             &self.gl,
-            scene.strip_generator.alpha_buf(),
+            &scene.strip_storage.alphas,
             encoded_paints,
             render_size,
         );

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -96,7 +96,7 @@ impl Renderer {
         self.programs.prepare(
             device,
             queue,
-            scene.strip_generator.alpha_buf(),
+            &scene.strip_storage.alphas,
             encoded_paints,
             render_size,
         );

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -17,7 +17,7 @@ use vello_common::peniko::color::palette::css::BLACK;
 use vello_common::peniko::{BlendMode, Compose, Fill, Mix};
 use vello_common::recording::{PushLayerCommand, Recordable, Recording, RenderCommand};
 use vello_common::strip::Strip;
-use vello_common::strip_generator::{StripGenerator, StripStorage};
+use vello_common::strip_generator::{GenerationMode, StripGenerator, StripStorage};
 
 /// Default tolerance for curve flattening
 pub(crate) const DEFAULT_TOLERANCE: f64 = 0.1;
@@ -151,7 +151,6 @@ impl Scene {
             transform,
             aliasing_threshold,
             &mut self.strip_storage,
-            true,
         );
         wide.generate(&self.strip_storage.strips, paint, 0);
     }
@@ -182,7 +181,6 @@ impl Scene {
             transform,
             aliasing_threshold,
             &mut self.strip_storage,
-            true,
         );
 
         wide.generate(&self.strip_storage.strips, paint, 0);
@@ -235,7 +233,6 @@ impl Scene {
                 self.transform,
                 self.aliasing_threshold,
                 &mut self.strip_storage,
-                true,
             );
 
             Some(self.strip_storage.strips.as_slice())
@@ -461,6 +458,7 @@ impl Scene {
     ) -> (StripStorage, Vec<usize>) {
         let (mut strip_storage, mut strip_start_indices) = buffers;
         strip_storage.clear();
+        strip_storage.set_generation_mode(GenerationMode::Append);
         strip_start_indices.clear();
 
         let saved_state = self.take_current_state();
@@ -476,7 +474,6 @@ impl Scene {
                         self.transform,
                         self.aliasing_threshold,
                         &mut strip_storage,
-                        false,
                     );
                     strip_start_indices.push(start_index);
                 }
@@ -487,7 +484,6 @@ impl Scene {
                         self.transform,
                         self.aliasing_threshold,
                         &mut strip_storage,
-                        false,
                     );
                     strip_start_indices.push(start_index);
                 }
@@ -498,7 +494,6 @@ impl Scene {
                         self.transform,
                         self.aliasing_threshold,
                         &mut strip_storage,
-                        false,
                     );
                     strip_start_indices.push(start_index);
                 }
@@ -509,7 +504,6 @@ impl Scene {
                         self.transform,
                         self.aliasing_threshold,
                         &mut strip_storage,
-                        false,
                     );
                     strip_start_indices.push(start_index);
                 }
@@ -521,7 +515,6 @@ impl Scene {
                         glyph_transform,
                         self.aliasing_threshold,
                         &mut strip_storage,
-                        false,
                     );
                     strip_start_indices.push(start_index);
                 }
@@ -533,7 +526,6 @@ impl Scene {
                         glyph_transform,
                         self.aliasing_threshold,
                         &mut strip_storage,
-                        false,
                     );
                     strip_start_indices.push(start_index);
                 }

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -322,7 +322,7 @@ impl Scene {
     pub fn reset(&mut self) {
         self.wide.reset();
         self.strip_generator.reset();
-        self.strip_storage.reset();
+        self.strip_storage.clear();
         self.encoded_paints.clear();
 
         let render_state = Self::default_render_state();
@@ -460,7 +460,7 @@ impl Scene {
         buffers: (StripStorage, Vec<usize>),
     ) -> (StripStorage, Vec<usize>) {
         let (mut strip_storage, mut strip_start_indices) = buffers;
-        strip_storage.reset();
+        strip_storage.clear();
         strip_start_indices.clear();
 
         let saved_state = self.take_current_state();

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -17,7 +17,7 @@ use vello_common::peniko::color::palette::css::BLACK;
 use vello_common::peniko::{BlendMode, Compose, Fill, Mix};
 use vello_common::recording::{PushLayerCommand, Recordable, Recording, RenderCommand};
 use vello_common::strip::Strip;
-use vello_common::strip_generator::StripGenerator;
+use vello_common::strip_generator::{StripGenerator, StripStorage};
 
 /// Default tolerance for curve flattening
 pub(crate) const DEFAULT_TOLERANCE: f64 = 0.1;
@@ -32,7 +32,6 @@ struct RenderState {
     pub(crate) transform: Affine,
     pub(crate) fill_rule: Fill,
     pub(crate) blend_mode: BlendMode,
-    pub(crate) alphas: Vec<u8>,
 }
 
 /// A render context for hybrid CPU/GPU rendering.
@@ -54,6 +53,7 @@ pub struct Scene {
     pub(crate) fill_rule: Fill,
     pub(crate) blend_mode: BlendMode,
     pub(crate) strip_generator: StripGenerator,
+    pub(crate) strip_storage: StripStorage,
 }
 
 impl Scene {
@@ -75,6 +75,7 @@ impl Scene {
                 height,
                 Level::try_detect().unwrap_or(Level::fallback()),
             ),
+            strip_storage: StripStorage::default(),
             transform: render_state.transform,
             fill_rule: render_state.fill_rule,
             blend_mode: render_state.blend_mode,
@@ -102,7 +103,6 @@ impl Scene {
             paint_transform,
             stroke,
             blend_mode,
-            alphas: vec![],
         }
     }
 
@@ -145,14 +145,15 @@ impl Scene {
         aliasing_threshold: Option<u8>,
     ) {
         let wide = &mut self.wide;
-        let func = |strips| wide.generate(strips, paint, 0);
         self.strip_generator.generate_filled_path(
             path,
             fill_rule,
             transform,
             aliasing_threshold,
-            func,
+            &mut self.strip_storage,
+            true,
         );
+        wide.generate(&self.strip_storage.strips, paint, 0);
     }
 
     /// Stroke a path with the current paint and stroke settings.
@@ -174,14 +175,17 @@ impl Scene {
         aliasing_threshold: Option<u8>,
     ) {
         let wide = &mut self.wide;
-        let func = |strips| wide.generate(strips, paint, 0);
+
         self.strip_generator.generate_stroked_path(
             path,
             &self.stroke,
             transform,
             aliasing_threshold,
-            func,
+            &mut self.strip_storage,
+            true,
         );
+
+        wide.generate(&self.strip_storage.strips, paint, 0);
     }
 
     /// Set the aliasing threshold.
@@ -225,17 +229,16 @@ impl Scene {
         mask: Option<Mask>,
     ) {
         let clip = if let Some(c) = clip_path {
-            let mut strip_buf = &[][..];
-
             self.strip_generator.generate_filled_path(
                 c,
                 self.fill_rule,
                 self.transform,
                 self.aliasing_threshold,
-                |strips| strip_buf = strips,
+                &mut self.strip_storage,
+                true,
             );
 
-            Some(strip_buf)
+            Some(self.strip_storage.strips.as_slice())
         } else {
             None
         };
@@ -319,6 +322,7 @@ impl Scene {
     pub fn reset(&mut self) {
         self.wide.reset();
         self.strip_generator.reset();
+        self.strip_storage.reset();
         self.encoded_paints.clear();
 
         let render_state = Self::default_render_state();
@@ -379,9 +383,9 @@ impl GlyphRenderer for Scene {
 impl Recordable for Scene {
     fn prepare_recording(&mut self, recording: &mut Recording) {
         let buffers = recording.take_cached_strips();
-        let (strips, alphas, strip_start_indices) =
+        let (strip_storage, strip_start_indices) =
             self.generate_strips_from_commands(recording.commands(), buffers);
-        recording.set_cached_strips(strips, alphas, strip_start_indices);
+        recording.set_cached_strips(strip_storage, strip_start_indices);
     }
 
     fn execute_recording(&mut self, recording: &Recording) {
@@ -453,45 +457,84 @@ impl Scene {
     fn generate_strips_from_commands(
         &mut self,
         commands: &[RenderCommand],
-        buffers: (Vec<Strip>, Vec<u8>, Vec<usize>),
-    ) -> (Vec<Strip>, Vec<u8>, Vec<usize>) {
-        let (mut collected_strips, mut cached_alphas, mut strip_start_indices) = buffers;
-        collected_strips.clear();
-        cached_alphas.clear();
+        buffers: (StripStorage, Vec<usize>),
+    ) -> (StripStorage, Vec<usize>) {
+        let (mut strip_storage, mut strip_start_indices) = buffers;
+        strip_storage.reset();
         strip_start_indices.clear();
 
-        let saved_state = self.take_current_state(cached_alphas);
+        let saved_state = self.take_current_state();
 
         for command in commands {
-            let start_index = collected_strips.len();
+            let start_index = strip_storage.strips.len();
 
             match command {
                 RenderCommand::FillPath(path) => {
-                    self.generate_fill_strips(path, &mut collected_strips, self.transform);
+                    self.strip_generator.generate_filled_path(
+                        path,
+                        self.fill_rule,
+                        self.transform,
+                        self.aliasing_threshold,
+                        &mut strip_storage,
+                        false,
+                    );
                     strip_start_indices.push(start_index);
                 }
                 RenderCommand::StrokePath(path) => {
-                    self.generate_stroke_strips(path, &mut collected_strips, self.transform);
+                    self.strip_generator.generate_stroked_path(
+                        path,
+                        &self.stroke,
+                        self.transform,
+                        self.aliasing_threshold,
+                        &mut strip_storage,
+                        false,
+                    );
                     strip_start_indices.push(start_index);
                 }
                 RenderCommand::FillRect(rect) => {
-                    let path = rect.to_path(DEFAULT_TOLERANCE);
-                    self.generate_fill_strips(&path, &mut collected_strips, self.transform);
+                    self.strip_generator.generate_filled_path(
+                        rect.to_path(DEFAULT_TOLERANCE),
+                        self.fill_rule,
+                        self.transform,
+                        self.aliasing_threshold,
+                        &mut strip_storage,
+                        false,
+                    );
                     strip_start_indices.push(start_index);
                 }
                 RenderCommand::StrokeRect(rect) => {
-                    let path = rect.to_path(DEFAULT_TOLERANCE);
-                    self.generate_stroke_strips(&path, &mut collected_strips, self.transform);
+                    self.strip_generator.generate_stroked_path(
+                        rect.to_path(DEFAULT_TOLERANCE),
+                        &self.stroke,
+                        self.transform,
+                        self.aliasing_threshold,
+                        &mut strip_storage,
+                        false,
+                    );
                     strip_start_indices.push(start_index);
                 }
                 RenderCommand::FillOutlineGlyph((path, transform)) => {
                     let glyph_transform = self.transform * *transform;
-                    self.generate_fill_strips(path, &mut collected_strips, glyph_transform);
+                    self.strip_generator.generate_filled_path(
+                        path,
+                        self.fill_rule,
+                        glyph_transform,
+                        self.aliasing_threshold,
+                        &mut strip_storage,
+                        false,
+                    );
                     strip_start_indices.push(start_index);
                 }
                 RenderCommand::StrokeOutlineGlyph((path, transform)) => {
                     let glyph_transform = self.transform * *transform;
-                    self.generate_stroke_strips(path, &mut collected_strips, glyph_transform);
+                    self.strip_generator.generate_stroked_path(
+                        path,
+                        &self.stroke,
+                        glyph_transform,
+                        self.aliasing_threshold,
+                        &mut strip_storage,
+                        false,
+                    );
                     strip_start_indices.push(start_index);
                 }
                 RenderCommand::SetTransform(transform) => {
@@ -503,14 +546,14 @@ impl Scene {
                 RenderCommand::SetStroke(stroke) => {
                     self.stroke = stroke.clone();
                 }
+
                 _ => {}
             }
         }
 
-        let collected_alphas = self.strip_generator.take_alpha_buf();
         self.restore_state(saved_state);
 
-        (collected_strips, collected_alphas, strip_start_indices)
+        (strip_storage, strip_start_indices)
     }
 
     fn process_geometry_command(
@@ -550,9 +593,9 @@ impl Scene {
         cached_alphas: &[u8],
     ) -> Vec<Strip> {
         // Calculate offset for alpha indices based on current buffer size.
-        let alpha_offset = self.strip_generator.alpha_buf().len() as u32;
+        let alpha_offset = self.strip_storage.alphas.len() as u32;
         // Extend current alpha buffer with cached alphas.
-        self.strip_generator.extend_alpha_buf(cached_alphas);
+        self.strip_storage.alphas.extend(cached_alphas);
         // Create adjusted strips with corrected alpha indices
         cached_strips
             .iter()
@@ -564,39 +607,8 @@ impl Scene {
             .collect()
     }
 
-    /// Generate strips for a filled path.
-    fn generate_fill_strips(&mut self, path: &BezPath, strips: &mut Vec<Strip>, transform: Affine) {
-        self.strip_generator.generate_filled_path(
-            path,
-            self.fill_rule,
-            transform,
-            self.aliasing_threshold,
-            |generated_strips| {
-                strips.extend_from_slice(generated_strips);
-            },
-        );
-    }
-
-    /// Generate strips for a stroked path.
-    fn generate_stroke_strips(
-        &mut self,
-        path: &BezPath,
-        strips: &mut Vec<Strip>,
-        transform: Affine,
-    ) {
-        self.strip_generator.generate_stroked_path(
-            path,
-            &self.stroke,
-            transform,
-            self.aliasing_threshold,
-            |generated_strips| {
-                strips.extend_from_slice(generated_strips);
-            },
-        );
-    }
-
     /// Save current rendering state.
-    fn take_current_state(&mut self, cached_alphas: Vec<u8>) -> RenderState {
+    fn take_current_state(&mut self) -> RenderState {
         RenderState {
             paint: self.paint.clone(),
             paint_transform: self.paint_transform,
@@ -604,7 +616,6 @@ impl Scene {
             fill_rule: self.fill_rule,
             blend_mode: self.blend_mode,
             stroke: core::mem::take(&mut self.stroke),
-            alphas: self.strip_generator.replace_alpha_buf(cached_alphas),
         }
     }
 
@@ -616,6 +627,5 @@ impl Scene {
         self.transform = state.transform;
         self.fill_rule = state.fill_rule;
         self.blend_mode = state.blend_mode;
-        self.strip_generator.set_alpha_buf(state.alphas);
     }
 }


### PR DESCRIPTION
I based this on top of #1206 to avoid merge conflicts.

Currently, the strip generator also stores the strip and alpha buffers. This is fine if we can assume that there only is one single buffer for those globally, but this has already been proven to be a bit awkard once recordings were introduced. In addition to that, it also makes things more difficult for the new clipping PR as well as an optimization I want to implement for multi-threaded rendering. 

Therefore, this PR separates them into two different objects by introducing a new `StripStorage` and forcing the user to explicitly pass a `StripStorage` that should be used as the basis for the generation when interacting with the strip generator.