### PR TITLE
Remove `wgpu` feature. Add `wgpu_27` and `wgpu_28` features.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,12 @@ env:
   # version like 1.70. Note that we only specify MAJOR.MINOR and not PATCH so that bugfixes still
   # come automatically. If the version specified here is no longer the latest stable version,
   # then please feel free to submit a PR that adjusts it along with the potential clippy fixes.
-  RUST_STABLE_VER: "1.91" # In quotes because otherwise (e.g.) 1.70 would be interpreted as 1.7
+  RUST_STABLE_VER: "1.92" # In quotes because otherwise (e.g.) 1.70 would be interpreted as 1.7
   # The purpose of checking with the minimum supported Rust toolchain is to detect its staleness.
   # If the compilation fails, then the version specified here needs to be bumped up to reality.
   # Be sure to also update the rust-version property in the workspace Cargo.toml file,
   # plus all the README.md files of the affected packages.
-  RUST_MIN_VER: "1.88"
+  RUST_MIN_VER: "1.92"
   # List of packages that will be checked with the minimum supported Rust version.
   # This should be limited to packages that are intended for publishing.
   RUST_MIN_VER_PKGS: "-p vello -p vello_encoding -p vello_shaders -p vello_api -p vello_common -p vello_cpu -p vello_hybrid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1301,6 +1301,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "gpu-alloc"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
+dependencies = [
+ "bitflags 2.9.4",
+ "gpu-alloc-types",
+]
+
+[[package]]
+name = "gpu-alloc-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
+dependencies = [
+ "bitflags 2.9.4",
+]
+
+[[package]]
+name = "gpu-allocator"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
+dependencies = [
+ "log",
+ "presser",
+ "thiserror 1.0.69",
+ "windows 0.58.0",
+]
+
+[[package]]
 name = "gpu-allocator"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1311,7 +1342,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.16",
- "windows 0.58.0",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -1530,7 +1561,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2022,6 +2053,21 @@ dependencies = [
 
 [[package]]
 name = "metal"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
+dependencies = [
+ "bitflags 2.9.4",
+ "block",
+ "core-graphics-types 0.2.0",
+ "foreign-types",
+ "log",
+ "objc",
+ "paste",
+]
+
+[[package]]
+name = "metal"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7047791b5bc903b8cd963014b355f71dc9864a9a0b727057676c1dcae5cbc15"
@@ -2081,6 +2127,32 @@ checksum = "ddd32fa8935aeadb8a8a6b6b351e40225570a37c43de67690383d87ef170cd08"
 dependencies = [
  "num-traits",
  "pxfm",
+]
+
+[[package]]
+name = "naga"
+version = "27.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "066cf25f0e8b11ee0df221219010f213ad429855f57c494f995590c861a9a7d8"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bitflags 2.9.4",
+ "cfg-if",
+ "cfg_aliases",
+ "codespan-reporting",
+ "half",
+ "hashbrown 0.16.0",
+ "hexf-parse",
+ "indexmap 2.11.3",
+ "libm",
+ "log",
+ "num-traits",
+ "once_cell",
+ "rustc-hash 1.1.0",
+ "spirv",
+ "thiserror 2.0.16",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -3911,8 +3983,10 @@ dependencies = [
  "thiserror 2.0.16",
  "vello_encoding",
  "vello_shaders",
- "wgpu",
- "wgpu-profiler",
+ "wgpu 27.0.1",
+ "wgpu 28.0.0",
+ "wgpu-profiler 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wgpu-profiler 0.25.0 (git+https://github.com/Wumpf/wgpu-profiler?rev=a50f97d1838117c5b48ad268ece06c50c7d94120)",
 ]
 
 [[package]]
@@ -4034,7 +4108,8 @@ dependencies = [
  "vello_common",
  "vello_sparse_shaders",
  "web-sys",
- "wgpu",
+ "wgpu 27.0.1",
+ "wgpu 28.0.0",
 ]
 
 [[package]]
@@ -4045,7 +4120,7 @@ dependencies = [
  "vello_common",
  "vello_example_scenes",
  "vello_hybrid",
- "wgpu",
+ "wgpu 28.0.0",
  "winit",
 ]
 
@@ -4055,7 +4130,8 @@ version = "0.6.0"
 dependencies = [
  "bytemuck",
  "log",
- "naga",
+ "naga 27.0.3",
+ "naga 28.0.0",
  "thiserror 2.0.16",
  "vello_encoding",
 ]
@@ -4064,7 +4140,7 @@ dependencies = [
 name = "vello_sparse_shaders"
 version = "0.0.4"
 dependencies = [
- "naga",
+ "naga 28.0.0",
 ]
 
 [[package]]
@@ -4087,7 +4163,7 @@ dependencies = [
  "wasm-bindgen-test",
  "wasmparser 0.235.0",
  "web-sys",
- "wgpu",
+ "wgpu 28.0.0",
 ]
 
 [[package]]
@@ -4388,7 +4464,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
- "wgpu",
 ]
 
 [[package]]
@@ -4549,6 +4624,35 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
+version = "27.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfe68bac7cde125de7a731c3400723cadaaf1703795ad3f4805f187459cd7a77"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.9.4",
+ "cfg-if",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.16.0",
+ "js-sys",
+ "log",
+ "naga 27.0.3",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "smallvec",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core 27.0.3",
+ "wgpu-hal 27.0.4",
+ "wgpu-types 27.0.1",
+]
+
+[[package]]
+name = "wgpu"
 version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9cb534d5ffd109c7d1135f34cdae29e60eab94855a625dcfe1705f8bc7ad79f"
@@ -4562,7 +4666,7 @@ dependencies = [
  "hashbrown 0.16.0",
  "js-sys",
  "log",
- "naga",
+ "naga 28.0.0",
  "parking_lot",
  "portable-atomic",
  "profiling",
@@ -4572,9 +4676,41 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "wgpu-core",
- "wgpu-hal",
- "wgpu-types",
+ "wgpu-core 28.0.0",
+ "wgpu-hal 28.0.0",
+ "wgpu-types 28.0.0",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "27.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27a75de515543b1897b26119f93731b385a19aea165a1ec5f0e3acecc229cae7"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.9.4",
+ "bytemuck",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.16.0",
+ "indexmap 2.11.3",
+ "log",
+ "naga 27.0.3",
+ "once_cell",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "rustc-hash 1.1.0",
+ "smallvec",
+ "thiserror 2.0.16",
+ "wgpu-core-deps-apple 27.0.0",
+ "wgpu-core-deps-emscripten 27.0.0",
+ "wgpu-core-deps-windows-linux-android 27.0.0",
+ "wgpu-hal 27.0.4",
+ "wgpu-types 27.0.1",
 ]
 
 [[package]]
