### PR TITLE
vello_common: Reduce the number of memsets in flattening

### DIFF
--- a/sparse_strips/vello_common/src/flatten_simd.rs
+++ b/sparse_strips/vello_common/src/flatten_simd.rs
@@ -526,7 +526,10 @@ fn flatten_cubic_simd<S: Simd>(simd: S, c: CubicBez, ctx: &mut FlattenCtx, accur
     estimate_subdiv_simd(simd, sqrt_tol, ctx);
     let sum: f32 = ctx.val[..n_quads].iter().sum();
     let n = ((0.5 * sum / sqrt_tol).ceil() as usize).max(1);
-    ctx.flattened_cubics.resize(n + 4, Point32::default());
+    let target_len = n + 4;
+    if target_len > ctx.flattened_cubics.len() {
+        ctx.flattened_cubics.resize(target_len, Point32::default());
+    }
 
     let step = sum / (n as f32);
     let step_recip = 1.0 / step;


### PR DESCRIPTION
These showed up in my profile:

Before:
<img width="1222" height="489" alt="image" src="https://github.com/user-attachments/assets/efe8f715-bc09-43a5-b208-89daff0e9c9f" />

After:
<img width="1226" height="466" alt="image" src="https://github.com/user-attachments/assets/bcaa21b7-8a49-4dbb-89a8-0e30c5b6298c" />

The problem is that depending on the number of lines of the cubic, we would keep growing and truncating the buffer holding the points.

However, since we only index the `flattened_cubic` buffer using the returned maximum value:
https://github.com/linebender/vello/blob/f9d134265d3909e204b8ab6a9be781fc4ba688c7/sparse_strips/vello_common/src/flatten_simd.rs#L142-L146

It is safe to never truncate the buffer and only grow it, if it's necessary.