### PR TITLE
[cpu] fix memory leak

### DIFF
--- a/sparse_strips/vello_cpu/src/dispatch/single_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/single_threaded.rs
@@ -261,13 +261,13 @@ mod tests {
         );
 
         // Ensure there is data to clear.
-        assert!(dispatcher.strip_storage.alphas.len() > 0);
-        assert!(dispatcher.wide.get(0, 0).cmds.len() > 0);
+        assert!(!dispatcher.strip_storage.alphas.is_empty());
+        assert!(!dispatcher.wide.get(0, 0).cmds.is_empty());
 
         dispatcher.reset();
 
         // Verify buffers are cleared.
-        assert_eq!(dispatcher.strip_storage.alphas.len(), 0);
-        assert_eq!(dispatcher.wide.get(0, 0).cmds.len(), 0);
+        assert!(dispatcher.strip_storage.alphas.is_empty());
+        assert!(dispatcher.wide.get(0, 0).cmds.is_empty());
     }
 }


### PR DESCRIPTION
### Context

In single threaded the `strip_storage` is not cleared when `reset` is called, resulting in a memory leak and an eventual crash.

### Investigation

This was found because in our WASM renderer we re-use the Vello CPU renderer and call `reset` on it. Eventually the browser would crash. The line `alpha_buf.extend_from_slice(&u8_vals.val);` in `vello_common/strip.rs` was the culprit. However, the root cause is that the alpha buffer was never reset.

### Fix

Clear the strip storage when reset is called (the same as the multithreaded dispatcher). 

I validated that this fixes the issue.