### PR TITLE
Reset layer_cmd_ranges

### DIFF
--- a/sparse_strips/vello_common/src/coarse.rs
+++ b/sparse_strips/vello_common/src/coarse.rs
@@ -325,6 +325,9 @@ impl<const MODE: u8> Wide<MODE> {
             tile.bg = PremulColor::from_alpha_color(TRANSPARENT);
             tile.cmds.clear();
             tile.layer_ids.truncate(1);
+            tile.layer_cmd_ranges.clear();
+            tile.layer_cmd_ranges
+                .insert(0, LayerCommandRanges::default());
         }
         self.attrs.clear();
         self.layer_stack.clear();


### PR DESCRIPTION
I noticed this wasn't reset on tile reset. I'm not sure whether that's intentional.