### PR TITLE
vello_hybrid: Add inline Pixmap rendering

### DIFF
--- a/sparse_strips/vello_common/src/image_cache.rs
+++ b/sparse_strips/vello_common/src/image_cache.rs
@@ -8,7 +8,10 @@
 
 use crate::multi_atlas::{AllocId, AtlasConfig, AtlasError, AtlasId, MultiAtlasManager};
 use crate::paint::ImageId;
+use alloc::sync::Arc;
 use alloc::vec::Vec;
+use hashbrown::HashMap;
+use crate::pixmap::Pixmap;
 
 /// Represents an image resource for rendering.
 #[derive(Debug)]
@@ -37,6 +40,150 @@ impl ImageResource {
     /// Returns the size as `[u32; 2]`.
     pub fn size(&self) -> [u32; 2] {
         [self.width as u32, self.height as u32]
+    }
+}
+
+/// An image that has been allocated in the [`ImageCache`] but not yet uploaded to the GPU.
+///
+/// After [`ImageCache::allocate`], the atlas slot and offset are reserved,
+/// but the pixel data hasn't been written yet. The renderer should iterate
+/// pending uploads and write each pixmap to the atlas before rendering.
+#[derive(Debug)]
+pub struct PendingImageUpload {
+    /// The image ID (use [`ImageCache::get`] with this id for `atlas_id` + offset).
+    pub image_id: ImageId,
+    /// The pixel data to upload.
+    pub pixmap: Arc<Pixmap>,
+}
+
+/// A registered pixmap entry with its last-used frame serial.
+#[derive(Debug, Clone, Copy)]
+struct PixmapEntry {
+    image_id: ImageId,
+    /// Frame serial when this entry was last referenced.
+    serial: u32,
+}
+
+/// Configuration for [`PixmapRegister`] eviction behaviour.
+#[derive(Clone, Debug)]
+pub struct PixmapRegisterConfig {
+    /// Maximum age (in frames) before an unused entry is evicted.
+    pub max_entry_age: u32,
+    /// How often (in frames) to run the eviction pass.
+    pub eviction_frequency: u32,
+}
+
+impl Default for PixmapRegisterConfig {
+    fn default() -> Self {
+        Self {
+            max_entry_age: 64,
+            eviction_frequency: 64,
+        }
+    }
+}
+
+/// Registry that maps `Arc<Pixmap>` pointer addresses to [`ImageId`]s.
+///
+/// This enables deduplication: the same `Arc<Pixmap>` (by pointer identity)
+/// is only allocated and uploaded once. Entries persist across frames so
+/// that a pixmap reused in consecutive frames doesn't get re-uploaded.
+///
+/// Stale entries (not referenced for
+/// [`max_entry_age`](PixmapRegisterConfig::max_entry_age) frames) are
+/// periodically evicted via [`maintain`](Self::maintain), which also
+/// deallocates their atlas space from the [`ImageCache`].
+#[derive(Debug)]
+pub struct PixmapRegister {
+    /// Maps `Arc<Pixmap>` pointer address to its entry.
+    map: HashMap<usize, PixmapEntry>,
+    /// Current frame counter, incremented each frame via [`tick`](Self::tick).
+    serial: u32,
+    /// Serial at which we last ran eviction.
+    last_eviction_serial: u32,
+    /// Eviction configuration.
+    config: PixmapRegisterConfig,
+}
+
+impl Default for PixmapRegister {
+    fn default() -> Self {
+        Self::new(PixmapRegisterConfig::default())
+    }
+}
+
+impl PixmapRegister {
+    /// Create a new register with the given eviction configuration.
+    pub fn new(config: PixmapRegisterConfig) -> Self {
+        Self {
+            map: HashMap::default(),
+            serial: 0,
+            last_eviction_serial: 0,
+            config,
+        }
+    }
+
+    /// Look up an `Arc<Pixmap>` by pointer identity.
+    ///
+    /// Returns the previously allocated [`ImageId`] if this exact `Arc` has
+    /// been registered before, or `None` if it hasn't. The entry's serial
+    /// is updated to mark it as recently used.
+    pub fn get(&mut self, pixmap: &Arc<Pixmap>) -> Option<ImageId> {
+        let ptr_key = Arc::as_ptr(pixmap) as usize;
+        if let Some(entry) = self.map.get_mut(&ptr_key) {
+            entry.serial = self.serial;
+            Some(entry.image_id)
+        } else {
+            None
+        }
+    }
+
+    /// Register a mapping from an `Arc<Pixmap>` pointer to an [`ImageId`].
+    pub fn insert(&mut self, pixmap: &Arc<Pixmap>, image_id: ImageId) {
+        let ptr_key = Arc::as_ptr(pixmap) as usize;
+        self.map.insert(
+            ptr_key,
+            PixmapEntry {
+                image_id,
+                serial: self.serial,
+            },
+        );
+    }
+
+    /// Advance the frame counter and potentially evict old entries.
+    ///
+    /// Should be called once per frame after rendering. Entries that haven't
+    /// been referenced for [`max_entry_age`](PixmapRegisterConfig::max_entry_age)
+    /// frames are removed and their atlas allocations are freed.
+    pub fn maintain(&mut self, image_cache: &mut ImageCache) {
+        self.tick();
+
+        let frames_since_eviction = self.serial.wrapping_sub(self.last_eviction_serial);
+        if frames_since_eviction < self.config.eviction_frequency {
+            return;
+        }
+
+        self.last_eviction_serial = self.serial;
+        self.evict_old_entries(image_cache);
+    }
+
+    /// Advance the frame counter.
+    fn tick(&mut self) {
+        self.serial = self.serial.wrapping_add(1);
+    }
+
+    /// Evict entries that haven't been used recently.
+    fn evict_old_entries(&mut self, image_cache: &mut ImageCache) {
+        let serial = self.serial;
+        let max_entry_age = self.config.max_entry_age;
+
+        self.map.retain(|_, entry| {
+            let age = serial.wrapping_sub(entry.serial);
+            if age > max_entry_age {
+                image_cache.deallocate(entry.image_id);
+                false
+            } else {
+                true
+            }
+        });
     }
 }
 

