### PR TITLE
vello_hybrid: Unify texture creation code in WebGL backend

### DIFF
--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -1394,7 +1394,7 @@ fn create_texture_inner(gl: &WebGl2RenderingContext, target: u32) -> WebGlTextur
         WebGl2RenderingContext::CLAMP_TO_EDGE as i32,
     );
     // Also only to be defensive, in theory this shouldn't be necessary since we use
-    // `NEAREST` for the filters/
+    // `NEAREST` for both filters.
     gl.tex_parameteri(
         WebGl2RenderingContext::TEXTURE_2D,
         WebGl2RenderingContext::TEXTURE_MAX_LEVEL,


### PR DESCRIPTION
Perhaps I am missing something obvious here, but I'm not sure I get why we were using different clamp/filtering modes for some textures? 🤔 If I'm not mistaken, we are only ever using direct texture loading, so it seems to me like it should be fine to always use the same mode? At least all WebGL tests still seem to pass, but please let me know if I'm wrong.

Other than that, this PR just puts all of that logic into a method to reduce code duplication. 🙂 