### PR TITLE
vello_common: Only apply filters to layers that actually need it

### DIFF
--- a/sparse_strips/vello_common/src/coarse.rs
+++ b/sparse_strips/vello_common/src/coarse.rs
@@ -709,6 +709,8 @@ impl<const MODE: u8> Wide<MODE> {
         let mut layer = self.layer_stack.pop().unwrap();
 
         if let Some(filter) = &layer.filter {
+            let mut final_bbox = WideTilesBbox::inverted();
+
             // Update render graph node with final bounding box
             if let Some(node_id) = self.filter_node_stack.pop() {
                 // Get the transform from the FilterLayer node and scale the expansion by it
@@ -728,7 +730,7 @@ impl<const MODE: u8> Wide<MODE> {
                         self.height_tiles(),
                     );
                     let clip_bbox = self.active_bbox();
-                    let final_bbox = expanded_bbox.intersect(clip_bbox);
+                    final_bbox = expanded_bbox.intersect(clip_bbox);
 
                     // Update both the local layer and the render graph node
                     layer.wtile_bbox = final_bbox;
@@ -740,8 +742,8 @@ impl<const MODE: u8> Wide<MODE> {
 
             // Generate filter commands for each tile (used for non-graph path rendering)
             // Apply filter BEFORE clipping (per SVG spec: filter → clip → mask → opacity → blend)
-            for x in 0..self.width_tiles() {
-                for y in 0..self.height_tiles() {
+            for x in final_bbox.x0()..final_bbox.x1() {
+                for y in final_bbox.y0()..final_bbox.y1() {
                     self.get_mut(x, y).filter(layer.layer_id, filter.clone());
                 }
             }


### PR DESCRIPTION
By definition, any wide tile that could potentially hold filter-relevant data will be within the bounding-box of the filter layer. Therefore, it's enough if we apply the `Filter` command only to layers that are within the bounding box. Leads to a modest improvement of the filter scene for vello_cpu:

Before:
```
Average FPS: 7.3
Average FPS: 6.4
Average FPS: 7.1
Average FPS: 7.9
Average FPS: 7.3
Average FPS: 6.6
Average FPS: 7.3
Average FPS: 7.3
Average FPS: 7.3
Average FPS: 7.4
Average FPS: 7.5
Average FPS: 6.9
Average FPS: 6.6
Average FPS: 6.9
Average FPS: 6.3
Average FPS: 7.7
Average FPS: 7.5
Average FPS: 7.7
```

After:
```
Average FPS: 8.4
Average FPS: 8.9
Average FPS: 9.2
Average FPS: 8.0
Average FPS: 9.0
Average FPS: 8.1
Average FPS: 7.9
Average FPS: 8.3
Average FPS: 7.8
Average FPS: 7.9
Average FPS: 7.8
Average FPS: 8.7
Average FPS: 7.2
```