### PR TITLE
vello_common: Optimize wide tile resetting

### DIFF
--- a/sparse_strips/vello_common/src/coarse.rs
+++ b/sparse_strips/vello_common/src/coarse.rs
@@ -131,11 +131,11 @@ impl NeedsBufLayerStack {
 #[derive(Debug)]
 pub struct Wide<const MODE: u8 = MODE_CPU> {
     /// The width of the container.
-    pub width: u16,
+    width: u16,
     /// The height of the container.
-    pub height: u16,
+    height: u16,
     /// The wide tiles in the container.
-    pub tiles: Vec<WideTile<MODE>>,
+    tiles: Vec<WideTile<MODE>>,
     /// Shared command properties, referenced by index from fill and clip commands.
     pub attrs: CommandAttrs,
     /// The stack of layers.


### PR DESCRIPTION
Stacked on top of #1479. This PR
- Adds a flag for tracking whether the `Wide` struct actually needs to be resetted. This makes sense because especially for the fast path, it's likely that we aren't actually using coarse rasterization. `reset` has been shown to take up a not insignificant amount of the frame time, so this seems worthy to do.
- It moves code for resetting a single wide tile into a dedicated function.