@@ -4593,7 +4729,7 @@ dependencies = [
  "hashbrown 0.16.0",
  "indexmap 2.11.3",
  "log",
- "naga",
+ "naga 28.0.0",
  "once_cell",
  "parking_lot",
  "portable-atomic",
@@ -4602,12 +4738,21 @@ dependencies = [
  "rustc-hash 1.1.0",
  "smallvec",
  "thiserror 2.0.16",
- "wgpu-core-deps-apple",
- "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-apple 28.0.0",
+ "wgpu-core-deps-emscripten 28.0.0",
  "wgpu-core-deps-wasm",
- "wgpu-core-deps-windows-linux-android",
- "wgpu-hal",
- "wgpu-types",
+ "wgpu-core-deps-windows-linux-android 28.0.0",
+ "wgpu-hal 28.0.0",
+ "wgpu-types 28.0.0",
+]
+
+[[package]]
+name = "wgpu-core-deps-apple"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0772ae958e9be0c729561d5e3fd9a19679bcdfb945b8b1a1969d9bfe8056d233"
+dependencies = [
+ "wgpu-hal 27.0.4",
 ]
 
 [[package]]
@@ -4616,7 +4761,16 @@ version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87b7b696b918f337c486bf93142454080a32a37832ba8a31e4f48221890047da"
 dependencies = [
- "wgpu-hal",
+ "wgpu-hal 28.0.0",
+]
+
+[[package]]
+name = "wgpu-core-deps-emscripten"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b06ac3444a95b0813ecfd81ddb2774b66220b264b3e2031152a4a29fda4da6b5"
+dependencies = [
+ "wgpu-hal 27.0.4",
 ]
 
 [[package]]
@@ -4625,7 +4779,7 @@ version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34b251c331f84feac147de3c4aa3aa45112622a95dd7ee1b74384fa0458dbd79"
 dependencies = [
- "wgpu-hal",
+ "wgpu-hal 28.0.0",
 ]
 
 [[package]]
@@ -4634,7 +4788,16 @@ version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12a2cf578ce8d7d50d0e63ddc2345c7dcb599f6eb90b888813406ea78b9b7010"
 dependencies = [
- "wgpu-hal",
+ "wgpu-hal 28.0.0",
+]
+
+[[package]]
+name = "wgpu-core-deps-windows-linux-android"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71197027d61a71748e4120f05a9242b2ad142e3c01f8c1b47707945a879a03c3"
+dependencies = [
+ "wgpu-hal 27.0.4",
 ]
 
 [[package]]
@@ -4643,7 +4806,56 @@ version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ca976e72b2c9964eb243e281f6ce7f14a514e409920920dcda12ae40febaae"
 dependencies = [
- "wgpu-hal",
+ "wgpu-hal 28.0.0",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "27.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b21cb61c57ee198bc4aff71aeadff4cbb80b927beb912506af9c780d64313ce"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set",
+ "bitflags 2.9.4",
+ "block",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "core-graphics-types 0.2.0",
+ "glow",
+ "glutin_wgl_sys",
+ "gpu-alloc",
+ "gpu-allocator 0.27.0",
+ "gpu-descriptor",
+ "hashbrown 0.16.0",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading",
+ "log",
+ "metal 0.32.0",
+ "naga 27.0.3",
+ "ndk-sys",
+ "objc",
+ "once_cell",
+ "ordered-float",
+ "parking_lot",
+ "portable-atomic",
+ "portable-atomic-util",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle",
+ "renderdoc-sys",
+ "smallvec",
+ "thiserror 2.0.16",
+ "wasm-bindgen",
+ "web-sys",
+ "wgpu-types 27.0.1",
+ "windows 0.58.0",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -4664,7 +4876,7 @@ dependencies = [
  "core-graphics-types 0.2.0",
  "glow",
  "glutin_wgl_sys",
- "gpu-allocator",
+ "gpu-allocator 0.28.0",
  "gpu-descriptor",
  "hashbrown 0.16.0",
  "js-sys",
@@ -4672,8 +4884,8 @@ dependencies = [
  "libc",
  "libloading",
  "log",
- "metal",
- "naga",
+ "metal 0.33.0",
+ "naga 28.0.0",
  "ndk-sys",
  "objc",
  "once_cell",
@@ -4689,9 +4901,20 @@ dependencies = [
  "thiserror 2.0.16",
  "wasm-bindgen",
  "web-sys",
- "wgpu-types",
+ "wgpu-types 28.0.0",
  "windows 0.62.2",
  "windows-core 0.62.2",
+]
+
+[[package]]
+name = "wgpu-profiler"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9f7c28673961ecb946c862b66b6ea1f9b70fca9106d31db6fbb812b7b794abf"
+dependencies = [
+ "parking_lot",
+ "thiserror 2.0.16",
+ "wgpu 27.0.1",
 ]
 
 [[package]]
@@ -4701,7 +4924,21 @@ source = "git+https://github.com/Wumpf/wgpu-profiler?rev=a50f97d1838117c5b48ad26
 dependencies = [
  "parking_lot",
  "thiserror 2.0.16",
- "wgpu",
+ "wgpu 28.0.0",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "27.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afdcf84c395990db737f2dd91628706cb31e86d72e53482320d368e52b5da5eb"
+dependencies = [
+ "bitflags 2.9.4",
+ "bytemuck",
+ "js-sys",
+ "log",
+ "thiserror 2.0.16",
+ "web-sys",
 ]
 
 [[package]]
@@ -4732,7 +4969,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
- "wgpu",
+ "wgpu 28.0.0",
 ]
 
 [[package]]
@@ -5249,7 +5486,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "web-time",
- "wgpu-profiler",
+ "wgpu-profiler 0.25.0 (git+https://github.com/Wumpf/wgpu-profiler?rev=a50f97d1838117c5b48ad268ece06c50c7d94120)",
  "winit",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,7 +475,7 @@ dependencies = [
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1128,7 +1128,7 @@ dependencies = [
  "read-fonts 0.29.3",
  "roxmltree",
  "smallvec",
- "windows",
+ "windows 0.58.0",
  "windows-core 0.58.0",
 ]
 
@@ -1301,34 +1301,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "gpu-alloc"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
-dependencies = [
- "bitflags 2.9.4",
- "gpu-alloc-types",
-]
-
-[[package]]
-name = "gpu-alloc-types"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
-dependencies = [
- "bitflags 2.9.4",
-]
-
-[[package]]
 name = "gpu-allocator"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
 dependencies = [
+ "ash",
+ "hashbrown 0.16.0",
  "log",
  "presser",
- "thiserror 1.0.69",
- "windows",
+ "thiserror 2.0.16",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -1406,6 +1389,8 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -1545,7 +1530,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.0",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -2037,9 +2022,9 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
+checksum = "c7047791b5bc903b8cd963014b355f71dc9864a9a0b727057676c1dcae5cbc15"
 dependencies = [
  "bitflags 2.9.4",
  "block",
@@ -2100,9 +2085,9 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "27.0.3"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "066cf25f0e8b11ee0df221219010f213ad429855f57c494f995590c861a9a7d8"
+checksum = "618f667225063219ddfc61251087db8a9aec3c3f0950c916b614e403486f1135"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -4564,12 +4549,13 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "27.0.1"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe68bac7cde125de7a731c3400723cadaaf1703795ad3f4805f187459cd7a77"
+checksum = "f9cb534d5ffd109c7d1135f34cdae29e60eab94855a625dcfe1705f8bc7ad79f"
 dependencies = [
  "arrayvec",
  "bitflags 2.9.4",
+ "bytemuck",
  "cfg-if",
  "cfg_aliases",
  "document-features",
@@ -4593,9 +4579,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "27.0.3"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27a75de515543b1897b26119f93731b385a19aea165a1ec5f0e3acecc229cae7"
+checksum = "8bb4c8b5db5f00e56f1f08869d870a0dff7c8bc7ebc01091fec140b0cf0211a9"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -4626,45 +4612,45 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0772ae958e9be0c729561d5e3fd9a19679bcdfb945b8b1a1969d9bfe8056d233"
+checksum = "87b7b696b918f337c486bf93142454080a32a37832ba8a31e4f48221890047da"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06ac3444a95b0813ecfd81ddb2774b66220b264b3e2031152a4a29fda4da6b5"
+checksum = "34b251c331f84feac147de3c4aa3aa45112622a95dd7ee1b74384fa0458dbd79"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-wasm"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1027dcf3b027a877e44819df7ceb0e2e98578830f8cd34cd6c3c7c2a7a50b7"
+checksum = "12a2cf578ce8d7d50d0e63ddc2345c7dcb599f6eb90b888813406ea78b9b7010"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71197027d61a71748e4120f05a9242b2ad142e3c01f8c1b47707945a879a03c3"
+checksum = "68ca976e72b2c9964eb243e281f6ce7f14a514e409920920dcda12ae40febaae"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "27.0.4"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b21cb61c57ee198bc4aff71aeadff4cbb80b927beb912506af9c780d64313ce"
+checksum = "293080d77fdd14d6b08a67c5487dfddbf874534bb7921526db56a7b75d7e3bef"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -4678,7 +4664,6 @@ dependencies = [
  "core-graphics-types 0.2.0",
  "glow",
  "glutin_wgl_sys",
- "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
  "hashbrown 0.16.0",
@@ -4705,15 +4690,14 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
- "windows",
- "windows-core 0.58.0",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
 name = "wgpu-profiler"
 version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9f7c28673961ecb946c862b66b6ea1f9b70fca9106d31db6fbb812b7b794abf"
+source = "git+https://github.com/Wumpf/wgpu-profiler?rev=a50f97d1838117c5b48ad268ece06c50c7d94120#a50f97d1838117c5b48ad268ece06c50c7d94120"
 dependencies = [
  "parking_lot",
  "thiserror 2.0.16",
@@ -4722,15 +4706,14 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "27.0.1"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afdcf84c395990db737f2dd91628706cb31e86d72e53482320d368e52b5da5eb"
+checksum = "e18308757e594ed2cd27dddbb16a139c42a683819d32a2e0b1b0167552f5840c"
 dependencies = [
  "bitflags 2.9.4",
  "bytemuck",
  "js-sys",
  "log",
- "thiserror 2.0.16",
  "web-sys",
 ]
 
@@ -4772,6 +4755,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.62.2",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4786,15 +4790,26 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.62.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.0",
- "windows-interface 0.59.1",
- "windows-link 0.2.0",
- "windows-result 0.4.0",
- "windows-strings 0.5.0",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading",
 ]
 
 [[package]]
@@ -4810,9 +4825,9 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4832,9 +4847,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4849,9 +4864,19 @@ checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-link"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+]
 
 [[package]]
 name = "windows-result"
@@ -4864,11 +4889,11 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4883,11 +4908,11 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4932,7 +4957,7 @@ version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4981,6 +5006,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.0",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,8 +129,23 @@ vello_dev_macros = { path = "sparse_strips/vello_dev_macros" }
 
 # NOTE: The wgpu and naga versions should be kept in sync, and make sure to keep this
 # in sync with the version badge in README.md and vello/README.md
-wgpu = { version = "28.0.0", default-features = false, features = ["std", "wgsl"] }
-naga = { version = "28.0.0", default-features = false }
+wgpu_27 = { package = "wgpu", version = "27.0.1", default-features = false, features = [
+    "std",
+    "wgsl",
+] }
+naga_27 = { package = "naga", version = "27.0.0", default-features = false }
+wgpu_profiler_27 = { package = "wgpu-profiler", version = "0.25.0" }
+
+# NOTE: The wgpu and naga versions should be kept in sync, and make sure to keep this
+# in sync with the version badge in README.md and vello/README.md
+wgpu_28 = { package = "wgpu", version = "28.0.0", default-features = false, features = [
+    "std",
+    "wgsl",
+] }
+naga_28 = { package = "naga", version = "28.0.0", default-features = false }
+# https://github.com/Wumpf/wgpu-profiler/pull/103
+wgpu_profiler_28 = { package = "wgpu-profiler", git = "https://github.com/Wumpf/wgpu-profiler", rev = "a50f97d1838117c5b48ad268ece06c50c7d94120" }
+
 log = "0.4.27"
 image = { version = "0.25.6", default-features = false }
 
@@ -139,8 +154,6 @@ clap = "4.5.38"
 anyhow = "1.0.98"
 pollster = "0.4.0"
 web-time = "1.1.0"
-# https://github.com/Wumpf/wgpu-profiler/pull/103
-wgpu-profiler = { git = "https://github.com/Wumpf/wgpu-profiler", rev = "a50f97d1838117c5b48ad268ece06c50c7d94120" }
 winit = "0.30.10"
 scenes = { path = "examples/scenes" }
 svg = "0.18.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ version = "0.6.0"
 edition = "2024"
 # Keep in sync with RUST_MIN_VER in .github/workflows/ci.yml, with the relevant README.md files
 # and with the MSRV in the `Unreleased` section of CHANGELOG.md.
-rust-version = "1.88"
+rust-version = "1.92"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/linebender/vello"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,8 +129,8 @@ vello_dev_macros = { path = "sparse_strips/vello_dev_macros" }
 
 # NOTE: The wgpu and naga versions should be kept in sync, and make sure to keep this
 # in sync with the version badge in README.md and vello/README.md
-wgpu = { version = "27.0.1", default-features = false, features = ["std", "wgsl"] }
-naga = { version = "27.0.0", default-features = false }
+wgpu = { version = "28.0.0", default-features = false, features = ["std", "wgsl"] }
+naga = { version = "28.0.0", default-features = false }
 log = "0.4.27"
 image = { version = "0.25.6", default-features = false }
 
@@ -139,7 +139,8 @@ clap = "4.5.38"
 anyhow = "1.0.98"
 pollster = "0.4.0"
 web-time = "1.1.0"
-wgpu-profiler = "0.25.0"
+# https://github.com/Wumpf/wgpu-profiler/pull/103
+wgpu-profiler = { git = "https://github.com/Wumpf/wgpu-profiler", rev = "a50f97d1838117c5b48ad268ece06c50c7d94120" }
 winit = "0.30.10"
 scenes = { path = "examples/scenes" }
 svg = "0.18.0"

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 default = ["wgpu-profiler"]
 # Enable the use of wgpu-profiler. This is an optional feature for times when we use a git dependency on
 # wgpu (which means the dependency used in wgpu-profiler would be incompatible)
-wgpu-profiler = ["dep:wgpu-profiler", "vello/wgpu-profiler"]
+wgpu-profiler = ["dep:wgpu_profiler_28", "vello/wgpu-profiler"]
 # Test for dependencies which implement std traits in ways that cause type inference issues.
 _ci_dep_features_to_test = ["dep:kurbo", "kurbo/schemars"]
 
@@ -35,7 +35,7 @@ scenes = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 pollster = { workspace = true }
-wgpu-profiler = { workspace = true, optional = true }
+wgpu_profiler_28 = { workspace = true, optional = true }
 
 winit = { workspace = true }
 log = { workspace = true }

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -28,6 +28,9 @@ use winit::application::ApplicationHandler;
 use winit::event::{ElementState, MouseButton, MouseScrollDelta, TouchPhase, WindowEvent};
 use winit::keyboard::{Key, ModifiersState, NamedKey};
 
+#[cfg(feature = "wgpu-profiler")]
+use wgpu_profiler_28 as wgpu_profiler;
+
 #[cfg(all(feature = "wgpu-profiler", not(target_arch = "wasm32")))]
 use std::time::Duration;
 #[cfg(all(feature = "wgpu-profiler", target_arch = "wasm32"))]

--- a/examples/with_winit/src/stats.rs
+++ b/examples/with_winit/src/stats.rs
@@ -251,7 +251,7 @@ fn round_up(n: usize, f: usize) -> usize {
 }
 
 #[cfg(feature = "wgpu-profiler")]
-use wgpu_profiler::GpuTimerQueryResult;
+use crate::wgpu_profiler::GpuTimerQueryResult;
 
 /// Formats the given number of seconds as a Duration.
 ///

--- a/sparse_strips/vello_cpu/examples/wasm_cpu/Cargo.toml
+++ b/sparse_strips/vello_cpu/examples/wasm_cpu/Cargo.toml
@@ -36,7 +36,6 @@ web-sys = { version = "0.3.77", features = [
     "KeyboardEvent",
     "CanvasRenderingContext2d",
 ] }
-wgpu = { workspace = true, features = ["webgl"], default-features = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 parley = { version = "0.5.0", default-features = false, features = ["std"] }

--- a/sparse_strips/vello_hybrid/Cargo.toml
+++ b/sparse_strips/vello_hybrid/Cargo.toml
@@ -19,7 +19,8 @@ targets = []
 bytemuck = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 vello_common = { workspace = true, features = ["std", "text"] }
-wgpu = { workspace = true, default-features = false, optional = true }
+wgpu_28 = { workspace = true, default-features = false, optional = true }
+wgpu_27 = { workspace = true, default-features = false, optional = true }
 vello_sparse_shaders = { workspace = true, optional = true }
 log = { workspace = true }
 guillotiere = "0.6.2"
@@ -47,13 +48,23 @@ vello_common = { workspace = true, features = ["pico_svg"] }
 roxmltree = "0.20.0"
 
 [features]
-default = ["wgpu", "wgpu_default"]
-std = ["wgpu", "vello_common/std"]
-wgpu = ["dep:wgpu", "dep:vello_sparse_shaders"]
+default = ["wgpu_28", "wgpu_28_default"]
+std = ["vello_common/std"]
+
+wgpu_27 = ["wgpu", "dep:wgpu_27", "dep:vello_sparse_shaders"]
 # Enable wgpu with its default features. If you need to customise the set of enabled wgpu features,
 # please disable this crate's default features, enable its "wgpu" feature, then depend on wgpu directly
 # with the features which you need enabled.
-wgpu_default = ["wgpu", "wgpu/default"]
+wgpu_27_default = ["wgpu_27", "wgpu_27/default"]
+
+wgpu_28 = ["wgpu", "dep:wgpu_28", "dep:vello_sparse_shaders"]
+# Enable wgpu with its default features. If you need to customise the set of enabled wgpu features,
+# please disable this crate's default features, enable its "wgpu" feature, then depend on wgpu directly
+# with the features which you need enabled.
+wgpu_28_default = ["wgpu_28", "wgpu_28/default"]
+
+# Internal feature only
+wgpu = ["dep:vello_sparse_shaders"]
 webgl = ["dep:js-sys", "dep:web-sys", "dep:vello_sparse_shaders", "vello_sparse_shaders/glsl"]
 
 [lints]

--- a/sparse_strips/vello_hybrid/examples/wgpu_webgl/Cargo.toml
+++ b/sparse_strips/vello_hybrid/examples/wgpu_webgl/Cargo.toml
@@ -35,7 +35,7 @@ web-sys = { version = "0.3.77", features = [
     "WheelEvent",
     "KeyboardEvent",
 ] }
-wgpu = { workspace = true, default-features = true, features = ["webgl"] }
+wgpu_28 = { workspace = true, default-features = true, features = ["webgl"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.50"

--- a/sparse_strips/vello_hybrid/examples/winit/Cargo.toml
+++ b/sparse_strips/vello_hybrid/examples/winit/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 winit = { workspace = true }
-wgpu = { workspace = true, default-features = true }
+wgpu_28 = { workspace = true, default-features = true }
 vello_common = { workspace = true }
 vello_hybrid = { workspace = true }
 vello_example_scenes = { workspace = true }

--- a/sparse_strips/vello_hybrid/examples/winit/src/main.rs
+++ b/sparse_strips/vello_hybrid/examples/winit/src/main.rs
@@ -23,6 +23,8 @@ use winit::{
     window::{Window, WindowId},
 };
 
+use wgpu_28 as wgpu;
+
 const ZOOM_STEP: f64 = 0.1;
 
 struct App<'s> {

--- a/sparse_strips/vello_hybrid/examples/winit/src/render_context.rs
+++ b/sparse_strips/vello_hybrid/examples/winit/src/render_context.rs
@@ -8,6 +8,7 @@
 
 use std::sync::Arc;
 
+use crate::wgpu;
 use vello_hybrid::{RenderTargetConfig, Renderer};
 use wgpu::{
     Adapter, Device, Features, Instance, Limits, Queue, Surface, SurfaceConfiguration,

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -18,6 +18,11 @@
 only break in edge cases, and some of them are also only related to conversions from f64 to f32."
 )]
 
+#[cfg(feature = "wgpu_27")]
+use wgpu_27 as wgpu;
+#[cfg(feature = "wgpu_28")]
+use wgpu_28 as wgpu;
+
 use alloc::vec::Vec;
 use alloc::{sync::Arc, vec};
 use core::{fmt::Debug, mem, num::NonZeroU64};
@@ -282,7 +287,7 @@ impl Renderer {
             depth_stencil_attachment: None,
             occlusion_query_set: None,
             timestamp_writes: None,
-            // wgpu28
+            #[cfg(feature = "wgpu_28")]
             multiview_mask: None,
         });
 
@@ -654,16 +659,20 @@ impl Programs {
                     &encoded_paints_bind_group_layout,
                     &gradient_bind_group_layout,
                 ],
+                #[cfg(feature = "wgpu_27")]
+                push_constant_ranges: &[],
+                #[cfg(feature = "wgpu_28")]
                 immediate_size: 0,
-                // push_constant_ranges: &[],
             });
 
         let clear_pipeline_layout =
             device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 label: Some("Clear Slots Pipeline Layout"),
                 bind_group_layouts: &[&clear_bind_group_layout],
+                #[cfg(feature = "wgpu_27")]
+                push_constant_ranges: &[],
+                #[cfg(feature = "wgpu_28")]
                 immediate_size: 0,
-                // push_constant_ranges: &[],
             });
 
         let strip_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
@@ -695,10 +704,10 @@ impl Programs {
             },
             depth_stencil: None,
             multisample: wgpu::MultisampleState::default(),
-            // wgpu28
+            #[cfg(feature = "wgpu_27")]
+            multiview: None,
+            #[cfg(feature = "wgpu_28")]
             multiview_mask: None,
-            // wgpu27
-            // multiview: None,
             cache: None,
         });
 
@@ -736,7 +745,9 @@ impl Programs {
             },
             depth_stencil: None,
             multisample: wgpu::MultisampleState::default(),
-            // multiview: None,
+            #[cfg(feature = "wgpu_27")]
+            multiview: None,
+            #[cfg(feature = "wgpu_28")]
             multiview_mask: None,
             cache: None,
         });
@@ -746,8 +757,10 @@ impl Programs {
             device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 label: Some("Atlas Clear Pipeline Layout"),
                 bind_group_layouts: &[],
+                #[cfg(feature = "wgpu_27")]
+                push_constant_ranges: &[],
+                #[cfg(feature = "wgpu_28")]
                 immediate_size: 0,
-                // push_constant_ranges: &[],
             });
         let atlas_clear_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
             label: Some("Atlas Clear Pipeline"),
@@ -775,10 +788,10 @@ impl Programs {
             },
             depth_stencil: None,
             multisample: wgpu::MultisampleState::default(),
-            // wgpu28
+            #[cfg(feature = "wgpu_27")]
+            multiview: None,
+            #[cfg(feature = "wgpu_28")]
             multiview_mask: None,
-            // wgpu27
-            // multiview: None,
             cache: None,
         });
 
