### PR TITLE
vello shaders: Refactor alpha inversion to handle faint alpha values

### DIFF
--- a/vello_shaders/shader/fine.wgsl
+++ b/vello_shaders/shader/fine.wgsl
@@ -1273,12 +1273,16 @@ fn main(
         if coords.x < config.target_width && coords.y < config.target_height {
             let fg = rgba[i];
             // let fg = base_color * (1.0 - foreground.a) + foreground;
-            // Max with a small epsilon to avoid NaNs
-            let a_inv = 1.0 / max(fg.a, 1e-6);
-            let rgba_sep = vec4(fg.rgb * a_inv, fg.a);
-            // Set rgba to 0 if fg.a is very faint.
-            let a_gate = step(1e-6, fg.a);
-            textureStore(output, vec2<i32>(coords), rgba_sep * a_gate);
+            var rgba_sep = vec4(0.0);
+            // Don't apply color if alpha is below threshold as
+            // this could lead to artifacts in rgb channels due to 
+            // division by very small number. Also protects against 
+            // division by zero.
+            if fg.a > 1e-6 {
+                let a_inv = 1.0 / fg.a;
+                rgba_sep = vec4(fg.rgb * a_inv, fg.a);
+            }
+            textureStore(output, vec2<i32>(coords), rgba_sep);
         }
     } 
 }


### PR DESCRIPTION
Tweak alpha inversion calculation to avoid artifacts with faint alpha values.

Contrary to MSAA16, Analytic area anti-aliasing does sometime return very faint alpha values. 

This can create artifacts that look like ghosting when looking at just the RGB channels in isolation, because the RGB values get boosted out of proportion by a very low alpha value. 

Usually, this is invisible, as it gets masked when drawing the final image using alpha blending, but it may be useful to correct for this at source.

Before the change: (Notice the artifacts in the RGB-only channel view (right))
<table>
<tr>
<td><img width="300" alt="image" src="https://github.com/user-attachments/assets/8e890f36-b840-46b2-be71-4d73d77e9bcc" /></td>
<td>
<img width="300"  alt="image" src="https://github.com/user-attachments/assets/e018a7bc-87d7-4692-a23a-ed5056b58f5d" />
</td>
</tr>
</table>


After the change: (Notice artifacts are corrected now in RGB-only channel view, while keeping same visual for RGBA)
<table>
<tr>
<td><img width="300" alt="image" src="https://github.com/user-attachments/assets/a01fb8dd-a023-4b79-99f0-a77f10e1a7df" /></td>
<td><img width="300" alt="image" src="https://github.com/user-attachments/assets/f339d7d7-f318-47dc-a3fb-cf734b0ec382" /></td>
</tr>
</table>