### PR TITLE
chore: remove gaussian blur filter snapshot image

### DIFF
--- a/sparse_strips/vello_sparse_tests/snapshots/filter_gaussian_blur.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/filter_gaussian_blur.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:941ddb72af8202a9680f8837c70affc4dcf3766e30ac46544d24d256b87a38a4
-size 4361


### PR DESCRIPTION
I accidentally committed a snapshot from a previously used test, but not the test itself.