### PR TITLE
vello_hybrid: Inline `process_paint` and `get_round`

### DIFF
--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -515,6 +515,7 @@ impl Scheduler {
     }
 
     // Find the appropriate round for rendering.
+    #[inline(always)]
     fn get_round(&mut self, el_round: usize) -> &mut Round {
         let rel_round = el_round.saturating_sub(self.round);
         if self.rounds_queue.len() == rel_round {
@@ -897,6 +898,7 @@ impl Scheduler {
     }
 
     /// Process a paint and return (`payload`, `paint`)
+    #[inline(always)]
     fn process_paint(
         paint: &Paint,
         scene: &Scene,


### PR DESCRIPTION
Using #1395 as a basis, this results in the following numbers:

Before (863ms):
<img width="1488" height="733" alt="image" src="https://github.com/user-attachments/assets/617e22b3-85f1-4004-80f8-d52aaf2bf178" />

After (775ms):
<img width="1491" height="736" alt="image" src="https://github.com/user-attachments/assets/7975a31f-4ba5-4688-8288-c816bbc784f6" />
