### PR TITLE
Add a CHANGELOG entry for the Peniko update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,8 @@ This release has an [MSRV][] of 1.86.
 
   - Breaking change: Gradients must have their alpha interpolation space specified. For this, you should use `InterpolationAlphaSpace::Premultiplied`, unless you are implementing a specification which indicates otherwise.
     Currently, only `InterpolationAlphaSpace::Premultiplied` is supported.
-  - Breaking change: `Gradient` kinds now have a corresponding struct. For example, `GradientKind::Linear {...}` is now `GradientKind::Linear(LinearGradientPosition {...})`.
-    This makes it possible to talk about gradient kinds in code individually.
+  - Breaking change: `Gradient` kinds now have a corresponding struct. For example, `GradientKind::Linear {...}` is now `LinearGradientPosition {...}.into()`.
+    This makes it possible to pass individual gradient kinds between functions.
   - `GradientKind::Sweep`'s defined semantics now match those which Vello previously implemented.
   - Breaking change: `Image` has been renamed to `ImageBrush`, consisting of an `ImageData` and an `ImageSampler`.
     The equivalent to the old `Image::new($data, $format, $width, $height)` is `ImageBrush::new(ImageData { data: $data, format: $format, width: $width, height: $height, alpha_type: ImageAlphaType::Alpha })`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,18 +15,38 @@ You can find its changes [documented below](#051---2025-08-22).
 
 This release has an [MSRV][] of 1.86.
 
-## Added
+### Added
 
 - `register_texture`, a helper for using `wgpu` textures in a Vello `Renderer`. ([#1161][] by [@DJMcNab][])
 - `push_luminance_mask_layer`, content within which is used as a luminance mask. ([#1183][] by [@DJMcNab][]).  
    This is a breaking change to Vello Encoding.
 
-## Changed
+### Changed
 
-- Breaking: Put `wgpu`'s default features behind a `wgpu_default` feature flag. ([#1229][] by [@StT191][])  
+- Breaking change: Put `wgpu`'s default features behind a `wgpu_default` feature flag. ([#1229][] by [@StT191][])  
   If you're using Vello with default features enabled, then no change is needed.
+- Breaking change: Updated Peniko to [v0.5.0](https://github.com/linebender/peniko/releases/tag/v0.5.0)
+ (This release hasn't happened yet, so that link isn't yet live; see [Peniko's CHANGELOG](https://github.com/linebender/peniko/blob/main/CHANGELOG.md)). ([#1224][] by [@DJMcNab][])  
+<!-- https://github.com/linebender/peniko/blob/main/CHANGELOG.md -->
+  This brings several important changes which allow Vello to be used in more use cases:
 
-## Fixed
+  - Breaking change: Gradients must have their alpha interpolation space specified. For this, you should use `InterpolationAlphaSpace::Premultiplied`, unless you are implementing a specification which indicates otherwise.
+    Currently, only `InterpolationAlphaSpace::Premultiplied` is supported.
+  - Breaking change: `Gradient` kinds now have a corresponding struct. For example, `GradientKind::Linear {...}` is now `GradientKind::Linear(LinearGradientPosition {...})`.
+    This makes it possible to talk about gradient kinds in code individually.
+  - `GradientKind::Sweep`'s defined semantics now match those which Vello previously implemented.
+  - Breaking change: `Image` has been renamed to `ImageBrush`, consisting of an `ImageData` and an `ImageSampler`.
+    The equivalent to the old `Image::new($data, $format, $width, $height)` is `ImageBrush::new(ImageData { data: $data, format: $format, width: $width, height: $height, alpha_type: ImageAlphaType::Alpha })`.
+    Only `ImageAlphaType::Alpha` is currently supported in Vello.
+
+### Linebender Resource Handle
+
+The `vello::peniko::Font` type used in Vello used to be provided by the Peniko crate, and this was used as vocabulary types for font resources between crates.
+However, this means that when Peniko made semver-incompatible releases, crates which used this type could no longer (easily) interoperate
+To resolve this, `vello::peniko::FontData` (which is the same type but renamed) is now a re-export from a new crate called [Linebender Resource Handle](https://crates.io/crates/linebender_resource_handle).
+These types have identical API as in previous releases, but will now be the same type across Peniko versions.
+
+### Fixed
 
 - Examples crashing when window is resized to zero. ([#1182][] by [@xStrom][])
 - Correct flattening tolerance calculation from 2D affine transforms. ([#1187][] by [@tomcur][])
@@ -35,7 +55,7 @@ This release has an [MSRV][] of 1.86.
 
 This release has an [MSRV][] of 1.85.
 
-## Changed
+### Changed
 
 - Upgrade `skrifa` to `0.35.0` ([#1169][] by [@nicoburns][])
 
@@ -43,7 +63,7 @@ This release has an [MSRV][] of 1.85.
 
 This release has an [MSRV][] of 1.85.
 
-## Added
+### Added
 
 - Breaking: Support for pipeline caches. ([#524][] by [@DJMcNab][])
 - Implement `Default` for `RendererOptions`. ([#524][] by [@DJMcNab][])
@@ -326,6 +346,7 @@ This release has an [MSRV][] of 1.75.
 [#1182]: https://github.com/linebender/vello/pull/1182
 [#1183]: https://github.com/linebender/vello/pull/1183
 [#1187]: https://github.com/linebender/vello/pull/1187
+[#1224]: https://github.com/linebender/vello/pull/1224
 [#1229]: https://github.com/linebender/vello/pull/1229
 
 <!-- Note that this still comparing against 0.5.0, because 0.5.1 is a cherry-picked patch -->

--- a/sparse_strips/vello_common/src/encode.rs
+++ b/sparse_strips/vello_common/src/encode.rs
@@ -19,7 +19,9 @@ use core::cell::OnceCell;
 use core::hash::{Hash, Hasher};
 use fearless_simd::{Simd, SimdBase, SimdFloat, f32x4, f32x16};
 use peniko::color::cache_key::{BitEq, BitHash, CacheKey};
-use peniko::{LinearGradientPosition, RadialGradientPosition, SweepGradientPosition};
+use peniko::{
+    InterpolationAlphaSpace, LinearGradientPosition, RadialGradientPosition, SweepGradientPosition,
+};
 use smallvec::ToSmallVec;
 // So we can just use `OnceCell` regardless of which feature is activated.
 #[cfg(feature = "multithreading")]
@@ -59,6 +61,12 @@ impl EncodeExt for Gradient {
         // First make sure that the gradient is valid and not degenerate.
         if let Err(paint) = validate(self) {
             return paint;
+        }
+        if self.interpolation_alpha_space != InterpolationAlphaSpace::Premultiplied {
+            unimplemented!(
+                "We don't yet support gradient interpolation which isn't premultiplied, found {:?}.",
+                self.interpolation_alpha_space
+            )
         }
 
         let mut has_opacities = self.stops.iter().any(|s| s.color.components[3] != 1.0);

--- a/vello_encoding/src/encoding.rs
+++ b/vello_encoding/src/encoding.rs
@@ -13,7 +13,7 @@ use peniko::color::{DynamicColor, palette};
 use peniko::kurbo::{Shape, Stroke};
 use peniko::{
     BrushRef, ColorStop, Extend, Fill, GradientKind, ImageBrushRef, ImageSampler,
-    LinearGradientPosition, RadialGradientPosition, SweepGradientPosition,
+    InterpolationAlphaSpace, LinearGradientPosition, RadialGradientPosition, SweepGradientPosition,
 };
 
 /// Encoded data streams for a scene.
@@ -286,57 +286,65 @@ impl Encoding {
                 };
                 self.encode_color(color);
             }
-            BrushRef::Gradient(gradient) => match gradient.kind {
-                GradientKind::Linear(LinearGradientPosition { start, end }) => {
-                    self.encode_linear_gradient(
-                        DrawLinearGradient {
-                            index: 0,
-                            p0: point_to_f32(start),
-                            p1: point_to_f32(end),
-                        },
-                        gradient.stops.iter().copied(),
-                        alpha,
-                        gradient.extend,
-                    );
+            BrushRef::Gradient(gradient) => {
+                if gradient.interpolation_alpha_space != InterpolationAlphaSpace::Premultiplied {
+                    unimplemented!(
+                        "We don't yet support gradient interpolation which isn't premultiplied, found {:?}.",
+                        gradient.interpolation_alpha_space
+                    )
                 }
-                GradientKind::Radial(RadialGradientPosition {
-                    start_center,
-                    start_radius,
-                    end_center,
-                    end_radius,
-                }) => {
-                    self.encode_radial_gradient(
-                        DrawRadialGradient {
-                            index: 0,
-                            p0: point_to_f32(start_center),
-                            p1: point_to_f32(end_center),
-                            r0: start_radius,
-                            r1: end_radius,
-                        },
-                        gradient.stops.iter().copied(),
-                        alpha,
-                        gradient.extend,
-                    );
+                match gradient.kind {
+                    GradientKind::Linear(LinearGradientPosition { start, end }) => {
+                        self.encode_linear_gradient(
+                            DrawLinearGradient {
+                                index: 0,
+                                p0: point_to_f32(start),
+                                p1: point_to_f32(end),
+                            },
+                            gradient.stops.iter().copied(),
+                            alpha,
+                            gradient.extend,
+                        );
+                    }
+                    GradientKind::Radial(RadialGradientPosition {
+                        start_center,
+                        start_radius,
+                        end_center,
+                        end_radius,
+                    }) => {
+                        self.encode_radial_gradient(
+                            DrawRadialGradient {
+                                index: 0,
+                                p0: point_to_f32(start_center),
+                                p1: point_to_f32(end_center),
+                                r0: start_radius,
+                                r1: end_radius,
+                            },
+                            gradient.stops.iter().copied(),
+                            alpha,
+                            gradient.extend,
+                        );
+                    }
+                    GradientKind::Sweep(SweepGradientPosition {
+                        center,
+                        start_angle,
+                        end_angle,
+                    }) => {
+                        use core::f32::consts::TAU;
+                        self.encode_sweep_gradient(
+                            DrawSweepGradient {
+                                index: 0,
+                                p0: point_to_f32(center),
+                                t0: start_angle / TAU,
+                                t1: end_angle / TAU,
+                            },
+                            gradient.stops.iter().copied(),
+                            alpha,
+                            gradient.extend,
+                        );
+                    }
                 }
-                GradientKind::Sweep(SweepGradientPosition {
-                    center,
-                    start_angle,
-                    end_angle,
-                }) => {
-                    use core::f32::consts::TAU;
-                    self.encode_sweep_gradient(
-                        DrawSweepGradient {
-                            index: 0,
-                            p0: point_to_f32(center),
-                            t0: start_angle / TAU,
-                            t1: end_angle / TAU,
-                        },
-                        gradient.stops.iter().copied(),
-                        alpha,
-                        gradient.extend,
-                    );
-                }
-            },
+            }
             BrushRef::Image(image) => {
                 self.encode_image(image, alpha);
             }


### PR DESCRIPTION
I forgot this in https://github.com/linebender/vello/pull/1224

I've also fixed the fact that `InterpolationAlphaSpace::Premultiplied` was being assumed, as I missed that in #1224.
I think the code I've added this in covers both Hybrid and CPU, as it is in Vello Common.