### PR TITLE
vello_common: Store strip data in tile units

### DIFF
--- a/sparse_strips/vello_common/src/strip.rs
+++ b/sparse_strips/vello_common/src/strip.rs
@@ -17,7 +17,7 @@ pub struct Strip {
     tile_x: u16,
     /// The y coordinate of the strip, in tile units.
     tile_y: u16,
-    // TODO: Change it so that alpha_idx is stored divided by Tile::WIDTH * TIlE::HEIGHT.
+    // TODO: Change it so that alpha_idx is stored divided by Tile::WIDTH * Tile::HEIGHT.
     // This will free up 4 more bits we can use in the future (or just increase the
     // number of permissible alpha values).
     /// Packed alpha index and fill gap flag.

--- a/sparse_strips/vello_common/src/strip.rs
+++ b/sparse_strips/vello_common/src/strip.rs
@@ -33,6 +33,7 @@ impl Strip {
     const FILL_GAP_MASK: u32 = 1 << 31;
 
     /// Creates a new strip.
+    #[inline]
     pub fn new(tile_x: u16, tile_y: u16, alpha_idx: u32, fill_gap: bool) -> Self {
         // Ensure `alpha_idx` does not collide with the fill flag bit.
         assert!(
@@ -48,16 +49,19 @@ impl Strip {
     }
 
     /// Creates a new sentinel strip.
+    #[inline]
     pub fn new_sentinel(tile_y: u16, alpha_idx: u32) -> Self {
         Self::new(u16::MAX, tile_y, alpha_idx, false)
     }
 
     /// Return whether the strip is a sentinel strip.
+    #[inline]
     pub fn is_sentinel(&self) -> bool {
         self.tile_x == u16::MAX
     }
 
     /// Return the x coordinate of the strip, in user coordinates.
+    #[inline]
     pub fn x(&self) -> u16 {
         if self.is_sentinel() {
             u16::MAX
@@ -67,16 +71,19 @@ impl Strip {
     }
 
     /// Return the y coordinate of the strip, in user coordinates.
+    #[inline]
     pub fn y(&self) -> u16 {
         self.tile_y * Tile::HEIGHT
     }
 
     /// Return the x coordinate of the strip, in tile units.
+    #[inline]
     pub fn tile_x(&self) -> u16 {
         self.tile_x
     }
 
     /// Return the y coordinate of the strip, in tile units.
+    #[inline]
     pub fn tile_y(&self) -> u16 {
         self.tile_y
     }

--- a/sparse_strips/vello_toy/src/debug.rs
+++ b/sparse_strips/vello_toy/src/debug.rs
@@ -228,8 +228,8 @@ fn draw_tile_areas(document: &mut Document, tiles: &Tiles) {
 fn draw_strip_areas(document: &mut Document, strips: &[Strip], alphas: &[u8]) {
     for i in 0..strips.len() {
         let strip = &strips[i];
-        let x = strip.x;
-        let y = strip.strip_y();
+        let x = strip.x();
+        let y = strip.tile_y();
 
         let end = strips
             .get(i + 1)
@@ -276,8 +276,8 @@ fn draw_strips(document: &mut Document, strips: &[Strip], alphas: &[u8]) {
                     + usize::from(x) * usize::from(Tile::HEIGHT)
                     + usize::from(y)];
                 let rect = Rectangle::new()
-                    .set("x", strip.x + x)
-                    .set("y", strip.y + y)
+                    .set("x", strip.x() + x)
+                    .set("y", strip.y() + y)
                     .set("width", 1)
                     .set("height", 1)
                     .set("fill", color)


### PR DESCRIPTION
# Context

In the near future, we want to be able to support negative coordinates. This applies to two different areas:
- We want to support negative coordinates in strips, so that we can cache strips even if parts of it lie outside of the current viewport.
- We want to support negative coordinates in wide tiles during fine rasterization, so that pixels at the border with neighboring filters can sample pixels that are strictly outside.

In order to do this, we need to eventually migrate from using `u16` to `i16` in most places, as has been discussed in office hours.

# Problem
Putting aside the complications that come from dealing with negative coordinates, a more immediate problem is that in the current implementation, this would reduce the maximum drawing area that can be used. Currently, we support a dimension of 65535x65535 (i.e. u16::MAX) in each direction, but after migrating to i16, this would be reduced to half of that, so around 32k pixels. While not dramatic, I do think it's unfortunate, especially because I _think_ we can avoid this problem by doing some preparatory work. Therefore, before we start migrating to using i16, I would propose restructuring the current code in a way that will make the migration easier. This will also allow us to split it into multiple PRs that are easier to review.

# Solution
Basically, in order to alleviate this problem, we can make use of the fact that our tiles always have a width/height of 4 (in the future, this might increase, but as long as we don't _decrease_ the tile size this will not matter). Since this is true, inside of `Strip`, we can store the x/y coordinates in _tile units_ instead of pixel coordinates, i.e. divided by 4. We actually already do this in `Tile`, but not in `Strip` yet. By doing so, even if we switch to using `i16` later on, we can still store the maximum coordinates `u16::MAX/4` inside of that, meaning that we can still represent the whole 65535x65535 pixel range (yay)! 

# PRs

Therefore, I am planning on opening the following PRs:
- Changing strips to store coordinates in tile units. <--- this PR
- Changing the strip clipping logic so that it won't overflow once we switch to i16.
- Changing all of the other methods in `WideTile` so that it won't overflow once we switch to i16.

While not strictly related, I noticed that we can do the same for alpha index: Instead of storing `alpha_buf.len()` as the offset, we can instead store `alpha_buf.len() / (Tile::WIDTH * Tile::HEIGHT)`, since it's guaranteed that each tile always has 16 alpha values. So that could be a fourth PR.

# Downside
The only downside that I can see is that if we go down this route, it will not be possible anymore to introduce the concept of footprints, since all of this is under the assumption that we are always properly aligned. But my understanding was that we weren't planning on re-introducing that, anyway.