@@ -1600,7 +1613,7 @@ impl RendererContext<'_> {
             depth_stencil_attachment: None,
             occlusion_query_set: None,
             timestamp_writes: None,
-            // wgpu28
+            #[cfg(feature = "wgpu_28")]
             multiview_mask: None,
         });
         render_pass.set_pipeline(&self.programs.strip_pipeline);
@@ -1651,7 +1664,7 @@ impl RendererContext<'_> {
                 depth_stencil_attachment: None,
                 occlusion_query_set: None,
                 timestamp_writes: None,
-                // wgpu28
+                #[cfg(feature = "wgpu_28")]
                 multiview_mask: None,
             });
 

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -282,6 +282,8 @@ impl Renderer {
             depth_stencil_attachment: None,
             occlusion_query_set: None,
             timestamp_writes: None,
+            // wgpu28
+            multiview_mask: None,
         });
 
         // Set scissor rectangle to limit clearing to specific region
@@ -652,14 +654,16 @@ impl Programs {
                     &encoded_paints_bind_group_layout,
                     &gradient_bind_group_layout,
                 ],
-                push_constant_ranges: &[],
+                immediate_size: 0,
+                // push_constant_ranges: &[],
             });
 
         let clear_pipeline_layout =
             device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 label: Some("Clear Slots Pipeline Layout"),
                 bind_group_layouts: &[&clear_bind_group_layout],
