### PR TITLE
Clean up formatting in sparse strips changelogs

### DIFF
--- a/sparse_strips/vello_common/CHANGELOG.md
+++ b/sparse_strips/vello_common/CHANGELOG.md
@@ -20,31 +20,29 @@ This release has an [MSRV][] of 1.88.
 This release has an [MSRV][] of 1.88.
 
 ### Added
-- A new module `clip` has been added allowing for the possibility
-  to intersect two strips to create a new strip representing their
-  intersection ([#1203][] by [@LaurenzV])
-- An `extend` method has been added to `StripStorage` to extends
-  its alphas/strips from another `StripStorage` ([#1203][] by [@LaurenzV])
-- Added a `from_parts` method for masks ([#1237][] by [@LaurenzV])
-- Add initial support for image filters ([#1286][] by [@grebmeg])
+
+- A new module `clip` has been added allowing for the possibility to intersect two strips to create a new strip representing their intersection. ([#1203][] by [@LaurenzV])
+- An `extend` method has been added to `StripStorage` to extends its alphas/strips from another `StripStorage`. ([#1203][] by [@LaurenzV])
+- Added a `from_parts` method for masks. ([#1237][] by [@LaurenzV])
+- Add initial support for image filters. ([#1286][] by [@grebmeg])
 
 ### Changed
-- `WideTile::generate` now takes an additional `BlendMode` as a parameter ([#1159][] by [@LaurenzV])
-- `CmdFill` and `CmdAlphaFill` now store a `BlendMode` instead of `Option<BlendMode>` ([#1159][] by [@LaurenzV])
-- `Strip` now implements `PartialEq` and `Eq` ([#1203][] by [@LaurenzV])
-- `Strip` now has a `is_sentinel` method ([#1203][] by [@LaurenzV])
-- `StripStorage` now implements `PartialEq` and `Eq` ([#1203][] by [@LaurenzV])
-- The `generate_filled_path` method of `StripGenerator` now takes
-  an optional clip path as input ([#1203][] by [@LaurenzV])
-- A new trait for approximate integer division by 255 has been added ([#1203][] by [@LaurenzV])
-- The `generate` method of `Wide` now takes an optional mask as an
-  additional argument ([#1237][] by [@LaurenzV])
-- `CmdFill` and `CmdAlphaFill` now store an optional mask ([#1237][] by [@LaurenzV])
-- Performance improvements for gradient rendering ([#1301][] by [@valadaptive])
-- Various changes to the logic for computing tile intersections and 
-  representation of tiles ([#1293][], [#1317][], [#1318][] by [@b0nes164])
-- Support for computing data necessary to implement multi-sampled anti-aliasing ([#1319][], by [@b0nes164])
-- Numerous performance and memory-efficiency improvements ([#1325][] by [@LaurenzV], [#1327][] by [@grebmeg], [#1336][] by [@tomcur], [#1338][] by [@taj-p])
+
+- `WideTile::generate` now takes an additional `BlendMode` as a parameter. ([#1159][] by [@LaurenzV])
+- `CmdFill` and `CmdAlphaFill` now store a `BlendMode` instead of `Option<BlendMode>`. ([#1159][] by [@LaurenzV])
+- `Strip` now implements `PartialEq` and `Eq`. ([#1203][] by [@LaurenzV])
+- `Strip` now has a `is_sentinel` method. ([#1203][] by [@LaurenzV])
+- `StripStorage` now implements `PartialEq` and `Eq`. ([#1203][] by [@LaurenzV])
+- The `generate_filled_path` method of `StripGenerator` now takes an optional clip path as input. ([#1203][] by [@LaurenzV])
+- A new trait for approximate integer division by 255 has been added. ([#1203][] by [@LaurenzV])
+- The `generate` method of `Wide` now takes an optional mask as an additional argument. ([#1237][] by [@LaurenzV])
+- `CmdFill` and `CmdAlphaFill` now store an optional mask. ([#1237][] by [@LaurenzV])
+- Performance improvements for gradient rendering. ([#1301][] by [@valadaptive])
+- Various changes to the logic for computing tile intersections and representation of tiles. ([#1293][], [#1317][], [#1318][] by [@b0nes164])
+- Support for computing data necessary to implement multi-sampled anti-aliasing. ([#1319][], by [@b0nes164])
+- Numerous performance and memory-efficiency improvements. ([#1325][] by [@LaurenzV], [#1327][] by [@grebmeg], [#1336][] by [@tomcur], [#1338][] by [@taj-p])
+
+See also the [vello_hybrid 0.0.5](../vello_hybrid/CHANGELOG.md#005---2026-01-08) and [vello_cpu 0.0.5](../vello_cpu/CHANGELOG.md#005---2026-01-08) releases.
 
 ## [0.0.4][] - 2025-10-17
 

--- a/sparse_strips/vello_cpu/CHANGELOG.md
+++ b/sparse_strips/vello_cpu/CHANGELOG.md
@@ -21,32 +21,28 @@ This release has an [MSRV][] of 1.88.
 
 ### Added
 
-- The `RenderContext` now has a `set_blend_mode` (and a corresponding `blend_mode` 
-  getter method) that can be used to support non-isolated blending ([#1159][] by [@LaurenzV])
-- The `RenderContext` now contains a `push_clip_path` and `pop_clip_path` method for performing non-isolated clipping ([#1203][] by [@LaurenzV])
+- The `RenderContext` now has a `set_blend_mode` (and a corresponding `blend_mode`  getter method) that can be used to support non-isolated blending. ([#1159][] by [@LaurenzV])
+- The `RenderContext` now contains a `push_clip_path` and `pop_clip_path` method for performing non-isolated clipping. ([#1203][] by [@LaurenzV])
 - Experimental support for image filter effects: ([#1286][] by [@grebmeg][])
   - New filter API methods on `RenderContext`:
-    - `set_filter_effect()` - Set a filter to be applied to subsequent drawing operations
-    - `push_filter_layer()` - Create a new layer with a filter effect
-  - `FilterEffect` trait providing both u8 and f32 precision variants for rendering 
-  across different backends.
+    - `set_filter_effect()` - Set a filter to be applied to subsequent drawing operations.
+    - `push_filter_layer()` - Create a new layer with a filter effect.
+  - `FilterEffect` trait providing both u8 and f32 precision variants for rendering across different backends.
   - Gaussian Blur filter with configurable standard deviation and edge modes (`None`, `Mirror`, `Wrap`, `Duplicate`).
     Uses an optimized decimated blur algorithm with automatic downsampling for performance.
   - Drop Shadow filter with customizable offset, blur radius, and shadow color.
   - Flood filter for solid color fills.
-- Added a `set_mask` method to make it possible to mask rendered
-  paths without inducing layer isolation ([#1237][] by [@LaurenzV])
-- Added support for conditionally disabling the u8 or f32 pipeline ([#1294][] by [@nicoburns])
-- Improve performance of rendering opaque images ([#1327][] by [@grebmeg])
-
-
+- Added a `set_mask` method to make it possible to mask rendered paths without inducing layer isolation. ([#1237][] by [@LaurenzV])
+- Added support for conditionally disabling the u8 or f32 pipeline. ([#1294][] by [@nicoburns])
+- Improve performance of rendering opaque images. ([#1327][] by [@grebmeg])
 
 ### Known Limitations
 
-- Filter effects currently support only single-primitive filters; filter graphs with multiple 
-  chained primitives are not yet supported.
-- Multithreaded rendering is not supported for filter effects; filters are only applied in 
-  single-threaded mode.
+- Filter effects currently support only single-primitive filters; filter graphs with multiple chained primitives are not yet supported.
+- Multithreaded rendering is not supported for filter effects; filters are only applied in single-threaded mode.
+
+See also the [vello_hybrid 0.0.5](../vello_hybrid/CHANGELOG.md#005---2026-01-08) and [vello_common 0.0.5](../vello_common/CHANGELOG.md#005---2026-01-08) releases.
+
 ## [0.0.4][] - 2025-10-17
 
 This release has an [MSRV][] of 1.86.

--- a/sparse_strips/vello_hybrid/CHANGELOG.md
+++ b/sparse_strips/vello_hybrid/CHANGELOG.md
@@ -21,7 +21,9 @@ This release has an [MSRV][] of 1.88.
 
 ### Added
 
-- The `Scene` now contains a `push_clip_path` and `pop_clip_path` method for performing non-isolated clipping ([#1203][] by [@LaurenzV])
+- The `Scene` now contains a `push_clip_path` and `pop_clip_path` method for performing non-isolated clipping. ([#1203][] by [@LaurenzV])
+
+See also the [vello_cpu 0.0.5](../vello_cpu/CHANGELOG.md#005---2026-01-08) and [vello_common 0.0.5](../vello_common/CHANGELOG.md#005---2026-01-08) releases.
 
 ## [0.0.4][] - 2025-10-17
 


### PR DESCRIPTION
This matches the formatting used in the root CHANGELOG, and follows our "one sentence per line" style for Markdown.