### PR TITLE
Fix bitmap glyph positioning with scaled transforms

### DIFF
--- a/vello/src/scene.rs
+++ b/vello/src/scene.rs
@@ -590,6 +590,10 @@ impl<'a> DrawGlyphs<'a> {
         )
         .to_vec();
         let location = LocationRef::new(&coords);
+
+        let transform_scale = run_transform.determinant().abs().sqrt() as f32;
+        let scaled_font_size = self.run.font_size * transform_scale;
+
         loop {
             let ppem = self.run.font_size;
             let outline_glyphs = (&mut glyphs).take_while(|glyph| {
@@ -711,15 +715,16 @@ impl<'a> DrawGlyphs<'a> {
                         }
                     };
                     let image = ImageBrush::new(image).multiply_alpha(self.brush_alpha);
-                    // Split into multiple statements because rustfmt breaks
-                    let transform =
-                        run_transform.pre_translate(Vec2::new(glyph.x.into(), glyph.y.into()));
+
+                    // Compute position in physical coordinates to handle scaled transforms correctly
+                    let glyph_physical_pos =
+                        run_transform * Point::new(glyph.x.into(), glyph.y.into());
 
                     // Logic copied from Skia without examination or careful understanding:
                     // https://github.com/google/skia/blob/61ac357e8e3338b90fb84983100d90768230797f/src/ports/SkTypeface_fontations.cpp#L664
 
-                    let image_scale_factor = self.run.font_size / bitmap.ppem_y;
-                    let font_units_to_size = self.run.font_size / upem;
+                    let image_scale_factor = scaled_font_size / bitmap.ppem_y;
+                    let font_units_to_size = scaled_font_size / upem;
 
                     // CoreText appears to special case Apple Color Emoji, adding
                     // a 100 font unit vertical offset. We do the same but only
@@ -734,7 +739,7 @@ impl<'a> DrawGlyphs<'a> {
                         bitmap.bearing_y
                     };
 
-                    let transform = transform
+                    let transform = Affine::translate(glyph_physical_pos.to_vec2())
                         .pre_translate(Vec2 {
                             x: (-bitmap.bearing_x * font_units_to_size).into(),
                             y: (bearing_y * font_units_to_size).into(),


### PR DESCRIPTION
When `draw_glyphs()` receives a scaled transform (e.g., `Affine::scale(2.0)`), bitmap glyphs (emoji) render at incorrect positions because:

1. Glyph position offset was scaled by the transform via `pre_translate`
2. But `image_scale_factor` and `font_units_to_size` only used unscaled `font_size`

This caused a position/size mismatch where bitmap glyphs appeared offset from their expected locations, with the error proportional to the scale factor.

## Fix

- Extract scale factor from transform using `determinant().abs().sqrt()`
- Compute glyph position in physical coordinates before applying to transform
- Use scaled font size for `image_scale_factor` and `font_units_to_size` calculations

## Screenshots
<img width="598" height="224" alt="CleanShot 2025-11-26 at 22 30 22" src="https://github.com/user-attachments/assets/fdb1952d-9f03-4112-9f0c-933d720930aa" />


<img width="598" height="222" alt="CleanShot 2025-11-26 at 22 28 06" src="https://github.com/user-attachments/assets/44c8d04a-d305-4601-acd4-53c238f9b0b1" />