-                push_constant_ranges: &[],
+                immediate_size: 0,
+                // push_constant_ranges: &[],
             });
 
         let strip_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
@@ -691,7 +695,10 @@ impl Programs {
             },
             depth_stencil: None,
             multisample: wgpu::MultisampleState::default(),
-            multiview: None,
+            // wgpu28
+            multiview_mask: None,
+            // wgpu27
+            // multiview: None,
             cache: None,
         });
 
@@ -729,7 +736,8 @@ impl Programs {
             },
             depth_stencil: None,
             multisample: wgpu::MultisampleState::default(),
-            multiview: None,
+            // multiview: None,
+            multiview_mask: None,
             cache: None,
         });
 
@@ -738,7 +746,8 @@ impl Programs {
             device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 label: Some("Atlas Clear Pipeline Layout"),
                 bind_group_layouts: &[],
-                push_constant_ranges: &[],
+                immediate_size: 0,
+                // push_constant_ranges: &[],
             });
         let atlas_clear_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
             label: Some("Atlas Clear Pipeline"),
@@ -766,7 +775,10 @@ impl Programs {
             },
             depth_stencil: None,
             multisample: wgpu::MultisampleState::default(),
-            multiview: None,
+            // wgpu28
+            multiview_mask: None,
+            // wgpu27
+            // multiview: None,
             cache: None,
         });
 
