### PR TITLE
Put wgpu's default features behind a 'wgpu_default' feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ This release has an [MSRV][] of 1.86.
 
 ## Changed
 
-- Breaking: Put `wgpu`'s default features behind a `wgpu_default` feature flag. ([#1229][] by [@StT191][])
+- Breaking: Put `wgpu`'s default features behind a `wgpu_default` feature flag. ([#1229][] by [@StT191][])  
+  If you're using Vello with default features enabled, then no change is needed.
 
 ## Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,12 @@ This release has an [MSRV][] of 1.86.
 ## Added
 
 - `register_texture`, a helper for using `wgpu` textures in a Vello `Renderer`. ([#1161][] by [@DJMcNab][])
-- `push_luminance_mask_layer`, content within which is used as a luminance mask. ([#1183][] by [@DJMcNab][]).  
+- `push_luminance_mask_layer`, content within which is used as a luminance mask. ([#1183][] by [@DJMcNab][]).
    This is a breaking change to Vello Encoding.
+
+## Changed
+
+- Breaking: Put `wgpu`'s default features behind a `wgpu_default` feature flag ([#1229][] by [@StT191][])
 
 ## Fixed
 
@@ -44,7 +48,7 @@ This release has an [MSRV][] of 1.85.
 - Implement `Default` for `RendererOptions`. ([#524][] by [@DJMcNab][])
 
 ```diff
- RendererOptions { 
+ RendererOptions {
      // ...
 +    ..Default::default()
  }
@@ -52,7 +56,7 @@ This release has an [MSRV][] of 1.85.
 
 ### Removed
 
-- Breaking: `Renderer::render_to_surface` has been removed. ([#803][] by [@DJMcNab][])  
+- Breaking: `Renderer::render_to_surface` has been removed. ([#803][] by [@DJMcNab][])
   This API was not fit for purpose, as it assumed that you would only ever use a single window.
   The new recommended way to use Vello to render to a surface is to use `Renderer::render_to_texture` to render to an
   intermediate texture, then blit from that to the surface yourself.
@@ -320,6 +324,7 @@ This release has an [MSRV][] of 1.75.
 [#1182]: https://github.com/linebender/vello/pull/1182
 [#1183]: https://github.com/linebender/vello/pull/1183
 [#1187]: https://github.com/linebender/vello/pull/1187
+[#1229]: https://github.com/linebender/vello/pull/1229
 
 <!-- Note that this still comparing against 0.5.0, because 0.5.1 is a cherry-picked patch -->
 [Unreleased]: https://github.com/linebender/vello/compare/v0.5.0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ This release has an [MSRV][] of 1.86.
 
 ## Changed
 
-- Breaking: Put `wgpu`'s default features behind a `wgpu_default` feature flag ([#1229][] by [@StT191][])
+- Breaking: Put `wgpu`'s default features behind a `wgpu_default` feature flag ([#1229] by [@StT191])
 
 ## Fixed
 
@@ -244,6 +244,7 @@ This release has an [MSRV][] of 1.75.
 [@waywardmonkeys]: https://github.com/waywardmonkeys
 [@xStrom]: https://github.com/xStrom
 [@yutannihilation]: https://github.com/yutannihilation
+[@StT191]: https://github.com/StT191
 
 [#416]: https://github.com/linebender/vello/pull/416
 [#435]: https://github.com/linebender/vello/pull/435

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,12 @@ This release has an [MSRV][] of 1.86.
 ## Added
 
 - `register_texture`, a helper for using `wgpu` textures in a Vello `Renderer`. ([#1161][] by [@DJMcNab][])
-- `push_luminance_mask_layer`, content within which is used as a luminance mask. ([#1183][] by [@DJMcNab][]).
+- `push_luminance_mask_layer`, content within which is used as a luminance mask. ([#1183][] by [@DJMcNab][]).  
    This is a breaking change to Vello Encoding.
 
 ## Changed
 
-- Breaking: Put `wgpu`'s default features behind a `wgpu_default` feature flag ([#1229] by [@StT191])
+- Breaking: Put `wgpu`'s default features behind a `wgpu_default` feature flag. ([#1229][] by [@StT191][])
 
 ## Fixed
 
@@ -56,7 +56,7 @@ This release has an [MSRV][] of 1.85.
 
 ### Removed
 
-- Breaking: `Renderer::render_to_surface` has been removed. ([#803][] by [@DJMcNab][])
+- Breaking: `Renderer::render_to_surface` has been removed. ([#803][] by [@DJMcNab][])  
   This API was not fit for purpose, as it assumed that you would only ever use a single window.
   The new recommended way to use Vello to render to a surface is to use `Renderer::render_to_texture` to render to an
   intermediate texture, then blit from that to the surface yourself.
@@ -237,6 +237,7 @@ This release has an [MSRV][] of 1.75.
 [@ratmice]: https://github.com/ratmice
 [@simbleau]: https://github.com/simbleau
 [@songhuaixu]: https://github.com/songhuaixu
+[@StT191]: https://github.com/StT191
 [@TheNachoBIT]: https://github.com/TheNachoBIT
 [@timtom-dev]: https://github.com/timtom-dev
 [@tomcur]: https://github.com/tomcur
@@ -244,7 +245,6 @@ This release has an [MSRV][] of 1.75.
 [@waywardmonkeys]: https://github.com/waywardmonkeys
 [@xStrom]: https://github.com/xStrom
 [@yutannihilation]: https://github.com/yutannihilation
-[@StT191]: https://github.com/StT191
 
 [#416]: https://github.com/linebender/vello/pull/416
 [#435]: https://github.com/linebender/vello/pull/435

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ vello_hybrid_scenes = { path = "sparse_strips/vello_hybrid/examples/scenes" }
 vello_dev_macros = { path = "sparse_strips/vello_dev_macros" }
 
 # NOTE: Make sure to keep this in sync with the version badge in README.md and vello/README.md
-wgpu = { version = "26.0.1" }
+wgpu = { version = "26.0.1", default-features = false, features = ["std", "wgsl"] }
 log = "0.4.27"
 image = { version = "0.25.6", default-features = false }
 

--- a/sparse_strips/vello_cpu/examples/wasm_cpu/Cargo.toml
+++ b/sparse_strips/vello_cpu/examples/wasm_cpu/Cargo.toml
@@ -35,7 +35,7 @@ web-sys = { version = "0.3.77", features = [
     "KeyboardEvent",
     "CanvasRenderingContext2d",
 ] }
-wgpu = { workspace = true, features = ["webgl"] }
+wgpu = { workspace = true, features = ["webgl"], default-features = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 parley = { version = "0.5.0", default-features = false, features = ["std"] }

--- a/sparse_strips/vello_hybrid/Cargo.toml
+++ b/sparse_strips/vello_hybrid/Cargo.toml
@@ -51,7 +51,7 @@ vello_common = { workspace = true, features = ["pico_svg"] }
 roxmltree = "0.20.0"
 
 [features]
-default = ["wgpu", "wgpu/default"]
+default = ["wgpu", "wgpu_default"]
 std = ["wgpu", "vello_common/std"]
 wgpu = ["dep:wgpu", "dep:vello_sparse_shaders"]
 wgpu_default = ["wgpu", "wgpu/default"]

--- a/sparse_strips/vello_hybrid/Cargo.toml
+++ b/sparse_strips/vello_hybrid/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 bytemuck = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 vello_common = { workspace = true, features = ["std", "text"] }
-wgpu = { workspace = true, optional = true }
+wgpu = { workspace = true, default-features = false, optional = true }
 vello_sparse_shaders = { workspace = true, optional = true }
 log = { workspace = true }
 guillotiere = "0.6.2"
@@ -51,7 +51,8 @@ vello_common = { workspace = true, features = ["pico_svg"] }
 roxmltree = "0.20.0"
 
 [features]
-default = ["wgpu"]
+default = ["wgpu", "wgpu/default"]
 std = ["wgpu", "vello_common/std"]
 wgpu = ["dep:wgpu", "dep:vello_sparse_shaders"]
+wgpu_default = ["wgpu", "wgpu/default"]
 webgl = ["dep:js-sys", "dep:web-sys", "dep:vello_sparse_shaders", "vello_sparse_shaders/glsl"]

--- a/sparse_strips/vello_hybrid/Cargo.toml
+++ b/sparse_strips/vello_hybrid/Cargo.toml
@@ -54,5 +54,8 @@ roxmltree = "0.20.0"
 default = ["wgpu", "wgpu_default"]
 std = ["wgpu", "vello_common/std"]
 wgpu = ["dep:wgpu", "dep:vello_sparse_shaders"]
+# Enable wgpu with its default features. If you need to customise the set of enabled wgpu features,
+# please disable this crate's default features, enable its "wgpu" feature, then depend on wgpu directly
+# with the features which you need enabled.
 wgpu_default = ["wgpu", "wgpu/default"]
 webgl = ["dep:js-sys", "dep:web-sys", "dep:vello_sparse_shaders", "vello_sparse_shaders/glsl"]

--- a/sparse_strips/vello_hybrid/examples/wgpu_webgl/Cargo.toml
+++ b/sparse_strips/vello_hybrid/examples/wgpu_webgl/Cargo.toml
@@ -35,7 +35,7 @@ web-sys = { version = "0.3.77", features = [
     "WheelEvent",
     "KeyboardEvent",
 ] }
-wgpu = { workspace = true, features = ["webgl"] }
+wgpu = { workspace = true, default-features = true, features = ["webgl"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.50"

--- a/sparse_strips/vello_hybrid/examples/winit/Cargo.toml
+++ b/sparse_strips/vello_hybrid/examples/winit/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 winit = { workspace = true }
-wgpu = { workspace = true }
+wgpu = { workspace = true, default-features = true }
 vello_common = { workspace = true }
 vello_hybrid = { workspace = true }
 vello_hybrid_scenes = { workspace = true }

--- a/sparse_strips/vello_sparse_tests/Cargo.toml
+++ b/sparse_strips/vello_sparse_tests/Cargo.toml
@@ -19,7 +19,7 @@ vello_api = { workspace = true }
 vello_common = { workspace = true, features = ["std"] }
 vello_cpu = { workspace = true, features = ["multithreading", "std"] }
 vello_hybrid = { workspace = true }
-wgpu = { workspace = true }
+wgpu = { workspace = true, default-features = true }
 pollster = { workspace = true }
 vello_dev_macros = { workspace = true }
 bytemuck = { workspace = true }

--- a/vello/Cargo.toml
+++ b/vello/Cargo.toml
@@ -16,13 +16,14 @@ default-target = "x86_64-unknown-linux-gnu"
 targets = []
 
 [features]
-default = ["wgpu"]
+default = ["wgpu", "wgpu_default"]
 # Enables GPU memory usage estimation. This performs additional computations
 # in order to estimate the minimum required allocations for buffers backing
 # bump-allocated GPU memory.
 # TODO: Turn this into a runtime option used at resolve time and remove the feature.
 bump_estimate = ["vello_encoding/bump_estimate"]
 wgpu = ["dep:wgpu", "dep:vello_shaders", "dep:futures-intrusive"]
+wgpu_default = ["wgpu", "wgpu/default"]
 
 # Development only features
 
@@ -46,7 +47,7 @@ vello_shaders = { workspace = true, optional = true }
 bytemuck = { workspace = true }
 skrifa = { workspace = true, features = ["std"] }
 peniko = { workspace = true, default-features = true }
-wgpu = { workspace = true, optional = true }
+wgpu = { workspace = true, default-features = false, optional = true }
 log = { workspace = true }
 static_assertions = { workspace = true }
 futures-intrusive = { workspace = true, optional = true }

--- a/vello/Cargo.toml
+++ b/vello/Cargo.toml
@@ -23,6 +23,9 @@ default = ["wgpu", "wgpu_default"]
 # TODO: Turn this into a runtime option used at resolve time and remove the feature.
 bump_estimate = ["vello_encoding/bump_estimate"]
 wgpu = ["dep:wgpu", "dep:vello_shaders", "dep:futures-intrusive"]
+# Enable wgpu with its default features. If you need to customise the set of enabled wgpu features,
+# please disable this crate's default features, enable its "wgpu" feature, then depend on wgpu directly
+# with the features which you need enabled.
 wgpu_default = ["wgpu", "wgpu/default"]
 
 # Development only features

--- a/vello/src/wgpu_engine.rs
+++ b/vello/src/wgpu_engine.rs
@@ -769,7 +769,15 @@ impl WgpuEngine {
         for id in free_images {
             if let Some((texture, view)) = self.bind_map.image_map.remove(&id) {
                 // TODO: have a pool to avoid needless re-allocation
+                #[allow(
+                    clippy::drop_non_drop,
+                    reason = "suppress warning when no wgpu backend is enabled"
+                )]
                 drop(texture);
+                #[allow(
+                    clippy::drop_non_drop,
+                    reason = "suppress warning when no wgpu backend is enabled"
+                )]
                 drop(view);
             }
         }

--- a/vello/src/wgpu_engine.rs
+++ b/vello/src/wgpu_engine.rs
@@ -767,18 +767,8 @@ impl WgpuEngine {
             }
         }
         for id in free_images {
-            if let Some((texture, view)) = self.bind_map.image_map.remove(&id) {
+            if let Some((_texture, _view)) = self.bind_map.image_map.remove(&id) {
                 // TODO: have a pool to avoid needless re-allocation
-                #[allow(
-                    clippy::drop_non_drop,
-                    reason = "suppress warning when no wgpu backend is enabled"
-                )]
-                drop(texture);
-                #[allow(
-                    clippy::drop_non_drop,
-                    reason = "suppress warning when no wgpu backend is enabled"
-                )]
-                drop(view);
             }
         }
         Ok(())


### PR DESCRIPTION
This PR enables users of `vello` to disable `wgpu`'s default features (see [#1225](https://github.com/linebender/vello/issues/1225)). This is especially useful as `wgpu` allows enabling and disabling of all backends via feature flags since version `25.0.0`.

The previous behavior is behind an new feature flag `wgpu_default` that is included in `vellos`'s default features so current users of `vello` who rely on them don't get surprised.