### PR TITLE
vello_common: Mark `strip::render_impl` `#[inline(always)]`

### DIFF
--- a/sparse_strips/vello_common/src/strip.rs
+++ b/sparse_strips/vello_common/src/strip.rs
@@ -103,6 +103,7 @@ pub fn render(
     dispatch!(level, simd => render_impl(simd, tiles, strip_buf, alpha_buf, fill_rule, aliasing_threshold, lines));
 }
 
+#[inline(always)]
 fn render_impl<S: Simd>(
     s: S,
     tiles: &Tiles,


### PR DESCRIPTION
Noticed this when I was experimenting a bit in this function and got a ~+250% regression, as it was no longer being inlined (x86) and had worse (dispatched) codegen.

It's called through `fearless_simd::dispatch`, which says functions should be marked `#[inline(always)]`.