@@ -1588,6 +1600,8 @@ impl RendererContext<'_> {
             depth_stencil_attachment: None,
             occlusion_query_set: None,
             timestamp_writes: None,
+            // wgpu28
+            multiview_mask: None,
         });
         render_pass.set_pipeline(&self.programs.strip_pipeline);
         render_pass.set_bind_group(0, &self.programs.resources.slot_bind_groups[ix], &[]);
@@ -1637,6 +1651,8 @@ impl RendererContext<'_> {
                 depth_stencil_attachment: None,
                 occlusion_query_set: None,
                 timestamp_writes: None,
+                // wgpu28
+                multiview_mask: None,
             });
 
             render_pass.set_pipeline(&self.programs.clear_pipeline);

--- a/sparse_strips/vello_sparse_shaders/Cargo.toml
+++ b/sparse_strips/vello_sparse_shaders/Cargo.toml
@@ -17,13 +17,13 @@ default-target = "x86_64-unknown-linux-gnu"
 targets = []
 
 [dependencies]
-naga = { workspace = true, features = ["wgsl-in", "glsl-out"], optional = true }
+naga_28 = { workspace = true, features = ["wgsl-in", "glsl-out"], optional = true }
 
 [build-dependencies]
-naga = { workspace = true, features = ["wgsl-in", "glsl-out"], optional = true }
+naga_28 = { workspace = true, features = ["wgsl-in", "glsl-out"], optional = true }
 
 [features]
