### PR TITLE
POC: add typestate pattern to the recording API to clarify usage

### DIFF
--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -15,7 +15,9 @@ use vello_common::paint::{Paint, PaintType};
 use vello_common::peniko::FontData;
 use vello_common::peniko::color::palette::css::BLACK;
 use vello_common::peniko::{BlendMode, Compose, Fill, Mix};
-use vello_common::recording::{PushLayerCommand, Recordable, Recorder, Recording, RenderCommand};
+use vello_common::recording::{
+    Active, Prepared, PushLayerCommand, Recordable, Recorder, Recording, RenderCommand, Unprepared,
+};
 use vello_common::strip::Strip;
 use vello_common::strip_generator::{GenerationMode, StripGenerator, StripStorage};
 
@@ -407,23 +409,24 @@ impl GlyphRenderer for Scene {
 }
 
 impl Recordable for Scene {
-    fn record<F>(&mut self, recording: &mut Recording, f: F)
+    fn record<F>(&mut self, mut recording: Recording<Active>, f: F) -> Recording<Unprepared>
     where
         F: FnOnce(&mut Recorder<'_>),
     {
-        let mut recorder = Recorder::new(recording, self.transform, self.take_glyph_caches());
+        let mut recorder = Recorder::new(&mut recording, self.transform, self.take_glyph_caches());
         f(&mut recorder);
         self.glyph_caches = Some(recorder.take_glyph_caches());
+        recording.finish_recording()
     }
 
-    fn prepare_recording(&mut self, recording: &mut Recording) {
+    fn prepare_recording(&mut self, mut recording: Recording<Unprepared>) -> Recording<Prepared> {
         let buffers = recording.take_cached_strips();
         let (strip_storage, strip_start_indices) =
             self.generate_strips_from_commands(recording.commands(), buffers);
-        recording.set_cached_strips(strip_storage, strip_start_indices);
+        recording.prepare(strip_storage, strip_start_indices)
     }
 
-    fn execute_recording(&mut self, recording: &Recording) {
+    fn execute_recording(&mut self, recording: &Recording<Prepared>) {
         let (cached_strips, cached_alphas) = recording.get_cached_strips();
         let adjusted_strips = self.prepare_cached_strips(cached_strips, cached_alphas);
 

--- a/sparse_strips/vello_sparse_tests/tests/recording.rs
+++ b/sparse_strips/vello_sparse_tests/tests/recording.rs
@@ -20,23 +20,23 @@ fn recording_basic(ctx: &mut impl Renderer) {
     ctx.set_paint(FUCHSIA);
     ctx.fill_rect(&Rect::new(52.0, 12.0, 88.0, 48.0));
 
-    let mut recording1 = Recording::new();
-    ctx.record(&mut recording1, |ctx| {
+    let recording1 = Recording::new();
+    let recording1 = ctx.record(recording1, |ctx| {
         ctx.set_paint(ORANGE);
         ctx.fill_rect(&Rect::new(12.0, 52.0, 48.0, 88.0));
         ctx.set_paint(REBECCA_PURPLE);
         ctx.fill_rect(&Rect::new(52.0, 52.0, 88.0, 88.0));
     });
 
-    let mut recording2 = Recording::new();
-    ctx.record(&mut recording2, |ctx| {
+    let recording2 = Recording::new();
+    let recording2 = ctx.record(recording2, |ctx| {
         ctx.set_paint(ORCHID);
         ctx.fill_rect(&Rect::new(4.0, 12.0, 8.0, 88.0));
         ctx.set_paint(PALE_VIOLET_RED);
         ctx.fill_rect(&Rect::new(92.0, 12.0, 96.0, 88.0));
     });
 
-    ctx.prepare_recording(&mut recording1);
+    let recording1 = ctx.prepare_recording(recording1);
     ctx.execute_recording(&recording1);
 
     ctx.set_paint(DARK_TURQUOISE);
@@ -44,39 +44,8 @@ fn recording_basic(ctx: &mut impl Renderer) {
     ctx.set_paint(LIGHT_SALMON);
     ctx.fill_rect(&Rect::new(12.0, 92.0, 88.0, 96.0));
 
-    ctx.prepare_recording(&mut recording2);
+    let recording2 = ctx.prepare_recording(recording2);
     ctx.execute_recording(&recording2);
-}
-
-#[vello_test]
-fn recording_incremental_build(ctx: &mut impl Renderer) {
-    let mut recording = Recording::new();
-
-    ctx.record(&mut recording, |ctx| {
-        ctx.set_paint(GREEN);
-        ctx.fill_rect(&Rect::new(12.0, 12.0, 48.0, 48.0));
-        ctx.set_paint(FUCHSIA);
-        ctx.fill_rect(&Rect::new(52.0, 12.0, 88.0, 48.0));
-        ctx.set_paint(ORANGE);
-        ctx.fill_rect(&Rect::new(12.0, 52.0, 48.0, 88.0));
-        ctx.set_paint(REBECCA_PURPLE);
-        ctx.fill_rect(&Rect::new(52.0, 52.0, 88.0, 88.0));
-    });
-    ctx.prepare_recording(&mut recording);
-
-    ctx.record(&mut recording, |ctx| {
-        ctx.set_paint(ORCHID);
-        ctx.fill_rect(&Rect::new(4.0, 12.0, 8.0, 88.0));
-        ctx.set_paint(PALE_VIOLET_RED);
-        ctx.fill_rect(&Rect::new(92.0, 12.0, 96.0, 88.0));
-        ctx.set_paint(DARK_TURQUOISE);
-        ctx.fill_rect(&Rect::new(12.0, 4.0, 88.0, 8.0));
-        ctx.set_paint(LIGHT_SALMON);
-        ctx.fill_rect(&Rect::new(12.0, 92.0, 88.0, 96.0));
-    });
-    ctx.prepare_recording(&mut recording);
-
-    ctx.execute_recording(&recording);
 }
 
 #[vello_test(width = 300, height = 70)]
@@ -84,8 +53,8 @@ fn recording_glyphs(ctx: &mut impl Renderer) {
     let font_size: f32 = 50_f32;
     let (font, glyphs) = layout_glyphs_roboto("Hello, world!", font_size);
 
-    let mut recording = Recording::new();
-    ctx.record(&mut recording, |ctx| {
+    let recording = Recording::new();
+    let recording = ctx.record(recording, |ctx| {
         ctx.set_transform(Affine::translate((0., f64::from(font_size))));
         ctx.set_paint(REBECCA_PURPLE.with_alpha(0.5));
         ctx.glyph_run(&font)
@@ -94,7 +63,7 @@ fn recording_glyphs(ctx: &mut impl Renderer) {
             .fill_glyphs(glyphs.into_iter());
     });
 
-    ctx.prepare_recording(&mut recording);
+    let recording = ctx.prepare_recording(recording);
     ctx.execute_recording(&recording);
 }
 
@@ -106,8 +75,8 @@ fn glyph_recording_outside_transform(ctx: &mut impl Renderer) {
     // Test differs from `recording_glyphs` as transform is set outside the recording context.
     ctx.set_transform(Affine::translate((0., f64::from(font_size))));
 
-    let mut recording = Recording::new();
-    ctx.record(&mut recording, |ctx| {
+    let recording = Recording::new();
+    let recording = ctx.record(recording, |ctx| {
         ctx.set_paint(REBECCA_PURPLE.with_alpha(0.5));
         ctx.glyph_run(&font)
             .font_size(font_size)
@@ -115,71 +84,33 @@ fn glyph_recording_outside_transform(ctx: &mut impl Renderer) {
             .fill_glyphs(glyphs.into_iter());
     });
 
-    ctx.prepare_recording(&mut recording);
-    ctx.execute_recording(&recording);
+    let recording = ctx.prepare_recording(recording);
+    let recording = ctx.execute_recording(&recording);
 }
 
 #[vello_test(width = 50, height = 50)]
 fn recording_is_executed_at_recorded_transform(ctx: &mut impl Renderer) {
     ctx.set_transform(Affine::translate((10., 10.)));
 
-    let mut recording = Recording::new();
-    ctx.record(&mut recording, |ctx| {
+    let recording = Recording::new();
+    let recording = ctx.record(recording, |ctx| {
         ctx.set_paint(FUCHSIA);
         ctx.fill_rect(&Rect::new(0.0, 0.0, 30.0, 30.0));
     });
 
-    ctx.prepare_recording(&mut recording);
-
+    let recording = ctx.prepare_recording(recording);
     ctx.set_transform(Affine::IDENTITY);
-    ctx.execute_recording(&recording);
-}
-
-#[vello_test(width = 300, height = 100)]
-fn recording_mixed_with_direct_drawing(ctx: &mut impl Renderer) {
-    let mut recording = Recording::new();
-    // Record a rectangle on the left.
-    ctx.set_transform(Affine::translate((20.0, 30.0)));
-    ctx.record(&mut recording, |ctx| {
-        ctx.set_paint(FUCHSIA);
-        ctx.fill_rect(&Rect::new(0.0, 0.0, 60.0, 40.0));
-    });
-
-    // Do not record central rectangle.
-    ctx.set_transform(Affine::IDENTITY);
-    ctx.set_paint(LIGHT_SALMON);
-    ctx.fill_rect(&Rect::new(120.0, 30.0, 180.0, 70.0));
-
-    // Record a glyph on the right.
-    let font_size: f32 = 40_f32;
-    let (font, glyphs) = layout_glyphs_roboto("A", font_size);
-    ctx.set_transform(Affine::translate((220.0, 60.0)));
-    ctx.record(&mut recording, |ctx| {
-        ctx.set_paint(ORANGE);
-        ctx.glyph_run(&font)
-            .font_size(font_size)
-            .hint(true)
-            .fill_glyphs(glyphs.into_iter());
-    });
-
-    ctx.prepare_recording(&mut recording);
-
-    // Paint half the canvas and half of the salmon rectangle.
-    ctx.set_transform(Affine::IDENTITY);
-    ctx.set_paint(GREEN);
-    ctx.fill_rect(&Rect::new(0.0, 0.0, 150.0, 100.0));
-
     ctx.execute_recording(&recording);
 }
 
 #[vello_test(width = 100, height = 100)]
 fn recording_can_be_repeatedly_executed_in_layers(ctx: &mut impl Renderer) {
-    let mut recording = Recording::new();
+    let recording = Recording::new();
     ctx.set_paint(DARK_TURQUOISE);
-    ctx.record(&mut recording, |ctx| {
+    let recording = ctx.record(recording, |ctx| {
         ctx.fill_rect(&Rect::new(10.0, 10.0, 90.0, 90.0));
     });
-    ctx.prepare_recording(&mut recording);
+    let recording = ctx.prepare_recording(recording);
 
     for _ in 0..10 {
         ctx.push_opacity_layer(0.02);
@@ -191,18 +122,18 @@ fn recording_can_be_repeatedly_executed_in_layers(ctx: &mut impl Renderer) {
 
 #[vello_test(width = 100, height = 100)]
 fn recording_can_be_cleared(ctx: &mut impl Renderer) {
-    let mut recording = Recording::new();
+    let recording = Recording::new();
     ctx.set_transform(Affine::translate((10., 10.)));
-    ctx.record(&mut recording, |ctx| {
+    let recording = ctx.record(recording, |ctx| {
         ctx.set_paint(ORANGE);
         ctx.fill_rect(&Rect::new(10.0, 10.0, 90.0, 90.0));
     });
-    ctx.prepare_recording(&mut recording);
+    let recording = ctx.prepare_recording(recording);
 
-    recording.clear();
+    let recording = recording.clear();
 
     ctx.set_transform(Affine::IDENTITY);
-    ctx.record(&mut recording, |ctx| {
+    let recording = ctx.record(recording, |ctx| {
         ctx.set_paint(GREEN);
         let mut triangle_path = BezPath::new();
         triangle_path.move_to((50.0, 10.0));
@@ -211,7 +142,7 @@ fn recording_can_be_cleared(ctx: &mut impl Renderer) {
         triangle_path.close_path();
         ctx.fill_path(&triangle_path);
     });
-    ctx.prepare_recording(&mut recording);
+    let recording = ctx.prepare_recording(recording);
     ctx.execute_recording(&recording);
 }
 
@@ -221,8 +152,8 @@ fn recording_is_executed_with_multiple_transforms(ctx: &mut impl Renderer) {
 
     let font_size: f32 = 10_f32;
     let (font, glyphs) = layout_glyphs_roboto("A", font_size);
-    let mut recording = Recording::new();
-    ctx.record(&mut recording, |ctx| {
+    let recording = Recording::new();
+    let recording = ctx.record(recording, |ctx| {
         ctx.set_paint(GOLD);
         ctx.fill_rect(&Rect::new(0.0, 0.0, 5.0, 5.0));
         ctx.set_paint(FUCHSIA);
@@ -243,7 +174,7 @@ fn recording_is_executed_with_multiple_transforms(ctx: &mut impl Renderer) {
     ctx.set_transform(Affine::translate((30., 30.)));
     ctx.set_paint(PALE_VIOLET_RED);
     ctx.fill_rect(&Rect::new(0.0, 0.0, 5.0, 5.0));
-    ctx.prepare_recording(&mut recording);
+    let recording = ctx.prepare_recording(recording);
 
     ctx.set_transform(Affine::translate((35., 35.)));
     ctx.set_paint(PURPLE);
@@ -253,8 +184,8 @@ fn recording_is_executed_with_multiple_transforms(ctx: &mut impl Renderer) {
 
 #[vello_test(width = 20, height = 20, no_ref)]
 fn recording_handles_completely_offscreen_content(ctx: &mut impl Renderer) {
-    let mut recording = Recording::new();
-    ctx.record(&mut recording, |ctx| {
+    let recording = Recording::new();
+    let recording = ctx.record(recording, |ctx| {
         ctx.set_paint(ORCHID);
         // A rectangle completely outside the viewport in then negative x and y direction.
         ctx.set_transform(Affine::translate((-200., -200.)));
@@ -264,6 +195,6 @@ fn recording_handles_completely_offscreen_content(ctx: &mut impl Renderer) {
         ctx.fill_rect(&Rect::new(0.0, 0.0, 10.0, 10.0));
     });
 
-    ctx.prepare_recording(&mut recording);
+    let recording = ctx.prepare_recording(recording);
     ctx.execute_recording(&recording);
 }


### PR DESCRIPTION
**Edit 2**: I think this is bad. This makes the ergonomics of actually using and passing a recording around quite awkward. Maybe a similar benefit could be made with a enum. Will keep this as a draft just to field feedback. I'll probably close in a week or so.

Edit: Naming of everything can be bikeshed. This is just a POC. This PR can also be discarded if there isn't an appetite for updating the recording APIs.


### Context

I've been recently using the Recording API and think the API can be further locked down by using type states.

### Why

This makes the "states" of the Recording explicit. There are 3 states:
 - `Active`: This recording can have commands pushed to it.
 - `Unprepared`: This recording is awaiting being prepared.
 - `Prepared`: This recording can be executed.

The state transitions are implemented by the `Recordable` trait.

With this pattern we can prevent some strange situations like (not expressible with this PR):

 - What happens if `execute` is called on an unprepared recording?
 - What happens if `prepare` is called multiple times?
 - What happens if methods are called in strange orders?
   - What if you: record, prepare, record, prepare, prepare, execute, record, execute?

This PR makes the usage of the `Recording` API explicit in the types.

### Test plan

Test cases.

Note that some of the more creative tests can no longer be expressed and have been removed.

