### PR TITLE
Add fast-path for skipping coarse rasterization and scheduling for scenes without layers

### DIFF
--- a/sparse_strips/vello_common/src/strip_generator.rs
+++ b/sparse_strips/vello_common/src/strip_generator.rs
@@ -35,6 +35,15 @@ pub enum GenerationMode {
 }
 
 impl StripStorage {
+    /// Create a new strip storage with the given generation mode.
+    pub fn new(generation_mode: GenerationMode) -> Self {
+        Self {
+            strips: Vec::new(),
+            alphas: Vec::new(),
+            generation_mode,
+        }
+    }
+
     /// Reset the storage.
     pub fn clear(&mut self) {
         self.strips.clear();

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -196,7 +196,7 @@ impl WebGlRenderer {
             self.fast_path_gpu_strips.clear();
 
             generate_gpu_strips_for_fast_path(
-                &scene.fast_strips_buffer,
+                &scene.fast_strips_buffer.paths,
                 scene,
                 &self.paint_idxs,
                 &mut self.fast_path_gpu_strips,

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -162,7 +162,7 @@ impl Renderer {
             self.fast_path_gpu_strips.clear();
 
             generate_gpu_strips_for_fast_path(
-                &scene.fast_strips_buffer,
+                &scene.fast_strips_buffer.paths,
                 scene,
                 &self.paint_idxs,
                 &mut self.fast_path_gpu_strips,

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -176,7 +176,7 @@
 only break in edge cases, and some of them are also only related to conversions from f64 to f32."
 )]
 
-use crate::scene::FastStripsBuffer;
+use crate::scene::FastStripsPath;
 use crate::{GpuStrip, RenderError, Scene};
 use alloc::collections::VecDeque;
 use alloc::vec::Vec;
@@ -1190,13 +1190,15 @@ fn has_non_zero_alpha(rgba: u32) -> bool {
 }
 
 pub(crate) fn generate_gpu_strips_for_fast_path(
-    buffer: &FastStripsBuffer,
+    paths: &[FastStripsPath],
     scene: &Scene,
     paint_idxs: &[u32],
     gpu_strips: &mut Vec<GpuStrip>,
 ) {
-    for path in &buffer.paths {
-        let strips = &buffer.strips[path.strips.clone()];
+    let strip_storage = scene.strip_storage.borrow();
+
+    for path in paths {
+        let strips = &strip_storage.strips[path.strips.clone()];
 
         if strips.is_empty() {
             continue;


### PR DESCRIPTION
This adds a fast path to vello_hybrid, where we avoid coarse rasterization and scheduling for all strips as long as no `push_layer` command is encountered.

As Alex rightly highlighted, this does have the disadvantage of not allowing the "if there is an opaque fill, clear all previous fill" optimization. However, it seems to me like this should be overshadowed by the improvements that come from not doing scheduling and coarse rasterization. Here are the timings for rendering 1000 frames of the GhotScript tiger:

Before (note in particular `Wide::generate` and `Scheduler::do_scene`:
<img width="1491" height="725" alt="image" src="https://github.com/user-attachments/assets/88d572f7-d596-47fb-877c-f1e08a8e976f" />

After:
<img width="1489" height="718" alt="image" src="https://github.com/user-attachments/assets/454c9975-b590-4030-bb5a-d200119a5e8f" />

