### PR TITLE
Vello API: A more sane design for paints

### DIFF
--- a/sparse_strips/vello_api/src/painter.rs
+++ b/sparse_strips/vello_api/src/painter.rs
@@ -87,6 +87,17 @@ impl From<BlurredRoundedRectBrush> for Paint {
     }
 }
 
+impl From<Color> for Paint {
+    fn from(value: Color) -> Self {
+        Self::StandardBrush {
+            brush: Brush::Solid(value),
+            // A paint_transform has no effect for a solid colour, so setting this
+            // paint_transform is not losing intent
+            paint_transform: Affine::IDENTITY,
+        }
+    }
+}
+
 /// A 2d scene or canvas.
 ///
 /// These types are used to prepare a sequence of vector shapes to later be drawn by a [`Renderer`].


### PR DESCRIPTION
Note that this proposed design is not yet implemented for any of the backends. It may be useful to spawn discussion.

This proposed design for the `Paint` enum maintains the prior separation between "brush" and "filled area" which motivated the prior design, without any of the other strangeness forced by it (namely especially the interaction with `PaintScene::append`).

It also demonstrates a possibility for per-renderer extensions, and the other motivation of non-object-transformed gradients.

Unfortunately, I doubt that I will be able to attend today's renderer OH to further present this.