### PR TITLE
Optimize `take_unpremultiplied` for in-place conversion

### DIFF
--- a/sparse_strips/vello_common/Cargo.toml
+++ b/sparse_strips/vello_common/Cargo.toml
@@ -17,7 +17,7 @@ default-target = "x86_64-unknown-linux-gnu"
 targets = []
 
 [dependencies]
-bytemuck = { workspace = true, features = [] }
+bytemuck = { workspace = true, features = ["extern_crate_alloc"] }
 peniko = { workspace = true, features = ["bytemuck"] }
 fearless_simd = { workspace = true }
 hashbrown = { version = "0.15", optional = true }


### PR DESCRIPTION
The `Pixmap::take_unpremultiplied` method was reworked to perform the RGBA conversion in-place, without allocating a new buffer to copy the entire image data (which can be very large in some cases).

This change reduces memory usage for large images and improves efficiency by skipping redundant calculations for fully transparent and fully opaque pixels.

A test was added to verify the correctness of the conversion.