-glsl = ["dep:naga"]
+glsl = ["dep:naga_28"]
 
 [lints]
 workspace = true

--- a/sparse_strips/vello_sparse_shaders/build.rs
+++ b/sparse_strips/vello_sparse_shaders/build.rs
@@ -8,6 +8,9 @@ use std::fmt::Write;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+#[cfg(feature = "glsl")]
+use naga_28 as naga;
+
 #[allow(warnings)]
 #[cfg(feature = "glsl")]
 #[path = "src/compile.rs"]

--- a/sparse_strips/vello_sparse_shaders/src/compile.rs
+++ b/sparse_strips/vello_sparse_shaders/src/compile.rs
@@ -1,6 +1,7 @@
 // Copyright 2025 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use crate::naga;
 use naga::{
     ShaderStage,
     back::glsl::{self, PipelineOptions, Version},

--- a/sparse_strips/vello_sparse_shaders/src/lib.rs
+++ b/sparse_strips/vello_sparse_shaders/src/lib.rs
@@ -8,4 +8,7 @@ mod compile;
 #[cfg(feature = "glsl")]
 mod types;
 
+#[cfg(feature = "glsl")]
+use naga_28 as naga;
+
 include!(concat!(env!("OUT_DIR"), "/compiled_shaders.rs"));

--- a/sparse_strips/vello_sparse_shaders/src/types.rs
+++ b/sparse_strips/vello_sparse_shaders/src/types.rs
@@ -26,7 +26,8 @@ impl ReflectionMap {
     /// Create a new `ReflectionMap` given the [`naga`] compile info.
     pub(crate) fn new(info: ReflectionInfo, global_vars: &Arena<GlobalVariable>) -> Self {
         debug_assert_eq!(info.varying.len(), 0, "unimplemented");
-        debug_assert_eq!(info.push_constant_items.len(), 0, "unimplemented");
+        // debug_assert_eq!(info.push_constant_items.len(), 0, "unimplemented");
+        debug_assert_eq!(info.immediates_items.len(), 0, "unimplemented");
         let mut texture_mapping = BTreeMap::default();
         let mut uniforms = BTreeMap::default();
 

--- a/sparse_strips/vello_sparse_shaders/src/types.rs
+++ b/sparse_strips/vello_sparse_shaders/src/types.rs
@@ -8,6 +8,7 @@
     reason = "False positives as this module is used at build time."
 )]
 
+use crate::naga;
 use naga::{Arena, GlobalVariable, back::glsl::ReflectionInfo};
 use std::collections::BTreeMap;
 

--- a/sparse_strips/vello_sparse_tests/Cargo.toml
+++ b/sparse_strips/vello_sparse_tests/Cargo.toml
@@ -19,7 +19,7 @@ vello_api = { workspace = true }
 vello_common = { workspace = true, features = ["std"] }
 vello_cpu = { workspace = true, features = ["multithreading", "std", "f32_pipeline"] }
 vello_hybrid = { workspace = true }
-wgpu = { workspace = true, default-features = true }
+wgpu_28 = { workspace = true, default-features = true }
 pollster = { workspace = true }
 vello_dev_macros = { workspace = true }
 bytemuck = { workspace = true }

--- a/vello/Cargo.toml
+++ b/vello/Cargo.toml
@@ -16,30 +16,41 @@ default-target = "x86_64-unknown-linux-gnu"
 targets = []
 
 [features]
-default = ["wgpu", "wgpu_default"]
+default = ["wgpu_28", "wgpu_28_default"]
 # Enables GPU memory usage estimation. This performs additional computations
 # in order to estimate the minimum required allocations for buffers backing
 # bump-allocated GPU memory.
 # TODO: Turn this into a runtime option used at resolve time and remove the feature.
 bump_estimate = ["vello_encoding/bump_estimate"]
-wgpu = ["dep:wgpu", "dep:vello_shaders", "dep:futures-intrusive"]
-# Enable wgpu with its default features. If you need to customise the set of enabled wgpu features,
+
+wgpu_27 = ["wgpu", "dep:wgpu_27"]
+# Enable wgpu 27 with its default features. If you need to customise the set of enabled wgpu features,
 # please disable this crate's default features, enable its "wgpu" feature, then depend on wgpu directly
 # with the features which you need enabled.
-wgpu_default = ["wgpu", "wgpu/default"]
+wgpu_27_default = ["wgpu_27", "wgpu_27/default"]
+
+
+wgpu_28 = ["wgpu", "dep:wgpu_28"]
+# Enable wgpu 28 with its default features. If you need to customise the set of enabled wgpu features,
+# please disable this crate's default features, enable its "wgpu" feature, then depend on wgpu directly
+# with the features which you need enabled.
+wgpu_28_default = ["wgpu_28", "wgpu_28/default"]
+# This is an internal feature not intended for public use. Please depend on a specific WGPU version (wgpu_27, etc)
+wgpu = ["dep:vello_shaders", "dep:futures-intrusive"]
+
 
 # Development only features
 
 # Enables debug features when using the "async" pipeline.
 # This is only intended for development of Vello itself.
 debug_layers = []
-# Enables an embedded wgpu-profiler profiler.
-# This is only intended for development of Vello itself.
-wgpu-profiler = ["dep:wgpu-profiler"]
 # Enables hot reloading of Vello shaders.
 # This is only intended for development of Vello itself.
 # In practise, this won't compile outside of the Vello repository.
 hot_reload = ["vello_shaders/compile"]
+# Enables an embedded wgpu-profiler profiler.
+# This is only intended for development of Vello itself.
+wgpu-profiler = ["dep:wgpu_profiler_28"]
 
 [lints]
 workspace = true
@@ -50,11 +61,15 @@ vello_shaders = { workspace = true, optional = true }
 bytemuck = { workspace = true }
 skrifa = { workspace = true, features = ["std"] }
 peniko = { workspace = true, default-features = true }
-wgpu = { workspace = true, default-features = false, optional = true }
 log = { workspace = true }
 static_assertions = { workspace = true }
 futures-intrusive = { workspace = true, optional = true }
-wgpu-profiler = { workspace = true, optional = true }
 thiserror = { workspace = true }
 # TODO: Add feature for built-in bitmap emoji support?
 png = { workspace = true }
+
+# WGPU dependencies
+wgpu_27 = { workspace = true, default-features = false, optional = true }
+wgpu_profiler_27 = { workspace = true, optional = true }
+wgpu_28 = { workspace = true, default-features = false, optional = true }
+wgpu_profiler_28 = { workspace = true, optional = true }

--- a/vello/src/debug/renderer.rs
+++ b/vello/src/debug/renderer.rs
@@ -7,6 +7,7 @@ use crate::{
     debug::validate::{LineEndpoint, validate_line_soup},
     recording::{BindType, DrawParams, ImageProxy, Recording, ResourceProxy, ShaderId},
     render::CapturedBuffers,
+    wgpu,
     wgpu_engine::WgpuEngine,
 };
 

--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -113,6 +113,13 @@ mod render;
 mod scene;
 mod shaders;
 
+#[cfg(feature = "wgpu_27")]
+pub use wgpu_27 as wgpu;
+#[cfg(feature = "wgpu_28")]
+pub use wgpu_28 as wgpu;
+#[cfg(all(feature = "wgpu_28", feature = "wgpu-profiler"))]
+use wgpu_profiler_28::{self as wgpu_profiler, GpuProfiler, GpuProfilerSettings};
+
 #[cfg(feature = "wgpu")]
 pub mod util;
 #[cfg(feature = "wgpu")]
@@ -140,8 +147,6 @@ pub use peniko::kurbo;
 
 #[cfg(feature = "wgpu")]
 use peniko::ImageData;
-#[cfg(feature = "wgpu")]
-pub use wgpu;
 
 pub use scene::{DrawGlyphs, Scene};
 pub use vello_encoding::{Glyph, NormalizedCoord};
@@ -162,8 +167,6 @@ use wgpu_engine::{ExternalResource, WgpuEngine};
 use std::{num::NonZeroUsize, sync::atomic::AtomicBool};
 #[cfg(feature = "wgpu")]
 use wgpu::{Device, Queue, TextureView};
-#[cfg(all(feature = "wgpu", feature = "wgpu-profiler"))]
-use wgpu_profiler::{GpuProfiler, GpuProfilerSettings};
 
 /// Represents the anti-aliasing method to use during a render pass.
 ///

--- a/vello/src/recording.rs
+++ b/vello/src/recording.rs
@@ -6,6 +6,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use peniko::ImageData;
 
+#[cfg(feature = "wgpu")]
+use crate::wgpu;
+
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct ShaderId(pub usize);
 

--- a/vello/src/shaders.rs
+++ b/vello/src/shaders.rs
@@ -4,7 +4,7 @@
 //! Load rendering shaders.
 
 #[cfg(feature = "wgpu")]
-use wgpu::Device;
+use crate::wgpu::Device;
 
 use crate::ShaderId;
 

--- a/vello/src/util.rs
+++ b/vello/src/util.rs
@@ -5,10 +5,14 @@
 
 use std::future::Future;
 
+use crate::wgpu;
 use wgpu::{
     Adapter, Device, Instance, Limits, Queue, Surface, SurfaceConfiguration, SurfaceTarget,
     Texture, TextureFormat, TextureView, util::TextureBlitter,
 };
+
+#[cfg(feature = "wgpu-profiler")]
+use crate::wgpu_profiler;
 
 use crate::{Error, Result};
 

--- a/vello/src/wgpu_engine.rs
+++ b/vello/src/wgpu_engine.rs
@@ -6,11 +6,15 @@ use std::cell::RefCell;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 
+use crate::wgpu;
 use wgpu::{
     BindGroup, BindGroupLayout, Buffer, BufferUsages, CommandEncoder, CommandEncoderDescriptor,
     ComputePassDescriptor, ComputePipeline, Device, PipelineCache, PipelineCompilationOptions,
     Queue, Texture, TextureAspect, TextureUsages, TextureView, TextureViewDimension,
 };
+
+#[cfg(feature = "wgpu-profiler")]
+use crate::wgpu_profiler;
 
 use crate::{
     Error, Result,
@@ -863,8 +867,10 @@ impl WgpuEngine {
             device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 label: None,
                 bind_group_layouts: &[&bind_group_layout],
+                #[cfg(feature = "wgpu_27")]
+                push_constant_ranges: &[],
+                #[cfg(feature = "wgpu_28")]
                 immediate_size: 0,
-                // push_constant_ranges: &[],
             });
         let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
             label: Some(label),

--- a/vello/src/wgpu_engine.rs
+++ b/vello/src/wgpu_engine.rs
@@ -334,7 +334,8 @@ impl WgpuEngine {
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: None,
             bind_group_layouts: &[&bind_group_layout],
-            push_constant_ranges: &[],
+            immediate_size: 0,
+            // push_constant_ranges: &[],
         });
         let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
             label: Some(label),
