### PR TITLE
[sparse strips] Remove `GlyphRenderer` dead code in tests

### DIFF
--- a/sparse_strips/vello_sparse_tests/tests/renderer.rs
+++ b/sparse_strips/vello_sparse_tests/tests/renderer.rs
@@ -4,7 +4,7 @@
 use std::cell::RefCell;
 use std::sync::Arc;
 
-use vello_common::glyph::{GlyphRenderer, GlyphRunBuilder, PreparedGlyph};
+use vello_common::glyph::{GlyphRenderer, GlyphRunBuilder};
 use vello_common::kurbo::{Affine, BezPath, Rect, Stroke};
 use vello_common::mask::Mask;
 use vello_common::paint::{ImageSource, PaintType};
@@ -16,7 +16,7 @@ use vello_hybrid::Scene;
 #[cfg(all(target_arch = "wasm32", feature = "webgl"))]
 use web_sys::WebGl2RenderingContext;
 
-pub(crate) trait Renderer: Sized + GlyphRenderer {
+pub(crate) trait Renderer: Sized {
     type GlyphRenderer: GlyphRenderer;
 
     fn new(
@@ -691,23 +691,5 @@ impl Renderer for HybridRenderer {
 
     fn execute_recording(&mut self, recording: &Recording) {
         self.scene.execute_recording(recording);
-    }
-}
-
-impl GlyphRenderer for HybridRenderer {
-    fn fill_glyph(&mut self, glyph: PreparedGlyph<'_>) {
-        self.scene.fill_glyph(glyph);
-    }
-
-    fn stroke_glyph(&mut self, glyph: PreparedGlyph<'_>) {
-        self.scene.stroke_glyph(glyph);
-    }
-
-    fn take_glyph_caches(&mut self) -> vello_common::glyph::GlyphCaches {
-        self.scene.take_glyph_caches()
-    }
-
-    fn restore_glyph_caches(&mut self, caches: vello_common::glyph::GlyphCaches) {
-        self.scene.restore_glyph_caches(caches);
     }
 }


### PR DESCRIPTION
The `Renderer` trait for sparse strips testing _does not_ actually depend on `GlyphRenderer` because `glyph_run` is calling the underlying implementation on either the `RenderContext` (Vello CPU) or `Scene` (Vello Hybrid) directly.

### Test plan

This is a test-only change, and can be validated by ensuring that this compiles & tests continue to pass.