### PR TITLE
vello classic: fix comment about tile inclusion in `coarse` shader

### DIFF
--- a/vello_shaders/shader/coarse.wgsl
+++ b/vello_shaders/shader/coarse.wgsl
@@ -332,9 +332,12 @@ fn main(
             let even_odd = (draw_flags & DRAW_INFO_FLAGS_FILL_RULE_BIT) != 0u;
             let n_segs = tile.segment_count_or_ix;
 
-            // If this draw object represents an even-odd fill and we know that no line segment
-            // crosses this tile and then this draw object should not contribute to the tile if its
-            // backdrop (i.e. the winding number of its top-left corner) is even.
+            // If no line segment crosses this tile and the backdrop (i.e. the winding number of
+            // its top-left corner) and fill rule are such that the tile is completely uncovered,
+            // and we're not blending, then the tile is completely clear. This draw object should
+            // then not contribute to the tile, unless it is a clip. If the draw object is a clip,
+            // the "clear" logic is inversed: the draw object doesn't contribute only when the
+            // tile is completely covered.
             let backdrop_clear = select(tile.backdrop, abs(tile.backdrop) & 1, even_odd) == 0;
             let include_tile = n_segs != 0u || (backdrop_clear == is_clip) || is_blend;
             if include_tile {

--- a/vello_shaders/src/cpu/coarse.rs
+++ b/vello_shaders/src/cpu/coarse.rs
@@ -272,9 +272,12 @@ fn coarse_main(
                     let even_odd = (draw_flags & DRAW_INFO_FLAGS_FILL_RULE_BIT) != 0;
                     let n_segs = tile.segment_count_or_ix;
 
-                    // If this draw object represents an even-odd fill and we know that no line segment
-                    // crosses this tile and then this draw object should not contribute to the tile if its
-                    // backdrop (i.e. the winding number of its top-left corner) is even.
+                    // If no line segment crosses this tile and the backdrop (i.e. the winding number of
+                    // its top-left corner) and fill rule are such that the tile is completely uncovered,
+                    // and we're not blending, then the tile is completely clear. This draw object should
+                    // then not contribute to the tile, unless it is a clip. If the draw object is a clip,
+                    // the "clear" logic is inversed: the draw object doesn't contribute only when the
+                    // tile is completely covered.
                     let backdrop_clear = if even_odd {
                         tile.backdrop.abs() & 1
                     } else {


### PR DESCRIPTION
The comment was introduced in https://github.com/linebender/vello/pull/399, but as written I believe that while it's correct for the state in 7a849140d1cd1c86ed8a4b79cbb15a5216b9e31a, it's no longer correct for the state in 4d24ce382fa102dd324b658ebfbbb87aae3bfd83 (after this suggestion was applied: https://github.com/linebender/vello/pull/399#discussion_r1378024036).