@@ -362,7 +363,8 @@ impl WgpuEngine {
             },
             depth_stencil: None,
             multisample: wgpu::MultisampleState::default(),
-            multiview: None,
+            // multiview: None,
+            multiview_mask: None,
             cache: self.pipeline_cache.as_ref(),
         });
         let id = self.shaders.len();
@@ -691,6 +693,8 @@ impl WgpuEngine {
                         depth_stencil_attachment: None,
                         occlusion_query_set: None,
                         timestamp_writes: None,
+                        // wgpu28
+                        multiview_mask: None,
                     });
                     #[cfg(feature = "wgpu-profiler")]
                     let query = profiler
@@ -859,7 +863,8 @@ impl WgpuEngine {
             device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 label: None,
                 bind_group_layouts: &[&bind_group_layout],
-                push_constant_ranges: &[],
+                immediate_size: 0,
+                // push_constant_ranges: &[],
             });
         let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
             label: Some(label),

--- a/vello_shaders/Cargo.toml
+++ b/vello_shaders/Cargo.toml
@@ -17,11 +17,11 @@ targets = []
 
 [features]
 default = ["wgsl", "cpu"]
-compile = ["dep:naga", "dep:thiserror", "dep:log"]
+compile = ["dep:naga_28", "dep:thiserror", "dep:log"]
 
 # Target shading language variants of the vello shaders to link into the library.
 wgsl = []
