### PR TITLE
sparse strips: Clarify blurred rounded rect radius means corner radius

### DIFF
--- a/sparse_strips/vello_common/src/blurred_rounded_rect.rs
+++ b/sparse_strips/vello_common/src/blurred_rounded_rect.rs
@@ -12,7 +12,7 @@ pub struct BlurredRoundedRectangle {
     pub rect: Rect,
     /// The color of the blurred rectangle.
     pub color: AlphaColor<Srgb>,
-    /// The radius of the blur effect.
+    /// The radius of the rounded rectangle's corners.
     pub radius: f32,
     /// The standard deviation of the blur effect.
     pub std_dev: f32,

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -273,7 +273,7 @@ impl RenderContext {
         self.temp_path.push(PathEl::ClosePath);
     }
 
-    /// Fill a blurred rectangle with the given radius and standard deviation.
+    /// Fill a blurred rectangle with the given corner radius and standard deviation.
     ///
     /// Note that this only works properly if the current paint is set to a solid color.
     /// If not, it will fall back to using black as the fill color.


### PR DESCRIPTION
Sometimes radius is used in this context to refer to blur kernel radius, which we encode as standard deviation.