### PR TITLE
vello_common: Always inline `push_buf` and `pop_buf`

### DIFF
--- a/sparse_strips/vello_common/src/coarse.rs
+++ b/sparse_strips/vello_common/src/coarse.rs
@@ -1434,6 +1434,7 @@ impl<const MODE: u8> WideTile<MODE> {
     /// - Regular layers: Use local `blend_buf` stack for temporary storage
     /// - Filtered layers: Materialized in persistent layer storage for filter processing
     /// - Clip layers: Special handling for clipping operations
+    #[inline(always)]
     fn push_buf(&mut self, layer_kind: LayerKind) {
         let top_layer = layer_kind.id();
         if matches!(layer_kind, LayerKind::Filtered(_)) {
@@ -1463,6 +1464,7 @@ impl<const MODE: u8> WideTile<MODE> {
     }
 
     /// Pop the most recent buffer.
+    #[inline(always)]
     fn pop_buf(&mut self) {
         if MODE == MODE_HYBRID {
             self.push_buf_indices.pop();


### PR DESCRIPTION
Gives a decent speed bump on a scene with 750 push/pop layer commands:

Before:
<img width="1488" height="703" alt="image" src="https://github.com/user-attachments/assets/0be1e832-66fd-4a6f-b423-5a2a9506c2fa" />

After:
<img width="1487" height="688" alt="image" src="https://github.com/user-attachments/assets/37a336af-6f33-4245-8c14-25dd4a8ee1e7" />
