### PR TITLE
Release Vello CPU v0.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3834,7 +3834,7 @@ dependencies = [
 
 [[package]]
 name = "vello_common"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "bytemuck",
  "fearless_simd",
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "vello_cpu"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "bytemuck",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ fearless_simd = { version = "0.2.0", default-features = false }
 
 # The below crates are experimental!
 vello_api = { path = "sparse_strips/vello_api", default-features = false }
-vello_common = { version = "0.0.1", path = "sparse_strips/vello_common", default-features = false }
+vello_common = { version = "0.0.3", path = "sparse_strips/vello_common", default-features = false }
 vello_cpu = { path = "sparse_strips/vello_cpu" }
 vello_hybrid = { path = "sparse_strips/vello_hybrid" }
 vello_sparse_shaders = { path = "sparse_strips/vello_sparse_shaders" }

--- a/sparse_strips/vello_common/Cargo.toml
+++ b/sparse_strips/vello_common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vello_common"
 # When updating, also update the version in the workspace dependency in the root Cargo.toml
-version = "0.0.1"
+version = "0.0.3"
 description = "Core data structures and utilities shared across the Vello rendering, including geometry processing and tiling logic."
 categories = ["rendering", "graphics"]
 keywords = ["2d", "vector-graphics"]

--- a/sparse_strips/vello_cpu/Cargo.toml
+++ b/sparse_strips/vello_cpu/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vello_cpu"
 # When moving past 0.0.x, also update caveats in the README
-version = "0.0.1"
+version = "0.0.3"
 description = "A CPU-based renderer for Vello, optimized for SIMD and multithreaded execution."
 categories = ["rendering", "graphics"]
 keywords = ["2d", "vector-graphics"]


### PR DESCRIPTION
Companion release that matches dependency versions with Vello 0.6.0 and Parley 0.6.0