### PR TITLE
Release Vello v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,14 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 # Changelog
 
-The latest published Vello release is [0.5.1](#051---2025-08-22) which was released on 2025-08-22.
-You can find its changes [documented below](#051---2025-08-22).
+The latest published Vello release is [0.6.0](#060---2025-10-03) which was released on 2025-10-03.
+You can find its changes [documented below](#060---2025-10-03).
 
 ## [Unreleased]
+
+This release has an [MSRV][] of 1.86.
+
+## [0.6.0][] - 2025-10-03
 
 This release has an [MSRV][] of 1.86.
 
@@ -368,6 +372,7 @@ This release has an [MSRV][] of 1.75.
 
 <!-- Note that this still comparing against 0.5.0, because 0.5.1 is a cherry-picked patch -->
 [Unreleased]: https://github.com/linebender/vello/compare/v0.5.0...HEAD
+[0.6.0]: https://github.com/linebender/vello/compare/v0.6.0...HEAD
 [0.5.1]: https://github.com/linebender/vello/compare/v0.5.0...v0.5.1
 <!-- Note that this still comparing against 0.4.0, because 0.4.1 is a cherry-picked patch -->
 [0.5.0]: https://github.com/linebender/vello/compare/v0.4.0...v0.5.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2050,7 +2050,7 @@ dependencies = [
 
 [[package]]
 name = "native_webgl"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "console_error_panic_hook",
  "console_log",
@@ -3793,7 +3793,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vello"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bytemuck",
  "futures-intrusive",
@@ -3811,7 +3811,7 @@ dependencies = [
 
 [[package]]
 name = "vello_api"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bytemuck",
  "peniko 0.5.0",
@@ -3871,7 +3871,7 @@ dependencies = [
 
 [[package]]
 name = "vello_encoding"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bytemuck",
  "guillotiere",
@@ -3898,11 +3898,11 @@ dependencies = [
 
 [[package]]
 name = "vello_filters_cpu"
-version = "0.5.0"
+version = "0.6.0"
 
 [[package]]
 name = "vello_hybrid"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bytemuck",
  "guillotiere",
@@ -3933,7 +3933,7 @@ dependencies = [
 
 [[package]]
 name = "vello_shaders"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bytemuck",
  "log",
@@ -4255,7 +4255,7 @@ dependencies = [
 
 [[package]]
 name = "wasm_cpu"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bytemuck",
  "console_error_panic_hook",
@@ -4601,7 +4601,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu_webgl"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ members = [
 # NOTE: When bumping this, remember to also bump the aforementioned other packages'
 #       version in the dependencies section at the bottom of this file.
 #       Additionally, bump the Vello dependency version in the 'simple' example.
-version = "0.5.0"
+version = "0.6.0"
 
 edition = "2024"
 # Keep in sync with RUST_MIN_VER in .github/workflows/ci.yml, with the relevant README.md files
@@ -95,9 +95,9 @@ clippy.wildcard_dependencies = "warn"
 # END LINEBENDER LINT SET
 
 [workspace.dependencies]
-vello = { version = "0.5.0", path = "vello" }
-vello_encoding = { version = "0.5.0", path = "vello_encoding" }
-vello_shaders = { version = "0.5.0", path = "vello_shaders" }
+vello = { version = "0.6.0", path = "vello" }
+vello_encoding = { version = "0.6.0", path = "vello_encoding" }
+vello_shaders = { version = "0.6.0", path = "vello_shaders" }
 bytemuck = { version = "1.23.0", features = ["derive"] }
 skrifa = { version = "0.37.0", default-features = false, features = ["autohint_shaping"] }
 # The version of kurbo used below should be kept in sync

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 # When using this example outside of the original Vello workspace,
 # remove the path property of the following Vello dependency requirement.
-vello = { version = "0.5.0", path = "../../vello" }
+vello = { version = "0.6.0", path = "../../vello" }
 anyhow = "1.0.98"
 pollster = "0.4.0"
 winit = "0.30.10"

--- a/examples/simple_sdl2/Cargo.toml
+++ b/examples/simple_sdl2/Cargo.toml
@@ -12,6 +12,6 @@ workspace = true
 [dependencies]
 # When using this example outside of the original Vello workspace,
 # remove the path property of the following Vello dependency requirement.
-vello = { version = "0.5.0", path = "../../vello" }
+vello = { version = "0.6.0", path = "../../vello" }
 pollster = "0.4.0"
 sdl2 = { version = "0.37.0", features = ["raw-window-handle", "bundled"] }


### PR DESCRIPTION
This is a caretaker release for wgpu v26 compatibility, along with a few other improvements.