### PR TITLE
Optimize `copy_solid` in the `lowp` pipeline for WASM

### DIFF
--- a/sparse_strips/vello_cpu/src/fine/lowp/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/lowp/mod.rs
@@ -102,7 +102,7 @@ impl<S: Simd> FineKernel<S> for U8Kernel {
             #[inline(always)]
             || {
                 let target: &mut [u32] = bytemuck::cast_slice_mut(dest);
-                target.fill(u32::from_ne_bytes(src))
+                target.fill(u32::from_ne_bytes(src));
             },
         );
     }


### PR DESCRIPTION
I've been experimenting with running our microbenchmarks on WASM, and noticed that the `opaque_*` benchmarks are _significantly_ slower than the ones with alpha compositing. After some experimenting, this small fix seems to speed up the benchmarks multiple times on WASM. This is a 6x (!!) speedup in this part of the pipeline for any rendering operation that involves fully opaque colors. This reproduces on both, Chrome, Firefox and Safari.

Before:
<img width="1395" height="277" alt="image" src="https://github.com/user-attachments/assets/18b825f5-c4a1-484f-a3c4-13cbd16b0b14" />


After:
<img width="1394" height="277" alt="image" src="https://github.com/user-attachments/assets/955a6c9c-adfc-4185-9ab6-79ed39158fe2" />

For reference, these are the results I get when running natively:
<img width="1393" height="278" alt="image" src="https://github.com/user-attachments/assets/5a4b97ca-1b16-44cd-b8cc-d1853ede5e09" />


This change doesn't seem to affect NEON. I'm not able to test AVX2.