### PR TITLE
Make benchmarks actually run on x86

### DIFF
--- a/sparse_strips/vello_dev_macros/src/bench.rs
+++ b/sparse_strips/vello_dev_macros/src/bench.rs
@@ -78,26 +78,28 @@ pub(crate) fn vello_bench_inner(_: TokenStream, item: TokenStream) -> TokenStrea
             //     run_float(b, vello_common::fearless_simd::Fallback::new());
             // });
 
-            #[cfg(target_arch = "aarch64")]
-            if let Some(neon) = Level::new().as_neon() {
-                c.bench_function(&get_bench_name(&#input_fn_name_str, "f32_neon"), |b| {
-                    run_float(b, neon);
-                });
-            }
+            // f32 benchmarks are disabled because they are only of secondary importance and take a long time
+            //
+            // #[cfg(target_arch = "aarch64")]
+            // if let Some(neon) = Level::new().as_neon() {
+            //     c.bench_function(&get_bench_name(&#input_fn_name_str, "f32_neon"), |b| {
+            //         run_float(b, neon);
+            //     });
+            // }
 
-            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-            if let Some(sse4_2) = Level::new().as_sse4_2() {
-                c.bench_function(&get_bench_name(&#input_fn_name_str, "f32_sse4_2"), |b| {
-                    run_float(b, sse4_2);
-                });
-            }
+            // #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+            // if let Some(sse4_2) = Level::new().as_sse4_2() {
+            //     c.bench_function(&get_bench_name(&#input_fn_name_str, "f32_sse4_2"), |b| {
+            //         run_float(b, sse4_2);
+            //     });
+            // }
 
-            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-            if let Some(avx2) = Level::new().as_avx2() {
-                c.bench_function(&get_bench_name(&#input_fn_name_str, "f32_avx2"), |b| {
-                    run_float(b, avx2);
-                });
-            }
+            // #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+            // if let Some(avx2) = Level::new().as_avx2() {
+            //     c.bench_function(&get_bench_name(&#input_fn_name_str, "f32_avx2"), |b| {
+            //         run_float(b, avx2);
+            //     });
+            // }
         }
     };
 


### PR DESCRIPTION
Prior to this most benchmarks were never instantiated on x86

on main this doesn't run SSE4.2 benchmarks if AVX2 is available because `.as_sse4_2()`  is [buggy](https://docs.rs/fearless_simd/latest/src/fearless_simd/lib.rs.html#282-287) in fearless_simd v0.3.0