### PR TITLE
vello_hybrid: Always inline `draw_mut`

### DIFF
--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -540,6 +540,7 @@ impl Scheduler {
     }
 
     // Find the appropriate draw call for rendering.
+    #[inline(always)]
     fn draw_mut(&mut self, el_round: usize, texture_idx: usize) -> &mut Draw {
         &mut self.get_round(el_round).draws[texture_idx]
     }


### PR DESCRIPTION
Before:
<img width="1492" height="735" alt="image" src="https://github.com/user-attachments/assets/cadd91f2-b2e2-4f36-9ff7-287a1ac4055f" />

After:
<img width="1482" height="733" alt="image" src="https://github.com/user-attachments/assets/c561b49f-8cf1-47a7-b663-527512983000" />
