### PR TITLE
Build `vello_hybrid` for wasm target on docs.rs

### DIFF
--- a/sparse_strips/vello_hybrid/Cargo.toml
+++ b/sparse_strips/vello_hybrid/Cargo.toml
@@ -11,9 +11,8 @@ repository.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
-# There are no platform specific docs.
 default-target = "x86_64-unknown-linux-gnu"
-targets = []
+targets = ["wasm32-unknown-unknown"]
 
 [dependencies]
 bytemuck = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
Vello Hybrid has a WebGL renderer that is only enabled on wasm. We should therefore build the wasm target on docs.rs so that the docs for that functionality are available on docs.rs.