### PR TITLE
vello_sparse_tests: Only use oxipng on none-WASM targets

### DIFF
--- a/sparse_strips/vello_sparse_tests/Cargo.toml
+++ b/sparse_strips/vello_sparse_tests/Cargo.toml
@@ -23,12 +23,14 @@ wgpu = { workspace = true, default-features = true }
 pollster = { workspace = true }
 vello_dev_macros = { workspace = true }
 bytemuck = { workspace = true }
-oxipng = { workspace = true, features = ["freestanding", "parallel"] }
 image = { workspace = true, features = ["png"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 skrifa = { workspace = true }
 smallvec = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+oxipng = { workspace = true, features = ["freestanding", "parallel"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen-test = "0.3.56"

--- a/sparse_strips/vello_sparse_tests/tests/util.rs
+++ b/sparse_strips/vello_sparse_tests/tests/util.rs
@@ -347,10 +347,17 @@ pub(crate) fn check_ref(
     let ref_path = REFS_PATH.join(format!("{test_name}.png"));
 
     let write_ref_image = || {
-        let optimized =
-            oxipng::optimize_from_memory(&encoded_image, &oxipng::Options::max_compression())
-                .unwrap();
-        std::fs::write(&ref_path, optimized).unwrap();
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let optimized =
+                oxipng::optimize_from_memory(&encoded_image, &oxipng::Options::max_compression())
+                    .unwrap();
+            std::fs::write(&ref_path, optimized).unwrap();
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            panic("Reference images cannot be created from WASM");
+        }
     };
 
     if !ref_path.exists() {


### PR DESCRIPTION
I'm having issues running the WebGL tests because oxipng seemingly can't be compiled to WASM (though it seems to work in CI, so not sure what's up with that). In any case, since we don't need to generate reference images from WASM, it's probably easiest to just not include it.