### PR TITLE
Fix bitmap glyph skew origin

### DIFF
--- a/vello/src/scene.rs
+++ b/vello/src/scene.rs
@@ -753,7 +753,14 @@ impl<'a> DrawGlyphs<'a> {
                         }),
                     };
                     if let Some(glyph_transform) = self.run.glyph_transform {
-                        transform *= glyph_transform.to_kurbo();
+                        let gt = glyph_transform.to_kurbo();
+                        let [a, b, c, d, e, f] = gt.as_coeffs();
+                        let corrected = Affine::new([a, -b, -c, d, e, f]);
+                        let h = f64::from(image.image.height);
+                        transform = transform
+                            * Affine::translate((0.0, h))
+                            * corrected
+                            * Affine::translate((0.0, -h));
                     }
                     self.scene.draw_image(image.as_ref(), transform);
                 }


### PR DESCRIPTION
Bitmap glyphs use Y-down coordinate system (top at y=0), while outline/COLR fonts use Y-up (baseline at y=0). When `glyph_transform` (skew for synthetic italic) is applied to bitmap glyphs, the skew origin is at the top-left corner instead of the baseline, causing the italic effect to lean in the wrong direction.

## Fix

- Negate the shear coefficients to account for Y-down coordinates
- Apply the skew around the bottom of the image (y=height) instead of the top (y=0)

## Screenshots
<img width="598" height="224" alt="CleanShot 2025-11-26 at 22 32 26" src="https://github.com/user-attachments/assets/56c0d378-9c47-4204-8096-d9f4eddee6da" />
<img width="598" height="224" alt="CleanShot 2025-11-26 at 22 32 50" src="https://github.com/user-attachments/assets/ba43b64c-6a56-4f74-9e0a-6e33666d83f4" />
