### PR TITLE
perf(vello_common): use SIMD dispatch in flattening codegen

### DIFF
--- a/sparse_strips/vello_common/src/flatten.rs
+++ b/sparse_strips/vello_common/src/flatten.rs
@@ -86,6 +86,7 @@ pub fn fill(
 }
 
 /// Flatten a filled bezier path into line segments.
+#[inline(always)]
 pub fn fill_impl<S: Simd>(
     simd: S,
     path: impl IntoIterator<Item = PathEl>,
@@ -94,7 +95,10 @@ pub fn fill_impl<S: Simd>(
     flatten_ctx: &mut FlattenCtx,
 ) {
     line_buf.clear();
-    let iter = path.into_iter().map(|el| affine * el);
+    let iter = path.into_iter().map(
+        #[inline(always)]
+        |el| affine * el,
+    );
 
     let mut lb = FlattenerCallback {
         line_buf,

--- a/sparse_strips/vello_common/src/flatten_simd.rs
+++ b/sparse_strips/vello_common/src/flatten_simd.rs
@@ -25,6 +25,7 @@ pub(crate) trait Callback {
 /// <https://docs.rs/kurbo/latest/kurbo/fn.flatten.html>
 ///
 /// This version works using a similar approach but using f32x4/f32x8 SIMD instead.
+#[inline(always)]
 pub(crate) fn flatten<S: Simd>(
     simd: S,
     path: impl IntoIterator<Item = PathEl>,
@@ -111,17 +112,12 @@ pub(crate) fn flatten<S: Simd>(
                         callback.callback(PathEl::LineTo(p3));
                     } else {
                         let c = CubicBez::new(p0, p1, p2, p3);
-                        let max = simd.vectorize(
-                            #[inline(always)]
-                            || {
-                                flatten_cubic_simd(
-                                    simd,
-                                    c,
-                                    flatten_ctx,
-                                    tolerance as f32,
-                                    &mut flattened_cubics,
-                                )
-                            },
+                        let max = flatten_cubic_simd(
+                            simd,
+                            c,
+                            flatten_ctx,
+                            tolerance as f32,
+                            &mut flattened_cubics,
                         );
 
                         for p in &flattened_cubics[1..max] {
@@ -156,6 +152,7 @@ fn approx_parabola_inv_integral(x: f64) -> f64 {
 }
 
 impl FlattenParamsExt for QuadBez {
+    #[inline(always)]
     fn estimate_subdiv(&self, sqrt_tol: f64) -> FlattenParams {
         // Determine transformation to $y = x^2$ parabola.
         let d01 = self.p1 - self.p0;
@@ -194,6 +191,7 @@ impl FlattenParamsExt for QuadBez {
         }
     }
 
+    #[inline(always)]
     fn determine_subdiv_t(&self, params: &FlattenParams, x: f64) -> f64 {
         let a = params.a0 + (params.a2 - params.a0) * x;
         let u = approx_parabola_inv_integral(a);


### PR DESCRIPTION
This is a ~10% reduction in flattening time on x86, I haven't measured AArch64.

Flattening was already dispatched to have access to the SIMD witness, but it did not yet unambiguously make use of target features for codegen as the functions weren't forced to be inlined.

```
flatten/Ghostscript_Tiger
                        time:   [208.76 µs 209.06 µs 209.42 µs]
                        change: [-12.177% -11.979% -11.768%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe
flatten/paris-30k       time:   [13.157 ms 13.202 ms 13.253 ms]
                        change: [-10.728% -10.307% -9.8772%] (p = 0.00 < 0.05)
                        Performance has improved.
```