### PR TITLE
vello_hybrid: Optimize rendering of opaque full-tile images

### DIFF
--- a/sparse_strips/vello_common/src/encode.rs
+++ b/sparse_strips/vello_common/src/encode.rs
@@ -507,12 +507,10 @@ impl EncodeExt for Image {
                 x_advance,
                 y_advance,
             },
-            ImageSource::OpaqueId(image) => EncodedImage {
-                source: ImageSource::OpaqueId(*image),
+            ImageSource::OpaqueId(image, may_have_opacities) => EncodedImage {
+                source: ImageSource::OpaqueId(*image, *may_have_opacities),
                 sampler,
-                // Safe fallback: we don't have access to pixel data for externally
-                // registered images, so we conservatively assume they have opacities.
-                may_have_opacities: true,
+                may_have_opacities: *may_have_opacities,
                 transform,
                 x_advance,
                 y_advance,

--- a/sparse_strips/vello_common/src/encode.rs
+++ b/sparse_strips/vello_common/src/encode.rs
@@ -498,23 +498,13 @@ impl EncodeExt for Image {
 
         let (x_advance, y_advance) = x_y_advances(&transform);
 
-        let encoded = match &self.image {
-            ImageSource::Pixmap(pixmap) => EncodedImage {
-                source: ImageSource::Pixmap(pixmap.clone()),
-                sampler,
-                may_have_opacities: pixmap.may_have_opacities(),
-                transform,
-                x_advance,
-                y_advance,
-            },
-            ImageSource::OpaqueId(image, may_have_opacities) => EncodedImage {
-                source: ImageSource::OpaqueId(*image, *may_have_opacities),
-                sampler,
-                may_have_opacities: *may_have_opacities,
-                transform,
-                x_advance,
-                y_advance,
-            },
+        let encoded = EncodedImage {
+            may_have_opacities: self.image.may_have_opacities(),
+            source: self.image.clone(),
+            sampler,
+            transform,
+            x_advance,
+            y_advance,
         };
 
         paints.push(EncodedPaint::Image(encoded));

--- a/sparse_strips/vello_common/src/paint.rs
+++ b/sparse_strips/vello_common/src/paint.rs
@@ -75,7 +75,7 @@ pub enum ImageSource {
     Pixmap(Arc<Pixmap>),
     /// Pixmap pixels were registered earlier; this is just a handle.
     ///
-    /// The `bool` indicates whether the image may contain non-opaque pixels.
+    /// The `bool` indicates whether the image may contain non-opaque pixels. If unsure, set this to `true`.
     OpaqueId(ImageId, bool),
 }
 

--- a/sparse_strips/vello_common/src/paint.rs
+++ b/sparse_strips/vello_common/src/paint.rs
@@ -74,7 +74,9 @@ pub enum ImageSource {
     /// Pixmap pixels travel with the scene packet.
     Pixmap(Arc<Pixmap>),
     /// Pixmap pixels were registered earlier; this is just a handle.
-    OpaqueId(ImageId),
+    ///
+    /// The `bool` indicates whether the image may contain non-opaque pixels.
+    OpaqueId(ImageId, bool),
 }
 
 impl ImageSource {

--- a/sparse_strips/vello_common/src/paint.rs
+++ b/sparse_strips/vello_common/src/paint.rs
@@ -74,12 +74,45 @@ pub enum ImageSource {
     /// Pixmap pixels travel with the scene packet.
     Pixmap(Arc<Pixmap>),
     /// Pixmap pixels were registered earlier; this is just a handle.
-    ///
-    /// The `bool` indicates whether the image may contain non-opaque pixels. If unsure, set this to `true`.
-    OpaqueId(ImageId, bool),
+    OpaqueId {
+        /// The image handle.
+        id: ImageId,
+        /// Whether the image may contain non-opaque pixels.
+        may_have_opacities: bool,
+    },
 }
 
 impl ImageSource {
+    /// Create an [`ImageSource`] from a pre-registered image handle.
+    ///
+    /// Conservatively assumes the image may have non-opaque pixels.
+    /// Use [`Self::opaque_id_with_opacity_hint`] when you know the image is fully opaque.
+    pub fn opaque_id(id: ImageId) -> Self {
+        Self::OpaqueId {
+            id,
+            may_have_opacities: true,
+        }
+    }
+
+    /// Create an [`ImageSource`] from a pre-registered image handle,
+    /// with an explicit hint about whether the image may have non-opaque pixels.
+    pub fn opaque_id_with_opacity_hint(id: ImageId, may_have_opacities: bool) -> Self {
+        Self::OpaqueId {
+            id,
+            may_have_opacities,
+        }
+    }
+
+    /// Returns whether this image source may contain non-opaque pixels.
+    pub fn may_have_opacities(&self) -> bool {
+        match self {
+            Self::Pixmap(p) => p.may_have_opacities(),
+            Self::OpaqueId {
+                may_have_opacities, ..
+            } => *may_have_opacities,
+        }
+    }
+
     /// Convert a [`peniko::ImageData`] to an [`ImageSource`].
     ///
     /// This is a somewhat lossy conversion, as the image data data is transformed to

--- a/sparse_strips/vello_cpu/src/api.rs
+++ b/sparse_strips/vello_cpu/src/api.rs
@@ -117,7 +117,7 @@ impl PaintScene for CPUScenePainter {
                             let image_index =
                                 brush.image.to_raw().try_into().expect("Handle this.");
                             Brush::Image(ImageBrush {
-                                image: ImageSource::OpaqueId(ImageId::new(image_index), true),
+                                image: ImageSource::opaque_id(ImageId::new(image_index)),
                                 sampler: brush.sampler,
                             })
                         }
@@ -171,7 +171,7 @@ impl PaintScene for CPUScenePainter {
                 // TODO: Make this read more easily.
                 let image_index = brush.image.to_raw().try_into().expect("Handle this.");
                 Brush::Image(ImageBrush {
-                    image: ImageSource::OpaqueId(ImageId::new(image_index), true),
+                    image: ImageSource::opaque_id(ImageId::new(image_index)),
                     sampler: brush.sampler,
                 })
             }

--- a/sparse_strips/vello_cpu/src/api.rs
+++ b/sparse_strips/vello_cpu/src/api.rs
@@ -117,7 +117,7 @@ impl PaintScene for CPUScenePainter {
                             let image_index =
                                 brush.image.to_raw().try_into().expect("Handle this.");
                             Brush::Image(ImageBrush {
-                                image: ImageSource::OpaqueId(ImageId::new(image_index)),
+                                image: ImageSource::OpaqueId(ImageId::new(image_index), true),
                                 sampler: brush.sampler,
                             })
                         }
@@ -171,7 +171,7 @@ impl PaintScene for CPUScenePainter {
                 // TODO: Make this read more easily.
                 let image_index = brush.image.to_raw().try_into().expect("Handle this.");
                 Brush::Image(ImageBrush {
-                    image: ImageSource::OpaqueId(ImageId::new(image_index)),
+                    image: ImageSource::OpaqueId(ImageId::new(image_index), true),
                     sampler: brush.sampler,
                 })
             }

--- a/sparse_strips/vello_cpu/src/fine/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/mod.rs
@@ -819,7 +819,7 @@ impl<S: Simd, T: FineKernel<S>> Fine<S, T> {
                     EncodedPaint::Image(i) => {
                         let pixmap = match &i.source {
                             ImageSource::Pixmap(p) => p.clone(),
-                            ImageSource::OpaqueId(id) => image_resolver
+                            ImageSource::OpaqueId { id, .. } => image_resolver
                                 .resolve(*id)
                                 .unwrap_or_else(|| panic!("Image {:?} not found in registry", id)),
                         };

--- a/sparse_strips/vello_example_scenes/src/multi_image.rs
+++ b/sparse_strips/vello_example_scenes/src/multi_image.rs
@@ -1,0 +1,155 @@
+// Copyright 2025 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Scene that renders multiple axis-aligned images at randomized positions across the viewport.
+//! Press "a"/"A" to add 50/1 images, "d"/"D" to remove 50/1 images.
+
+use crate::{ExampleScene, RenderingContext};
+use std::fmt::{Debug, Formatter, Result};
+use vello_common::color::palette::css::WHITE;
+use vello_common::kurbo::{Affine, Rect};
+use vello_common::paint::{Image, ImageSource};
+use vello_common::peniko::{Extend, ImageQuality, ImageSampler};
+
+const BATCH_SIZE: usize = 50;
+const IMG_W: f64 = 640.0;
+const IMG_H: f64 = 480.0;
+const MIN_SCALE: f64 = 0.1;
+const MAX_SCALE: f64 = 1.5;
+
+/// Pre-computed placement for a single image (normalised 0..1 coordinates).
+struct ImagePlacement {
+    nx: f64,
+    ny: f64,
+    scale: f64,
+}
+
+/// Scene state for the multi-image example.
+pub struct MultiImageScene {
+    img_source: ImageSource,
+    rng: Rng,
+    placements: Vec<ImagePlacement>,
+}
+
+impl Debug for MultiImageScene {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        f.debug_struct("MultiImageScene")
+            .field("count", &self.placements.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl MultiImageScene {
+    /// Create a new multi-image scene starting with `BATCH_SIZE` images.
+    pub fn new(img_source: ImageSource) -> Self {
+        let mut scene = Self {
+            img_source,
+            rng: Rng::new(0xDEAD_BEEF_CAFE_BABE),
+            placements: Vec::new(),
+        };
+        scene.placements.push(ImagePlacement {
+            nx: 0.1,
+            ny: 0.1,
+            scale: 2.0,
+        });
+        scene
+    }
+
+    fn add_one(&mut self) {
+        self.placements.push(ImagePlacement {
+            nx: self.rng.range_f64(0.0, 1.0),
+            ny: self.rng.range_f64(0.0, 1.0),
+            scale: self.rng.range_f64(MIN_SCALE, MAX_SCALE),
+        });
+    }
+
+    fn add_batch(&mut self) {
+        for _ in 0..BATCH_SIZE {
+            self.add_one();
+        }
+    }
+}
+
+impl ExampleScene for MultiImageScene {
+    fn render(&mut self, ctx: &mut impl RenderingContext, root_transform: Affine) {
+        let vw = ctx.width() as f64;
+        let vh = ctx.height() as f64;
+        let [a, b, c, d, e, f] = root_transform.as_coeffs();
+        let snapped_root = Affine::new([a, b, c, d, e.round(), f.round()]);
+
+        for p in &self.placements {
+            let x = (p.nx * vw).round();
+            let y = (p.ny * vh).round();
+            let w = (IMG_W * p.scale).round();
+            let h = (IMG_H * p.scale).round();
+
+            ctx.set_transform(snapped_root * Affine::translate((x, y)));
+            ctx.set_paint_transform(Affine::scale(p.scale));
+            ctx.set_paint(Image {
+                image: self.img_source.clone(),
+                sampler: ImageSampler {
+                    x_extend: Extend::Pad,
+                    y_extend: Extend::Pad,
+                    quality: ImageQuality::Medium,
+                    alpha: 1.0,
+                },
+            });
+            ctx.fill_rect(&Rect::new(0.0, 0.0, w, h));
+        }
+
+        ctx.set_transform(Affine::IDENTITY);
+        ctx.set_paint(WHITE);
+        ctx.fill_rect(&Rect::new(0.0, 0.0, 1.0, 1.0));
+    }
+
+    fn handle_key(&mut self, key: &str) -> bool {
+        match key {
+            "a" => {
+                self.add_batch();
+                true
+            }
+            "A" => {
+                self.add_one();
+                true
+            }
+            "d" => {
+                let new_len = self.placements.len().saturating_sub(BATCH_SIZE);
+                self.placements.truncate(new_len);
+                true
+            }
+            "D" => {
+                self.placements.pop();
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn status(&self) -> Option<String> {
+        Some(format!("{} images", self.placements.len()))
+    }
+}
+
+/// Minimal xorshift64 PRNG.
+struct Rng(u64);
+
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Self(seed)
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+
+    fn range_f64(&mut self, lo: f64, hi: f64) -> f64 {
+        let t =
+            (self.next_u64() & 0x000F_FFFF_FFFF_FFFF) as f64 / (0x0010_0000_0000_0000_u64 as f64);
+        lo + t * (hi - lo)
+    }
+}

--- a/sparse_strips/vello_example_scenes/src/multi_image.rs
+++ b/sparse_strips/vello_example_scenes/src/multi_image.rs
@@ -7,7 +7,7 @@
 use crate::{ExampleScene, RenderingContext};
 use std::fmt::{Debug, Formatter, Result};
 use vello_common::color::palette::css::WHITE;
-use vello_common::kurbo::{Affine, Rect};
+use vello_common::kurbo::{Affine, Rect, Vec2};
 use vello_common::paint::{Image, ImageSource};
 use vello_common::peniko::{Extend, ImageQuality, ImageSampler};
 
@@ -74,8 +74,8 @@ impl ExampleScene for MultiImageScene {
     fn render(&mut self, ctx: &mut impl RenderingContext, root_transform: Affine) {
         let vw = ctx.width() as f64;
         let vh = ctx.height() as f64;
-        let [a, b, c, d, e, f] = root_transform.as_coeffs();
-        let snapped_root = Affine::new([a, b, c, d, e.round(), f.round()]);
+        let t = root_transform.translation();
+        let snapped_root = root_transform.with_translation(Vec2::new(t.x.round(), t.y.round()));
 
         for p in &self.placements {
             let x = (p.nx * vw).round();

--- a/sparse_strips/vello_hybrid/examples/native_webgl/src/lib.rs
+++ b/sparse_strips/vello_hybrid/examples/native_webgl/src/lib.rs
@@ -285,8 +285,8 @@ pub async fn run_interactive(canvas_width: u16, canvas_height: u16) {
 
     let scenes = {
         let v = vello_example_scenes::get_example_scenes(vec![
-            ImageSource::OpaqueId(ImageId::new(0)),
-            ImageSource::OpaqueId(ImageId::new(1)),
+            ImageSource::OpaqueId(ImageId::new(0), true),
+            ImageSource::OpaqueId(ImageId::new(1), true),
         ])
         .into_vec();
         v.into_boxed_slice()

--- a/sparse_strips/vello_hybrid/examples/native_webgl/src/lib.rs
+++ b/sparse_strips/vello_hybrid/examples/native_webgl/src/lib.rs
@@ -285,8 +285,8 @@ pub async fn run_interactive(canvas_width: u16, canvas_height: u16) {
 
     let scenes = {
         let v = vello_example_scenes::get_example_scenes(vec![
-            ImageSource::OpaqueId(ImageId::new(0), true),
-            ImageSource::OpaqueId(ImageId::new(1), true),
+            ImageSource::opaque_id(ImageId::new(0)),
+            ImageSource::opaque_id(ImageId::new(1)),
         ])
         .into_vec();
         v.into_boxed_slice()

--- a/sparse_strips/vello_hybrid/examples/wgpu_webgl/src/lib.rs
+++ b/sparse_strips/vello_hybrid/examples/wgpu_webgl/src/lib.rs
@@ -396,8 +396,8 @@ pub async fn run_interactive(canvas_width: u16, canvas_height: u16) {
         .unwrap();
 
     let scenes = vello_example_scenes::get_example_scenes(vec![
-        ImageSource::OpaqueId(ImageId::new(0)),
-        ImageSource::OpaqueId(ImageId::new(1)),
+        ImageSource::OpaqueId(ImageId::new(0), true),
+        ImageSource::OpaqueId(ImageId::new(1), true),
     ]);
 
     let app_state = Rc::new(RefCell::new(AppState::new(canvas.clone(), scenes).await));

--- a/sparse_strips/vello_hybrid/examples/wgpu_webgl/src/lib.rs
+++ b/sparse_strips/vello_hybrid/examples/wgpu_webgl/src/lib.rs
@@ -396,8 +396,8 @@ pub async fn run_interactive(canvas_width: u16, canvas_height: u16) {
         .unwrap();
 
     let scenes = vello_example_scenes::get_example_scenes(vec![
-        ImageSource::OpaqueId(ImageId::new(0), true),
-        ImageSource::OpaqueId(ImageId::new(1), true),
+        ImageSource::opaque_id(ImageId::new(0)),
+        ImageSource::opaque_id(ImageId::new(1)),
     ]);
 
     let app_state = Rc::new(RefCell::new(AppState::new(canvas.clone(), scenes).await));

--- a/sparse_strips/vello_hybrid/examples/winit/src/main.rs
+++ b/sparse_strips/vello_hybrid/examples/winit/src/main.rs
@@ -39,12 +39,13 @@ struct App<'s> {
     frame_count: u32,
     fps_update_time: Instant,
     accumulated_frame_time: f64,
+    accumulated_render_time: f64,
 }
 
 fn main() {
     #[cfg(not(target_arch = "wasm32"))]
     let (scenes, start_scene_index) = {
-        let mut start_scene_index = 0;
+        let mut start_scene_index = 6; // MultiImageScene
         let args: Vec<String> = env::args().collect();
         let mut svg_paths: Vec<&str> = Vec::new();
 
@@ -60,8 +61,8 @@ fn main() {
             }
         }
         let img_sources = vec![
-            ImageSource::OpaqueId(ImageId::new(0)),
-            ImageSource::OpaqueId(ImageId::new(1)),
+            ImageSource::OpaqueId(ImageId::new(0), false),
+            ImageSource::OpaqueId(ImageId::new(1), true),
         ];
         let scenes = if svg_paths.is_empty() {
             get_example_scenes(None, img_sources)
@@ -75,8 +76,8 @@ fn main() {
     #[cfg(target_arch = "wasm32")]
     let (scenes, start_scene_index) = (
         get_example_scenes(vec![
-            ImageSource::OpaqueId(ImageId::new(0)),
-            ImageSource::OpaqueId(ImageId::new(1)),
+            ImageSource::OpaqueId(ImageId::new(0), true),
+            ImageSource::OpaqueId(ImageId::new(1), true),
         ]),
         0,
     );
@@ -96,6 +97,7 @@ fn main() {
         frame_count: 0,
         fps_update_time: now,
         accumulated_frame_time: 0.0,
+        accumulated_render_time: 0.0,
     };
 
     let event_loop = EventLoop::new().unwrap();
@@ -288,21 +290,32 @@ impl ApplicationHandler for App<'_> {
                     if now.duration_since(self.fps_update_time).as_secs_f64() >= 1.0 {
                         let avg_frame_time = self.accumulated_frame_time / self.frame_count as f64;
                         let avg_fps = 1000.0 / avg_frame_time;
-                        println!("Average FPS: {avg_fps:.1}");
+                        let avg_render_time =
+                            self.accumulated_render_time / self.frame_count as f64;
+                        let status = self.scenes[self.current_scene]
+                            .status()
+                            .map(|s| format!(" - {s}"))
+                            .unwrap_or_default();
+                        println!(
+                            "FPS: {avg_fps:.1} | render: {avg_render_time:.2}ms | frame: {avg_frame_time:.2}ms{status}"
+                        );
                         window.set_title(&format!(
-                            "Vello Hybrid - Scene {} - {:.1} FPS ({:.2}ms avg)",
-                            self.current_scene, avg_fps, avg_frame_time
+                            "Vello Hybrid - Scene {} - {:.1} FPS (render {:.2}ms){status}",
+                            self.current_scene, avg_fps, avg_render_time
                         ));
 
                         // Reset counters
                         self.frame_count = 0;
                         self.accumulated_frame_time = 0.0;
+                        self.accumulated_render_time = 0.0;
                         self.fps_update_time = now;
                     }
                 }
                 self.last_frame_time = Some(now);
 
                 self.scene.reset();
+
+                let render_start = Instant::now();
 
                 self.scene.set_transform(self.transform);
                 self.scenes[self.current_scene].render(&mut self.scene, self.transform);
@@ -345,6 +358,8 @@ impl ApplicationHandler for App<'_> {
                 surface_texture.present();
 
                 device_handle.device.poll(wgpu::PollType::Poll).unwrap();
+
+                self.accumulated_render_time += render_start.elapsed().as_secs_f64() * 1000.0;
 
                 // Request continuous redraw for FPS measurement
                 window.request_redraw();

--- a/sparse_strips/vello_hybrid/examples/winit/src/main.rs
+++ b/sparse_strips/vello_hybrid/examples/winit/src/main.rs
@@ -61,8 +61,8 @@ fn main() {
             }
         }
         let img_sources = vec![
-            ImageSource::OpaqueId(ImageId::new(0), false),
-            ImageSource::OpaqueId(ImageId::new(1), true),
+            ImageSource::opaque_id_with_opacity_hint(ImageId::new(0), false),
+            ImageSource::opaque_id(ImageId::new(1)),
         ];
         let scenes = if svg_paths.is_empty() {
             get_example_scenes(None, img_sources)
@@ -76,8 +76,8 @@ fn main() {
     #[cfg(target_arch = "wasm32")]
     let (scenes, start_scene_index) = (
         get_example_scenes(vec![
-            ImageSource::OpaqueId(ImageId::new(0), true),
-            ImageSource::OpaqueId(ImageId::new(1), true),
+            ImageSource::opaque_id(ImageId::new(0)),
+            ImageSource::opaque_id(ImageId::new(1)),
         ]),
         0,
     );

--- a/sparse_strips/vello_hybrid/src/api.rs
+++ b/sparse_strips/vello_hybrid/src/api.rs
@@ -115,7 +115,7 @@ impl PaintScene for HybridScenePainter {
                             let image_index =
                                 brush.image.to_raw().try_into().expect("Handle this.");
                             Brush::Image(ImageBrush {
-                                image: ImageSource::OpaqueId(ImageId::new(image_index), true),
+                                image: ImageSource::opaque_id(ImageId::new(image_index)),
                                 sampler: brush.sampler,
                             })
                         }
@@ -168,7 +168,7 @@ impl PaintScene for HybridScenePainter {
                 // TODO: Make this read more easily.
                 let image_index = brush.image.to_raw().try_into().expect("Handle this.");
                 Brush::Image(ImageBrush {
-                    image: ImageSource::OpaqueId(ImageId::new(image_index), true),
+                    image: ImageSource::opaque_id(ImageId::new(image_index)),
                     sampler: brush.sampler,
                 })
             }

--- a/sparse_strips/vello_hybrid/src/api.rs
+++ b/sparse_strips/vello_hybrid/src/api.rs
@@ -115,7 +115,7 @@ impl PaintScene for HybridScenePainter {
                             let image_index =
                                 brush.image.to_raw().try_into().expect("Handle this.");
                             Brush::Image(ImageBrush {
-                                image: ImageSource::OpaqueId(ImageId::new(image_index)),
+                                image: ImageSource::OpaqueId(ImageId::new(image_index), true),
                                 sampler: brush.sampler,
                             })
                         }
@@ -168,7 +168,7 @@ impl PaintScene for HybridScenePainter {
                 // TODO: Make this read more easily.
                 let image_index = brush.image.to_raw().try_into().expect("Handle this.");
                 Brush::Image(ImageBrush {
-                    image: ImageSource::OpaqueId(ImageId::new(image_index)),
+                    image: ImageSource::OpaqueId(ImageId::new(image_index), true),
                     sampler: brush.sampler,
                 })
             }

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -362,7 +362,7 @@ impl WebGlRenderer {
             self.paint_idxs[encoded_paint_idx] = current_idx;
             match paint {
                 EncodedPaint::Image(img) => {
-                    if let ImageSource::OpaqueId(image_id, _) = img.source {
+                    if let ImageSource::OpaqueId { id: image_id, .. } = img.source {
                         let image_resource: Option<&ImageResource> = self.image_cache.get(image_id);
                         if let Some(image_resource) = image_resource {
                             let gpu_image = self.encode_image_paint(img, image_resource);

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -362,7 +362,7 @@ impl WebGlRenderer {
             self.paint_idxs[encoded_paint_idx] = current_idx;
             match paint {
                 EncodedPaint::Image(img) => {
-                    if let ImageSource::OpaqueId(image_id) = img.source {
+                    if let ImageSource::OpaqueId(image_id, _) = img.source {
                         let image_resource: Option<&ImageResource> = self.image_cache.get(image_id);
                         if let Some(image_resource) = image_resource {
                             let gpu_image = self.encode_image_paint(img, image_resource);

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -308,7 +308,7 @@ impl Renderer {
             self.paint_idxs[encoded_paint_idx] = current_idx;
             match paint {
                 EncodedPaint::Image(img) => {
-                    if let ImageSource::OpaqueId(image_id, _) = img.source {
+                    if let ImageSource::OpaqueId { id: image_id, .. } = img.source {
                         let image_resource: Option<&ImageResource> = self.image_cache.get(image_id);
                         if let Some(image_resource) = image_resource {
                             let image_paint = self.encode_image_paint(img, image_resource);

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -308,7 +308,7 @@ impl Renderer {
             self.paint_idxs[encoded_paint_idx] = current_idx;
             match paint {
                 EncodedPaint::Image(img) => {
-                    if let ImageSource::OpaqueId(image_id) = img.source {
+                    if let ImageSource::OpaqueId(image_id, _) = img.source {
                         let image_resource: Option<&ImageResource> = self.image_cache.get(image_id);
                         if let Some(image_resource) = image_resource {
                             let image_paint = self.encode_image_paint(img, image_resource);

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -1061,7 +1061,7 @@ impl Scheduler {
 
                 match scene.encoded_paints.get(paint_id) {
                     Some(EncodedPaint::Image(encoded_image)) => match &encoded_image.source {
-                        ImageSource::OpaqueId(_, _) => {
+                        ImageSource::OpaqueId { .. } => {
                             let paint_packed = (COLOR_SOURCE_PAYLOAD << 30)
                                 | (PAINT_TYPE_IMAGE << 27)
                                 | (paint_idx & 0x07FFFFFF);

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -1061,7 +1061,7 @@ impl Scheduler {
 
                 match scene.encoded_paints.get(paint_id) {
                     Some(EncodedPaint::Image(encoded_image)) => match &encoded_image.source {
-                        ImageSource::OpaqueId(_) => {
+                        ImageSource::OpaqueId(_, _) => {
                             let paint_packed = (COLOR_SOURCE_PAYLOAD << 30)
                                 | (PAINT_TYPE_IMAGE << 27)
                                 | (paint_idx & 0x07FFFFFF);

--- a/sparse_strips/vello_sparse_tests/tests/image.rs
+++ b/sparse_strips/vello_sparse_tests/tests/image.rs
@@ -604,7 +604,7 @@ const HELLO_WORLD: &[Sprite] = &[
 #[vello_test(width = 60, height = 30, skip_hybrid)]
 fn image_spritesheet(ctx: &mut impl Renderer) {
     let atlas_id = ctx.register_image(load_image!("glyph_atlas"));
-    let atlas_src = ImageSource::OpaqueId(atlas_id);
+    let atlas_src = ImageSource::opaque_id(atlas_id);
 
     let start_x = 10.0;
     let start_y = 8.0;

--- a/sparse_strips/vello_sparse_tests/tests/renderer.rs
+++ b/sparse_strips/vello_sparse_tests/tests/renderer.rs
@@ -552,7 +552,7 @@ impl Renderer for HybridRenderer {
 
         self.queue.submit([encoder.finish()]);
 
-        ImageSource::OpaqueId(image_id)
+        ImageSource::OpaqueId(image_id, pixmap.may_have_opacities())
     }
 
     fn register_image(&mut self, pixmap: Arc<Pixmap>) -> ImageId {
@@ -793,7 +793,7 @@ impl Renderer for HybridRenderer {
 
     fn get_image_source(&mut self, pixmap: Arc<Pixmap>) -> ImageSource {
         let image_id = self.renderer.borrow_mut().upload_image(&pixmap);
-        ImageSource::OpaqueId(image_id)
+        ImageSource::OpaqueId(image_id, pixmap.may_have_opacities())
     }
 
     fn register_image(&mut self, pixmap: Arc<Pixmap>) -> ImageId {

--- a/sparse_strips/vello_sparse_tests/tests/renderer.rs
+++ b/sparse_strips/vello_sparse_tests/tests/renderer.rs
@@ -552,7 +552,7 @@ impl Renderer for HybridRenderer {
 
         self.queue.submit([encoder.finish()]);
 
-        ImageSource::OpaqueId(image_id, pixmap.may_have_opacities())
+        ImageSource::opaque_id_with_opacity_hint(image_id, pixmap.may_have_opacities())
     }
 
     fn register_image(&mut self, pixmap: Arc<Pixmap>) -> ImageId {
@@ -793,7 +793,7 @@ impl Renderer for HybridRenderer {
 
     fn get_image_source(&mut self, pixmap: Arc<Pixmap>) -> ImageSource {
         let image_id = self.renderer.borrow_mut().upload_image(&pixmap);
-        ImageSource::OpaqueId(image_id, pixmap.may_have_opacities())
+        ImageSource::opaque_id_with_opacity_hint(image_id, pixmap.may_have_opacities())
     }
 
     fn register_image(&mut self, pixmap: Arc<Pixmap>) -> ImageId {


### PR DESCRIPTION
Skip prior draw commands when a wide tile is fully covered by an opaque fill (opaque image). This avoids unnecessary compositing work for tiles that would be entirely overwritten.

I also added additional examples that allocate more and more images when pressing “a”, so I could run a very rough benchmark. It shows roughly a 1.65x improvement in the image randomized positioning scenario.

I am not entirely happy with the approach of carrying `may_have_opacities` inside `ImageSource`, but I have not come up with a better solution yet. I would really welcome any ideas if you have suggestions.

before|after
---|---
<video src=https://github.com/user-attachments/assets/6207df28-032f-4fd0-8223-d47b6e4eeb38/>|<video src=https://github.com/user-attachments/assets/85c47dda-e493-4a59-92f0-28ccf3212302/>






