### PR TITLE
docs: update vello hybrid readme and lib.rs to include feature-flags

### DIFF
--- a/sparse_strips/vello_hybrid/README.md
+++ b/sparse_strips/vello_hybrid/README.md
@@ -29,7 +29,9 @@ This crate serves as an optimized hybrid rendering engine, leveraging both CPU a
 - `wgpu_default` (enabled by default): Enables wgpu with its default hardware backends (such as Vulkan, Metal, and DX12).
 - `webgl`: Enables the WebGL rendering backend for browser support, using GLSL shaders for compatibility.
 
-If you need to customize the set of enabled wgpu features, disable this crate's default features then enable its wgpu feature, and then use the wgpu flag directly with the specific features you require.
+If you need to customize the set of enabled wgpu features, disable this crate's default features then enable its `wgpu` feature.
+You can then depend on wgpu directly, setting the specific features you require.
+Don't forget to also disable wgpu's default features.
 
 ## Minimum supported Rust Version (MSRV)
 

--- a/sparse_strips/vello_hybrid/src/lib.rs
+++ b/sparse_strips/vello_hybrid/src/lib.rs
@@ -26,7 +26,9 @@
 //! - `wgpu_default` (enabled by default): Enables wgpu with its default hardware backends (such as Vulkan, Metal, and DX12).
 //! - `webgl`: Enables the WebGL rendering backend for browser support, using GLSL shaders for compatibility.
 //!
-//! If you need to customize the set of enabled wgpu features, disable this crate's default features then enable its wgpu feature, and then use the wgpu flag directly with the specific features you require.
+//! If you need to customize the set of enabled wgpu features, disable this crate's default features then enable its `wgpu` feature.
+//! You can then depend on wgpu directly, setting the specific features you require.
+//! Don't forget to also disable wgpu's default features.
 //!
 //! ## Architecture
 //!


### PR DESCRIPTION
Resolves #1355 

I added the feature flags for Vello Hybrid in the README and also in its `lib.rs`, which weren't there

I had to add a new features flag section since it already has a features section, but I didn't want to mix it up

I also added the note from the `Cargo.toml`  about the default vs wgpu configuration, which seemed like a useful detail.

This is my first time contributing here, so let me know if the formatting looks off or if you'd rather I merge the two feature sections