### PR TITLE
Filter Effects API Proposal

### DIFF
--- a/sparse_strips/vello_common/src/filter_effects.rs
+++ b/sparse_strips/vello_common/src/filter_effects.rs
@@ -1,0 +1,699 @@
+// Copyright 2025 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Filter effects API based on the W3C Filter Effects specification.
+//!
+//! This module provides a comprehensive filter system supporting both high-level
+//! CSS filter functions and low-level SVG filter primitives. The API is designed
+//! to follow the W3C Filter Effects Module Level 1 specification.
+//!
+//! See: <https://drafts.fxtf.org/filter-effects/>
+
+use crate::color::{AlphaColor, Srgb};
+use crate::kurbo::Rect;
+use alloc::vec::Vec;
+use std::collections::BTreeMap;
+
+/// The main filter system.
+#[derive(Debug, Clone)]
+pub struct Filter {
+    /// Filter graph defining the effect pipeline.
+    pub graph: FilterGraph,
+    /// Bounds where the filter should be applied.
+    pub bounds: Option<Rect>,
+}
+
+impl Filter {
+    /// Create a simple filter system from a filter function.
+    pub fn from_function(function: FilterFunction) -> Self {
+        let mut graph = FilterGraph::new();
+
+        // Convert function to primitive
+        let primitive = match function {
+            FilterFunction::Blur { radius } => FilterPrimitive::GaussianBlur {
+                std_deviation: radius,
+            },
+            FilterFunction::Brightness { amount } => FilterPrimitive::ComponentTransfer {
+                red_function: Some(TransferFunction::Linear {
+                    slope: amount,
+                    intercept: 0.0,
+                }),
+                green_function: Some(TransferFunction::Linear {
+                    slope: amount,
+                    intercept: 0.0,
+                }),
+                blue_function: Some(TransferFunction::Linear {
+                    slope: amount,
+                    intercept: 0.0,
+                }),
+                alpha_function: None,
+            },
+            FilterFunction::Grayscale { amount } => {
+                let mut matrix = matrices::IDENTITY;
+                for i in 0..3 {
+                    for j in 0..3 {
+                        matrix[i * 5 + j] = matrices::IDENTITY[i * 5 + j] * (1.0 - amount)
+                            + matrices::GRAYSCALE[i * 5 + j] * amount;
+                    }
+                }
+                FilterPrimitive::ColorMatrix { matrix }
+            }
+            // TODO: Implement other filter functions
+            _ => FilterPrimitive::GaussianBlur { std_deviation: 1.0 },
+        };
+
+        let filter_id = graph.add(primitive, None);
+        graph.set_output(filter_id);
+
+        Self {
+            graph,
+            bounds: None,
+        }
+    }
+
+    /// Create a filter system from a filter primitive.
+    pub fn from_primitive(primitive: FilterPrimitive) -> Self {
+        let mut graph = FilterGraph::new();
+        let filter_id = graph.add(primitive, None);
+        graph.set_output(filter_id);
+
+        Self {
+            graph,
+            bounds: None,
+        }
+    }
+}
+
+/// A directed acyclic graph (DAG) of filter operations.
+#[derive(Debug, Clone)]
+pub struct FilterGraph {
+    /// All filter primitives in the graph.
+    pub primitives: Vec<FilterPrimitive>,
+    /// Connections between filter primitives.
+    pub connections: BTreeMap<FilterId, FilterInputs>,
+    /// The final output filter.
+    pub output: FilterId,
+    /// Next available filter ID.
+    next_id: u32,
+}
+
+impl Default for FilterGraph {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FilterGraph {
+    /// Create a new empty filter graph.
+    pub fn new() -> Self {
+        Self {
+            primitives: Vec::new(),
+            connections: BTreeMap::new(),
+            output: FilterId(0),
+            next_id: 0,
+        }
+    }
+
+    /// Add a filter primitive with optional inputs.
+    pub fn add(&mut self, primitive: FilterPrimitive, inputs: Option<FilterInputs>) -> FilterId {
+        let id = FilterId(self.next_id);
+        self.next_id += 1;
+        self.primitives.push(primitive);
+
+        if let Some(inputs) = inputs {
+            self.connections.insert(id, inputs);
+        }
+
+        id
+    }
+
+    /// Set the output filter for the graph.
+    pub fn set_output(&mut self, output: FilterId) {
+        self.output = output;
+    }
+}
+
+/// All possible filter effects.
+#[derive(Debug, Clone)]
+pub enum FilterEffect {
+    /// Simple, high-level filter functions.
+    Function(FilterFunction),
+    /// Low-level filter primitives (granular control).
+    Primitive(FilterPrimitive),
+    // Custom shader effects (potential future feature)
+    // Custom(CustomShaderFilter),
+}
+
+/// High-level filter functions for common effects (css filter functions).
+/// @see <https://drafts.fxtf.org/filter-effects/#filter-functions>
+#[derive(Debug, Clone)]
+pub enum FilterFunction {
+    /// Gaussian blur effect.
+    Blur {
+        /// Blur radius in pixels.
+        radius: f32,
+    },
+    /// Brightness adjustment.
+    Brightness {
+        /// 0.0 = black, 1.0 = normal, >1.0 = brighter.
+        amount: f32,
+    },
+    /// Contrast adjustment.
+    Contrast {
+        /// 0.0 = gray, 1.0 = normal, >1.0 = higher contrast.
+        amount: f32,
+    },
+    /// Drop shadow effect.
+    DropShadow {
+        /// Horizontal offset in pixels.
+        dx: f32,
+        /// Vertical offset in pixels.
+        dy: f32,
+        /// Blur radius in pixels.
+        blur: f32,
+        /// Shadow color with alpha.
+        color: AlphaColor<Srgb>,
+    },
+    /// Grayscale conversion.
+    Grayscale {
+        /// 0.0 = original, 1.0 = full grayscale.
+        amount: f32,
+    },
+    /// Hue rotation.
+    HueRotate {
+        /// Angle in degrees.
+        angle: f32,
+    },
+    /// Color inversion.
+    Invert {
+        /// 0.0 = original, 1.0 = fully inverted.
+        amount: f32,
+    },
+    /// Opacity adjustment.
+    Opacity {
+        /// 0.0 = transparent, 1.0 = opaque.
+        amount: f32,
+    },
+    /// Saturation adjustment.
+    Saturate {
+        /// 0.0 = grayscale, 1.0 = normal, >1.0 = oversaturated.
+        amount: f32,
+    },
+    /// Sepia tone effect.
+    Sepia {
+        /// 0.0 = original, 1.0 = full sepia.
+        amount: f32,
+    },
+}
+
+/// Low-level filter primitives for granular control (svg filter primitives).
+/// @see <https://drafts.fxtf.org/filter-effects/#FilterPrimitivesOverview>
+#[derive(Debug, Clone)]
+pub enum FilterPrimitive {
+    /// Gaussian blur filter.
+    GaussianBlur {
+        /// Standard deviation for blur.
+        std_deviation: f32,
+    },
+    /// Matrix-based color transformation.
+    ColorMatrix {
+        /// 4x5 matrix: [r,g,b,a,offset] for each channel.
+        matrix: [f32; 20],
+    },
+    /// Geometric offset/translation.
+    Offset {
+        /// Horizontal offset in pixels.
+        dx: f32,
+        /// Vertical offset in pixels.
+        dy: f32,
+    },
+    /// Generate solid color fill.
+    Flood {
+        /// Fill color with alpha.
+        color: AlphaColor<Srgb>,
+    },
+    /// Composite two inputs using Porter-Duff operations.
+    Composite {
+        /// Compositing operator to use.
+        operator: CompositeOperator,
+    },
+    /// Blend two inputs using blend modes.
+    Blend {
+        /// Blend mode to apply.
+        mode: BlendMode,
+    },
+    /// Morphological operations (dilate/erode).
+    Morphology {
+        /// Morphological operator (erode or dilate).
+        operator: MorphologyOperator,
+        /// Operation radius in pixels.
+        radius: f32,
+    },
+    /// Custom convolution kernel.
+    ConvolveMatrix {
+        /// Convolution kernel definition.
+        kernel: ConvolutionKernel,
+    },
+    /// Generate Perlin noise/turbulence.
+    Turbulence {
+        /// Base frequency for noise generation.
+        base_frequency: f32,
+        /// Number of octaves for fractal noise.
+        num_octaves: u32,
+        /// Random seed for noise generation.
+        seed: u32,
+        /// Type of turbulence (fractal or turbulence).
+        turbulence_type: TurbulenceType,
+    },
+    /// Displace pixels using a displacement map.
+    DisplacementMap {
+        /// Displacement scale factor.
+        scale: f32,
+        /// Color channel to use for X displacement.
+        x_channel: ColorChannel,
+        /// Color channel to use for Y displacement.
+        y_channel: ColorChannel,
+    },
+    /// Per-channel component transfer (lookup tables).
+    ComponentTransfer {
+        /// Transfer function for red channel.
+        red_function: Option<TransferFunction>,
+        /// Transfer function for green channel.
+        green_function: Option<TransferFunction>,
+        /// Transfer function for blue channel.
+        blue_function: Option<TransferFunction>,
+        /// Transfer function for alpha channel.
+        alpha_function: Option<TransferFunction>,
+    },
+    /// Reference an external image.
+    Image {
+        /// Reference to image in atlas.
+        image_id: u32,
+        /// Optional 2D transform matrix.
+        transform: Option<[f32; 6]>,
+    },
+    /// Tile input to fill region.
+    Tile,
+    /// Diffuse lighting simulation.
+    DiffuseLighting {
+        /// Surface scale factor for height calculation.
+        surface_scale: f32,
+        /// Diffuse reflection constant.
+        diffuse_constant: f32,
+        /// Kernel unit length for calculations.
+        kernel_unit_length: f32,
+        /// Light source configuration.
+        light_source: LightSource,
+    },
+    /// Specular lighting simulation.
+    SpecularLighting {
+        /// Surface scale factor for height calculation.
+        surface_scale: f32,
+        /// Specular reflection constant.
+        specular_constant: f32,
+        /// Specular reflection exponent.
+        specular_exponent: f32,
+        /// Kernel unit length for calculations.
+        kernel_unit_length: f32,
+        /// Light source configuration.
+        light_source: LightSource,
+    },
+}
+
+/// Unique identifier for a filter primitive in the graph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct FilterId(pub u32);
+
+/// Input connections for a filter primitive.
+#[derive(Debug, Clone)]
+pub struct FilterInputs {
+    /// Primary input ("in" attribute in SVG).
+    pub primary: FilterInput,
+    /// Secondary input ("in2" attribute in SVG, for composite/blend operations).
+    pub secondary: Option<FilterInput>,
+}
+
+impl FilterInputs {
+    /// Create filter inputs with a single input.
+    pub fn single(input: FilterInput) -> Self {
+        Self {
+            primary: input,
+            secondary: None,
+        }
+    }
+
+    /// Create filter inputs with two inputs (for composite, blend, etc.).
+    pub fn dual(input1: FilterInput, input2: FilterInput) -> Self {
+        Self {
+            primary: input1,
+            secondary: Some(input2),
+        }
+    }
+}
+
+/// A single filter input.
+#[derive(Debug, Clone)]
+pub enum FilterInput {
+    /// Input from a source (`SourceGraphic`, `SourceAlpha`, etc.).
+    Source(FilterSource),
+    /// Input from another filter's result.
+    Result(FilterId),
+}
+
+/// Filter input sources.
+#[derive(Debug, Clone, Copy)]
+pub enum FilterSource {
+    /// The original graphic content.
+    SourceGraphic,
+    /// Alpha channel. of the original graphic.
+    SourceAlpha,
+    /// Background image content.
+    BackgroundImage,
+    /// Alpha channel. of background image.
+    BackgroundAlpha,
+    /// Fill paint as input.
+    FillPaint,
+    /// Stroke paint as input.
+    StrokePaint,
+}
+
+/// Pre-built compound effects for common use cases.
+#[derive(Debug, Clone)]
+pub enum CompoundFilter {
+    /// Drop shadow effect. (offset + blur + composite)
+    DropShadow {
+        /// Horizontal offset in pixels.
+        dx: f32,
+        /// Vertical offset in pixels.
+        dy: f32,
+        /// Blur radius in pixels.
+        blur: f32,
+        /// Shadow color with alpha.
+        color: AlphaColor<Srgb>,
+    },
+    /// Inner shadow effect.
+    InnerShadow {
+        /// Horizontal offset in pixels.
+        dx: f32,
+        /// Vertical offset in pixels.
+        dy: f32,
+        /// Blur radius in pixels.
+        blur: f32,
+        /// Shadow color with alpha.
+        color: AlphaColor<Srgb>,
+    },
+    /// Glow effect (blur + composite).
+    Glow {
+        /// Blur radius in pixels.
+        blur: f32,
+        /// Glow color with alpha.
+        color: AlphaColor<Srgb>,
+    },
+    /// Bevel effect (lighting simulation).
+    Bevel {
+        /// Light angle in degrees.
+        angle: f32,
+        /// Bevel distance in pixels.
+        distance: f32,
+        /// Highlight color.
+        highlight: AlphaColor<Srgb>,
+        /// Shadow color.
+        shadow: AlphaColor<Srgb>,
+    },
+    /// Emboss effect.
+    Emboss {
+        /// Emboss angle in degrees.
+        angle: f32,
+        /// Emboss depth.
+        depth: f32,
+        /// Effect amount/strength.
+        amount: f32,
+    },
+}
+
+/// Composite operators for combining filter inputs.
+#[derive(Debug, Clone, Copy)]
+pub enum CompositeOperator {
+    /// Source over destination.
+    Over,
+    /// Source in destination.
+    In,
+    /// Source out destination.
+    Out,
+    /// Source atop destination.
+    Atop,
+    /// Source xor destination.
+    Xor,
+    /// Arithmetic combination with custom coefficients.
+    Arithmetic {
+        /// Coefficient for source * destination.
+        k1: f32,
+        /// Coefficient for source.
+        k2: f32,
+        /// Coefficient for destination.
+        k3: f32,
+        /// Constant offset.
+        k4: f32,
+    },
+}
+
+/// Blend modes for combining colors.
+#[derive(Debug, Clone, Copy)]
+pub enum BlendMode {
+    /// Normal blending (no special effect).
+    Normal,
+    /// Multiply colors (darkening effect).
+    Multiply,
+    /// Screen colors (lightening effect).
+    Screen,
+    /// Overlay blending.
+    Overlay,
+    /// Darken colors.
+    Darken,
+    /// Lighten colors.
+    Lighten,
+    /// Color dodge effect.
+    ColorDodge,
+    /// Color burn effect.
+    ColorBurn,
+    /// Hard light blending.
+    HardLight,
+    /// Soft light blending.
+    SoftLight,
+    /// Difference blending.
+    Difference,
+    /// Exclusion blending.
+    Exclusion,
+    /// Hue blending.
+    Hue,
+    /// Saturation blending.
+    Saturation,
+    /// Color blending.
+    Color,
+    /// Luminosity blending.
+    Luminosity,
+}
+
+/// Morphological operators for dilate/erode operations.
+#[derive(Debug, Clone, Copy)]
+pub enum MorphologyOperator {
+    /// Erode operation (shrink shapes).
+    Erode,
+    /// Dilate operation (expand shapes).
+    Dilate,
+}
+
+/// Convolution kernel for custom filtering operations.
+#[derive(Debug, Clone)]
+pub struct ConvolutionKernel {
+    /// Kernel size (e.g., 3 for 3x3).
+    pub size: u32,
+    /// Kernel values.
+    pub values: Vec<f32>,
+    /// Normalization divisor.
+    pub divisor: f32,
+    /// Bias to add to result.
+    pub bias: f32,
+    /// Whether to preserve alpha channel.
+    pub preserve_alpha: bool,
+}
+
+/// Types of turbulence noise generation.
+#[derive(Debug, Clone, Copy)]
+pub enum TurbulenceType {
+    /// Fractal noise (smooth).
+    FractalNoise,
+    /// Turbulence noise (more chaotic).
+    Turbulence,
+}
+
+/// Color channels for displacement mapping.
+#[derive(Debug, Clone, Copy)]
+pub enum ColorChannel {
+    /// Red color channel.
+    Red,
+    /// Green color channel.
+    Green,
+    /// Blue color channel.
+    Blue,
+    /// Alpha channel.
+    Alpha,
+}
+
+/// Transfer functions for component transfer operations.
+#[derive(Debug, Clone)]
+pub enum TransferFunction {
+    /// Identity function (no change).
+    Identity,
+    /// Table lookup function.
+    Table {
+        /// Lookup table values.
+        values: Vec<f32>,
+    },
+    /// Discrete step function.
+    Discrete {
+        /// Step values.
+        values: Vec<f32>,
+    },
+    /// Linear function: slope * input + intercept.
+    Linear {
+        /// Linear slope coefficient.
+        slope: f32,
+        /// Linear intercept offset.
+        intercept: f32,
+    },
+    /// Gamma correction function.
+    Gamma {
+        /// Gamma amplitude.
+        amplitude: f32,
+        /// Gamma exponent.
+        exponent: f32,
+        /// Gamma offset.
+        offset: f32,
+    },
+}
+
+/// Light source configurations for lighting effects.
+#[derive(Debug, Clone)]
+pub enum LightSource {
+    /// Distant light source (like the sun).
+    Distant {
+        /// Light azimuth angle in degrees.
+        azimuth: f32,
+        /// Light elevation angle in degrees.
+        elevation: f32,
+    },
+    /// Point light source at specific coordinates.
+    Point {
+        /// Light X position.
+        x: f32,
+        /// Light Y position.
+        y: f32,
+        /// Light Z position.
+        z: f32,
+    },
+    /// Spot light with direction and cone.
+    Spot {
+        /// Light X position.
+        x: f32,
+        /// Light Y position.
+        y: f32,
+        /// Light Z position.
+        z: f32,
+        /// X coordinate the light points at.
+        points_at_x: f32,
+        /// Y coordinate the light points at.
+        points_at_y: f32,
+        /// Z coordinate the light points at.
+        points_at_z: f32,
+        /// Specular reflection exponent.
+        specular_exponent: f32,
+        /// Optional cone angle limit in degrees.
+        limiting_cone_angle: Option<f32>,
+    },
+}
+
+/// Common color transformation matrices
+pub mod matrices {
+    /// Identity matrix (no change).
+    pub const IDENTITY: [f32; 20] = [
+        1.0, 0.0, 0.0, 0.0, 0.0, // Red
+        0.0, 1.0, 0.0, 0.0, 0.0, // Green
+        0.0, 0.0, 1.0, 0.0, 0.0, // Blue
+        0.0, 0.0, 0.0, 1.0, 0.0, // Alpha
+    ];
+
+    /// Extract alpha channel to RGB (for shadow effects).
+    pub const ALPHA_TO_BLACK: [f32; 20] = [
+        0.0, 0.0, 0.0, 1.0, 0.0, // Red = Alpha
+        0.0, 0.0, 0.0, 1.0, 0.0, // Green = Alpha
+        0.0, 0.0, 0.0, 1.0, 0.0, // Blue = Alpha
+        0.0, 0.0, 0.0, 1.0, 0.0, // Alpha = Alpha
+    ];
+
+    /// Grayscale conversion. matrix.
+    pub const GRAYSCALE: [f32; 20] = [
+        0.2126, 0.7152, 0.0722, 0.0, 0.0, // Red
+        0.2126, 0.7152, 0.0722, 0.0, 0.0, // Green
+        0.2126, 0.7152, 0.0722, 0.0, 0.0, // Blue
+        0.0, 0.0, 0.0, 1.0, 0.0, // Alpha
+    ];
+
+    /// Sepia tone matrix.
+    pub const SEPIA: [f32; 20] = [
+        0.393, 0.769, 0.189, 0.0, 0.0, // Red
+        0.349, 0.686, 0.168, 0.0, 0.0, // Green
+        0.272, 0.534, 0.131, 0.0, 0.0, // Blue
+        0.0, 0.0, 0.0, 1.0, 0.0, // Alpha
+    ];
+}
+
+/// Common convolution kernels
+pub mod kernels {
+    use super::ConvolutionKernel;
+    use alloc::vec;
+
+    /// 3x3 Gaussian blur kernel.
+    pub fn gaussian_3x3() -> ConvolutionKernel {
+        ConvolutionKernel {
+            size: 3,
+            values: vec![1.0, 2.0, 1.0, 2.0, 4.0, 2.0, 1.0, 2.0, 1.0],
+            divisor: 16.0,
+            bias: 0.0,
+            preserve_alpha: false,
+        }
+    }
+
+    /// 3x3 Sharpen kernel.
+    pub fn sharpen_3x3() -> ConvolutionKernel {
+        ConvolutionKernel {
+            size: 3,
+            values: vec![0.0, -1.0, 0.0, -1.0, 5.0, -1.0, 0.0, -1.0, 0.0],
+            divisor: 1.0,
+            bias: 0.0,
+            preserve_alpha: true,
+        }
+    }
+
+    /// 3x3 Edge detection kernel.
+    pub fn edge_detect_3x3() -> ConvolutionKernel {
+        ConvolutionKernel {
+            size: 3,
+            values: vec![-1.0, -1.0, -1.0, -1.0, 8.0, -1.0, -1.0, -1.0, -1.0],
+            divisor: 1.0,
+            bias: 0.0,
+            preserve_alpha: true,
+        }
+    }
+
+    /// 3x3 Emboss kernel.
+    pub fn emboss_3x3() -> ConvolutionKernel {
+        ConvolutionKernel {
+            size: 3,
+            values: vec![-2.0, -1.0, 0.0, -1.0, 1.0, 1.0, 0.0, 1.0, 2.0],
+            divisor: 1.0,
+            bias: 0.5,
+            preserve_alpha: true,
+        }
+    }
+}

--- a/sparse_strips/vello_common/src/lib.rs
+++ b/sparse_strips/vello_common/src/lib.rs
@@ -66,6 +66,7 @@ pub mod coarse;
 #[cfg(feature = "text")]
 pub mod colr;
 pub mod encode;
+pub mod filter_effects;
 pub mod flatten;
 pub(crate) mod flatten_simd;
 #[cfg(feature = "text")]

--- a/sparse_strips/vello_common/src/recording.rs
+++ b/sparse_strips/vello_common/src/recording.rs
@@ -3,6 +3,7 @@
 
 //! Recording API for caching sparse strips
 
+use crate::filter_effects::Filter;
 #[cfg(feature = "text")]
 use crate::glyph::{GlyphRenderer, GlyphRunBuilder, GlyphType, PreparedGlyph};
 use crate::kurbo::{Affine, BezPath, Rect, Stroke};
@@ -99,6 +100,8 @@ pub struct PushLayerCommand {
     pub opacity: Option<f32>,
     /// Mask.
     pub mask: Option<Mask>,
+    /// Filter system.
+    pub filter: Option<Filter>,
 }
 
 /// Individual rendering commands that can be recorded.
@@ -409,6 +412,7 @@ impl<'a> Recorder<'a> {
         blend_mode: Option<BlendMode>,
         opacity: Option<f32>,
         mask: Option<Mask>,
+        filter: Option<Filter>,
     ) {
         self.recording
             .add_command(RenderCommand::PushLayer(PushLayerCommand {
@@ -416,12 +420,18 @@ impl<'a> Recorder<'a> {
                 blend_mode,
                 opacity,
                 mask,
+                filter,
             }));
     }
 
     /// Push a new clip layer.
     pub fn push_clip_layer(&mut self, clip_path: &BezPath) {
-        self.push_layer(Some(clip_path), None, None, None);
+        self.push_layer(Some(clip_path), None, None, None, None);
+    }
+
+    /// Push a new filter layer.
+    pub fn push_filter_layer(&mut self, filter: Filter) {
+        self.push_layer(None, None, None, None, Some(filter));
     }
 
     /// Pop the last pushed layer.

--- a/sparse_strips/vello_sparse_tests/tests/filter_effects.rs
+++ b/sparse_strips/vello_sparse_tests/tests/filter_effects.rs
@@ -1,0 +1,285 @@
+// Copyright 2025 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Tests demonstrating the filter effects API usage.
+
+use crate::renderer::Renderer;
+use vello_common::color::AlphaColor;
+use vello_common::filter_effects::*;
+use vello_common::kurbo::Rect;
+use vello_common::paint::PaintType;
+use vello_cpu::color::palette::css::{BLUE, GREEN, RED, YELLOW};
+use vello_dev_macros::vello_test;
+
+/// Simple filter function usage
+#[vello_test]
+fn simple_filter_functions(ctx: &mut impl Renderer) {
+    // Simple blur filter on a rectangle
+    ctx.set_paint(PaintType::Solid(BLUE));
+    ctx.set_filter_effect(Filter::from_function(FilterFunction::Blur { radius: 5.0 }));
+    ctx.fill_rect(&Rect::new(10.0, 10.0, 100.0, 100.0));
+
+    // Grayscale filter with brightness adjustment
+    ctx.set_filter_effect(Filter::from_function(FilterFunction::Grayscale {
+        amount: 1.0,
+    }));
+    ctx.fill_rect(&Rect::new(120.0, 10.0, 210.0, 100.0));
+
+    // Drop shadow effect
+    ctx.set_filter_effect(Filter::from_function(FilterFunction::DropShadow {
+        dx: 3.0,
+        dy: 3.0,
+        blur: 2.0,
+        color: AlphaColor::new([0.0, 0.0, 0.0, 0.5]),
+    }));
+    ctx.fill_rect(&Rect::new(230.0, 10.0, 320.0, 100.0));
+}
+
+/// Filter layer usage (affects multiple elements)
+#[vello_test]
+fn filter_layers(ctx: &mut impl Renderer) {
+    // Push a blur layer that affects all subsequent drawing
+    ctx.push_filter_layer(Filter::from_function(FilterFunction::Blur { radius: 3.0 }));
+
+    // Everything drawn here will be blurred
+    ctx.set_paint(PaintType::Solid(RED));
+    ctx.fill_rect(&Rect::new(10.0, 10.0, 100.0, 100.0));
+
+    ctx.set_paint(PaintType::Solid(GREEN));
+    ctx.fill_rect(&Rect::new(50.0, 50.0, 150.0, 150.0));
+
+    // Pop the blur layer
+    ctx.pop_layer();
+
+    // This rectangle won't be blurred
+    ctx.set_paint(PaintType::Solid(BLUE));
+    ctx.fill_rect(&Rect::new(200.0, 10.0, 300.0, 100.0));
+}
+
+/// Filter primitives usage
+#[vello_test]
+fn filter_primitives(ctx: &mut impl Renderer) {
+    // Color matrix transformation (sepia effect)
+    ctx.set_paint(PaintType::Solid(RED));
+    ctx.set_filter_effect(Filter::from_primitive(FilterPrimitive::ColorMatrix {
+        matrix: matrices::SEPIA,
+    }));
+    ctx.fill_rect(&Rect::new(10.0, 10.0, 100.0, 100.0));
+
+    // Morphological operation (dilate)
+    ctx.set_filter_effect(Filter::from_primitive(FilterPrimitive::Morphology {
+        operator: MorphologyOperator::Dilate,
+        radius: 2.0,
+    }));
+    ctx.fill_rect(&Rect::new(120.0, 10.0, 220.0, 100.0));
+
+    // Turbulence noise
+    ctx.set_filter_effect(Filter::from_primitive(FilterPrimitive::Turbulence {
+        base_frequency: 0.1,
+        num_octaves: 3,
+        seed: 42,
+        turbulence_type: TurbulenceType::FractalNoise,
+    }));
+    ctx.fill_rect(&Rect::new(240.0, 10.0, 340.0, 100.0));
+}
+
+/// Complex filter graph (DAG) usage
+#[vello_test]
+fn complex_filter_graph(ctx: &mut impl Renderer) {
+    // Build a complex drop shadow effect using helper function
+    let shadow_graph = build_drop_shadow_graph();
+
+    // Create filter system and apply the complex shadow filter
+    ctx.push_filter_layer(Filter {
+        graph: shadow_graph,
+        bounds: Some(Rect::new(0.0, 0.0, 800.0, 600.0)),
+    });
+
+    // Draw rectangle that will have shadow
+    ctx.set_paint(PaintType::Solid(YELLOW));
+    ctx.fill_rect(&Rect::new(50.0, 50.0, 300.0, 100.0));
+
+    ctx.pop_layer();
+}
+
+/// Chained filters
+#[vello_test]
+fn chained_filters(ctx: &mut impl Renderer) {
+    // Create a filter chain: blur -> brightness -> contrast using helper function
+    let filter_chain = build_chained_filter_graph();
+
+    ctx.push_filter_layer(Filter {
+        graph: filter_chain,
+        bounds: Some(Rect::new(0.0, 0.0, 400.0, 300.0)),
+    });
+
+    // Draw multiple elements that will all be affected by the filter chain
+    ctx.set_paint(PaintType::Solid(RED));
+    ctx.fill_rect(&Rect::new(10.0, 10.0, 100.0, 100.0));
+
+    ctx.set_paint(PaintType::Solid(GREEN));
+    ctx.fill_rect(&Rect::new(50.0, 50.0, 150.0, 150.0));
+
+    ctx.set_paint(PaintType::Solid(BLUE));
+    ctx.fill_rect(&Rect::new(90.0, 90.0, 190.0, 190.0));
+
+    ctx.pop_layer();
+}
+
+/// Filter bounds optimization
+#[vello_test]
+fn filter_bounds_optimization(ctx: &mut impl Renderer) {
+    // Create a bounded blur filter using helper function
+    ctx.push_filter_layer(Filter {
+        graph: build_blur_graph(10.0),
+        bounds: Some(Rect::new(0.0, 0.0, 200.0, 200.0)),
+    });
+
+    // Only content within the bounds will be processed by the blur
+    ctx.set_paint(PaintType::Solid(BLUE));
+    // Inside bounds - will be blurred
+    ctx.fill_rect(&Rect::new(10.0, 10.0, 180.0, 180.0));
+
+    ctx.pop_layer();
+
+    // This content is outside the filter bounds and won't be affected
+    ctx.set_paint(PaintType::Solid(BLUE));
+    // Outside bounds - no blur
+    ctx.fill_rect(&Rect::new(250.0, 10.0, 400.0, 180.0));
+}
+
+/// Build a complex drop shadow filter graph
+/// @see <https://drafts.fxtf.org/filter-effects/#dropshadowEquivalent>
+fn build_drop_shadow_graph() -> FilterGraph {
+    let mut graph = FilterGraph::new();
+
+    // Step 1: Extract alpha channel for shadow
+    let alpha_extract = graph.add(
+        FilterPrimitive::ColorMatrix {
+            matrix: matrices::ALPHA_TO_BLACK,
+        },
+        Some(FilterInputs::single(FilterInput::Source(
+            FilterSource::SourceGraphic,
+        ))),
+    );
+
+    // Step 2: Offset the shadow
+    let shadow_offset = graph.add(
+        FilterPrimitive::Offset { dx: 4.0, dy: 4.0 },
+        Some(FilterInputs::single(FilterInput::Result(alpha_extract))),
+    );
+
+    // Step 3: Blur the shadow
+    let shadow_blur = graph.add(
+        FilterPrimitive::GaussianBlur { std_deviation: 3.0 },
+        Some(FilterInputs::single(FilterInput::Result(shadow_offset))),
+    );
+
+    // Step 4: Create shadow color (no inputs - generates content)
+    let shadow_color = graph.add(FilterPrimitive::Flood { color: YELLOW }, None);
+
+    // Step 5: Composite shadow color with blurred shape
+    let shadow_composite = graph.add(
+        FilterPrimitive::Composite {
+            operator: CompositeOperator::In,
+        },
+        Some(FilterInputs::dual(
+            FilterInput::Result(shadow_color),
+            FilterInput::Result(shadow_blur),
+        )),
+    );
+
+    // Step 6: Composite shadow with original
+    let final_composite = graph.add(
+        FilterPrimitive::Composite {
+            operator: CompositeOperator::Over,
+        },
+        Some(FilterInputs::dual(
+            FilterInput::Result(shadow_composite),
+            FilterInput::Source(FilterSource::SourceGraphic),
+        )),
+    );
+
+    // Set the output
+    graph.set_output(final_composite);
+
+    graph
+}
+
+/// Build a chained filter graph: blur -> brightness -> contrast
+fn build_chained_filter_graph() -> FilterGraph {
+    let mut graph = FilterGraph::new();
+
+    // Step 1: Blur filter
+    let blur_result = graph.add(
+        FilterPrimitive::GaussianBlur { std_deviation: 2.0 },
+        Some(FilterInputs::single(FilterInput::Source(
+            FilterSource::SourceGraphic,
+        ))),
+    );
+
+    // Step 2: Brightness filter
+    let brightness_result = graph.add(
+        FilterPrimitive::ComponentTransfer {
+            red_function: Some(TransferFunction::Linear {
+                slope: 1.2,
+                intercept: 0.0,
+            }),
+            green_function: Some(TransferFunction::Linear {
+                slope: 1.2,
+                intercept: 0.0,
+            }),
+            blue_function: Some(TransferFunction::Linear {
+                slope: 1.2,
+                intercept: 0.0,
+            }),
+            alpha_function: None,
+        },
+        Some(FilterInputs::single(FilterInput::Result(blur_result))),
+    );
+
+    // Step 3: Contrast filter
+    let contrast_slope = 1.5;
+    let contrast_intercept = 0.5 * (1.0 - contrast_slope);
+    let contrast_result = graph.add(
+        FilterPrimitive::ComponentTransfer {
+            red_function: Some(TransferFunction::Linear {
+                slope: contrast_slope,
+                intercept: contrast_intercept,
+            }),
+            green_function: Some(TransferFunction::Linear {
+                slope: contrast_slope,
+                intercept: contrast_intercept,
+            }),
+            blue_function: Some(TransferFunction::Linear {
+                slope: contrast_slope,
+                intercept: contrast_intercept,
+            }),
+            alpha_function: None,
+        },
+        Some(FilterInputs::single(FilterInput::Result(brightness_result))),
+    );
+
+    // Set the final output
+    graph.set_output(contrast_result);
+
+    graph
+}
+
+/// Build a simple blur filter graph
+fn build_blur_graph(std_deviation: f32) -> FilterGraph {
+    let mut graph = FilterGraph::new();
+
+    // Add blur filter with source graphic input
+    let blur_result = graph.add(
+        FilterPrimitive::GaussianBlur { std_deviation },
+        Some(FilterInputs::single(FilterInput::Source(
+            FilterSource::SourceGraphic,
+        ))),
+    );
+
+    // Set the output
+    graph.set_output(blur_result);
+
+    graph
+}

--- a/sparse_strips/vello_sparse_tests/tests/mod.rs
+++ b/sparse_strips/vello_sparse_tests/tests/mod.rs
@@ -34,6 +34,7 @@ mod basic;
 mod blurred_rounded_rect;
 mod clip;
 mod compose;
+mod filter_effects;
 mod glyph;
 mod gradient;
 mod image;


### PR DESCRIPTION
### Filter Effects API Proposal

This proposal is based on my understanding of the [Filter Effects specification](https://drafts.fxtf.org/filter-effects). It doesn’t go into the internal implementation details, which may or may not influence the API design later. However, I wanted to share this initial draft API to gather early feedback from everyone. I’d love to hear any thoughts or ideas, either here or in Zulip.

In the PR, you’ll also find a simple test `tests/filter_effects.rs` that serves as a demo of the API in action, along with `filter_effects.rs`, which consolidates all the necessary input types.

The filter effects system is designed as a flexible API that supports both simple high-level effects (like blur, brightness, and drop shadows) and complex custom filter pipelines built from composable primitives.

### Architecture Overview
The filter system API is built around three main concepts:
- `Filter` — the main container that holds a filter graph and optional bounds.
- `FilterGraph` — a directed acyclic graph of filter operations.
- `FilterFunction` and `FilterPrimitive` — the actual operations that transform pixels.

### Two-Level API Design

- High-Level: Filter Functions. These high-level functions correspond to CSS filter functions and are automatically converted to low-level primitives.
```rust
// Simple blur effect
ctx.set_filter_effect(FilterSystem::from_function(FilterFunction::Blur {
    radius: 5.0,
}));

// Grayscale conversion
ctx.set_filter_effect(FilterSystem::from_function(FilterFunction::Grayscale { 
    amount: 1.0 
}));

// Drop shadow
ctx.set_filter_effect(FilterSystem::from_function(FilterFunction::DropShadow {
    dx: 3.0, dy: 3.0, blur: 2.0,
    color: AlphaColor::new([0.0, 0.0, 0.0, 0.5]),
}));
```

- Low-Level: Filter Primitives. 
```rust
// Direct color matrix transformation
ctx.set_filter_effect(FilterSystem::from_primitive(FilterPrimitive::ColorMatrix {
    matrix: matrices::SEPIA,
}));

// Morphological operations
ctx.set_filter_effect(FilterSystem::from_primitive(FilterPrimitive::Morphology {
    operator: MorphologyOperator::Dilate,
    radius: 2.0,
}));
```

### Filter Graph System
For complex effects, you can build custom filter graphs ([drop-shadow](https://drafts.fxtf.org/filter-effects/#dropshadowEquivalent) below as an example):
```rust
fn build_drop_shadow_graph() -> FilterGraph {
    let mut graph = FilterGraph::new();
    
    // Extract alpha channel
    let alpha_extract = graph.add(
        FilterPrimitive::ColorMatrix { matrix: matrices::ALPHA_TO_BLACK },
        Some(FilterInputs::single(FilterInput::Source(FilterSource::SourceGraphic)))
    );
    
    // Offset the shadow
    let shadow_offset = graph.add(
        FilterPrimitive::Offset { dx: 4.0, dy: 4.0 },
        Some(FilterInputs::single(FilterInput::Result(alpha_extract)))
    );
    
    // Blur the shadow
    let shadow_blur = graph.add(
        FilterPrimitive::GaussianBlur { std_deviation: 3.0 },
        Some(FilterInputs::single(FilterInput::Result(shadow_offset)))
    );
    
    // Composite with original
    let final_composite = graph.add(
        FilterPrimitive::Composite { operator: CompositeOperator::Over },
        Some(FilterInputs::dual(
            FilterInput::Result(shadow_blur),
            FilterInput::Source(FilterSource::SourceGraphic)
        ))
    );
    
    graph.set_output(final_composite);
    graph
}
```

### Usage Patterns
- Per-Element Filters. Apply filters to individual drawing operations:
```rust
ctx.set_filter_effect(blur_filter);
// This rectangle will be blurred
ctx.fill_rect(&rect);
```

- Filter Layers. Apply filters to groups of elements:
```rust
ctx.push_filter_layer(blur_filter);
// Both rectangles will be blurred
ctx.fill_rect(&rect1);
ctx.fill_rect(&rect2);
ctx.pop_layer();
```

- Bounded Filters. Optimize performance by limiting filter processing to specific regions:
```rust
let filter_system = Filter {
    graph: blur_graph,
    bounds: Some(Rect::new(0.0, 0.0, 200.0, 200.0)),
};
```