### PR TITLE
vello_common: Deduplicate some calculations

### DIFF
--- a/sparse_strips/vello_common/src/flatten_simd.rs
+++ b/sparse_strips/vello_common/src/flatten_simd.rs
@@ -340,14 +340,14 @@ fn approx_parabola_integral_simd<S: Simd, F: SimdFloat<S, Element = f32>>(x: F) 
 ///
 /// SIMD version of [`approx_parabola_inv_integral`].
 #[inline(always)]
-fn approx_parabola_inv_integral_simd<S: Simd, F: SimdFloat<S, Element = f32>>(x: F) -> F {
-    let simd = x.witness();
+fn approx_parabola_inv_integral_simd<S: Simd>(x: f32x8<S>) -> f32x8<S> {
+    let simd = x.simd;
 
     const B: f32 = 0.39;
     const ONE_MINUS_B: f32 = 1.0 - B;
 
-    let temp = F::splat(simd, 0.25).mul_add(x * x, B * B).sqrt();
-    let factor = F::splat(simd, ONE_MINUS_B) + temp;
+    let temp = f32x8::splat(simd, 0.25).mul_add(x * x, B * B).sqrt();
+    let factor = f32x8::splat(simd, ONE_MINUS_B) + temp;
     x * factor
 }
 


### PR DESCRIPTION
Use `fearless_simd::SimdFloat` to be generic over the exact SIMD float vector type, add docs, simplify some naming.

No effect on benches (as expected).

```
flatten/Ghostscript_Tiger
                        time:   [180.00 µs 180.16 µs 180.34 µs]
                        change: [-0.0671% +0.0992% +0.2713%] (p = 0.28 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  7 (7.00%) high mild
  3 (3.00%) high severe
flatten/paris-30k       time:   [9.1750 ms 9.1992 ms 9.2262 ms]
                        change: [-0.2555% +0.0402% +0.3712%] (p = 0.81 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
```