### PR TITLE
fix from_peniko_image to use new ImageBrushRef

### DIFF
--- a/sparse_strips/vello_common/src/paint.rs
+++ b/sparse_strips/vello_common/src/paint.rs
@@ -6,7 +6,8 @@
 use crate::pixmap::Pixmap;
 use alloc::sync::Arc;
 use peniko::{
-    color::{AlphaColor, PremulRgba8, Srgb}, Gradient, ImageBrushRef, ImageQuality, ImageSampler
+    Gradient, ImageBrushRef, ImageQuality, ImageSampler,
+    color::{AlphaColor, PremulRgba8, Srgb},
 };
 
 /// A paint that needs to be resolved via its index.


### PR DESCRIPTION
downstream, e.g: anyrender_vello_cpu, passes `ImageBrush<&'a ImageData>`, but from_peniko_image only takes `&ImageBrush<ImageData>`, this fixes the function to instead take ImageBrushRef to fix that.