### PR TITLE
vello_common: Stop pushing clip attrs in `pop_clip` when there are zero strips

### DIFF
--- a/sparse_strips/vello_common/src/coarse.rs
+++ b/sparse_strips/vello_common/src/coarse.rs
@@ -979,7 +979,7 @@ impl<const MODE: u8> Wide<MODE> {
         let clip_attrs_idx = self.attrs.clip.len() as u32;
         let alpha_base_idx;
         if n_strips == 0 {
-            alpha_base_idx = 0
+            alpha_base_idx = 0;
         } else {
             alpha_base_idx = strips[0].alpha_idx();
             self.attrs.clip.push(ClipAttrs {


### PR DESCRIPTION
See https://github.com/linebender/vello/pull/1443#pullrequestreview-3808520289.