### PR TITLE
Release version 0.0.5 for sparse strips

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3944,7 +3944,7 @@ dependencies = [
 
 [[package]]
 name = "vello_common"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "bytemuck",
  "fearless_simd",
@@ -3960,7 +3960,7 @@ dependencies = [
 
 [[package]]
 name = "vello_cpu"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "bytemuck",
  "crossbeam-channel",
@@ -4024,7 +4024,7 @@ version = "0.6.0"
 
 [[package]]
 name = "vello_hybrid"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "bytemuck",
  "guillotiere",
@@ -4066,7 +4066,7 @@ dependencies = [
 
 [[package]]
 name = "vello_sparse_shaders"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "naga",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,10 +120,10 @@ fearless_simd = { version = "0.3.0", default-features = false }
 
 # The below crates are experimental!
 vello_api = { path = "sparse_strips/vello_api", default-features = false }
-vello_common = { version = "0.0.4", path = "sparse_strips/vello_common", default-features = false }
-vello_cpu = { path = "sparse_strips/vello_cpu" }
-vello_hybrid = { path = "sparse_strips/vello_hybrid" }
-vello_sparse_shaders = { version = "0.0.4", path = "sparse_strips/vello_sparse_shaders" }
+vello_common = { version = "0.0.5", path = "sparse_strips/vello_common", default-features = false }
+vello_cpu = { version = "0.0.5", path = "sparse_strips/vello_cpu" }
+vello_hybrid = { version = "0.0.5", path = "sparse_strips/vello_hybrid" }
+vello_sparse_shaders = { version = "0.0.5", path = "sparse_strips/vello_sparse_shaders" }
 vello_example_scenes = { path = "sparse_strips/vello_example_scenes" }
 vello_dev_macros = { path = "sparse_strips/vello_dev_macros" }
 

--- a/sparse_strips/vello_common/CHANGELOG.md
+++ b/sparse_strips/vello_common/CHANGELOG.md
@@ -8,10 +8,14 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 # Changelog
 
-The latest published vello_common release is [0.0.4](#004---2025-10-17) which was released on 2025-10-17.
-You can find its changes [documented below](#004---2025-10-17).
+The latest published vello_common release is [0.0.5](#005---2026-01-08) which was released on 2026-01-08.
+You can find its changes [documented below](#005---2026-01-08).
 
 ## [Unreleased]
+
+This release has an [MSRV][] of 1.88.
+
+## [0.0.5][] - 2026-01-08
 
 This release has an [MSRV][] of 1.88.
 
@@ -95,7 +99,8 @@ See also the [vello_cpu 0.0.1](../vello_cpu/CHANGELOG.md#001---2025-05-10) relea
 [#1203]: https://github.com/linebender/vello/pull/1203
 [#1159]: https://github.com/linebender/vello/pull/1159
 
-[Unreleased]: https://github.com/linebender/fearless_simd/compare/sparse-strips-v0.0.4...HEAD
+[Unreleased]: https://github.com/linebender/fearless_simd/compare/sparse-strips-v0.0.5...HEAD
+[0.0.5]: https://github.com/linebender/vello/compare/sparse-stips-v0.0.4...sparse-strips-v0.0.5
 [0.0.4]: https://github.com/linebender/vello/compare/sparse-stips-v0.0.3...sparse-strips-v0.0.4
 [0.0.3]: https://github.com/linebender/vello/compare/sparse-stips-v0.0.2...sparse-strips-v0.0.3
 [0.0.2]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.1...sparse-stips-v0.0.2

--- a/sparse_strips/vello_common/Cargo.toml
+++ b/sparse_strips/vello_common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vello_common"
 # When updating, also update the version in the workspace dependency in the root Cargo.toml
-version = "0.0.4"
+version = "0.0.5"
 description = "Core data structures and utilities shared across the Vello rendering, including geometry processing and tiling logic."
 categories = ["rendering", "graphics"]
 keywords = ["2d", "vector-graphics"]

--- a/sparse_strips/vello_cpu/CHANGELOG.md
+++ b/sparse_strips/vello_cpu/CHANGELOG.md
@@ -8,10 +8,14 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 # Changelog
 
-The latest published vello_cpu release is [0.0.4](#004---2025-10-17) which was released on 2025-10-17.
-You can find its changes [documented below](#004---2025-10-17).
+The latest published vello_cpu release is [0.0.5](#005---2026-01-08) which was released on 2026-01-08.
+You can find its changes [documented below](#005---2026-01-08).
 
 ## [Unreleased]
+
+This release has an [MSRV][] of 1.88.
+
+## [0.0.5][] - 2026-01-08
 
 This release has an [MSRV][] of 1.88.
 
@@ -86,7 +90,8 @@ See also the [vello_common 0.0.1](../vello_common/CHANGELOG.md#001---2025-05-10)
 [#1294]: https://github.com/linebender/vello/pull/1294
 [#1327]: https://github.com/linebender/vello/pull/1327
 
-[Unreleased]: https://github.com/linebender/fearless_simd/compare/sparse-strips-v0.0.4...HEAD
+[Unreleased]: https://github.com/linebender/fearless_simd/compare/sparse-strips-v0.0.5...HEAD
+[0.0.5]: https://github.com/linebender/vello/compare/sparse-stips-v0.0.4...sparse-strips-v0.0.5
 [0.0.4]: https://github.com/linebender/vello/compare/sparse-stips-v0.0.3...sparse-strips-v0.0.4
 [0.0.3]: https://github.com/linebender/vello/compare/sparse-stips-v0.0.2...sparse-strips-v0.0.3
 [0.0.2]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.1...sparse-stips-v0.0.2

--- a/sparse_strips/vello_cpu/Cargo.toml
+++ b/sparse_strips/vello_cpu/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vello_cpu"
 # When moving past 0.0.x, also update caveats in the README
-version = "0.0.4"
+version = "0.0.5"
 description = "A CPU-based renderer for Vello, optimized for SIMD and multithreaded execution."
 categories = ["rendering", "graphics"]
 keywords = ["2d", "vector-graphics"]

--- a/sparse_strips/vello_hybrid/CHANGELOG.md
+++ b/sparse_strips/vello_hybrid/CHANGELOG.md
@@ -8,10 +8,14 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 # Changelog
 
-The latest published vello_hybrid release is [0.0.4](#004---2025-10-17) which was released on 2025-10-17.
-You can find its changes [documented below](#004---2025-10-17).
+The latest published vello_hybrid release is [0.0.5](#005---2026-01-08) which was released on 2026-01-08.
+You can find its changes [documented below](#005---2026-01-08).
 
 ## [Unreleased]
+
+This release has an [MSRV][] of 1.88.
+
+## [0.0.5][] - 2026-01-08
 
 This release has an [MSRV][] of 1.88.
 
@@ -31,7 +35,8 @@ See also the [vello_cpu 0.0.4](../vello_cpu/CHANGELOG.md#004---2025-10-17) and [
 
 [#1203]: https://github.com/linebender/vello/pull/1203
 
-[Unreleased]: https://github.com/linebender/fearless_simd/compare/sparse-strips-v0.0.4...HEAD
+[Unreleased]: https://github.com/linebender/fearless_simd/compare/sparse-strips-v0.0.5...HEAD
+[0.0.5]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.4...sparse-strips-v0.0.5
 [0.0.4]: https://github.com/linebender/vello/compare/ca6b1e4c7f5b0d95953c3b524f5d3952d5669c5a...sparse-strips-v0.0.4
 
 [MSRV]: README.md#minimum-supported-rust-version-msrv

--- a/sparse_strips/vello_hybrid/Cargo.toml
+++ b/sparse_strips/vello_hybrid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vello_hybrid"
-version = "0.0.4"
+version = "0.0.5"
 description = "A hybrid CPU/GPU renderer for Vello, balancing computation between CPU and GPU for efficiency."
 categories = ["rendering", "graphics"]
 keywords = ["2d", "vector-graphics"]

--- a/sparse_strips/vello_sparse_shaders/Cargo.toml
+++ b/sparse_strips/vello_sparse_shaders/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vello_sparse_shaders"
 # When updating, also update the version in the workspace dependency in the root Cargo.toml
-version = "0.0.4"
+version = "0.0.5"
 description = "Provide compilation of wgsl to glsl to support the WebGL `vello_hybrid` backend."
 categories = ["rendering", "graphics"]
 keywords = ["2d", "vector-graphics"]


### PR DESCRIPTION
Verified that it publishes with `--dry-run`.