### PR TITLE
Prepare `vello_cpu` v0.0.2 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1055,7 +1055,7 @@ dependencies = [
  "objc2-core-text",
  "objc2-foundation 0.3.1",
  "peniko",
- "read-fonts 0.29.3",
+ "read-fonts",
  "roxmltree",
  "smallvec",
  "windows",
@@ -2500,7 +2500,7 @@ dependencies = [
  "fontique",
  "hashbrown 0.15.3",
  "peniko",
- "skrifa 0.31.3",
+ "skrifa",
  "swash",
 ]
 
@@ -2784,16 +2784,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04ca636dac446b5664bd16c069c00a9621806895b8bb02c2dc68542b23b8f25d"
 dependencies = [
  "bytemuck",
- "font-types",
-]
-
-[[package]]
-name = "read-fonts"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8941f8e9d5f8ad3aebea330d01ac68c0167600eb31a86ecd86e97be4d13b51f5"
-dependencies = [
- "bytemuck",
  "core_maths",
  "font-types",
 ]
@@ -2967,7 +2957,7 @@ dependencies = [
  "image",
  "rand",
  "roxmltree",
- "skrifa 0.36.0",
+ "skrifa",
  "vello",
  "web-time",
 ]
@@ -3146,18 +3136,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbeb4ca4399663735553a09dd17ce7e49a0a0203f03b706b39628c4d913a8607"
 dependencies = [
  "bytemuck",
- "read-fonts 0.29.3",
-]
-
-[[package]]
-name = "skrifa"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37004372610e83ee2a4c69c7d896b41f33da6a3dc1a4fe07dd9b2629a549b1dc"
-dependencies = [
- "bytemuck",
  "core_maths",
- "read-fonts 0.34.0",
+ "read-fonts",
 ]
 
 [[package]]
@@ -3292,7 +3272,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f745de914febc7c9ab4388dfaf94bbc87e69f57bb41133a9b0c84d4be49856f3"
 dependencies = [
- "skrifa 0.31.3",
+ "skrifa",
  "yazi",
  "zeno",
 ]
@@ -3692,7 +3672,7 @@ dependencies = [
  "log",
  "peniko",
  "png",
- "skrifa 0.36.0",
+ "skrifa",
  "static_assertions",
  "thiserror 2.0.12",
  "vello_encoding",
@@ -3736,7 +3716,7 @@ dependencies = [
  "peniko",
  "png",
  "roxmltree",
- "skrifa 0.36.0",
+ "skrifa",
  "smallvec",
 ]
 
@@ -3768,7 +3748,7 @@ dependencies = [
  "bytemuck",
  "guillotiere",
  "peniko",
- "skrifa 0.36.0",
+ "skrifa",
  "smallvec",
 ]
 
@@ -3845,7 +3825,7 @@ dependencies = [
  "image",
  "oxipng",
  "pollster",
- "skrifa 0.36.0",
+ "skrifa",
  "smallvec",
  "vello_api",
  "vello_common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3706,7 +3706,7 @@ dependencies = [
 
 [[package]]
 name = "vello_common"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "bytemuck",
  "fearless_simd",
@@ -3722,7 +3722,7 @@ dependencies = [
 
 [[package]]
 name = "vello_cpu"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "bytemuck",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ fearless_simd = { version = "0.2.0", default-features = false }
 
 # The below crates are experimental!
 vello_api = { path = "sparse_strips/vello_api", default-features = false }
-vello_common = { version = "0.0.1", path = "sparse_strips/vello_common", default-features = false }
+vello_common = { version = "0.0.2", path = "sparse_strips/vello_common", default-features = false }
 vello_cpu = { path = "sparse_strips/vello_cpu" }
 vello_hybrid = { path = "sparse_strips/vello_hybrid" }
 vello_sparse_shaders = { path = "sparse_strips/vello_sparse_shaders" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ vello = { version = "0.5.0", path = "vello" }
 vello_encoding = { version = "0.5.0", path = "vello_encoding" }
 vello_shaders = { version = "0.5.0", path = "vello_shaders" }
 bytemuck = { version = "1.23.0", features = ["derive"] }
-skrifa = { version = "0.36.0", default-features = false, features = ["autohint_shaping"] }
+skrifa = { version = "0.31.3", default-features = false, features = ["autohint_shaping"] }
 # The version of kurbo used below should be kept in sync
 # with the version of kurbo used by peniko.
 peniko = { version = "0.4.0", default-features = false }

--- a/sparse_strips/vello_common/Cargo.toml
+++ b/sparse_strips/vello_common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vello_common"
 # When updating, also update the version in the workspace dependency in the root Cargo.toml
-version = "0.0.1"
+version = "0.0.2"
 description = "Core data structures and utilities shared across the Vello rendering, including geometry processing and tiling logic."
 categories = ["rendering", "graphics"]
 keywords = ["2d", "vector-graphics"]

--- a/sparse_strips/vello_cpu/Cargo.toml
+++ b/sparse_strips/vello_cpu/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vello_cpu"
 # When moving past 0.0.x, also update caveats in the README
-version = "0.0.1"
+version = "0.0.2"
 description = "A CPU-based renderer for Vello, optimized for SIMD and multithreaded execution."
 categories = ["rendering", "graphics"]
 keywords = ["2d", "vector-graphics"]


### PR DESCRIPTION
- Downgrades `skrifa` dep to 0.31 (matches Parley 0.5 and Vello 0.5.0)
- Bumps the version number to `0.0.2`.

This PR is against the `cpu-v0.0.x` branch, which is just `main` at commit 289f4919b58e349ccbca39fe23e8cd3d0acadc86 (the commit before the peniko 0.5 bump landed)

As this is a pre-0.1 release this PR does not bother with a changelog. A changelog and the usual release admin will commence with the upcoming `v0.1.0` release.