### PR TITLE
[sparse_strips] fix out of bounds recording crash

### DIFF
--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -859,6 +859,10 @@ impl RenderContext {
             .copied()
             .unwrap_or(adjusted_strips.len());
         let count = end - start;
+        if count == 0 {
+            // There are no strips to generate.
+            return;
+        }
         assert!(
             start < adjusted_strips.len() && count > 0,
             "Invalid strip range"

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -588,6 +588,10 @@ impl Scene {
             .copied()
             .unwrap_or(adjusted_strips.len());
         let count = end - start;
+        if count == 0 {
+            // There are no strips to generate.
+            return;
+        }
         assert!(
             start < adjusted_strips.len() && count > 0,
             "Invalid strip range: start={start}, end={end}, count={count}"

--- a/sparse_strips/vello_sparse_tests/snapshots/recording_handles_offscreen_content.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/recording_handles_offscreen_content.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:108bdd50a674a7af2e73be72cefe99663d89c144aade8be489d3ab294acd01ee
+size 463

--- a/sparse_strips/vello_sparse_tests/tests/recording.rs
+++ b/sparse_strips/vello_sparse_tests/tests/recording.rs
@@ -207,3 +207,20 @@ fn recording_can_be_cleared(ctx: &mut impl Renderer) {
     ctx.prepare_recording(&mut recording);
     ctx.execute_recording(&recording);
 }
+
+#[vello_test(width = 20, height = 20, no_ref)]
+fn recording_handles_completely_offscreen_content(ctx: &mut impl Renderer) {
+    let mut recording = Recording::new();
+    ctx.record(&mut recording, |ctx| {
+        ctx.set_paint(ORCHID);
+        // A rectangle completely outside the viewport in then negative x and y direction.
+        ctx.set_transform(Affine::translate((-200., -200.)));
+        ctx.fill_rect(&Rect::new(0.0, 0.0, 10.0, 10.0));
+        // A rectangle completely outside the viewport in then positive x and y direction.
+        ctx.set_transform(Affine::translate((200., 200.)));
+        ctx.fill_rect(&Rect::new(0.0, 0.0, 10.0, 10.0));
+    });
+
+    ctx.prepare_recording(&mut recording);
+    ctx.execute_recording(&recording);
+}


### PR DESCRIPTION
### Context

Previously, recording crashes when executing strips that are out of bounds.

https://github.com/user-attachments/assets/f3409cb4-b1b2-45a9-8703-b157ac3ad38d

After this PR – out of bounds strips are handled:


https://github.com/user-attachments/assets/6fe68444-157c-4fca-b84f-7f76952348b5



### Why?

`execute_recording`:
 - Iterates over the recording commands, unconditionally calling `process_geometry_command` on the strips.
 - Except – for commands which are fully offscreen there are no strips to process.

Previously this would cause a crash. The new behavior is we handle an empty count of strips – meaning there is nothing to render for this command.

### Test plan

Added a test which renders completely outside the viewport. It used to crash and no longer crashes. I also tested manually.


