### PR TITLE
vello_common: Use the `PIXEL_CENTER_OFFSET` constant when shifting images

### DIFF
--- a/sparse_strips/vello_common/src/encode.rs
+++ b/sparse_strips/vello_common/src/encode.rs
@@ -493,7 +493,8 @@ impl EncodeExt for Image {
 
         // Similarly to gradients, apply the `PIXEL_CENTER_OFFSET` offset so we sample at the center of
         // a pixel.
-        let transform = transform.inverse() * Affine::translate((PIXEL_CENTER_OFFSET, PIXEL_CENTER_OFFSET));
+        let transform =
+            transform.inverse() * Affine::translate((PIXEL_CENTER_OFFSET, PIXEL_CENTER_OFFSET));
 
         let (x_advance, y_advance) = x_y_advances(&transform);
 


### PR DESCRIPTION
We are already using it for gradients, but for images they were still hardcoded.