### PR TITLE
Enable `std` feature on fearless_simd for runtime feature detection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ rayon = { version = "1.11.0" }
 thread_local = "1.1.9"
 crossbeam-channel = "0.5.15"
 ordered-channel = { version = "1.2.0", features = ["crossbeam-channel"] }
-fearless_simd = { version = "0.3.0", default-features = false }
+fearless_simd = { version = "0.3.0" }
 
 # The below crates are experimental!
 vello_api = { path = "sparse_strips/vello_api", default-features = false }


### PR DESCRIPTION
Without the `std` feature, [runtime feature detection is documented as being unavailable](https://github.com/linebender/fearless_simd/blob/05f68a43dd3a815d4e7247f6cfacfec739d3fb50/fearless_simd/Cargo.toml#L23-L25).

Runtime feature detection still works in benchmarks, not sure why. Possibly due to workspace feature unification, but that may very well break for anyone depending on vello via crates.io