### PR TITLE
vello_common: Optimize layer pushing for filter layers without clip path

### DIFF
--- a/sparse_strips/vello_common/src/coarse.rs
+++ b/sparse_strips/vello_common/src/coarse.rs
@@ -845,7 +845,7 @@ impl<const MODE: u8> Wide<MODE> {
             // Generate filter commands for each tile (used for non-graph path rendering)
             // Apply filter BEFORE clipping (per SVG spec: filter → clip → mask → opacity → blend)
             // Also ensure that each wide tile in the filter bbox (out of which some might not
-            // have been drawn on yet) has a `PushBuf` command.
+            // have been drawn on) has a `PushBuf` command.
             for x in final_bbox.x0()..final_bbox.x1() {
                 for y in final_bbox.y0()..final_bbox.y1() {
                     let idx = self.get_idx(x, y);


### PR DESCRIPTION
Gives a good boost CPU-side on our filter demo scene:

Before:
<img width="1430" height="733" alt="image" src="https://github.com/user-attachments/assets/818b3252-6d20-48c2-82e4-a8afae76c5fd" />

After:
<img width="1432" height="735" alt="image" src="https://github.com/user-attachments/assets/5dbdde2e-18dd-4ad3-9fba-65d9a2b64a6c" />

For vello_cpu, this obviously won't help much since the bottleneck lies in the actual filter application, but for vello_hybrid this will be helpful!