### PR TITLE
feat(util): add BlitterWithLoadOp for compositing use cases

### DIFF
--- a/vello/src/util.rs
+++ b/vello/src/util.rs
@@ -348,6 +348,7 @@ impl BlitterWithLoadOp {
                     load: load_op,
                     store: wgpu::StoreOp::Store,
                 },
+                depth_slice: None,
             })],
             depth_stencil_attachment: None,
             timestamp_writes: None,


### PR DESCRIPTION
## Summary

Add `BlitterWithLoadOp` to enable compositing Vello content over existing GPU-rendered content.

## Motivation

When integrating Vello into applications that render other GPU content first (e.g., compute shader heatmaps, external renderers like Silk.NET), the final blit needs `LoadOp::Load` to preserve the existing surface content. Currently, `TextureBlitter::copy()` uses `LoadOp::Clear`, making compositing impossible without duplicating the blitter code.

## Solution

Add a new `BlitterWithLoadOp` struct to `vello/src/util.rs` with:
- `new(device, format)` - creates the blitter pipeline
- `copy_with_loadop(device, encoder, src, dst, loadop)` - blits with configurable LoadOp

Compositing workflow:
1. External renderer → Surface (LoadOp::Clear)
2. Vello compute shaders → Intermediate texture  
3. BlitterWithLoadOp → Surface (LoadOp::Load, preserves step 1)
4. Present

## Changes

- `vello/src/util.rs`: Add `BlitterWithLoadOp` struct and `blitter_loadop` field to `RenderSurface`

## Backwards Compatibility

Fully backwards compatible - existing `TextureBlitter` and `copy()` method unchanged.
