### PR TITLE
vello_hybrid: Use a pool for storing `Round` objects

### DIFF
--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -246,7 +246,7 @@ impl RoundPool {
 
         // Avoid caching too many objects in adversarial scenarios.
         if self.0.len() < MAX_ELEMENTS {
-            // Make sure the round is resetted if we reuse it in the future.
+            // Make sure the round is reset if we reuse it in the future.
             round.clear();
 
             self.0.push(round);


### PR DESCRIPTION
A round object stores a number of vectors for tracking the state of the round: 

https://github.com/linebender/vello/blob/6a45f75661129aa3dcbfeeaed5bbdae2451b880e/sparse_strips/vello_hybrid/src/schedule.rs#L236-L248

In particular, for each texture slot it holds a `Draw` object, which itself stores all of the strips that are needed for that round. Since it's quite a common case that all draws are scheduled for the first round, this vector can get pretty big.

Currently, each time we want to create a new round, we do so by initializing a new one via `Round::default`:
https://github.com/linebender/vello/blob/6a45f75661129aa3dcbfeeaed5bbdae2451b880e/sparse_strips/vello_hybrid/src/schedule.rs#L552-L554

Once the round is flushed, the round object is popped from the queue and then simply discarded:
https://github.com/linebender/vello/blob/6a45f75661129aa3dcbfeeaed5bbdae2451b880e/sparse_strips/vello_hybrid/src/schedule.rs#L492-L493

Therefore, in each frame we have to recreate the rounds (and their allocations) from new.

This PR proposes to store a small allocator pool for `Round` objects in `Scheduler`. Each time we need a new round, we first try to fetch an existing object from the pool, and once the round is popped we submit it back to the pool. This way, the objects can be reused.

The reduction of allocations, while not a huge win in terms of performance, is also visible in the profile:

Before:
<img width="1484" height="734" alt="image" src="https://github.com/user-attachments/assets/66c9d072-44d8-41d2-9966-4633b1a977b4" />

After:
<img width="1489" height="733" alt="image" src="https://github.com/user-attachments/assets/9a7bd258-e6f2-4425-b59f-32d9c09d31e4" />
