### PR TITLE
Reuse allocations across multiple runs in multi-threading

### DIFF
--- a/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
@@ -606,7 +606,7 @@ impl<T> AllocationManager<T> {
     ///
     /// The vector is guaranteed to have been cleared before.
     fn get(&mut self) -> Vec<T> {
-        self.entries.pop().unwrap_or(vec![])
+        self.entries.pop().unwrap_or_default()
     }
 
     /// Insert a new allocation in the store.

--- a/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
@@ -51,10 +51,7 @@ pub(crate) struct MultiThreadedDispatcher {
     wide: Wide,
     /// The thread pool that is used for dispatching tasks.
     thread_pool: ThreadPool,
-    /// The current batch of paths we want to render.
-    task_batch: Vec<RenderTaskType>,
-    /// The path containing all elements of the current batch.
-    batch_path: BezPath,
+    allocation_group: AllocationGroup,
     /// The cost of the current batch.
     batch_cost: f32,
     /// The sender used to dispatch new rendering tasks from the main thread.
@@ -102,6 +99,8 @@ pub(crate) struct MultiThreadedDispatcher {
     strip_storage: StripStorage,
     level: Level,
     flushed: bool,
+    // So that we can reuse memory allocations across different runs.
+    allocations: Allocations,
 }
 
 impl MultiThreadedDispatcher {
@@ -114,7 +113,6 @@ impl MultiThreadedDispatcher {
         // + 1 because the main thread also stores an alpha buffer, used for recordings.
         let alpha_storage = MaybePresent::new(vec![vec![]; usize::from(num_threads + 1)]);
         let workers = Arc::new(ThreadLocal::new());
-        let task_batch = vec![];
 
         {
             // Start counting from 1, as thread_idx 0 is reserved for the main thread.
@@ -137,8 +135,8 @@ impl MultiThreadedDispatcher {
         let mut dispatcher = Self {
             wide,
             thread_pool,
-            task_batch,
-            batch_path: Default::default(),
+            allocations: Default::default(),
+            allocation_group: Default::default(),
             batch_cost,
             task_idx,
             flushed,
@@ -224,8 +222,8 @@ impl MultiThreadedDispatcher {
             self.init();
         }
 
-        let cost = estimate_render_task_cost(&task, self.batch_path.elements());
-        self.task_batch.push(task);
+        let cost = estimate_render_task_cost(&task, &self.allocation_group.path);
+        self.allocation_group.render_tasks.push(task);
         self.batch_cost += cost;
 
         if self.batch_cost > COST_THRESHOLD {
@@ -237,8 +235,6 @@ impl MultiThreadedDispatcher {
         self.send_pending_tasks();
 
         self.batch_cost = 0.0;
-        self.task_batch.clear();
-        self.batch_path.truncate(0);
     }
 
     fn bump_task_idx(&mut self) -> u32 {
@@ -249,16 +245,12 @@ impl MultiThreadedDispatcher {
 
     fn send_pending_tasks(&mut self) {
         let task_idx = self.bump_task_idx();
-        let tasks = self.task_batch.as_slice();
-        let path = self.batch_path.elements();
+        let allocation_group =
+            std::mem::replace(&mut self.allocation_group, self.allocations.get());
         let task_sender = self.task_sender.as_mut().unwrap();
         let task = RenderTask {
             idx: task_idx,
-            // TODO: Explore whether the main thread can hold a store of previous allocations so
-            // we can reuse them. Same for the strips that are returned from
-            // a child thread.
-            path: path.into(),
-            tasks: tasks.into(),
+            allocation_group,
         };
         task_sender.send(task).unwrap();
         self.run_coarse(true);
@@ -281,23 +273,25 @@ impl MultiThreadedDispatcher {
 
         loop {
             match result_receiver.try_recv() {
-                Ok(task) => {
-                    for cmd in task.tasks {
+                Ok(mut task) => {
+                    let num_tasks = task.allocation_group.coarse_tasks.len();
+                    for cmd in task.allocation_group.coarse_tasks.drain(0..num_tasks) {
                         match cmd {
                             CoarseTaskType::RenderPath {
                                 strips: strip_range,
                                 paint,
                                 thread_id,
                             } => self.wide.generate(
-                                &task.strips[strip_range.start as usize..strip_range.end as usize],
-                                paint,
+                                &task.allocation_group.strips
+                                    [strip_range.start as usize..strip_range.end as usize],
+                                paint.clone(),
                                 thread_id,
                             ),
                             CoarseTaskType::RenderWideCommand {
                                 strips,
                                 paint,
                                 thread_id,
-                            } => self.wide.generate(&strips, paint, thread_id),
+                            } => self.wide.generate(&strips, paint.clone(), thread_id),
                             CoarseTaskType::PushLayer {
                                 thread_id,
                                 clip_path,
@@ -306,7 +300,7 @@ impl MultiThreadedDispatcher {
                                 opacity,
                             } => {
                                 let clip_path = clip_path.map(|strip_range| {
-                                    &task.strips
+                                    &task.allocation_group.strips
                                         [strip_range.start as usize..strip_range.end as usize]
                                 });
 
@@ -316,6 +310,8 @@ impl MultiThreadedDispatcher {
                             CoarseTaskType::PopLayer => self.wide.pop_layer(),
                         }
                     }
+
+                    self.allocations.put(task.allocation_group);
                 }
                 Err(e) => match e {
                     TryRecvError::Empty => {
@@ -391,9 +387,9 @@ impl Dispatcher for MultiThreadedDispatcher {
         paint: Paint,
         aliasing_threshold: Option<u8>,
     ) {
-        let start = self.batch_path.elements().len() as u32;
-        self.batch_path.extend(path);
-        let end = self.batch_path.elements().len() as u32;
+        let start = self.allocation_group.path.len() as u32;
+        self.allocation_group.path.extend(path);
+        let end = self.allocation_group.path.len() as u32;
         self.register_task(RenderTaskType::FillPath {
             path_range: start..end,
             transform,
@@ -411,9 +407,9 @@ impl Dispatcher for MultiThreadedDispatcher {
         paint: Paint,
         aliasing_threshold: Option<u8>,
     ) {
-        let start = self.batch_path.elements().len() as u32;
-        self.batch_path.extend(path);
-        let end = self.batch_path.elements().len() as u32;
+        let start = self.allocation_group.path.len() as u32;
+        self.allocation_group.path.extend(path);
+        let end = self.allocation_group.path.len() as u32;
         self.register_task(RenderTaskType::StrokePath {
             path_range: start..end,
             transform,
@@ -434,9 +430,9 @@ impl Dispatcher for MultiThreadedDispatcher {
         mask: Option<Mask>,
     ) {
         let mapped_clip = clip_path.map(|c| {
-            let start = self.batch_path.elements().len() as u32;
-            self.batch_path.extend(c);
-            let end = self.batch_path.elements().len() as u32;
+            let start = self.allocation_group.path.len() as u32;
+            self.allocation_group.path.extend(c);
+            let end = self.allocation_group.path.len() as u32;
             (start..end, clip_transform)
         });
 
@@ -456,9 +452,8 @@ impl Dispatcher for MultiThreadedDispatcher {
 
     fn reset(&mut self) {
         self.wide.reset();
-        self.task_batch.clear();
+        self.allocation_group.clear();
         self.batch_cost = 0.0;
-        self.batch_path.truncate(0);
         self.task_idx = 0;
         self.flushed = false;
         self.task_sender = None;
@@ -600,11 +595,80 @@ impl Debug for MultiThreadedDispatcher {
     }
 }
 
+struct AllocationManager<T> {
+    entries: Vec<Vec<T>>,
+}
+
+impl<T> AllocationManager<T> {
+    fn get(&mut self) -> Vec<T> {
+        self.entries.pop().unwrap_or(vec![])
+    }
+
+    fn put(&mut self, mut allocation: Vec<T>) {
+        allocation.clear();
+        self.entries.push(allocation);
+    }
+}
+
+impl<T> Default for AllocationManager<T> {
+    fn default() -> Self {
+        Self { entries: vec![] }
+    }
+}
+
+#[derive(Default)]
+struct Allocations {
+    render_tasks: AllocationManager<RenderTaskType>,
+    paths: AllocationManager<PathEl>,
+    strips: AllocationManager<Strip>,
+    coarse_tasks: AllocationManager<CoarseTaskType>,
+}
+
+impl Allocations {
+    fn get(&mut self) -> AllocationGroup {
+        let render_tasks = self.render_tasks.get();
+        let path = self.paths.get();
+        let strips = self.strips.get();
+        let coarse_tasks = self.coarse_tasks.get();
+
+        AllocationGroup {
+            path,
+            render_tasks,
+            coarse_tasks,
+            strips,
+        }
+    }
+
+    fn put(&mut self, allocation: AllocationGroup) {
+        self.render_tasks.put(allocation.render_tasks);
+        self.paths.put(allocation.path);
+        self.strips.put(allocation.strips);
+        self.coarse_tasks.put(allocation.coarse_tasks);
+    }
+}
+
+#[derive(Default, Debug)]
+pub(crate) struct AllocationGroup {
+    pub(crate) path: Vec<PathEl>,
+    pub(crate) render_tasks: Vec<RenderTaskType>,
+    pub(crate) strips: Vec<Strip>,
+    pub(crate) coarse_tasks: Vec<CoarseTaskType>,
+}
+
+impl AllocationGroup {
+    fn clear(&mut self) {
+        self.path.clear();
+        self.render_tasks.clear();
+        self.strips.clear();
+        self.coarse_tasks.clear();
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct RenderTask {
     pub(crate) idx: u32,
-    pub(crate) path: Box<[PathEl]>,
-    pub(crate) tasks: Box<[RenderTaskType]>,
+    /// The path elements of the task.
+    pub(crate) allocation_group: AllocationGroup,
 }
 
 #[derive(Debug, Clone)]
@@ -640,10 +704,10 @@ pub(crate) enum RenderTaskType {
 }
 
 pub(crate) struct CoarseTask {
-    pub(crate) strips: Box<[Strip]>,
-    pub(crate) tasks: Vec<CoarseTaskType>,
+    allocation_group: AllocationGroup,
 }
 
+#[derive(Debug)]
 pub(crate) enum CoarseTaskType {
     RenderPath {
         thread_id: u8,

--- a/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
@@ -795,7 +795,7 @@ mod tests {
     use crate::Level;
     use crate::color::palette::css::BLUE;
     use crate::dispatch::Dispatcher;
-    use crate::dispatch::multi_threaded::{MultiThreadedDispatcher};
+    use crate::dispatch::multi_threaded::MultiThreadedDispatcher;
     use crate::kurbo::{Affine, Rect, Shape};
     use crate::peniko::Fill;
     use vello_common::paint::{Paint, PremulColor};


### PR DESCRIPTION
@taj-p Thanks for the suggestion, has a nice performance impact!!

<img width="1512" height="436" alt="image" src="https://github.com/user-attachments/assets/1da977e8-3e8e-4a7c-9439-30c902e81dfc" />
<img width="1512" height="402" alt="image" src="https://github.com/user-attachments/assets/75361191-4bbc-4168-b802-fb4f825841b1" />
<img width="1510" height="403" alt="image" src="https://github.com/user-attachments/assets/db0d8404-dfb0-43ae-9a84-cc2f10026d58" />
<img width="1512" height="397" alt="image" src="https://github.com/user-attachments/assets/f988d634-8621-4349-ac85-606b517b2588" />
