### PR TITLE
Use `XxxGradientPosition {...}.into()` instead of `GradientKind::Xxx(XxxGradientPosition {...})`

### DIFF
--- a/sparse_strips/vello_bench/src/fine/gradient.rs
+++ b/sparse_strips/vello_bench/src/fine/gradient.rs
@@ -35,20 +35,22 @@ pub fn gradient(c: &mut Criterion) {
 
 #[vello_bench]
 fn many_stops<S: Simd, N: FineKernel<S>>(b: &mut Bencher<'_>, fine: &mut Fine<S, N>) {
-    let kind = GradientKind::Linear(LinearGradientPosition {
+    let kind = LinearGradientPosition {
         start: Point::new(128.0, 128.0),
         end: Point::new(134.0, 134.0),
-    });
+    }
+    .into();
 
     gradient_base(b, fine, peniko::Extend::Repeat, kind, get_many_stops());
 }
 
 #[vello_bench]
 fn transparent<S: Simd, N: FineKernel<S>>(b: &mut Bencher<'_>, fine: &mut Fine<S, N>) {
-    let kind = GradientKind::Linear(LinearGradientPosition {
+    let kind = LinearGradientPosition {
         start: Point::new(128.0, 128.0),
         end: Point::new(134.0, 134.0),
-    });
+    }
+    .into();
 
     gradient_base(
         b,
@@ -65,7 +67,6 @@ mod extend {
     use vello_common::fearless_simd::Simd;
     use vello_common::kurbo::Point;
     use vello_common::peniko;
-    use vello_common::peniko::GradientKind;
     use vello_cpu::{
         fine::{Fine, FineKernel},
         peniko::LinearGradientPosition,
@@ -77,10 +78,11 @@ mod extend {
         fine: &mut Fine<S, N>,
         extend: peniko::Extend,
     ) {
-        let kind = GradientKind::Linear(LinearGradientPosition {
+        let kind = LinearGradientPosition {
             start: Point::new(128.0, 128.0),
             end: Point::new(134.0, 134.0),
-        });
+        }
+        .into();
 
         gradient_base(b, fine, extend, kind, stops_blue_green_red_yellow_opaque());
     }
@@ -107,7 +109,6 @@ mod linear {
     use vello_common::fearless_simd::Simd;
     use vello_common::kurbo::Point;
     use vello_common::peniko;
-    use vello_common::peniko::GradientKind;
 
     use vello_cpu::{
         fine::{Fine, FineKernel},
@@ -117,10 +118,11 @@ mod linear {
 
     #[vello_bench]
     pub(super) fn opaque<S: Simd, N: FineKernel<S>>(b: &mut Bencher<'_>, fine: &mut Fine<S, N>) {
-        let kind = GradientKind::Linear(LinearGradientPosition {
+        let kind = LinearGradientPosition {
             start: Point::new(128.0, 128.0),
             end: Point::new(134.0, 134.0),
-        });
+        }
+        .into();
 
         gradient_base(
             b,
@@ -140,7 +142,6 @@ mod radial {
     use vello_common::fearless_simd::Simd;
     use vello_common::kurbo::Point;
     use vello_common::peniko;
-    use vello_common::peniko::GradientKind;
     use vello_common::tile::Tile;
     use vello_cpu::{
         fine::{Fine, FineKernel},
@@ -150,12 +151,13 @@ mod radial {
 
     #[vello_bench]
     pub(super) fn opaque<S: Simd, N: FineKernel<S>>(b: &mut Bencher<'_>, fine: &mut Fine<S, N>) {
-        let kind = GradientKind::Radial(RadialGradientPosition {
+        let kind = RadialGradientPosition {
             start_center: Point::new(WideTile::WIDTH as f64 / 2.0, (Tile::HEIGHT / 2) as f64),
             start_radius: 25.0,
             end_center: Point::new(WideTile::WIDTH as f64 / 2.0, (Tile::HEIGHT / 2) as f64),
             end_radius: 75.0,
-        });
+        }
+        .into();
 
         gradient_base(
             b,
@@ -171,7 +173,7 @@ mod radial {
         b: &mut Bencher<'_>,
         fine: &mut Fine<S, N>,
     ) {
-        let kind = GradientKind::Radial(RadialGradientPosition {
+        let kind = RadialGradientPosition {
             start_center: Point::new(WideTile::WIDTH as f64 / 2.0, (Tile::HEIGHT / 2) as f64),
             start_radius: 25.0,
             end_center: Point::new(
@@ -179,7 +181,8 @@ mod radial {
                 (Tile::HEIGHT / 2) as f64 + 5.0,
             ),
             end_radius: 75.0,
-        });
+        }
+        .into();
 
         gradient_base(
             b,
@@ -199,7 +202,6 @@ mod sweep {
     use vello_common::fearless_simd::Simd;
     use vello_common::kurbo::Point;
     use vello_common::peniko;
-    use vello_common::peniko::GradientKind;
     use vello_common::tile::Tile;
     use vello_cpu::{
         fine::{Fine, FineKernel},
@@ -209,11 +211,12 @@ mod sweep {
 
     #[vello_bench]
     pub(super) fn opaque<S: Simd, N: FineKernel<S>>(b: &mut Bencher<'_>, fine: &mut Fine<S, N>) {
-        let kind = GradientKind::Sweep(SweepGradientPosition {
+        let kind = SweepGradientPosition {
             center: Point::new(WideTile::WIDTH as f64 / 2.0, (Tile::HEIGHT / 2) as f64),
             start_angle: 70.0_f32.to_radians(),
             end_angle: 250.0_f32.to_radians(),
-        });
+        }
+        .into();
 
         gradient_base(
             b,

--- a/sparse_strips/vello_common/src/colr.rs
+++ b/sparse_strips/vello_common/src/colr.rs
@@ -8,7 +8,7 @@ use crate::color::{AlphaColor, DynamicColor};
 use crate::glyph::{ColorGlyph, OutlinePath};
 use crate::kurbo::{Affine, BezPath, Point, Rect, Shape};
 use crate::math::FloatExt;
-use crate::peniko::{self, BlendMode, ColorStops, Compose, Extend, Gradient, GradientKind, Mix};
+use crate::peniko::{self, BlendMode, ColorStops, Compose, Extend, Gradient, Mix};
 use alloc::boxed::Box;
 use alloc::vec;
 use alloc::vec::Vec;
@@ -237,7 +237,7 @@ impl ColorPainter for ColrPainter<'_> {
                     self.painter.fill_solid(stops[0].color.to_alpha_color());
                 } else {
                     let grad = Gradient {
-                        kind: GradientKind::Linear(LinearGradientPosition { start: p0, end: p1 }),
+                        kind: LinearGradientPosition { start: p0, end: p1 }.into(),
                         stops,
                         extend,
                         ..Default::default()
@@ -268,12 +268,13 @@ impl ColorPainter for ColrPainter<'_> {
                 }
 
                 let grad = Gradient {
-                    kind: GradientKind::Radial(RadialGradientPosition {
+                    kind: RadialGradientPosition {
                         start_center: p0,
                         start_radius: r0,
                         end_center: p1,
                         end_radius: r1,
-                    }),
+                    }
+                    .into(),
                     stops,
                     extend,
                     ..Default::default()
@@ -317,11 +318,12 @@ impl ColorPainter for ColrPainter<'_> {
                 // We need to invert the direction of the gradient to bridge the gap between
                 // peniko and COLR.
                 let grad = Gradient {
-                    kind: GradientKind::Sweep(SweepGradientPosition {
+                    kind: SweepGradientPosition {
                         center: Point::new(p0.x, -p0.y),
                         start_angle: start_angle.to_radians(),
                         end_angle: end_angle.to_radians(),
-                    }),
+                    }
+                    .into(),
                     stops,
                     extend,
                     ..Default::default()

--- a/sparse_strips/vello_common/src/encode.rs
+++ b/sparse_strips/vello_common/src/encode.rs
@@ -1087,7 +1087,7 @@ mod tests {
     use crate::color::DynamicColor;
     use crate::color::palette::css::{BLACK, BLUE, GREEN};
     use crate::kurbo::{Affine, Point};
-    use crate::peniko::{ColorStop, ColorStops, GradientKind};
+    use crate::peniko::{ColorStop, ColorStops};
     use alloc::vec;
     use peniko::{LinearGradientPosition, RadialGradientPosition};
     use smallvec::smallvec;
@@ -1097,10 +1097,11 @@ mod tests {
         let mut buf = vec![];
 
         let gradient = Gradient {
-            kind: GradientKind::Linear(LinearGradientPosition {
+            kind: LinearGradientPosition {
                 start: Point::new(0.0, 0.0),
                 end: Point::new(20.0, 0.0),
-            }),
+            }
+            .into(),
             ..Default::default()
         };
 
@@ -1115,10 +1116,11 @@ mod tests {
         let mut buf = vec![];
 
         let gradient = Gradient {
-            kind: GradientKind::Linear(LinearGradientPosition {
+            kind: LinearGradientPosition {
                 start: Point::new(0.0, 0.0),
                 end: Point::new(20.0, 0.0),
-            }),
+            }
+            .into(),
             stops: ColorStops(smallvec![ColorStop {
                 offset: 0.0,
                 color: DynamicColor::from_alpha_color(GREEN),
@@ -1138,10 +1140,11 @@ mod tests {
         let mut buf = vec![];
 
         let gradient = Gradient {
-            kind: GradientKind::Linear(LinearGradientPosition {
+            kind: LinearGradientPosition {
                 start: Point::new(0.0, 0.0),
                 end: Point::new(20.0, 0.0),
-            }),
+            }
+            .into(),
             stops: ColorStops(smallvec![
                 ColorStop {
                     offset: 1.0,
@@ -1166,10 +1169,11 @@ mod tests {
         let mut buf = vec![];
 
         let gradient = Gradient {
-            kind: GradientKind::Linear(LinearGradientPosition {
+            kind: LinearGradientPosition {
                 start: Point::new(0.0, 0.0),
                 end: Point::new(0.0, 0.0),
-            }),
+            }
+            .into(),
             stops: ColorStops(smallvec![
                 ColorStop {
                     offset: 0.0,
@@ -1194,12 +1198,13 @@ mod tests {
         let mut buf = vec![];
 
         let gradient = Gradient {
-            kind: GradientKind::Radial(RadialGradientPosition {
+            kind: RadialGradientPosition {
                 start_center: Point::new(0.0, 0.0),
                 start_radius: 20.0,
                 end_center: Point::new(0.0, 0.0),
                 end_radius: 20.0,
-            }),
+            }
+            .into(),
             stops: ColorStops(smallvec![
                 ColorStop {
                     offset: 0.0,

--- a/sparse_strips/vello_example_scenes/src/gradient.rs
+++ b/sparse_strips/vello_example_scenes/src/gradient.rs
@@ -13,9 +13,7 @@ use crate::{ExampleScene, RenderingContext};
 use smallvec::smallvec;
 use vello_common::color::palette::css::{BLACK, BLUE, LIME, RED, WHITE, YELLOW};
 use vello_common::kurbo::{Affine, Ellipse, Point, Rect, Shape, Stroke};
-use vello_common::peniko::{
-    Color, ColorStop, ColorStops, Extend, Gradient, GradientKind, color::DynamicColor,
-};
+use vello_common::peniko::{Color, ColorStop, ColorStops, Extend, Gradient, color::DynamicColor};
 use vello_common::peniko::{LinearGradientPosition, RadialGradientPosition, SweepGradientPosition};
 
 /// Gradient scene state
@@ -69,10 +67,11 @@ impl ExampleScene for GradientExtendScene {
                     let end_y = height * 0.5;
 
                     Gradient {
-                        kind: GradientKind::Linear(LinearGradientPosition {
+                        kind: LinearGradientPosition {
                             start: Point::new(start_x, start_y),
                             end: Point::new(end_x, end_y),
-                        }),
+                        }
+                        .into(),
                         stops: create_color_stops(&colors),
                         extend,
                         ..Default::default()
@@ -88,12 +87,13 @@ impl ExampleScene for GradientExtendScene {
                     let radius = (width * 0.25) as f32;
 
                     Gradient {
-                        kind: GradientKind::Radial(RadialGradientPosition {
+                        kind: RadialGradientPosition {
                             start_center: Point::new(center_x, center_y),
                             start_radius: radius * 0.25,
                             end_center: Point::new(center_x, center_y),
                             end_radius: radius,
-                        }),
+                        }
+                        .into(),
                         stops: create_color_stops(&colors),
                         extend,
                         ..Default::default()
@@ -104,11 +104,12 @@ impl ExampleScene for GradientExtendScene {
                     let center_y = height * 0.5;
 
                     Gradient {
-                        kind: GradientKind::Sweep(SweepGradientPosition {
+                        kind: SweepGradientPosition {
                             center: Point::new(center_x, center_y),
                             start_angle: 30.0_f32.to_radians(),
                             end_angle: 150.0_f32.to_radians(),
-                        }),
+                        }
+                        .into(),
                         stops: create_color_stops(&colors),
                         extend,
                         ..Default::default()
@@ -187,12 +188,13 @@ impl ExampleScene for RadialScene {
             ctx.fill_rect(&Rect::new(0.0, 0.0, width, height));
 
             let gradient = Gradient {
-                kind: GradientKind::Radial(RadialGradientPosition {
+                kind: RadialGradientPosition {
                     start_center: Point::new(x0, y0),
                     start_radius: r0,
                     end_center: Point::new(x1, y1),
                     end_radius: r1,
-                }),
+                }
+                .into(),
                 stops: create_color_stops(&colors),
                 extend,
                 ..Default::default()

--- a/sparse_strips/vello_hybrid/src/gradient_cache.rs
+++ b/sparse_strips/vello_hybrid/src/gradient_cache.rs
@@ -292,9 +292,7 @@ mod tests {
     use vello_common::color::{ColorSpaceTag, DynamicColor, HueDirection};
     use vello_common::encode::{EncodeExt, EncodedPaint};
     use vello_common::kurbo::{Affine, Point};
-    use vello_common::peniko::{
-        Color, ColorStop, ColorStops, Gradient, GradientKind, LinearGradientPosition,
-    };
+    use vello_common::peniko::{Color, ColorStop, ColorStops, Gradient, LinearGradientPosition};
 
     fn insert_entries(cache: &mut GradientRampCache, count: usize) {
         for i in 0..count {
@@ -321,10 +319,11 @@ mod tests {
 
     fn create_gradient(offset: f32) -> Gradient {
         Gradient {
-            kind: GradientKind::Linear(LinearGradientPosition {
+            kind: LinearGradientPosition {
                 start: Point::new(0.0, 0.0),
                 end: Point::new(100.0, 0.0),
-            }),
+            }
+            .into(),
             stops: ColorStops(
                 vec![
                     ColorStop {

--- a/sparse_strips/vello_sparse_tests/tests/gradient.rs
+++ b/sparse_strips/vello_sparse_tests/tests/gradient.rs
@@ -7,7 +7,7 @@ use smallvec::smallvec;
 use vello_common::color::palette::css::{BLACK, BLUE, GREEN, WHITE, YELLOW};
 use vello_common::color::{ColorSpaceTag, DynamicColor};
 use vello_common::kurbo::{Point, Rect};
-use vello_common::peniko::{ColorStop, ColorStops, Gradient, GradientKind};
+use vello_common::peniko::{ColorStop, ColorStops, Gradient};
 use vello_cpu::peniko::LinearGradientPosition;
 use vello_dev_macros::vello_test;
 
@@ -20,10 +20,11 @@ fn gradient_on_3_wide_tiles(ctx: &mut impl Renderer) {
     let rect = Rect::new(4.0, 4.0, 596.0, 28.0);
 
     let gradient = Gradient {
-        kind: GradientKind::Linear(LinearGradientPosition {
+        kind: LinearGradientPosition {
             start: Point::new(0.0, 0.0),
             end: Point::new(600.0, 0.0),
-        }),
+        }
+        .into(),
         stops: stops_green_blue(),
         ..Default::default()
     };
@@ -37,10 +38,11 @@ fn gradient_with_global_alpha(ctx: &mut impl Renderer) {
     let rect = Rect::new(10.0, 10.0, 90.0, 90.0);
 
     let gradient = Gradient {
-        kind: GradientKind::Linear(LinearGradientPosition {
+        kind: LinearGradientPosition {
             start: Point::new(10.0, 0.0),
             end: Point::new(90.0, 0.0),
-        }),
+        }
+        .into(),
         stops: stops_blue_green_red_yellow(),
         ..Default::default()
     }
@@ -61,10 +63,11 @@ fn gradient_with_color_spaces(ctx: &mut impl Renderer, stops: ColorStops) {
 
     for cs in COLOR_SPACES {
         let gradient = Gradient {
-            kind: GradientKind::Linear(LinearGradientPosition {
+            kind: LinearGradientPosition {
                 start: Point::new(10.0, 0.0),
                 end: Point::new(190.0, 0.0),
-            }),
+            }
+            .into(),
             stops: stops.clone(),
             interpolation_cs: *cs,
             ..Default::default()
@@ -117,10 +120,11 @@ fn padded_stops(ctx: &mut impl Renderer, offset_1: f32, offset_2: f32) {
     let rect = Rect::new(10.0, 10.0, 90.0, 90.0);
 
     let gradient = Gradient {
-        kind: GradientKind::Linear(LinearGradientPosition {
+        kind: LinearGradientPosition {
             start: Point::new(10.0, 0.0),
             end: Point::new(90.0, 0.0),
-        }),
+        }
+        .into(),
         stops: ColorStops(smallvec![
             ColorStop {
                 offset: offset_1,
@@ -163,7 +167,7 @@ mod linear {
     use peniko::Extend;
     use std::f64::consts::PI;
     use vello_common::kurbo::{Affine, Point, Rect};
-    use vello_common::peniko::{self, Gradient, GradientKind};
+    use vello_common::peniko::{self, Gradient};
     use vello_cpu::peniko::LinearGradientPosition;
     use vello_dev_macros::vello_test;
 
@@ -172,10 +176,11 @@ mod linear {
         let rect = Rect::new(10.0, 10.0, 90.0, 90.0);
 
         let gradient = Gradient {
-            kind: GradientKind::Linear(LinearGradientPosition {
+            kind: LinearGradientPosition {
                 start: Point::new(10.0, 0.0),
                 end: Point::new(90.0, 0.0),
-            }),
+            }
+            .into(),
             stops: stops_green_blue(),
             ..Default::default()
         };
@@ -189,10 +194,11 @@ mod linear {
         let rect = Rect::new(10.0, 10.0, 90.0, 90.0);
 
         let gradient = Gradient {
-            kind: GradientKind::Linear(LinearGradientPosition {
+            kind: LinearGradientPosition {
                 start: Point::new(10.0, 0.0),
                 end: Point::new(90.0, 0.0),
-            }),
+            }
+            .into(),
             stops: stops_green_blue_with_alpha(),
             ..Default::default()
         };
@@ -205,7 +211,7 @@ mod linear {
         let rect = Rect::new(10.0, 10.0, 90.0, 90.0);
 
         let gradient = Gradient {
-            kind: GradientKind::Linear(LinearGradientPosition { start, end }),
+            kind: LinearGradientPosition { start, end }.into(),
             stops: stops_green_blue(),
             ..Default::default()
         };
@@ -238,10 +244,11 @@ mod linear {
         let rect = Rect::new(10.0, 10.0, 90.0, 90.0);
 
         let gradient = Gradient {
-            kind: GradientKind::Linear(LinearGradientPosition {
+            kind: LinearGradientPosition {
                 start: Point::new(40.0, 40.0),
                 end: Point::new(50.0, 60.0),
-            }),
+            }
+            .into(),
             stops: stops_blue_green_red_yellow(),
             extend,
             ..Default::default()
@@ -271,10 +278,11 @@ mod linear {
         let rect = Rect::new(10.0, 10.0, 90.0, 90.0);
 
         let gradient = Gradient {
-            kind: GradientKind::Linear(LinearGradientPosition {
+            kind: LinearGradientPosition {
                 start: Point::new(10.0, 0.0),
                 end: Point::new(90.0, 0.0),
-            }),
+            }
+            .into(),
             stops: stops_blue_green_red_yellow(),
             ..Default::default()
         };
@@ -288,10 +296,11 @@ mod linear {
         let path = crossed_line_star();
 
         let gradient = Gradient {
-            kind: GradientKind::Linear(LinearGradientPosition {
+            kind: LinearGradientPosition {
                 start: Point::new(0.0, 0.0),
                 end: Point::new(100.0, 0.0),
-            }),
+            }
+            .into(),
             stops: stops_blue_green_red_yellow(),
             ..Default::default()
         };
@@ -309,10 +318,11 @@ mod linear {
         let rect = Rect::new(10.0, 10.0, 90.0, 90.0);
 
         let gradient = Gradient {
-            kind: GradientKind::Linear(LinearGradientPosition {
+            kind: LinearGradientPosition {
                 start: Point::new(47.5, 47.5),
                 end: Point::new(50.5, 52.5),
-            }),
+            }
+            .into(),
             stops: stops_blue_green_red_yellow(),
             extend: Extend::Repeat,
             ..Default::default()
@@ -327,10 +337,11 @@ mod linear {
         let rect = Rect::new(10.0, 10.0, 90.0, 90.0);
 
         let gradient = Gradient {
-            kind: GradientKind::Linear(LinearGradientPosition {
+            kind: LinearGradientPosition {
                 start: Point::new(47.5, 47.5),
                 end: Point::new(50.5, 52.5),
-            }),
+            }
+            .into(),
             stops: stops_blue_green_red_yellow(),
             extend: Extend::Reflect,
             ..Default::default()
@@ -351,10 +362,11 @@ mod linear {
         let rect = Rect::new(l, t, r, b);
 
         let gradient = Gradient {
-            kind: GradientKind::Linear(LinearGradientPosition {
+            kind: LinearGradientPosition {
                 start: Point::new(l, t),
                 end: Point::new(r, b),
-            }),
+            }
+            .into(),
             stops: stops_blue_green_red_yellow(),
             ..Default::default()
         };
@@ -854,7 +866,7 @@ mod sweep {
     };
     use peniko::Extend;
     use vello_common::kurbo::{Affine, Point, Rect};
-    use vello_common::peniko::{self, ColorStops, Gradient, GradientKind};
+    use vello_common::peniko::{self, ColorStops, Gradient};
     use vello_cpu::peniko::SweepGradientPosition;
     use vello_dev_macros::vello_test;
 
@@ -862,11 +874,12 @@ mod sweep {
         let rect = Rect::new(10.0, 10.0, 90.0, 90.0);
 
         let gradient = Gradient {
-            kind: GradientKind::Sweep(SweepGradientPosition {
+            kind: SweepGradientPosition {
                 center,
                 start_angle: 0.0_f32.to_radians(),
                 end_angle: 360.0_f32.to_radians(),
-            }),
+            }
+            .into(),
             stops,
             ..Default::default()
         };
@@ -901,11 +914,12 @@ mod sweep {
         let path = crossed_line_star();
 
         let gradient = Gradient {
-            kind: GradientKind::Sweep(SweepGradientPosition {
+            kind: SweepGradientPosition {
                 center: Point::new(50.0, 50.0),
                 start_angle: 0.0_f32.to_radians(),
                 end_angle: 360.0_f32.to_radians(),
-            }),
+            }
+            .into(),
             stops: stops_blue_green_red_yellow(),
             ..Default::default()
         };
@@ -918,11 +932,12 @@ mod sweep {
         let rect = Rect::new(10.0, 10.0, 90.0, 90.0);
 
         let gradient = Gradient {
-            kind: GradientKind::Sweep(SweepGradientPosition {
+            kind: SweepGradientPosition {
                 center: Point::new(50.0, 50.0),
                 start_angle: 150.0_f32.to_radians(),
                 end_angle: 210.0_f32.to_radians(),
-            }),
+            }
+            .into(),
             stops: stops_blue_green_red_yellow(),
             extend,
             ..Default::default()
@@ -958,11 +973,12 @@ mod sweep {
         let rect = Rect::new(l, t, r, b);
 
         let gradient = Gradient {
-            kind: GradientKind::Sweep(SweepGradientPosition {
+            kind: SweepGradientPosition {
                 center: Point::new((l + r) / 2.0, (t + b) / 2.0),
                 start_angle: 150.0_f32.to_radians(),
                 end_angle: 210.0_f32.to_radians(),
-            }),
+            }
+            .into(),
             stops: stops_blue_green_red_yellow(),
             ..Default::default()
         };

--- a/sparse_strips/vello_sparse_tests/tests/mask.rs
+++ b/sparse_strips/vello_sparse_tests/tests/mask.rs
@@ -7,7 +7,7 @@ use vello_common::color::DynamicColor;
 use vello_common::color::palette::css::{BLACK, LIME, RED, YELLOW};
 use vello_common::kurbo::{Point, Rect};
 use vello_common::mask::Mask;
-use vello_common::peniko::{ColorStop, ColorStops, Gradient, GradientKind};
+use vello_common::peniko::{ColorStop, ColorStops, Gradient};
 use vello_cpu::peniko::LinearGradientPosition;
 use vello_cpu::{Level, RenderMode, RenderSettings};
 use vello_cpu::{Pixmap, RenderContext};
@@ -24,10 +24,11 @@ pub(crate) fn example_mask(alpha_mask: bool) -> Mask {
     let mut mask_ctx = RenderContext::new_with(100, 100, settings);
 
     let grad = Gradient {
-        kind: GradientKind::Linear(LinearGradientPosition {
+        kind: LinearGradientPosition {
             start: Point::new(10.0, 0.0),
             end: Point::new(90.0, 0.0),
-        }),
+        }
+        .into(),
         stops: ColorStops(smallvec![
             ColorStop {
                 offset: 0.0,

--- a/sparse_strips/vello_sparse_tests/tests/mix.rs
+++ b/sparse_strips/vello_sparse_tests/tests/mix.rs
@@ -9,8 +9,7 @@ use vello_common::color::{AlphaColor, DynamicColor, Srgb};
 use vello_common::kurbo::{Affine, Point, Rect};
 use vello_common::paint::{Image, ImageSource};
 use vello_common::peniko::{
-    BlendMode, Color, ColorStop, ColorStops, Compose, Extend, Gradient, GradientKind, ImageQuality,
-    Mix,
+    BlendMode, Color, ColorStop, ColorStops, Compose, Extend, Gradient, ImageQuality, Mix,
 };
 use vello_cpu::peniko::LinearGradientPosition;
 use vello_dev_macros::vello_test;
@@ -25,10 +24,11 @@ fn mix(ctx: &mut impl Renderer, blend_mode: BlendMode) {
     let rect = Rect::new(0.0, 0.0, 80.0, 80.0);
 
     let gradient = Gradient {
-        kind: GradientKind::Linear(LinearGradientPosition {
+        kind: LinearGradientPosition {
             start: Point::new(0.0, 0.0),
             end: Point::new(80.0, 0.0),
-        }),
+        }
+        .into(),
         stops: ColorStops(smallvec![
             ColorStop {
                 offset: 0.0,


### PR DESCRIPTION
This is both easier to understand and easier to write.

Follow-up to #1224 