### PR TITLE
fix transform handling in sparse_strips recording API

### DIFF
--- a/sparse_strips/vello_common/src/recording.rs
+++ b/sparse_strips/vello_common/src/recording.rs
@@ -158,6 +158,11 @@ impl Recording {
         }
     }
 
+    /// Return the initial transform of the recording.
+    pub fn relative_transform(&self) -> Option<&Affine> {
+        self.relative_transform.as_ref()
+    }
+
     /// Set the transform.
     pub(crate) fn set_transform(&mut self, transform: Affine) {
         if self.relative_transform.is_none() {
@@ -171,7 +176,15 @@ impl Recording {
     /// can be relatively transformed.
     pub fn enforce_matching_transform(&self, transform: &Affine) {
         let relative_transform = self.relative_transform.unwrap();
-        assert!(relative_transform.eq(transform), "renderer must set_transform to match recording before executing recording")
+        let a_coeffs = relative_transform.as_coeffs();
+        let b_coeffs = transform.as_coeffs();
+        let tolerance = 1e-6;
+
+        for i in 0..6 {
+            if (a_coeffs[i] - b_coeffs[i]).abs() > tolerance {
+                panic!("renderer must set_transform to match recording before executing recording")
+            }
+        }
     }
 
     /// Get commands as a slice.

--- a/sparse_strips/vello_common/src/recording.rs
+++ b/sparse_strips/vello_common/src/recording.rs
@@ -174,11 +174,14 @@ impl Recording {
     /// Until recording can be relatively positioned, enforce that renderer set_transform matches
     /// the recording's initial conditions. This will make forward migration easier once recording
     /// can be relatively transformed.
-    /// 
+    ///
     /// TODO: This can be removed when relative transform of recording is implemented.
     pub fn enforce_matching_transform(&self, transform: &Affine) {
         let relative_transform = self.relative_transform.unwrap();
-        assert_eq!(relative_transform, *transform, "renderer must set_transform to match recording before executing recording");
+        assert_eq!(
+            relative_transform, *transform,
+            "renderer must set_transform to match recording before executing recording"
+        );
     }
 
     /// Get commands as a slice.

--- a/sparse_strips/vello_common/src/recording.rs
+++ b/sparse_strips/vello_common/src/recording.rs
@@ -167,7 +167,7 @@ impl Recording {
         self.transform = transform;
     }
 
-    /// Until recording can be relatively positioned, enforce that renderer set_transform matches
+    /// Until recording can be relatively positioned, enforce that renderer `set_transform` matches
     /// the recording's initial conditions. This will make forward migration easier once recording
     /// can be relatively transformed.
     ///

--- a/sparse_strips/vello_common/src/recording.rs
+++ b/sparse_strips/vello_common/src/recording.rs
@@ -174,10 +174,16 @@ impl Recording {
     /// TODO: This can be removed when relative transform of recording is implemented.
     pub fn enforce_matching_transform(&self, transform: &Affine) {
         let relative_transform = self.relative_transform.unwrap();
-        assert_eq!(
-            relative_transform, *transform,
-            "renderer must set_transform to match recording before executing recording"
-        );
+        // Although Affine implements `eq`, WASM tests require this more flexible check.
+        let a_coeffs = relative_transform.as_coeffs();
+        let b_coeffs = transform.as_coeffs();
+        let tolerance = 1e-6;
+
+        for i in 0..6 {
+            if (a_coeffs[i] - b_coeffs[i]).abs() > tolerance {
+                panic!("renderer must set_transform to match recording before executing recording")
+            }
+        }
     }
 
     /// Get commands as a slice.

--- a/sparse_strips/vello_common/src/recording.rs
+++ b/sparse_strips/vello_common/src/recording.rs
@@ -174,17 +174,11 @@ impl Recording {
     /// Until recording can be relatively positioned, enforce that renderer set_transform matches
     /// the recording's initial conditions. This will make forward migration easier once recording
     /// can be relatively transformed.
+    /// 
+    /// TODO: This can be removed when relative transform of recording is implemented.
     pub fn enforce_matching_transform(&self, transform: &Affine) {
         let relative_transform = self.relative_transform.unwrap();
-        let a_coeffs = relative_transform.as_coeffs();
-        let b_coeffs = transform.as_coeffs();
-        let tolerance = 1e-6;
-
-        for i in 0..6 {
-            if (a_coeffs[i] - b_coeffs[i]).abs() > tolerance {
-                panic!("renderer must set_transform to match recording before executing recording")
-            }
-        }
+        assert_eq!(relative_transform, *transform, "renderer must set_transform to match recording before executing recording");
     }
 
     /// Get commands as a slice.

--- a/sparse_strips/vello_common/src/recording.rs
+++ b/sparse_strips/vello_common/src/recording.rs
@@ -301,9 +301,6 @@ pub trait Recordable {
     /// via `prepare_recording()`, or when you want to execute commands immediately
     /// without explicit preparation.
     ///
-    /// Note: Currently if the renderer transform does not match the recording being executed the
-    /// method will panic.
-    ///
     /// # Example
     /// ```ignore
     /// let mut recording = Recording::new();

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -859,6 +859,10 @@ impl RenderContext {
             .copied()
             .unwrap_or(adjusted_strips.len());
         let count = end - start;
+        if count == 0 {
+            // There are no strips to generate.
+            return;
+        }
         assert!(
             start < adjusted_strips.len() && count > 0,
             "Invalid strip range"

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -657,7 +657,6 @@ impl Recordable for RenderContext {
     }
 
     fn execute_recording(&mut self, recording: &Recording) {
-        recording.enforce_matching_transform(&self.transform);
         let (cached_strips, cached_alphas) = recording.get_cached_strips();
         let adjusted_strips = self.prepare_cached_strips(cached_strips, cached_alphas);
 

--- a/sparse_strips/vello_hybrid/examples/scenes/src/svg.rs
+++ b/sparse_strips/vello_hybrid/examples/scenes/src/svg.rs
@@ -86,7 +86,7 @@ fn try_reuse_recording(
     let start = std::time::Instant::now();
     // Case 1: Identical transforms - can reuse directly
     if let Some(transform) = recording.relative_transform() {
-        if *transform == current_transform {
+        if transforms_are_identical(*transform, current_transform) {
             scene.set_transform(*transform);
             scene.execute_recording(recording);
             #[cfg(not(target_arch = "wasm32"))]
@@ -129,6 +129,20 @@ fn print_render_stats(render_type: &str, elapsed: std::time::Duration, recording
         recording.strip_count(),
         recording.alpha_count()
     );
+}
+
+/// Check if two transforms are identical (within tolerance)
+fn transforms_are_identical(a: Affine, b: Affine) -> bool {
+    let a_coeffs = a.as_coeffs();
+    let b_coeffs = b.as_coeffs();
+    let tolerance = 1e-6;
+
+    for i in 0..6 {
+        if (a_coeffs[i] - b_coeffs[i]).abs() > tolerance {
+            return false;
+        }
+    }
+    true
 }
 
 impl SvgScene {

--- a/sparse_strips/vello_hybrid/examples/scenes/src/svg.rs
+++ b/sparse_strips/vello_hybrid/examples/scenes/src/svg.rs
@@ -86,7 +86,7 @@ fn try_reuse_recording(
     let start = std::time::Instant::now();
     // Case 1: Identical transforms - can reuse directly
     if let Some(transform) = recording.relative_transform() {
-        if transforms_are_identical(*transform, current_transform) {
+        if *transform == current_transform {
             scene.set_transform(*transform);
             scene.execute_recording(recording);
             #[cfg(not(target_arch = "wasm32"))]
@@ -129,20 +129,6 @@ fn print_render_stats(render_type: &str, elapsed: std::time::Duration, recording
         recording.strip_count(),
         recording.alpha_count()
     );
-}
-
-/// Check if two transforms are identical (within tolerance)
-fn transforms_are_identical(a: Affine, b: Affine) -> bool {
-    let a_coeffs = a.as_coeffs();
-    let b_coeffs = b.as_coeffs();
-    let tolerance = 1e-6;
-
-    for i in 0..6 {
-        if (a_coeffs[i] - b_coeffs[i]).abs() > tolerance {
-            return false;
-        }
-    }
-    true
 }
 
 impl SvgScene {

--- a/sparse_strips/vello_hybrid/examples/scenes/src/svg.rs
+++ b/sparse_strips/vello_hybrid/examples/scenes/src/svg.rs
@@ -84,7 +84,7 @@ struct CachedRecording {
 
 impl CachedRecording {
     fn new() -> Self {
-        CachedRecording {
+        Self {
             transform_key: None,
             recording: Recording::new(),
         }
@@ -130,7 +130,7 @@ fn record_fresh(scene_obj: &mut SvgScene, scene: &mut Scene, current_transform: 
     scene.prepare_recording(new_recording);
     scene.execute_recording(new_recording);
     #[cfg(not(target_arch = "wasm32"))]
-    print_render_stats("Fresh     ", start.elapsed(), &new_recording);
+    print_render_stats("Fresh     ", start.elapsed(), new_recording);
 }
 
 /// Print timing and statistics for a render operation

--- a/sparse_strips/vello_hybrid/examples/scenes/src/text.rs
+++ b/sparse_strips/vello_hybrid/examples/scenes/src/text.rs
@@ -90,6 +90,20 @@ impl ExampleScene for TextScene {
     }
 }
 
+/// Check if two transforms are identical (within tolerance)
+fn transforms_are_identical(a: Affine, b: Affine) -> bool {
+    let a_coeffs = a.as_coeffs();
+    let b_coeffs = b.as_coeffs();
+    let tolerance = 1e-6;
+
+    for i in 0..6 {
+        if (a_coeffs[i] - b_coeffs[i]).abs() > tolerance {
+            return false;
+        }
+    }
+    true
+}
+
 impl TextScene {
     /// Create a new `TextScene` with the given text.
     pub fn new(text: &str) -> Self {
@@ -149,7 +163,7 @@ fn try_reuse_recording(
 
     // Case 1: Identical transforms - can reuse directly
     if let Some(transform) = recording.relative_transform() {
-        if *transform == current_transform {
+        if transforms_are_identical(*transform, current_transform) {
             scene.set_transform(*transform);
             scene.execute_recording(recording);
             #[cfg(not(target_arch = "wasm32"))]

--- a/sparse_strips/vello_hybrid/examples/scenes/src/text.rs
+++ b/sparse_strips/vello_hybrid/examples/scenes/src/text.rs
@@ -146,7 +146,7 @@ struct CachedRecording {
 
 impl CachedRecording {
     fn new() -> Self {
-        CachedRecording {
+        Self {
             transform_key: None,
             recording: Recording::new(),
         }
@@ -193,7 +193,7 @@ fn record_fresh(scene_obj: &mut TextScene, scene: &mut Scene, current_transform:
     scene.prepare_recording(recording);
     scene.execute_recording(recording);
     #[cfg(not(target_arch = "wasm32"))]
-    print_render_stats("Fresh     ", start.elapsed(), &recording);
+    print_render_stats("Fresh     ", start.elapsed(), recording);
 }
 
 /// Print timing and statistics for a render operation

--- a/sparse_strips/vello_hybrid/examples/scenes/src/text.rs
+++ b/sparse_strips/vello_hybrid/examples/scenes/src/text.rs
@@ -39,8 +39,8 @@ pub struct TextScene {
     layout: Layout<ColorBrush>,
     /// Whether recording functionality is enabled
     recording_enabled: bool,
-    /// The recording to reuse, if any
-    recording: Option<Recording>,
+    /// The recording to reuse
+    recording: CachedRecording,
 }
 
 impl fmt::Debug for TextScene {
@@ -53,11 +53,9 @@ impl ExampleScene for TextScene {
     fn render(&mut self, scene: &mut Scene, root_transform: Affine) {
         if self.recording_enabled {
             // Try to reuse existing recording if possible
-            if let Some(recording) = &mut self.recording {
-                let render_result = try_reuse_recording(scene, recording, root_transform);
-                if render_result.is_reused {
-                    return;
-                }
+            let render_result = try_reuse_recording(scene, &mut self.recording, root_transform);
+            if render_result.is_reused {
+                return;
             }
 
             // If we get here, we need to record fresh
@@ -88,20 +86,6 @@ impl ExampleScene for TextScene {
             _ => false,
         }
     }
-}
-
-/// Check if two transforms are identical (within tolerance)
-fn transforms_are_identical(a: Affine, b: Affine) -> bool {
-    let a_coeffs = a.as_coeffs();
-    let b_coeffs = b.as_coeffs();
-    let tolerance = 1e-6;
-
-    for i in 0..6 {
-        if (a_coeffs[i] - b_coeffs[i]).abs() > tolerance {
-            return false;
-        }
-    }
-    true
 }
 
 impl TextScene {
@@ -137,7 +121,7 @@ impl TextScene {
         Self {
             layout,
             recording_enabled: true,
-            recording: None,
+            recording: CachedRecording::new(),
         }
     }
 }
@@ -152,24 +136,42 @@ struct RenderResult {
     is_reused: bool,
 }
 
+struct CachedRecording {
+    // The transform the recording was taken at. Informs if recording can be re-used or if it needs
+    // to be re-recorded.
+    pub(crate) transform_key: Option<Affine>,
+    // The recording absolutely positioned from the `transform_key`.
+    recording: Recording,
+}
+
+impl CachedRecording {
+    fn new() -> Self {
+        CachedRecording {
+            transform_key: None,
+            recording: Recording::new(),
+        }
+    }
+}
+
 /// Try to reuse an existing recording, either directly (TODO: or with translation)
 fn try_reuse_recording(
     scene: &mut Scene,
-    recording: &mut Recording,
+    recording: &mut CachedRecording,
     current_transform: Affine,
 ) -> RenderResult {
+    // There is no `transform_key` meaning there is no valid recording to execute.
+    let Some(recording_transform) = recording.transform_key else {
+        return RenderResult { is_reused: false };
+    };
     #[cfg(not(target_arch = "wasm32"))]
     let start = std::time::Instant::now();
 
     // Case 1: Identical transforms - can reuse directly
-    if let Some(transform) = recording.relative_transform() {
-        if transforms_are_identical(*transform, current_transform) {
-            scene.set_transform(*transform);
-            scene.execute_recording(recording);
-            #[cfg(not(target_arch = "wasm32"))]
-            print_render_stats("Identical ", start.elapsed(), recording);
-            return RenderResult { is_reused: true };
-        }
+    if transforms_are_identical(recording_transform, current_transform) {
+        scene.execute_recording(&recording.recording);
+        #[cfg(not(target_arch = "wasm32"))]
+        print_render_stats("Identical ", start.elapsed(), &recording.recording);
+        return RenderResult { is_reused: true };
     }
 
     // TODO: Implement "Case 2: Check if we can use with translation"
@@ -182,17 +184,16 @@ fn try_reuse_recording(
 fn record_fresh(scene_obj: &mut TextScene, scene: &mut Scene, current_transform: Affine) {
     #[cfg(not(target_arch = "wasm32"))]
     let start = std::time::Instant::now();
-    let mut recording = Recording::new();
-    scene.set_transform(current_transform);
-    scene.record(&mut recording, |recorder| {
-        render_text_record(scene_obj, recorder);
+    scene_obj.recording.transform_key = Some(current_transform);
+    let recording = &mut scene_obj.recording.recording;
+    recording.clear();
+    scene.record(recording, |recorder| {
+        render_text_record(&mut scene_obj.layout, recorder, current_transform);
     });
-    scene.prepare_recording(&mut recording);
-    scene.execute_recording(&recording);
+    scene.prepare_recording(recording);
+    scene.execute_recording(recording);
     #[cfg(not(target_arch = "wasm32"))]
     print_render_stats("Fresh     ", start.elapsed(), &recording);
-
-    scene_obj.recording = Some(recording);
 }
 
 /// Print timing and statistics for a render operation
@@ -207,14 +208,25 @@ fn print_render_stats(render_type: &str, elapsed: std::time::Duration, recording
     );
 }
 
+/// Check if two transforms are identical (within tolerance)
+fn transforms_are_identical(a: Affine, b: Affine) -> bool {
+    let a_coeffs = a.as_coeffs();
+    let b_coeffs = b.as_coeffs();
+    let tolerance = 1e-6;
+
+    for i in 0..6 {
+        if (a_coeffs[i] - b_coeffs[i]).abs() > tolerance {
+            return false;
+        }
+    }
+    true
+}
+
 impl TextScene {
     /// Toggle recording functionality on/off
     /// Returns the new state (true = enabled, false = disabled)
     pub fn toggle_recording(&mut self) -> bool {
         self.recording_enabled = !self.recording_enabled;
-        if !self.recording_enabled {
-            self.recording = None;
-        }
         self.recording_enabled
     }
 }
@@ -230,8 +242,9 @@ fn render_text(state: &mut TextScene, ctx: &mut Scene) {
 }
 
 /// Render text to recording
-fn render_text_record(state: &mut TextScene, ctx: &mut Recorder<'_>) {
-    for line in state.layout.lines() {
+fn render_text_record(layout: &mut Layout<ColorBrush>, ctx: &mut Recorder<'_>, transform: Affine) {
+    ctx.set_transform(transform);
+    for line in layout.lines() {
         for item in line.items() {
             if let PositionedLayoutItem::GlyphRun(glyph_run) = item {
                 render_glyph_run_record(ctx, &glyph_run, 30);

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -410,7 +410,6 @@ impl Recordable for Scene {
     }
 
     fn execute_recording(&mut self, recording: &Recording) {
-        recording.enforce_matching_transform(&self.transform);
         let (cached_strips, cached_alphas) = recording.get_cached_strips();
         let adjusted_strips = self.prepare_cached_strips(cached_strips, cached_alphas);
 

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -588,6 +588,10 @@ impl Scene {
             .copied()
             .unwrap_or(adjusted_strips.len());
         let count = end - start;
+        if count == 0 {
+            // There are no strips to generate.
+            return;
+        }
         assert!(
             start < adjusted_strips.len() && count > 0,
             "Invalid strip range: start={start}, end={end}, count={count}"

--- a/sparse_strips/vello_sparse_tests/snapshots/glyph_recording_outside_transform.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/glyph_recording_outside_transform.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d04433f79b627b11a8c0d67f3699c3fb3ef81d3485b50a07a234815be886b4bf
+size 2409

--- a/sparse_strips/vello_sparse_tests/snapshots/recording_can_be_cleared.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/recording_can_be_cleared.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc2202a361f51dee345ddea50a9c759f15b5d06bb801b49255cc9dce499d77a8
+size 104

--- a/sparse_strips/vello_sparse_tests/snapshots/recording_can_be_cleared.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/recording_can_be_cleared.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cc2202a361f51dee345ddea50a9c759f15b5d06bb801b49255cc9dce499d77a8
-size 104
+oid sha256:5d3ee5faa021e9320485268cd1aabaf5cd76342643fcef97593d89f24040cc2a
+size 335

--- a/sparse_strips/vello_sparse_tests/snapshots/recording_can_be_repeatedly_executed_in_layers.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/recording_can_be_repeatedly_executed_in_layers.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26f24dd5c60a9a7f84b039e8c19c6ddc01b9e337994e3dd3887c14067d23a54d
+size 104

--- a/sparse_strips/vello_sparse_tests/snapshots/recording_handles_offscreen_content.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/recording_handles_offscreen_content.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:108bdd50a674a7af2e73be72cefe99663d89c144aade8be489d3ab294acd01ee
+size 463

--- a/sparse_strips/vello_sparse_tests/snapshots/recording_is_executed_at_recorded_transform.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/recording_is_executed_at_recorded_transform.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08f950f078c1ec89093ae5a9989634d458202acbe467ce6e25d388867c68cf1d
+size 95

--- a/sparse_strips/vello_sparse_tests/snapshots/recording_is_executed_with_multiple_transforms.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/recording_is_executed_with_multiple_transforms.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b67c66ce7fed9d7741305732ca606d7c4f7017647f47ba0095491b63eec64476
+size 253

--- a/sparse_strips/vello_sparse_tests/snapshots/recording_mixed_with_direct_drawing.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/recording_mixed_with_direct_drawing.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56f191f2427f5ecca61275f6321936984d7c3652ed6d933a8676c1bfc726bacb
+size 680

--- a/sparse_strips/vello_sparse_tests/snapshots/recording_mixed_with_direct_drawing.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/recording_mixed_with_direct_drawing.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:56f191f2427f5ecca61275f6321936984d7c3652ed6d933a8676c1bfc726bacb
-size 680
+oid sha256:d6226ef72abdb69e6d850fb17072afb1a5072e7a90ff7f86f7a3242c07b7c7b8
+size 765

--- a/sparse_strips/vello_sparse_tests/tests/recording.rs
+++ b/sparse_strips/vello_sparse_tests/tests/recording.rs
@@ -118,7 +118,7 @@ fn glyph_recording_outside_transform(ctx: &mut impl Renderer) {
 }
 
 #[vello_test(width = 1, height = 1, no_ref)]
-fn executing_recording_with_different_transform_crashes(ctx: &mut impl Renderer) {
+fn recording_without_identical_transform_crashes(ctx: &mut impl Renderer) {
     ctx.set_transform(Affine::translate((0., 1.)));
     let mut recording = Recording::new();
     ctx.record(&mut recording, |ctx| {});
@@ -187,4 +187,25 @@ fn recording_can_be_repeatedly_executed_in_layers(ctx: &mut impl Renderer) {
         ctx.execute_recording(&recording);
         ctx.pop_layer();
     }
+}
+
+#[vello_test(width = 100, height = 100)]
+fn recording_can_be_cleared(ctx: &mut impl Renderer) {
+    let mut recording = Recording::new();
+    ctx.set_transform(Affine::translate((1.,1.)));
+    ctx.record(&mut recording, |ctx| {
+        ctx.set_paint(ORANGE);
+        ctx.fill_rect(&Rect::new(10.0, 10.0, 90.0, 90.0));
+    });
+    ctx.prepare_recording(&mut recording);
+
+    recording.clear();
+
+    ctx.set_transform(Affine::IDENTITY);
+    ctx.record(&mut recording, |ctx| {
+        ctx.set_paint(GREEN);
+        ctx.fill_rect(&Rect::new(10.0, 10.0, 90.0, 90.0));
+    });
+    ctx.prepare_recording(&mut recording);
+    ctx.execute_recording(&recording);
 }

--- a/sparse_strips/vello_sparse_tests/tests/recording.rs
+++ b/sparse_strips/vello_sparse_tests/tests/recording.rs
@@ -121,7 +121,7 @@ fn glyph_recording_outside_transform(ctx: &mut impl Renderer) {
 fn recording_without_identical_transform_crashes(ctx: &mut impl Renderer) {
     ctx.set_transform(Affine::translate((0., 1.)));
     let mut recording = Recording::new();
-    ctx.record(&mut recording, |ctx| {});
+    ctx.record(&mut recording, |_| {});
 
     ctx.prepare_recording(&mut recording);
 

--- a/sparse_strips/vello_sparse_tests/tests/recording.rs
+++ b/sparse_strips/vello_sparse_tests/tests/recording.rs
@@ -192,7 +192,7 @@ fn recording_can_be_repeatedly_executed_in_layers(ctx: &mut impl Renderer) {
 #[vello_test(width = 100, height = 100)]
 fn recording_can_be_cleared(ctx: &mut impl Renderer) {
     let mut recording = Recording::new();
-    ctx.set_transform(Affine::translate((1.,1.)));
+    ctx.set_transform(Affine::translate((1., 1.)));
     ctx.record(&mut recording, |ctx| {
         ctx.set_paint(ORANGE);
         ctx.fill_rect(&Rect::new(10.0, 10.0, 90.0, 90.0));

--- a/sparse_strips/vello_sparse_tests/tests/recording.rs
+++ b/sparse_strips/vello_sparse_tests/tests/recording.rs
@@ -171,3 +171,20 @@ fn recording_mixed_with_direct_drawing(ctx: &mut impl Renderer) {
 
     ctx.execute_recording(&recording);
 }
+
+#[vello_test(width = 100, height = 100)]
+fn recording_can_be_repeatedly_executed_in_layers(ctx: &mut impl Renderer) {
+    let mut recording = Recording::new();
+    ctx.set_paint(DARK_TURQUOISE);
+    ctx.record(&mut recording, |ctx| {
+        ctx.fill_rect(&Rect::new(10.0, 10.0, 90.0, 90.0));
+    });
+    ctx.prepare_recording(&mut recording);
+
+    for _ in 0..10 {
+        ctx.push_opacity_layer(0.02);
+        ctx.set_paint(FUCHSIA);
+        ctx.execute_recording(&recording);
+        ctx.pop_layer();
+    }
+}

--- a/sparse_strips/vello_sparse_tests/tests/recording.rs
+++ b/sparse_strips/vello_sparse_tests/tests/recording.rs
@@ -207,3 +207,20 @@ fn recording_can_be_cleared(ctx: &mut impl Renderer) {
     ctx.prepare_recording(&mut recording);
     ctx.execute_recording(&recording);
 }
+
+#[vello_test(width = 20, height = 20, no_ref)]
+fn recording_handles_completely_offscreen_content(ctx: &mut impl Renderer) {
+    let mut recording = Recording::new();
+    ctx.record(&mut recording, |ctx| {
+        ctx.set_paint(ORCHID);
+        // A rectangle completely outside the viewport in then negative x and y direction.
+        ctx.set_transform(Affine::translate((-200., -200.)));
+        ctx.fill_rect(&Rect::new(0.0, 0.0, 10.0, 10.0));
+        // A rectangle completely outside the viewport in then positive x and y direction.
+        ctx.set_transform(Affine::translate((200., 200.)));
+        ctx.fill_rect(&Rect::new(0.0, 0.0, 10.0, 10.0));
+    });
+
+    ctx.prepare_recording(&mut recording);
+    ctx.execute_recording(&recording);
+}

--- a/sparse_strips/vello_sparse_tests/tests/recording.rs
+++ b/sparse_strips/vello_sparse_tests/tests/recording.rs
@@ -117,30 +117,28 @@ fn glyph_recording_outside_transform(ctx: &mut impl Renderer) {
     ctx.execute_recording(&recording);
 }
 
-#[vello_test(width = 1, height = 1, no_ref)]
-fn recording_without_identical_transform_crashes(ctx: &mut impl Renderer) {
-    ctx.set_transform(Affine::translate((0., 1.)));
+#[vello_test(width = 50, height = 50)]
+fn recording_is_executed_at_recorded_transform(ctx: &mut impl Renderer) {
+    ctx.set_transform(Affine::translate((10., 10.)));
+
     let mut recording = Recording::new();
-    ctx.record(&mut recording, |_| {});
+    ctx.record(&mut recording, |ctx| {
+        ctx.set_paint(FUCHSIA);
+        ctx.fill_rect(&Rect::new(0.0, 0.0, 30.0, 30.0));
+    });
 
     ctx.prepare_recording(&mut recording);
 
-    ctx.set_transform(Affine::translate((0., 0.)));
-    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        ctx.execute_recording(&recording);
-    }));
-    assert!(
-        result.is_err(),
-        "Expected panic as renderer transform does not match recording"
-    );
+    ctx.set_transform(Affine::IDENTITY);
+    ctx.execute_recording(&recording);
 }
 
 #[vello_test(width = 300, height = 100)]
 fn recording_mixed_with_direct_drawing(ctx: &mut impl Renderer) {
     let mut recording = Recording::new();
     // Record a rectangle on the left.
+    ctx.set_transform(Affine::translate((20.0, 30.0)));
     ctx.record(&mut recording, |ctx| {
-        ctx.set_transform(Affine::translate((20.0, 30.0)));
         ctx.set_paint(FUCHSIA);
         ctx.fill_rect(&Rect::new(0.0, 0.0, 60.0, 40.0));
     });
@@ -164,7 +162,7 @@ fn recording_mixed_with_direct_drawing(ctx: &mut impl Renderer) {
 
     ctx.prepare_recording(&mut recording);
 
-    // Change transform and clear the canvas.
+    // Clear the canvas.
     ctx.set_transform(Affine::IDENTITY);
     ctx.set_paint(GREEN);
     ctx.fill_rect(&Rect::new(0.0, 0.0, 300.0, 100.0));
@@ -192,7 +190,7 @@ fn recording_can_be_repeatedly_executed_in_layers(ctx: &mut impl Renderer) {
 #[vello_test(width = 100, height = 100)]
 fn recording_can_be_cleared(ctx: &mut impl Renderer) {
     let mut recording = Recording::new();
-    ctx.set_transform(Affine::translate((1., 1.)));
+    ctx.set_transform(Affine::translate((10., 10.)));
     ctx.record(&mut recording, |ctx| {
         ctx.set_paint(ORANGE);
         ctx.fill_rect(&Rect::new(10.0, 10.0, 90.0, 90.0));

--- a/sparse_strips/vello_sparse_tests/tests/renderer.rs
+++ b/sparse_strips/vello_sparse_tests/tests/renderer.rs
@@ -485,15 +485,15 @@ impl Renderer for HybridRenderer {
     }
 
     fn record(&mut self, recording: &mut Recording, f: impl FnOnce(&mut Recorder<'_>)) {
-        self.scene.record(recording, f);
+        Recordable::record(&mut self.scene, recording, f);
     }
 
     fn prepare_recording(&mut self, recording: &mut Recording) {
-        self.scene.prepare_recording(recording);
+        Recordable::prepare_recording(&mut self.scene, recording);
     }
 
     fn execute_recording(&mut self, recording: &Recording) {
-        self.scene.execute_recording(recording);
+        Recordable::execute_recording(&mut self.scene, recording);
     }
 }
 


### PR DESCRIPTION
### Context

I was investigating using the recording API ran into a rough edge where the transform was not correctly captured by the recording.

This PR enforces that transforms are handled in the recording, and adds more tests to make the recorder API usage clearer. 

## Change

https://github.com/linebender/vello/blob/418803ed8420f569b0687b72d5d33d363b90c3d5/sparse_strips/vello_common/src/recording.rs#L426-L430

https://github.com/linebender/vello/blob/418803ed8420f569b0687b72d5d33d363b90c3d5/sparse_strips/vello_common/src/recording.rs#L364-L368

 - `Recorder::glyph_run` used `self.recording.transform` eagerly, without the `recording.transform` ever being set. This resulted in the glyph_run unconditionally using `Affine::IDENTITY`. This is fixed in this PR by setting the transform eagerly whenever `set_transform` is called on the recorder.


However, glyph_run's transform could still be wrong if a `set_transform` was not within the recording. For example the following code would set a transform on the rendering context, but then the glyph_run would be built at `Affine::IDENTITY`:

```rs
    ctx.set_transform(Affine::translate((0., f64::from(font_size))));

    let mut recording = Recording::new();
    ctx.record(&mut recording, |ctx| {
        ctx.set_paint(REBECCA_PURPLE.with_alpha(0.5));
        ctx.glyph_run(&font)
            .font_size(font_size)
            .hint(true)
            .fill_glyphs(glyphs.into_iter());
    });
```

This was fixed by modifying the `record` trait such that it is no longer built in. Now it eagerly pushes a `set_transform` such that the transform of the recording is tracked. This correctly builds the glyphs.

Fix: Recording is now correctly absolutely positioned when it is replayed because it _always_ pushes a set_transform on recording start.

### Test plan

Added multiple unique test cases and also checked the examples.


Results from `cargo run -p vello_hybrid_winit --release`:

```sh
# GhostTiger
SVG  | Fresh     : 12.040ms | Strips: 6850 | Alphas: 308048
SVG  | Identical : 0.957ms | Strips: 6850 | Alphas: 308048
SVG  | Identical : 0.483ms | Strips: 6850 | Alphas: 308048
# Text
Text | Fresh     : 0.693ms | Strips: 89 | Alphas: 2896
Text | Fresh     : 0.215ms | Strips: 89 | Alphas: 2896
Text | Fresh     : 0.212ms | Strips: 91 | Alphas: 3248
Text | Identical : 0.004ms | Strips: 91 | Alphas: 3248
Text | Identical : 0.015ms | Strips: 91 | Alphas: 3248
```

Results from `cargo run_wasm -p native_webgl --release`:
 - Checked performance tab and you can't even see the `request_animation_frame` that contains the cached render 😆 .

### Caveats

Note – recording API still crashes if the sparse strips go off the top left of the screen. That behavior remains consistent with `main`.

This PR fixes the transform handling of the recording – maintaining the expected behavior that the recording will be replayed at the transforms that it was recorded at. In the future we can extend this API to add a translation when we support it. Or we can add a new API that executes a recording at a translation.