--- a/sparse_strips/vello_common/src/image_cache.rs
+++ b/sparse_strips/vello_common/src/image_cache.rs
@@ -8,10 +8,11 @@
 
 use crate::multi_atlas::{AllocId, AtlasConfig, AtlasError, AtlasId, MultiAtlasManager};
 use crate::paint::ImageId;
+use crate::pixmap::Pixmap;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use hashbrown::HashMap;
-use crate::pixmap::Pixmap;
+use hashbrown::hash_map::Entry;
 
 /// Represents an image resource for rendering.
 #[derive(Debug)]
@@ -146,6 +147,28 @@ impl PixmapRegister {
                 serial: self.serial,
             },
         );
+    }
+
+    /// Look up a pixmap by pointer identity, or insert a new entry using
+    /// the provided closure if it hasn't been registered yet.
+    pub fn get_or_insert_with<E>(
+        &mut self,
+        pixmap: &Arc<Pixmap>,
+        f: impl FnOnce() -> Result<ImageId, E>,
+    ) -> Result<ImageId, E> {
+        let ptr_key = Arc::as_ptr(pixmap) as usize;
+        let serial = self.serial;
+        match self.map.entry(ptr_key) {
+            Entry::Occupied(mut entry) => {
+                entry.get_mut().serial = serial;
+                Ok(entry.get().image_id)
+            }
+            Entry::Vacant(entry) => {
+                let image_id = f()?;
+                entry.insert(PixmapEntry { image_id, serial });
+                Ok(image_id)
+            }
+        }
     }
 
     /// Advance the frame counter and potentially evict old entries.
