### PR TITLE
Port to latest Fearless SIMD commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,8 +935,7 @@ dependencies = [
 [[package]]
 name = "fearless_simd"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb8f822f06d1b452a9207f11ce3292f7ee6c23d5d2e7ddfd07990a9107804850"
+source = "git+https://github.com/linebender/fearless_simd?rev=a6723a80adeba198ab8b1323caff3ca75a080e48#a6723a80adeba198ab8b1323caff3ca75a080e48"
 dependencies = [
  "bytemuck",
  "libm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ rayon = { version = "1.10.0" }
 thread_local = "1.1.8"
 crossbeam-channel = "0.5.15"
 ordered-channel = { version = "1.2.0", features = ["crossbeam-channel"] }
-fearless_simd = { version = "0.2.0", default-features = false }
+fearless_simd = { git = "https://github.com/linebender/fearless_simd", rev = "a6723a80adeba198ab8b1323caff3ca75a080e48", default-features = false }
 
 # The below crates are experimental!
 vello_api = { path = "sparse_strips/vello_api", default-features = false }

--- a/sparse_strips/vello_common/src/encode.rs
+++ b/sparse_strips/vello_common/src/encode.rs
@@ -903,7 +903,7 @@ impl FromF32Color for u8 {
 
     fn from_f32<S: Simd>(mut color: f32x4<S>) -> [Self; 4] {
         let simd = color.simd;
-        color = f32x4::splat(simd, 0.5).madd(color, f32x4::splat(simd, 255.0));
+        color = color.madd(f32x4::splat(simd, 255.0), f32x4::splat(simd, 0.5));
 
         [
             color[0] as Self,
@@ -955,11 +955,11 @@ impl<T: FromF32Color> GradientLut<T> {
             let scales = f32x16::block_splat(f32x4::from_slice(simd, &range.scale));
 
             ramp_range.step_by(4).for_each(|idx| {
-                let t_vals = add_factor.madd(f32x4::splat(simd, idx as f32), inv_lut_scale);
+                let t_vals = f32x4::splat(simd, idx as f32).madd(inv_lut_scale, add_factor);
 
                 let t_vals = element_wise_splat(simd, t_vals);
 
-                let mut result = biases.madd(scales, t_vals);
+                let mut result = scales.madd(t_vals, biases);
                 let alphas = result.splat_4th();
                 // Due to floating-point impreciseness, it can happen that
                 // values either become greater than 1 or the RGB channels

--- a/sparse_strips/vello_common/src/flatten.rs
+++ b/sparse_strips/vello_common/src/flatten.rs
@@ -6,7 +6,7 @@
 use crate::flatten_simd::Callback;
 use crate::kurbo::{self, Affine, PathEl, Stroke, StrokeCtx, StrokeOpts};
 use alloc::vec::Vec;
-use fearless_simd::{Level, Simd, simd_dispatch};
+use fearless_simd::{Level, Simd, dispatch};
 use log::warn;
 
 pub use crate::flatten_simd::FlattenCtx;
@@ -82,16 +82,8 @@ pub fn fill(
     line_buf: &mut Vec<Line>,
     ctx: &mut FlattenCtx,
 ) {
-    fill_dispatch(level, path, affine, line_buf, ctx);
+    dispatch!(level, simd => fill_impl(simd, path, affine, line_buf, ctx));
 }
-
-simd_dispatch!(fn fill_dispatch(
-    level,
-    path: impl IntoIterator<Item = PathEl>, 
-    affine: Affine,
-    line_buf: &mut Vec<Line>, 
-    ctx: &mut FlattenCtx
-) = fill_impl);
 
 /// Flatten a filled bezier path into line segments.
 pub fn fill_impl<S: Simd>(

--- a/sparse_strips/vello_common/src/flatten_simd.rs
+++ b/sparse_strips/vello_common/src/flatten_simd.rs
@@ -368,7 +368,7 @@ fn eval_cubics_simd<S: Simd>(simd: S, c: &CubicBez, n: usize, result: &mut Flatt
         even_pts[i * 4..][..4].copy_from_slice(&low.val);
         odd_pts[i * 4..][..4].copy_from_slice(&high.val);
 
-        t = t + t_inc;
+        t += t_inc;
     }
 
     even_pts[n * 2..][..8].copy_from_slice(&p3_128.val);
@@ -483,7 +483,7 @@ fn output_lines_simd<S: Simd>(
 
         out[j * 8..][..8].copy_from_slice(&p.val);
 
-        a = a + a_inc;
+        a += a_inc;
     }
 }
 

--- a/sparse_strips/vello_common/src/flatten_simd.rs
+++ b/sparse_strips/vello_common/src/flatten_simd.rs
@@ -401,7 +401,10 @@ fn estimate_subdiv_simd<S: Simd>(simd: S, sqrt_tol: f32, ctx: &mut FlattenCtx) {
         let ddy = d01y - d12y;
         let d02x = d01x + d12x;
         let d02y = d01y + d12y;
-        let cross = (d02x * ddy).msub(d02y, ddx);
+        // TODO: The old version of this code was actually the following (except without a double negation on ARM).
+        // We need to choose one.
+        let cross = -ddx.msub(d02y, d02x * ddy);
+
         let x0_x2_a = {
             let (d01x_low, _) = simd.split_f32x8(d01x);
             let (d12x_low, _) = simd.split_f32x8(d12x);

--- a/sparse_strips/vello_common/src/flatten_simd.rs
+++ b/sparse_strips/vello_common/src/flatten_simd.rs
@@ -401,9 +401,8 @@ fn estimate_subdiv_simd<S: Simd>(simd: S, sqrt_tol: f32, ctx: &mut FlattenCtx) {
         let ddy = d01y - d12y;
         let d02x = d01x + d12x;
         let d02y = d01y + d12y;
-        // TODO: The old version of this code was actually the following (except without a double negation on ARM).
-        // We need to choose one.
-        let cross = -ddx.msub(d02y, d02x * ddy);
+        // (d02x * ddy) - (d02y * ddx)
+        let cross = ddx.madd(-d02y, d02x * ddy);
 
         let x0_x2_a = {
             let (d01x_low, _) = simd.split_f32x8(d01x);

--- a/sparse_strips/vello_common/src/flatten_simd.rs
+++ b/sparse_strips/vello_common/src/flatten_simd.rs
@@ -263,7 +263,7 @@ fn approx_parabola_integral_simd<S: Simd>(x: f32x8<S>) -> f32x8<S> {
     const D: f32 = 0.67;
     const D_POWI_4: f32 = 0.201_511_2;
 
-    let temp1 = f32x8::splat(simd, D_POWI_4).madd(f32x8::splat(simd, 0.25), x * x);
+    let temp1 = f32x8::splat(simd, 0.25).madd(x * x, f32x8::splat(simd, D_POWI_4));
     let temp2 = temp1.sqrt();
     let temp3 = temp2.sqrt();
     let temp4 = f32x8::splat(simd, 1.0) - f32x8::splat(simd, D);
@@ -278,7 +278,7 @@ fn approx_parabola_integral_simd_x4<S: Simd>(x: f32x4<S>) -> f32x4<S> {
     const D: f32 = 0.67;
     const D_POWI_4: f32 = 0.201_511_2;
 
-    let temp1 = f32x4::splat(simd, D_POWI_4).madd(f32x4::splat(simd, 0.25), x * x);
+    let temp1 = f32x4::splat(simd, 0.25).madd(x * x, f32x4::splat(simd, D_POWI_4));
     let temp2 = temp1.sqrt();
     let temp3 = temp2.sqrt();
     let temp4 = f32x4::splat(simd, 1.0) - f32x4::splat(simd, D);
@@ -294,7 +294,7 @@ fn approx_parabola_inv_integral_simd<S: Simd>(x: f32x8<S>) -> f32x8<S> {
     const ONE_MINUS_B: f32 = 1.0 - B;
 
     let temp1 = f32x8::splat(simd, B * B);
-    let temp2 = temp1.madd(f32x8::splat(simd, 0.25), x * x);
+    let temp2 = f32x8::splat(simd, 0.25).madd(x * x, temp1);
     let temp3 = temp2.sqrt();
     let temp4 = f32x8::splat(simd, ONE_MINUS_B) + temp3;
 
@@ -319,9 +319,9 @@ fn eval_simd<S: Simd>(
     let im0 = p0 * mt * mt * mt;
     let im1 = p1 * mt * mt * 3.0;
     let im2 = p2 * mt * 3.0;
-    let im3 = im2.madd(p3, t) * t;
+    let im3 = p3.madd(t, im2) * t;
 
-    im0.madd(im1 + im3, t)
+    (im1 + im3).madd(t, im0)
 }
 
 #[inline(always)]
@@ -386,8 +386,8 @@ fn estimate_subdiv_simd<S: Simd>(simd: S, sqrt_tol: f32, ctx: &mut FlattenCtx) {
         let p_onehalf = f32x8::from_slice(simd, &odd_pts[i * 8..][..8]);
         let p2 = f32x8::from_slice(simd, &even_pts[(i * 8 + 2)..][..8]);
         let x = p0 * -0.5;
-        let x1 = x.madd(p_onehalf, 2.0);
-        let p1 = x1.madd(p2, -0.5);
+        let x1 = p_onehalf.madd(2.0, x);
+        let p1 = p2.madd(-0.5, x1);
 
         odd_pts[(i * 8)..][..8].copy_from_slice(&p1.val);
 
@@ -414,11 +414,11 @@ fn estimate_subdiv_simd<S: Simd>(simd: S, sqrt_tol: f32, ctx: &mut FlattenCtx) {
 
             simd.combine_f32x4(d12y_low, d01y_low)
         };
-        let x0_x2_num = x0_x2_a.madd(temp1, ddy);
+        let x0_x2_num = temp1.madd(ddy, x0_x2_a);
         let x0_x2 = x0_x2_num / cross;
         let (ddx_low, _) = simd.split_f32x8(ddx);
         let (ddy_low, _) = simd.split_f32x8(ddy);
-        let dd_hypot = (ddx_low * ddx_low).madd(ddy_low, ddy_low).sqrt();
+        let dd_hypot = ddy_low.madd(ddy_low, ddx_low * ddx_low).sqrt();
         let (x0, x2) = simd.split_f32x8(x0_x2);
         let scale_denom = dd_hypot * (x2 - x0);
         let (temp2, _) = simd.split_f32x8(cross);
@@ -467,19 +467,19 @@ fn output_lines_simd<S: Simd>(
 
     const IOTA2: [f32; 8] = [0., 0., 1., 1., 2., 2., 3., 3.];
     let iota2 = f32x8::from_slice(simd, IOTA2.as_ref());
-    let x = f32x8::splat(simd, x0).madd(dx, iota2);
+    let x = iota2.madd(dx, f32x8::splat(simd, x0));
     let da = f32x8::splat(simd, ctx.da[i]);
-    let mut a = f32x8::splat(simd, ctx.a0[i]).madd(da, x);
+    let mut a = da.madd(x, f32x8::splat(simd, ctx.a0[i]));
     let a_inc = 4.0 * dx * da;
     let uscale = f32x8::splat(simd, ctx.uscale[i]);
 
     for j in 0..n.div_ceil(4) {
         let u = approx_parabola_inv_integral_simd(a);
-        let t = (-ctx.u0[i] * uscale).madd(u, uscale);
+        let t = u.madd(uscale, -ctx.u0[i] * uscale);
         let mt = 1.0 - t;
         let z = p0 * mt * mt;
-        let z1 = z.madd(p1, 2.0 * t * mt);
-        let p = z1.madd(p2, t * t);
+        let z1 = p1.madd(2.0 * t * mt, z);
+        let p = p2.madd(t * t, z1);
 
         out[j * 8..][..8].copy_from_slice(&p.val);
 

--- a/sparse_strips/vello_common/src/strip.rs
+++ b/sparse_strips/vello_common/src/strip.rs
@@ -182,7 +182,7 @@ fn render_impl<S: Simd>(
                     for x in 0..Tile::WIDTH as usize {
                         let area = location_winding[x];
                         let coverage = area.abs();
-                        let mulled = p1.madd(coverage, p2);
+                        let mulled = coverage.madd(p2, p1);
                         // Note that we are not storing the location winding here but the actual
                         // alpha value as f32, so we reuse the variable as a temporary storage.
                         // Also note that we need the `min` here because the winding can be > 1
@@ -198,9 +198,9 @@ fn render_impl<S: Simd>(
                     #[expect(clippy::needless_range_loop, reason = "dimension clarity")]
                     for x in 0..Tile::WIDTH as usize {
                         let area = location_winding[x];
-                        let im1 = p1.madd(area, p1).floor();
-                        let coverage = area.madd(p2, im1).abs();
-                        let mulled = p1.madd(p3, coverage);
+                        let im1 = area.madd(p1, p1).floor();
+                        let coverage = p2.madd(im1, area).abs();
+                        let mulled = p3.madd(coverage, p1);
                         // TODO: It is possible that, unlike for `NonZero`, we don't need the `min`
                         // here.
                         location_winding[x] = mulled.min(p3);
@@ -359,9 +359,9 @@ fn render_impl<S: Simd>(
             let ymin = px_top_y.max(ymin);
             let ymax = px_bottom_y.min(ymax);
             let h = (ymax - ymin).max(0.0);
-            accumulated_winding = accumulated_winding.madd(sign, h);
+            accumulated_winding = h.madd(sign, accumulated_winding);
             for x_idx in 0..Tile::WIDTH {
-                location_winding[x_idx as usize] = location_winding[x_idx as usize].madd(sign, h);
+                location_winding[x_idx as usize] = h.madd(sign, location_winding[x_idx as usize]);
             }
 
             if line_right_x < 0. {
@@ -404,27 +404,27 @@ fn render_impl<S: Simd>(
             // situated. The resulting slope calculation for the edge the line is situated on
             // will be NaN, as `0 * inf` results in NaN. This is true for both the left and
             // right edge. In both cases, the call to `f32::max` will set this to `ymin`.
-            let line_px_left_y = line_top_y
-                .madd(px_left_x - line_top_x, y_slope)
+            let line_px_left_y = (px_left_x - line_top_x)
+                .madd(y_slope, line_top_y)
                 .max_precise(ymin)
                 .min_precise(ymax);
-            let line_px_right_y = line_top_y
-                .madd(px_right_x - line_top_x, y_slope)
+            let line_px_right_y = (px_right_x - line_top_x)
+                .madd(y_slope, line_top_y)
                 .max_precise(ymin)
                 .min_precise(ymax);
 
             // `x_slope` is always finite, as horizontal geometry is elided.
             let line_px_left_yx =
-                f32x4::splat(s, line_top_x).madd(line_px_left_y - line_top_y, x_slope);
+                (line_px_left_y - line_top_y).madd(x_slope, f32x4::splat(s, line_top_x));
             let line_px_right_yx =
-                f32x4::splat(s, line_top_x).madd(line_px_right_y - line_top_y, x_slope);
+                (line_px_right_y - line_top_y).madd(x_slope, f32x4::splat(s, line_top_x));
             let h = (line_px_right_y - line_px_left_y).abs();
 
             // The trapezoidal area enclosed between the line and the right edge of the pixel
             // square.
             let area = 0.5 * h * (2. * px_right_x - line_px_right_yx - line_px_left_yx);
-            location_winding[x_idx as usize] += acc.madd(sign, area);
-            acc = acc.madd(sign, h);
+            location_winding[x_idx as usize] += area.madd(sign, acc);
+            acc = h.madd(sign, acc);
         }
 
         accumulated_winding += acc;

--- a/sparse_strips/vello_common/src/strip.rs
+++ b/sparse_strips/vello_common/src/strip.rs
@@ -95,26 +95,8 @@ pub fn render(
     aliasing_threshold: Option<u8>,
     lines: &[Line],
 ) {
-    render_dispatch(
-        level,
-        tiles,
-        strip_buf,
-        alpha_buf,
-        fill_rule,
-        aliasing_threshold,
-        lines,
-    );
+    dispatch!(level, simd => render_impl(simd, tiles, strip_buf, alpha_buf, fill_rule, aliasing_threshold, lines));
 }
-
-simd_dispatch!(fn render_dispatch(
-    level,
-    tiles: &Tiles,
-    strip_buf: &mut Vec<Strip>,
-    alpha_buf: &mut Vec<u8>,
-    fill_rule: Fill,
-    aliasing_threshold: Option<u8>,
-    lines: &[Line],
-) = render_impl);
 
 fn render_impl<S: Simd>(
     s: S,

--- a/sparse_strips/vello_common/src/strip.rs
+++ b/sparse_strips/vello_common/src/strip.rs
@@ -423,11 +423,10 @@ fn render_impl<S: Simd>(
             // The trapezoidal area enclosed between the line and the right edge of the pixel
             // square.
             let area = 0.5 * h * (2. * px_right_x - line_px_right_yx - line_px_left_yx);
-            location_winding[x_idx as usize] =
-                location_winding[x_idx as usize] + acc.madd(sign, area);
+            location_winding[x_idx as usize] += acc.madd(sign, area);
             acc = acc.madd(sign, h);
         }
 
-        accumulated_winding = accumulated_winding + acc;
+        accumulated_winding += acc;
     }
 }

--- a/sparse_strips/vello_cpu/src/fine/common/gradient/radial.rs
+++ b/sparse_strips/vello_cpu/src/fine/common/gradient/radial.rs
@@ -93,7 +93,7 @@ impl<S: Simd> SimdGradientKind<S> for SimdRadialKind<S> {
                 }
 
                 if !focal_data.is_natively_focal() {
-                    t = t + *fp1;
+                    t += *fp1;
                 }
 
                 if focal_data.is_swapped() {

--- a/sparse_strips/vello_cpu/src/fine/common/gradient/sweep.rs
+++ b/sparse_strips/vello_cpu/src/fine/common/gradient/sweep.rs
@@ -45,9 +45,9 @@ fn x_y_to_unit_angle<S: Simd>(simd: S, x: f32x8<S>, y: f32x8<S>) -> f32x8<S> {
     let slope = x_abs.min(y_abs) / x_abs.max(y_abs);
     let s = slope * slope;
 
-    let a = f32x8::splat(simd, 2.476_102e-2).madd(f32x8::splat(simd, -7.054_738_2e-3), s);
-    let b = f32x8::splat(simd, -5.185_397e-2).madd(a, s);
-    let c = f32x8::splat(simd, 0.159_121_17).madd(b, s);
+    let a = f32x8::splat(simd, -7.054_738_2e-3).madd(s, f32x8::splat(simd, 2.476_102e-2));
+    let b = a.madd(s, f32x8::splat(simd, -5.185_397e-2));
+    let c = b.madd(s, f32x8::splat(simd, 0.159_121_17));
 
     let mut phi = slope * c;
 

--- a/sparse_strips/vello_cpu/src/fine/common/image.rs
+++ b/sparse_strips/vello_cpu/src/fine/common/image.rs
@@ -416,10 +416,8 @@ pub(crate) fn extend<S: Simd>(
         // Otherwise, we might sample out-of-bounds pixels.
         crate::peniko::Extend::Pad => val.min(max - bias).max(f32x4::splat(simd, 0.0)),
         crate::peniko::Extend::Repeat => {
-            // floor := ((val * inv_max).floor() * max) is the nearest multiple of `max` below val.
-            // We need `val - floor`, but fearless_simd doesn't provide that as a mul_add style operation.
-            // Instead we do `-(floor-val)`, which is equivalent.
-            (-max.msub((val * inv_max).floor(), val))
+            // floor := (val * inv_max).floor() * max is the nearest multiple of `max` below val.
+            max.madd(-(val * inv_max).floor(), val)
                 // In certain edge cases, we might still end up with a higher number.
                 .min(max - 1.0)
         }

--- a/sparse_strips/vello_cpu/src/fine/common/image.rs
+++ b/sparse_strips/vello_cpu/src/fine/common/image.rs
@@ -259,7 +259,7 @@ impl<S: Simd> Iterator for FilteredImagePainter<'_, S> {
                         let color_sample = sample(x_positions, y_positions);
                         let w = element_wise_splat(self.simd, cx[x_idx] * cy[y_idx]);
 
-                        interpolated_color = interpolated_color.madd(w, color_sample);
+                        interpolated_color = w.madd(color_sample, interpolated_color);
                     }
                 }
 
@@ -298,7 +298,7 @@ impl<S: Simd> Iterator for FilteredImagePainter<'_, S> {
                         let color_sample = sample(x_positions, y_positions);
                         let w = element_wise_splat(self.simd, cx[x_idx] * cy[y_idx]);
 
-                        interpolated_color = interpolated_color.madd(w, color_sample);
+                        interpolated_color = w.madd(color_sample, interpolated_color);
                     }
                 }
 
@@ -492,7 +492,7 @@ fn single_weight<S: Simd>(
     c: f32x4<S>,
     d: f32x4<S>,
 ) -> f32x4<S> {
-    a.madd(b.madd(c.madd(t, d), t), t)
+    t.madd(d, c).madd(t, b).madd(t, a)
 }
 
 /// Mitchell filter with the variables B = 1/3 and C = 1/3.

--- a/sparse_strips/vello_cpu/src/fine/common/image.rs
+++ b/sparse_strips/vello_cpu/src/fine/common/image.rs
@@ -75,7 +75,7 @@ impl<S: Simd> Iterator for PlainNNImagePainter<'_, S> {
 
         let samples = sample(self.simd, &self.data, x_pos, self.y_positions);
 
-        self.cur_x_pos = self.cur_x_pos + self.advance;
+        self.cur_x_pos += self.advance;
 
         Some(samples)
     }
@@ -263,7 +263,7 @@ impl<S: Simd> Iterator for FilteredImagePainter<'_, S> {
                     }
                 }
 
-                interpolated_color = interpolated_color * f32x16::splat(self.simd, 1.0 / 255.0);
+                interpolated_color *= f32x16::splat(self.simd, 1.0 / 255.0);
             }
             ImageQuality::High => {
                 // Compare to <https://github.com/google/skia/blob/84ff153b0093fc83f6c77cd10b025c06a12c5604/src/opts/SkRasterPipeline_opts.h#L5030-L5075>.
@@ -302,7 +302,7 @@ impl<S: Simd> Iterator for FilteredImagePainter<'_, S> {
                     }
                 }
 
-                interpolated_color = interpolated_color * f32x16::splat(self.simd, 1.0 / 255.0);
+                interpolated_color *= f32x16::splat(self.simd, 1.0 / 255.0);
 
                 let alphas = interpolated_color.splat_4th();
 

--- a/sparse_strips/vello_cpu/src/fine/common/rounded_blurred_rect.rs
+++ b/sparse_strips/vello_cpu/src/fine/common/rounded_blurred_rect.rs
@@ -137,12 +137,16 @@ impl<S: Simd> Iterator for AlphaCalculator<S> {
         );
         let r = &self.r;
 
-        let y = j + r.v1.msub(r.v1, r.height);
-        let y0 = y.abs().msub(r.v1, r.h) + r.r1;
+        // Equivalent to j + r.v1 - r.v1 * r.height
+        let y = j - r.v1.msub(r.height, r.v1);
+        // Equivalent to r.r1 + y.abs() - (r.h * r.v1)
+        let y0 = r.r1 - r.h.msub(r.v1, y.abs());
         let y1 = y0.max(r.v0);
 
-        let x = i + r.v1.msub(r.v1, r.width);
-        let x0 = x.abs().msub(r.v1, r.w) + r.r1;
+        // Equivalent to i + r.v1 - r.v1 * r.width
+        let x = i - r.v1.msub(r.width, r.v1);
+        // Equivalent to r.r1 + x.abs() - (r.w * r.v1)
+        let x0 = r.r1 - r.w.msub(r.v1, x.abs());
         let x1 = x0.max(r.v0);
         let d_pos = (x1.powf(r.exponent) + y1.powf(r.exponent)).powf(r.recip_exponent);
         let d_neg = x0.max(y0).min(r.v0);

--- a/sparse_strips/vello_cpu/src/fine/common/rounded_blurred_rect.rs
+++ b/sparse_strips/vello_cpu/src/fine/common/rounded_blurred_rect.rs
@@ -218,11 +218,11 @@ impl<S: Simd> FloatExt<S> for f32x8<S> {
     fn compute_erf7(simd: S, x: Self) -> Self {
         let x = x * Self::splat(simd, core::f32::consts::FRAC_2_SQRT_PI);
         let xx = x * x;
-        let p1 = Self::splat(simd, 0.03395).madd(Self::splat(simd, 0.0104), xx);
-        let p2 = Self::splat(simd, 0.24295).madd(p1, xx);
+        let p1 = Self::splat(simd, 0.0104).madd(xx, Self::splat(simd, 0.03395));
+        let p2 = p1.madd(xx, Self::splat(simd, 0.24295));
         let p3 = x * xx;
-        let x = x.madd(p2, p3);
-        let denom = Self::splat(simd, 1.0).madd(x, x).sqrt();
+        let x = p2.madd(p3, x);
+        let denom = x.madd(x, Self::splat(simd, 1.0)).sqrt();
         x / denom
     }
 

--- a/sparse_strips/vello_cpu/src/fine/highp/blend.rs
+++ b/sparse_strips/vello_cpu/src/fine/highp/blend.rs
@@ -288,9 +288,9 @@ fn clip_color<S: Simd>(r: &mut f32x4<S>, g: &mut f32x4<S>, b: &mut f32x4<S>) {
 
 fn set_lum<S: Simd>(r: &mut f32x4<S>, g: &mut f32x4<S>, b: &mut f32x4<S>, l: f32x4<S>) {
     let d = l - lum(*r, *g, *b);
-    *r = *r + d;
-    *g = *g + d;
-    *b = *b + d;
+    *r += d;
+    *g += d;
+    *b += d;
 
     clip_color(r, g, b);
 }

--- a/sparse_strips/vello_cpu/src/fine/highp/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/highp/mod.rs
@@ -302,7 +302,8 @@ mod alpha_fill {
     ) {
         let bg_c = f32x16::from_slice(s, dest);
         let mask_a = extract_masks(s, masks);
-        let inv_src_a_mask_a = one.msub(src_a, mask_a);
+        // 1 - src_a * mask_a
+        let inv_src_a_mask_a = -(src_a.msub(mask_a, one));
 
         let res = bg_c.madd(inv_src_a_mask_a, src_c * mask_a);
         dest.copy_from_slice(&res.val);

--- a/sparse_strips/vello_cpu/src/fine/highp/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/highp/mod.rs
@@ -319,7 +319,7 @@ fn extract_masks<S: Simd>(simd: S, masks: &[u8]) -> f32x16<S> {
     ]
     .simd_into(simd);
 
-    base_mask = base_mask * f32x4::splat(simd, 1.0 / 255.0);
+    base_mask *= f32x4::splat(simd, 1.0 / 255.0);
 
     let res = f32x16::block_splat(base_mask);
     let zip_low = res.zip_low(res);

--- a/sparse_strips/vello_cpu/src/fine/highp/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/highp/mod.rs
@@ -208,7 +208,7 @@ mod fill {
         one_minus_alpha: f32x16<S>,
     ) {
         let mut bg_c = f32x16::from_slice(s, dest);
-        bg_c = src.madd(one_minus_alpha, bg_c);
+        bg_c = one_minus_alpha.madd(bg_c, src);
         dest.copy_from_slice(&bg_c.val);
     }
 }
@@ -304,7 +304,7 @@ mod alpha_fill {
         let mask_a = extract_masks(s, masks);
         let inv_src_a_mask_a = one.msub(src_a, mask_a);
 
-        let res = (src_c * mask_a).madd(bg_c, inv_src_a_mask_a);
+        let res = bg_c.madd(inv_src_a_mask_a, src_c * mask_a);
         dest.copy_from_slice(&res.val);
     }
 }

--- a/sparse_strips/vello_cpu/src/fine/highp/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/highp/mod.rs
@@ -303,7 +303,7 @@ mod alpha_fill {
         let bg_c = f32x16::from_slice(s, dest);
         let mask_a = extract_masks(s, masks);
         // 1 - src_a * mask_a
-        let inv_src_a_mask_a = -(src_a.msub(mask_a, one));
+        let inv_src_a_mask_a = src_a.madd(-mask_a, one);
 
         let res = bg_c.madd(inv_src_a_mask_a, src_c * mask_a);
         dest.copy_from_slice(&res.val);

--- a/sparse_strips/vello_cpu/src/fine/lowp/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/lowp/mod.rs
@@ -368,9 +368,9 @@ fn mix<S: Simd>(src_c: u8x32<S>, bg_c: u8x32<S>, blend_mode: BlendMode) -> u8x32
 
     let to_u8 = |val1: f32x16<S>, val2: f32x16<S>| {
         let val1 =
-            f32_to_u8(f32x16::splat(val1.simd, 0.5).madd(f32x16::splat(val1.simd, 255.0), val1));
+            f32_to_u8(f32x16::splat(val1.simd, 255.0).madd(val1, f32x16::splat(val1.simd, 0.5)));
         let val2 =
-            f32_to_u8(f32x16::splat(val2.simd, 0.5).madd(f32x16::splat(val2.simd, 255.0), val2));
+            f32_to_u8(f32x16::splat(val2.simd, 255.0).madd(val2, f32x16::splat(val2.simd, 0.5)));
 
         val1.simd.combine_u8x16(val1, val2)
     };

--- a/sparse_strips/vello_cpu/src/fine/lowp/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/lowp/mod.rs
@@ -361,8 +361,8 @@ fn mix<S: Simd>(src_c: u8x32<S>, bg_c: u8x32<S>, blend_mode: BlendMode) -> u8x32
         let (a, b) = src_c.simd.split_u8x32(val);
         let mut a = u8_to_f32(a);
         let mut b = u8_to_f32(b);
-        a = a * f32x16::splat(src_c.simd, 1.0 / 255.0);
-        b = b * f32x16::splat(src_c.simd, 1.0 / 255.0);
+        a *= f32x16::splat(src_c.simd, 1.0 / 255.0);
+        b *= f32x16::splat(src_c.simd, 1.0 / 255.0);
         (a, b)
     };
 

--- a/sparse_strips/vello_cpu/src/fine/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/mod.rs
@@ -79,7 +79,7 @@ impl<S: Simd> NumericVec<S> for u8x16<S> {
     fn from_f32(simd: S, val: f32x16<S>) -> Self {
         let v1 = f32x16::splat(simd, 255.0);
         let v2 = f32x16::splat(simd, 0.5);
-        let mulled = v2.madd(v1, val);
+        let mulled = v1.madd(val, v2);
 
         f32_to_u8(mulled)
     }
@@ -661,7 +661,7 @@ impl<S: Simd> PosExt<S> for f32x4<S> {
         let columns: [f32; Tile::HEIGHT as usize] = [0.0, 1.0, 2.0, 3.0];
         let column_mask: Self = columns.simd_into(simd);
 
-        Self::splat(simd, pos).madd(column_mask, Self::splat(simd, y_advance))
+        column_mask.madd(Self::splat(simd, y_advance), Self::splat(simd, pos))
     }
 }
 

--- a/sparse_strips/vello_cpu/src/fine/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/mod.rs
@@ -79,7 +79,7 @@ impl<S: Simd> NumericVec<S> for u8x16<S> {
     fn from_f32(simd: S, val: f32x16<S>) -> Self {
         let v1 = f32x16::splat(simd, 255.0);
         let v2 = f32x16::splat(simd, 0.5);
-        let mulled = v1.madd(val, v2);
+        let mulled = val.madd(v1, v2);
 
         f32_to_u8(mulled)
     }


### PR DESCRIPTION
Note:
- I still need to port the uses of `simd_dispatch` to `dispatch`, but pushing so the other changes can be reviewed.
- The negation on `msub` *should* be optimised out on neon (see [#simd > Porting Vello to latest Fearless SIMD](https://xi.zulipchat.com/#narrow/channel/514230-simd/topic/Porting.20Vello.20to.20latest.20Fearless.20SIMD/with/542926308))