-msl = ["naga?/msl-out"]
+msl = ["naga_27?/msl-out", "naga_28?/msl-out"]
 
 # Enable the CPU versions of the shaders
 cpu = ["dep:bytemuck", "dep:vello_encoding"]
@@ -31,12 +31,14 @@ workspace = true
 
 [dependencies]
 bytemuck = { workspace = true, optional = true }
-naga = { workspace = true, features = ["wgsl-in"], optional = true }
+naga_27 = { workspace = true, features = ["wgsl-in"], optional = true }
+naga_28 = { workspace = true, features = ["wgsl-in"], optional = true }
 thiserror = { workspace = true, optional = true }
 vello_encoding = { workspace = true, optional = true }
 log = { workspace = true, optional = true }
 
 [build-dependencies]
-naga = { workspace = true, features = ["wgsl-in"] }
+naga_27 = { workspace = true, features = ["wgsl-in"] }
+naga_28 = { workspace = true, features = ["wgsl-in"] }
 thiserror = { workspace = true }
 log = { workspace = true }

--- a/vello_shaders/src/compile/mod.rs
+++ b/vello_shaders/src/compile/mod.rs
@@ -1,6 +1,8 @@
 // Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use naga_28 as naga;
+
 use naga::front::wgsl;
 use naga::valid::{Capabilities, ModuleInfo, ValidationError, ValidationFlags};
 use naga::{AddressSpace, ArraySize, ImageClass, Module, StorageAccess, WithSpan};

--- a/vello_shaders/src/compile/msl.rs
+++ b/vello_shaders/src/compile/msl.rs
@@ -1,9 +1,9 @@
 // Copyright 2023 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use super::naga::back::msl as naga_msl;
 use super::{BindType, ShaderInfo};
 use crate::types::msl::BindingIndex;
-use naga::back::msl as naga_msl;
 
 pub fn translate(shader: &ShaderInfo) -> Result<String, naga_msl::Error> {
     let mut map = naga_msl::EntryPointResourceMap::default();


### PR DESCRIPTION
# Objective

Allow the same version of Vello to compile with multiple versions of WGPU (current v27 and v28):

- This should make it easier to upgrade to new versions of WGPU promptly without worrying about leaving users who may still need an older WGPU version behind.
- In many cases, it may also make upgrading WGPU a non-breaking change.

## Prior Art

The `i-slint-core` crate has similar feature flags for WGPU versions (https://docs.rs/crate/i-slint-core/latest/features)

## Changes made

- Replace the `wgpu` and `naga` feature flags in the `vello`, `vello_hybrid`, `vello_shaders` and `vello_sparse_shaders` crates with `wgpu_27`, `wgpu_28` (and `naga_27`, `naga_28`) feature flags.
- Re-export e.g. `wgpu_28 as wgpu` in the crate roots
- The `wgpu-profiler` and `hot-reload` debug features are currently configured to only work with the latest WGPU version.

## Todo

- [ ] Use crates.io version of `wgpu-profiler` once https://github.com/Wumpf/wgpu-profiler/pull/103 lands