@@ -446,6 +469,30 @@ mod tests {
         assert!(cache.get(id3).is_some());
         assert!(cache.get(id4).is_some());
         assert_eq!(cache.get(id4).unwrap().width, 80);
+    }
+
+    #[test]
+    fn test_pixmap_register_deduplication() {
+        let mut register = PixmapRegister::default();
+
+        let pixmap = Arc::new(Pixmap::new(2, 2));
+        let image_id = ImageId::new(42);
+
+        // First lookup should miss.
+        assert!(register.get(&pixmap).is_none());
+
+        register.insert(&pixmap, image_id);
+
+        // Same Arc should return the cached id.
+        assert_eq!(register.get(&pixmap).unwrap(), image_id);
+
+        // A clone of the Arc (same pointer) should also hit.
+        let cloned = pixmap.clone();
+        assert_eq!(register.get(&cloned).unwrap(), image_id);
+
+        // A *different* Arc with identical content should miss (pointer identity).
+        let different_pixmap = Arc::new(Pixmap::new(2, 2));
+        assert!(register.get(&different_pixmap).is_none());
     }
 
     #[test]

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -45,7 +45,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 use bytemuck::{Pod, Zeroable};
 use core::fmt::Debug;
-use vello_common::image_cache::{ImageCache, ImageResource};
+use vello_common::image_cache::{ImageCache, ImageResource, PendingImageUpload, PixmapRegister};
 use vello_common::multi_atlas::{AtlasConfig, AtlasId};
 use vello_common::render_graph::LayerId;
 use vello_common::{
@@ -101,6 +101,14 @@ pub struct WebGlRenderer {
     filter_context: FilterContext,
     /// State used for constructing filter passes.
     filter_pass_state: FilterPassState,
+    /// Registry mapping `Arc<Pixmap>` pointer addresses to allocated `ImageId`s.
+    ///
+    /// Persists across frames so that the same `Arc<Pixmap>` is only uploaded once.
+    pixmap_register: PixmapRegister,
+    /// Pixmaps allocated in the image cache but not yet uploaded to the GPU atlas.
+    ///
+    /// Drained and uploaded at the start of each render call, before scheduling.
+    pending_uploads: Vec<PendingImageUpload>,
 }
 
 impl WebGlRenderer {
@@ -170,6 +178,8 @@ impl WebGlRenderer {
             gradient_cache,
             filter_context,
             filter_pass_state: FilterPassState::default(),
+            pixmap_register: PixmapRegister::default(),
+            pending_uploads: Vec::new(),
         }
     }
 
@@ -187,6 +197,7 @@ impl WebGlRenderer {
         );
 
         self.render_scene(scene, render_size, true)?;
+        self.pixmap_register.maintain(&mut self.image_cache);
 
         // Blit the view framebuffer to the default framebuffer (canvas element), reflecting the
         // image along the Y axis to complete the WebGPU to WebGL2 coordinate transform.
@@ -306,6 +317,7 @@ impl WebGlRenderer {
         );
 
         let result = self.render_scene(scene, &atlas_render_size, false);
+        self.pixmap_register.maintain(&mut self.image_cache);
 
         // Restore the real atlas texture array.
         core::mem::swap(
@@ -353,6 +365,7 @@ impl WebGlRenderer {
         )?;
 
         self.prepare_gpu_encoded_paints(&encoded_paints);
+        self.upload_pending_images();
 
         self.programs
             .maybe_resize_atlas_texture_array(&self.gl, self.image_cache.atlas_count() as u32);
@@ -541,13 +554,38 @@ impl WebGlRenderer {
             self.paint_idxs[encoded_paint_idx] = current_idx;
             match paint {
                 EncodedPaint::Image(img) => {
-                    if let ImageSource::OpaqueId { id: image_id, .. } = img.source {
-                        let image_resource: Option<&ImageResource> = self.image_cache.get(image_id);
-                        if let Some(image_resource) = image_resource {
-                            let gpu_image = self.encode_image_paint(img, image_resource);
-                            self.encoded_paints[encoded_paint_idx] = gpu_image;
-                            current_idx += GPU_ENCODED_IMAGE_SIZE_TEXELS;
-                        }
+                    let image_id = match &img.source {
+                        ImageSource::OpaqueId { id, .. } => Some(*id),
+                        ImageSource::Pixmap(pixmap) => match self.pixmap_register.get(pixmap) {
+                            Some(id) => Some(id),
+                            None => {
+                                match self.image_cache.allocate(
+                                    pixmap.width().into(),
+                                    pixmap.height().into(),
+                                    0,
+                                ) {
+                                    Ok(id) => {
+                                        self.pixmap_register.insert(pixmap, id);
+                                        self.pending_uploads.push(PendingImageUpload {
+                                            image_id: id,
+                                            pixmap: pixmap.clone(),
+                                        });
+                                        Some(id)
+                                    }
+                                    Err(e) => {
+                                        log::warn!("Failed to allocate pixmap in atlas: {e:?}");
+                                        None
+                                    }
+                                }
+                            }
+                        },
+                    };
+                    if let Some(image_id) = image_id
+                        && let Some(image_resource) = self.image_cache.get(image_id)
+                    {
+                        let gpu_image = self.encode_image_paint(img, image_resource);
+                        self.encoded_paints[encoded_paint_idx] = gpu_image;
+                        current_idx += GPU_ENCODED_IMAGE_SIZE_TEXELS;
                     }
                 }
                 EncodedPaint::Gradient(gradient) => {
@@ -573,6 +611,17 @@ impl WebGlRenderer {
             }
         }
         self.paint_idxs[encoded_paints.len()] = current_idx;
+    }
+
+    /// Upload any pixmaps that were allocated during [`Self::prepare_gpu_encoded_paints`]
+    /// but haven't been written to the GPU atlas yet.
+    fn upload_pending_images(&mut self) {
+        let uploads: Vec<_> = self.pending_uploads.drain(..).collect();
+        for upload in uploads {
+            self.programs
+                .maybe_resize_atlas_texture_array(&self.gl, self.image_cache.atlas_count() as u32);
+            self.write_to_atlas(upload.image_id, &upload.pixmap, None);
+        }
     }
 
     fn encode_image_paint(

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -46,7 +46,7 @@ use alloc::vec::Vec;
 use bytemuck::{Pod, Zeroable};
 use core::fmt::Debug;
 use vello_common::image_cache::{ImageCache, ImageResource, PendingImageUpload, PixmapRegister};
-use vello_common::multi_atlas::{AtlasConfig, AtlasId};
+use vello_common::multi_atlas::{AtlasConfig, AtlasError, AtlasId};
 use vello_common::render_graph::LayerId;
 use vello_common::{
     coarse::WideTile,
@@ -364,7 +364,7 @@ impl WebGlRenderer {
             &mut encoded_paints,
         )?;
 
-        self.prepare_gpu_encoded_paints(&encoded_paints);
+        self.prepare_gpu_encoded_paints(&encoded_paints)?;
         self.upload_pending_images();
 
         self.programs
@@ -544,7 +544,10 @@ impl WebGlRenderer {
         self.gl.delete_framebuffer(Some(&temp_framebuffer));
     }
 
-    fn prepare_gpu_encoded_paints(&mut self, encoded_paints: &[EncodedPaint]) {
+    fn prepare_gpu_encoded_paints(
+        &mut self,
+        encoded_paints: &[EncodedPaint],
+    ) -> Result<(), RenderError> {
         self.encoded_paints
             .resize_with(encoded_paints.len(), || GPU_PAINT_PLACEHOLDER);
         self.paint_idxs.resize(encoded_paints.len() + 1, 0);
@@ -556,29 +559,21 @@ impl WebGlRenderer {
                 EncodedPaint::Image(img) => {
                     let image_id = match &img.source {
                         ImageSource::OpaqueId { id, .. } => Some(*id),
-                        ImageSource::Pixmap(pixmap) => match self.pixmap_register.get(pixmap) {
-                            Some(id) => Some(id),
-                            None => {
-                                match self.image_cache.allocate(
-                                    pixmap.width().into(),
-                                    pixmap.height().into(),
+                        ImageSource::Pixmap(pixmap) => {
+                            let id = self.pixmap_register.get_or_insert_with(pixmap, || {
+                                let id = self.image_cache.allocate(
+                                    pixmap.width(),
+                                    pixmap.height(),
                                     0,
-                                ) {
-                                    Ok(id) => {
-                                        self.pixmap_register.insert(pixmap, id);
-                                        self.pending_uploads.push(PendingImageUpload {
-                                            image_id: id,
-                                            pixmap: pixmap.clone(),
-                                        });
-                                        Some(id)
-                                    }
-                                    Err(e) => {
-                                        log::warn!("Failed to allocate pixmap in atlas: {e:?}");
-                                        None
-                                    }
-                                }
-                            }
-                        },
+                                )?;
+                                self.pending_uploads.push(PendingImageUpload {
+                                    image_id: id,
+                                    pixmap: pixmap.clone(),
+                                });
+                                Ok::<_, AtlasError>(id)
+                            })?;
+                            Some(id)
+                        }
                     };
                     if let Some(image_id) = image_id
                         && let Some(image_resource) = self.image_cache.get(image_id)
@@ -611,17 +606,17 @@ impl WebGlRenderer {
             }
         }
         self.paint_idxs[encoded_paints.len()] = current_idx;
+        Ok(())
     }
 
     /// Upload any pixmaps that were allocated during [`Self::prepare_gpu_encoded_paints`]
     /// but haven't been written to the GPU atlas yet.
     fn upload_pending_images(&mut self) {
-        let uploads: Vec<_> = self.pending_uploads.drain(..).collect();
-        for upload in uploads {
-            self.programs
-                .maybe_resize_atlas_texture_array(&self.gl, self.image_cache.atlas_count() as u32);
+        let mut uploads = core::mem::take(&mut self.pending_uploads);
+        for upload in uploads.drain(..) {
             self.write_to_atlas(upload.image_id, &upload.pixmap, None);
         }
+        self.pending_uploads = uploads;
     }
 
     fn encode_image_paint(

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -356,7 +356,7 @@ impl Renderer {
         encoded_paints: &[EncodedPaint],
         clear: bool,
     ) -> Result<(), RenderError> {
-        self.prepare_gpu_encoded_paints(encoded_paints);
+        self.prepare_gpu_encoded_paints(encoded_paints)?;
         self.upload_pending_images(device, queue, encoder);
         // TODO: For the time being, we upload the entire alpha buffer as one big chunk. As a future
         // refinement, we could have a bounded alpha buffer, and break draws when the alpha
@@ -589,7 +589,10 @@ impl Renderer {
         render_pass.draw(0..4, 0..1);
     }
 
-    fn prepare_gpu_encoded_paints(&mut self, encoded_paints: &[EncodedPaint]) {
+    fn prepare_gpu_encoded_paints(
+        &mut self,
+        encoded_paints: &[EncodedPaint],
+    ) -> Result<(), RenderError> {
         self.encoded_paints
             .resize_with(encoded_paints.len(), || GPU_PAINT_PLACEHOLDER);
         self.paint_idxs.resize(encoded_paints.len() + 1, 0);
@@ -601,29 +604,21 @@ impl Renderer {
                 EncodedPaint::Image(img) => {
                     let image_id = match &img.source {
                         ImageSource::OpaqueId { id, .. } => Some(*id),
-                        ImageSource::Pixmap(pixmap) => match self.pixmap_register.get(pixmap) {
-                            Some(id) => Some(id),
-                            None => {
-                                match self.image_cache.allocate(
-                                    pixmap.width().into(),
-                                    pixmap.height().into(),
+                        ImageSource::Pixmap(pixmap) => {
+                            let id = self.pixmap_register.get_or_insert_with(pixmap, || {
+                                let id = self.image_cache.allocate(
+                                    pixmap.width(),
+                                    pixmap.height(),
                                     0,
-                                ) {
-                                    Ok(id) => {
-                                        self.pixmap_register.insert(pixmap, id);
-                                        self.pending_uploads.push(PendingImageUpload {
-                                            image_id: id,
-                                            pixmap: pixmap.clone(),
-                                        });
-                                        Some(id)
-                                    }
-                                    Err(e) => {
-                                        log::warn!("Failed to allocate pixmap in atlas: {e:?}");
-                                        None
-                                    }
-                                }
-                            }
-                        },
+                                )?;
+                                self.pending_uploads.push(PendingImageUpload {
+                                    image_id: id,
+                                    pixmap: pixmap.clone(),
+                                });
+                                Ok::<_, AtlasError>(id)
+                            })?;
+                            Some(id)
+                        }
                     };
                     if let Some(image_id) = image_id
                         && let Some(image_resource) = self.image_cache.get(image_id)
@@ -656,6 +651,7 @@ impl Renderer {
             }
         }
         self.paint_idxs[encoded_paints.len()] = current_idx;
+        Ok(())
     }
 
     /// Upload any pixmaps that were allocated during [`Self::prepare_gpu_encoded_paints`]
@@ -666,15 +662,8 @@ impl Renderer {
         queue: &Queue,
         encoder: &mut CommandEncoder,
     ) {
-        let uploads: Vec<_> = self.pending_uploads.drain(..).collect();
-        for upload in uploads {
-            Programs::maybe_resize_atlas_texture_array(
-                device,
-                encoder,
-                &mut self.programs.resources,
-                &self.programs.atlas_bind_group_layout,
-                self.image_cache.atlas_count() as u32,
-            );
+        let mut uploads = core::mem::take(&mut self.pending_uploads);
+        for upload in uploads.drain(..) {
             self.write_to_atlas(
                 device,
                 queue,
@@ -684,6 +673,7 @@ impl Renderer {
                 None,
             );
         }
+        self.pending_uploads = uploads;
     }
 
     fn encode_image_paint(

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -42,7 +42,7 @@ use alloc::vec::Vec;
 use alloc::{sync::Arc, vec};
 use bytemuck::{Pod, Zeroable};
 use core::{fmt::Debug, num::NonZeroU64};
-use vello_common::image_cache::{ImageCache, ImageResource};
+use vello_common::image_cache::{ImageCache, ImageResource, PendingImageUpload, PixmapRegister};
 use vello_common::multi_atlas::{AtlasConfig, AtlasError, AtlasId};
 use vello_common::render_graph::LayerId;
 use vello_common::{
@@ -99,6 +99,14 @@ pub struct Renderer {
     filter_context: FilterContext,
     /// State used for constructing filter passes.
     filter_pass_state: FilterPassState,
+    /// Registry mapping `Arc<Pixmap>` pointer addresses to allocated `ImageId`s.
+    ///
+    /// Persists across frames so that the same `Arc<Pixmap>` is only uploaded once.
+    pixmap_register: PixmapRegister,
+    /// Pixmaps allocated in the image cache but not yet uploaded to the GPU atlas.
+    ///
+    /// Drained and uploaded at the start of each render call, before scheduling.
+    pending_uploads: Vec<PendingImageUpload>,
 }
 
 impl Renderer {
@@ -141,6 +149,8 @@ impl Renderer {
             paint_idxs: Vec::new(),
             filter_context,
             filter_pass_state: FilterPassState::default(),
+            pixmap_register: PixmapRegister::default(),
+            pending_uploads: Vec::new(),
         }
     }
 
@@ -227,6 +237,7 @@ impl Renderer {
             &encoded_paints,
             false,
         );
+        self.pixmap_register.maintain(&mut self.image_cache);
 
         encoded_paints.truncate(scene_paint_count);
         result
@@ -314,6 +325,7 @@ impl Renderer {
             &encoded_paints,
             false,
         );
+        self.pixmap_register.maintain(&mut self.image_cache);
 
         // Restore the real atlas bind group.
         core::mem::swap(
@@ -345,6 +357,7 @@ impl Renderer {
         clear: bool,
     ) -> Result<(), RenderError> {
         self.prepare_gpu_encoded_paints(encoded_paints);
+        self.upload_pending_images(device, queue, encoder);
         // TODO: For the time being, we upload the entire alpha buffer as one big chunk. As a future
         // refinement, we could have a bounded alpha buffer, and break draws when the alpha
         // buffer fills.
@@ -586,13 +599,38 @@ impl Renderer {
             self.paint_idxs[encoded_paint_idx] = current_idx;
             match paint {
                 EncodedPaint::Image(img) => {
-                    if let ImageSource::OpaqueId { id: image_id, .. } = img.source {
-                        let image_resource: Option<&ImageResource> = self.image_cache.get(image_id);
-                        if let Some(image_resource) = image_resource {
-                            let image_paint = self.encode_image_paint(img, image_resource);
-                            self.encoded_paints[encoded_paint_idx] = image_paint;
-                            current_idx += GPU_ENCODED_IMAGE_SIZE_TEXELS;
-                        }
+                    let image_id = match &img.source {
+                        ImageSource::OpaqueId { id, .. } => Some(*id),
+                        ImageSource::Pixmap(pixmap) => match self.pixmap_register.get(pixmap) {
+                            Some(id) => Some(id),
+                            None => {
+                                match self.image_cache.allocate(
+                                    pixmap.width().into(),
+                                    pixmap.height().into(),
+                                    0,
+                                ) {
+                                    Ok(id) => {
+                                        self.pixmap_register.insert(pixmap, id);
+                                        self.pending_uploads.push(PendingImageUpload {
+                                            image_id: id,
+                                            pixmap: pixmap.clone(),
+                                        });
+                                        Some(id)
+                                    }
+                                    Err(e) => {
+                                        log::warn!("Failed to allocate pixmap in atlas: {e:?}");
+                                        None
+                                    }
+                                }
+                            }
+                        },
+                    };
+                    if let Some(image_id) = image_id
+                        && let Some(image_resource) = self.image_cache.get(image_id)
+                    {
+                        let image_paint = self.encode_image_paint(img, image_resource);
+                        self.encoded_paints[encoded_paint_idx] = image_paint;
+                        current_idx += GPU_ENCODED_IMAGE_SIZE_TEXELS;
                     }
                 }
                 EncodedPaint::Gradient(gradient) => {
@@ -618,6 +656,34 @@ impl Renderer {
             }
         }
         self.paint_idxs[encoded_paints.len()] = current_idx;
+    }
+
+    /// Upload any pixmaps that were allocated during [`Self::prepare_gpu_encoded_paints`]
+    /// but haven't been written to the GPU atlas yet.
+    fn upload_pending_images(
+        &mut self,
+        device: &Device,
+        queue: &Queue,
+        encoder: &mut CommandEncoder,
+    ) {
+        let uploads: Vec<_> = self.pending_uploads.drain(..).collect();
+        for upload in uploads {
+            Programs::maybe_resize_atlas_texture_array(
+                device,
+                encoder,
+                &mut self.programs.resources,
+                &self.programs.atlas_bind_group_layout,
+                self.image_cache.atlas_count() as u32,
+            );
+            self.write_to_atlas(
+                device,
+                queue,
+                encoder,
+                upload.image_id,
+                &upload.pixmap,
+                None,
+            );
+        }
     }
 
     fn encode_image_paint(

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -192,7 +192,7 @@ use vello_common::strip_generator::StripStorage;
 use vello_common::{
     coarse::{Cmd, WideTile},
     encode::EncodedPaint,
-    paint::{ImageSource, Paint},
+    paint::Paint,
     tile::Tile,
 };
 
@@ -1595,16 +1595,13 @@ impl Scheduler {
         scene_strip_y: u16,
     ) -> (u32, u32) {
         match encoded_paint {
-            EncodedPaint::Image(encoded_image) => match &encoded_image.source {
-                ImageSource::OpaqueId { .. } => {
-                    let paint_packed = (COLOR_SOURCE_PAYLOAD << 29)
-                        | (PAINT_TYPE_IMAGE << 26)
-                        | (paint_idx & 0x03FF_FFFF);
-                    let scene_strip_xy = ((scene_strip_y as u32) << 16) | (scene_strip_x as u32);
-                    (scene_strip_xy, paint_packed)
-                }
-                _ => unimplemented!("Unsupported image source"),
-            },
+            EncodedPaint::Image(_) => {
+                let paint_packed = (COLOR_SOURCE_PAYLOAD << 29)
+                    | (PAINT_TYPE_IMAGE << 26)
+                    | (paint_idx & 0x03FF_FFFF);
+                let scene_strip_xy = ((scene_strip_y as u32) << 16) | (scene_strip_x as u32);
+                (scene_strip_xy, paint_packed)
+            }
             EncodedPaint::Gradient(gradient) => {
                 use vello_common::encode::EncodedKind;
                 let gradient_paint_type = match &gradient.kind {

--- a/sparse_strips/vello_sparse_tests/snapshots/image_pixmap_source.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/image_pixmap_source.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a19b95fef8293d05d0bcaa9c5d1801cb11f728ba01f4e9e297c50faa370403e8
+size 145

--- a/sparse_strips/vello_sparse_tests/tests/image.rs
+++ b/sparse_strips/vello_sparse_tests/tests/image.rs
@@ -673,8 +673,7 @@ fn image_spritesheet_tinted(ctx: &mut impl Renderer) {
 ///
 /// This exercises the hybrid renderer's `PixmapRegister` + `PendingImageUpload` path,
 /// where inline pixmaps are automatically allocated in the image cache and uploaded
-/// to the GPU atlas on demand. The same `Arc<Pixmap>` is used for two fills in
-/// different locations, verifying that deduplication works (only one atlas upload).
+/// to the GPU atlas on demand.
 #[vello_test]
 fn image_pixmap_source(ctx: &mut impl Renderer) {
     let pixmap = load_image!("rgb_image_2x2");

--- a/sparse_strips/vello_sparse_tests/tests/image.rs
+++ b/sparse_strips/vello_sparse_tests/tests/image.rs
@@ -668,3 +668,36 @@ fn image_spritesheet_tinted(ctx: &mut impl Renderer) {
         cursor_x += glyph.width;
     }
 }
+
+/// Test that `ImageSource::Pixmap` renders directly without Pixmap pre-uploading.
+///
+/// This exercises the hybrid renderer's `PixmapRegister` + `PendingImageUpload` path,
+/// where inline pixmaps are automatically allocated in the image cache and uploaded
+/// to the GPU atlas on demand. The same `Arc<Pixmap>` is used for two fills in
+/// different locations, verifying that deduplication works (only one atlas upload).
+#[vello_test]
+fn image_pixmap_source(ctx: &mut impl Renderer) {
+    let pixmap = load_image!("rgb_image_2x2");
+    let image_source = ImageSource::Pixmap(pixmap);
+
+    let sampler = ImageSampler {
+        x_extend: Extend::Repeat,
+        y_extend: Extend::Repeat,
+        quality: ImageQuality::Low,
+        alpha: 1.0,
+    };
+
+    // First fill in the top-left quadrant.
+    ctx.set_paint(Image {
+        image: image_source.clone(),
+        sampler,
+    });
+    ctx.fill_rect(&Rect::new(5.0, 5.0, 45.0, 45.0));
+
+    // Second fill with the same pixmap in the bottom-right quadrant.
+    ctx.set_paint(Image {
+        image: image_source,
+        sampler,
+    });
+    ctx.fill_rect(&Rect::new(55.0, 55.0, 95.0, 95.0));
+}


### PR DESCRIPTION
This PR adds support for rendering `Arc<Pixmap>` images directly via `ImageSource::Pixmap` in `vello_hybrid`, without requiring callers to manually pre-upload them. The renderer automatically deduplicates pixmaps by pointer identity across frames and lazily uploads them to the GPU atlas on demand, with periodic eviction of stale entries.