### PR TITLE
vello_hybrid: Better support for rendering to RGBA8 textures on targets without native RGBA8

### DIFF
--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -34,7 +34,7 @@ use crate::{
         },
     },
     scene::Scene,
-    schedule::{LoadOp, RendererBackend, Scheduler, SchedulerState},
+    schedule::{LoadOp, OutputTarget, RenderTarget, RendererBackend, Scheduler, SchedulerState},
 };
 use alloc::sync::Arc;
 use alloc::vec;
@@ -175,7 +175,8 @@ impl WebGlRenderer {
             "Render size must match drawing buffer size"
         );
 
-        self.render_scene(scene, render_size, true)?;
+        let view_fb = &self.programs.resources.view_framebuffer;
+        self.render_scene(scene, render_size, OutputTarget::FinalView(view_fb), true)?;
 
         // Blit the view framebuffer to the default framebuffer (canvas element), reflecting the
         // image along the Y axis to complete the WebGPU to WebGL2 coordinate transform.
@@ -280,12 +281,9 @@ impl WebGlRenderer {
             atlas_id.as_u32() as i32,
         );
 
-        // Swap the view framebuffer and render size so the scheduler renders to the
-        // atlas layer instead of the normal view.
-        let saved_framebuffer = core::mem::replace(
-            &mut self.programs.resources.view_framebuffer,
-            atlas_framebuffer,
-        );
+        // Swap the render size so the config buffer and viewport match the atlas dimensions.
+        // TODO: This is not great, we should somehow tie the render size directly to the current
+        // output target.
         let saved_render_size =
             core::mem::replace(&mut self.programs.render_size, atlas_render_size);
 
@@ -296,7 +294,12 @@ impl WebGlRenderer {
             &mut self.programs.resources.stub_atlas_texture_array,
         );
 
-        let result = self.render_scene(scene, &self.programs.render_size.clone(), false);
+        let result = self.render_scene(
+            scene,
+            &self.programs.render_size.clone(),
+            OutputTarget::IntermediateTexture(&atlas_framebuffer),
+            false,
+        );
 
         // Restore the real atlas texture array.
         core::mem::swap(
@@ -304,12 +307,8 @@ impl WebGlRenderer {
             &mut self.programs.resources.stub_atlas_texture_array,
         );
 
-        // Restore the original view framebuffer and cache the atlas FBO for reuse.
-        let atlas_fb = core::mem::replace(
-            &mut self.programs.resources.view_framebuffer,
-            saved_framebuffer,
-        );
-        self.programs.resources.atlas_render_framebuffer = Some(atlas_fb);
+        // Cache the atlas FBO for reuse.
+        self.programs.resources.atlas_render_framebuffer = Some(atlas_framebuffer);
 
         self.programs.render_size = saved_render_size;
 
@@ -327,6 +326,7 @@ impl WebGlRenderer {
         &mut self,
         scene: &Scene,
         render_size: &RenderSize,
+        output_target: OutputTarget<&WebGlFramebuffer>,
         clear: bool,
     ) -> Result<(), RenderError> {
         self.prepare_gpu_encoded_paints(&scene.encoded_paints);
@@ -343,14 +343,24 @@ impl WebGlRenderer {
         );
 
         if clear {
-            self.programs.clear_view_framebuffer(&self.gl);
+            let framebuffer = match output_target {
+                // Note that the intermediate texture case is currently not hit since we never
+                // clear when calling `render_to_atlas`.
+                OutputTarget::FinalView(fb) | OutputTarget::IntermediateTexture(fb) => fb,
+            };
+            clear_framebuffer(framebuffer, &self.gl);
         }
         let mut ctx = WebGlRendererContext {
             programs: &mut self.programs,
             gl: &self.gl,
         };
-        self.scheduler
-            .do_scene(&mut self.scheduler_state, &mut ctx, scene, &self.paint_idxs)?;
+        self.scheduler.do_scene(
+            &mut self.scheduler_state,
+            &mut ctx,
+            scene,
+            &self.paint_idxs,
+            output_target,
+        )?;
         self.gradient_cache.maintain();
 
         Ok(())
@@ -1161,16 +1171,6 @@ impl WebGlPrograms {
         gradient_cache.restore_luts(luts);
     }
 
-    /// Clear the view framebuffer.
-    fn clear_view_framebuffer(&mut self, gl: &WebGl2RenderingContext) {
-        gl.bind_framebuffer(
-            WebGl2RenderingContext::FRAMEBUFFER,
-            Some(&self.resources.view_framebuffer),
-        );
-        gl.clear_color(0.0, 0.0, 0.0, 0.0);
-        gl.clear(WebGl2RenderingContext::COLOR_BUFFER_BIT);
-    }
-
     /// Upload strip data to GPU.
     fn upload_strips(&mut self, gl: &WebGl2RenderingContext, strips: &[GpuStrip]) {
         if strips.is_empty() {
@@ -1756,61 +1756,69 @@ struct WebGlRendererContext<'a> {
 }
 
 impl WebGlRendererContext<'_> {
-    /// Render the strips to either the view or a slot texture (depending on `ix`).
-    fn do_strip_render_pass(&mut self, strips: &[GpuStrip], ix: usize, load: LoadOp) {
-        debug_assert!(ix < 3, "Invalid texture index");
+    /// Render the strips to the given target.
+    fn do_strip_render_pass(
+        &mut self,
+        strips: &[GpuStrip],
+        target: RenderTarget<&WebGlFramebuffer>,
+        load: LoadOp,
+    ) {
         if strips.is_empty() {
             return;
         }
         self.programs.upload_strips(self.gl, strips);
 
         // Bind the appropriate framebuffer.
-        if ix == 2 {
-            self.gl.bind_framebuffer(
-                WebGl2RenderingContext::FRAMEBUFFER,
-                Some(&self.programs.resources.view_framebuffer),
-            );
-            // Set viewport to match view framebuffer.
-            let width = self.programs.render_size.width;
-            let height = self.programs.render_size.height;
-            self.gl.viewport(0, 0, width as i32, height as i32);
+        match target {
+            RenderTarget::Output(output) => {
+                let framebuffer = match output {
+                    OutputTarget::FinalView(fb) | OutputTarget::IntermediateTexture(fb) => fb,
+                };
+                self.gl
+                    .bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, Some(framebuffer));
+                // Set viewport to match view framebuffer.
+                let width = self.programs.render_size.width;
+                let height = self.programs.render_size.height;
+                self.gl.viewport(0, 0, width as i32, height as i32);
 
-            // Use view config buffer for rendering to the main view.
-            self.gl.bind_buffer_base(
-                WebGl2RenderingContext::UNIFORM_BUFFER,
-                self.programs.strip_uniforms.config_vs_block_index,
-                Some(&self.programs.resources.view_config_buffer),
-            );
-            self.gl.bind_buffer_base(
-                WebGl2RenderingContext::UNIFORM_BUFFER,
-                self.programs.strip_uniforms.config_fs_block_index,
-                Some(&self.programs.resources.view_config_buffer),
-            );
-        } else {
-            self.gl.bind_framebuffer(
-                WebGl2RenderingContext::FRAMEBUFFER,
-                Some(&self.programs.resources.slot_framebuffers[ix]),
-            );
-            // Set viewport to match slot framebuffer.
-            // TODO: Remove the slot height texture calculation.
-            let total_slots: usize = (self.programs.resources.max_texture_dimension_2d
-                / u32::from(Tile::HEIGHT)) as usize;
-            // Set viewport to match slot texture.
-            let height = u32::from(Tile::HEIGHT) * total_slots as u32;
-            self.gl
-                .viewport(0, 0, i32::from(WideTile::WIDTH), height as i32);
+                // Use view config buffer for rendering to the output view.
+                self.gl.bind_buffer_base(
+                    WebGl2RenderingContext::UNIFORM_BUFFER,
+                    self.programs.strip_uniforms.config_vs_block_index,
+                    Some(&self.programs.resources.view_config_buffer),
+                );
+                self.gl.bind_buffer_base(
+                    WebGl2RenderingContext::UNIFORM_BUFFER,
+                    self.programs.strip_uniforms.config_fs_block_index,
+                    Some(&self.programs.resources.view_config_buffer),
+                );
+            }
+            RenderTarget::SlotTexture(idx) => {
+                self.gl.bind_framebuffer(
+                    WebGl2RenderingContext::FRAMEBUFFER,
+                    Some(&self.programs.resources.slot_framebuffers[idx as usize]),
+                );
+                // Set viewport to match slot framebuffer.
+                // TODO: Remove the slot height texture calculation.
+                let total_slots: usize = (self.programs.resources.max_texture_dimension_2d
+                    / u32::from(Tile::HEIGHT)) as usize;
+                // Set viewport to match slot texture.
+                let height = u32::from(Tile::HEIGHT) * total_slots as u32;
+                self.gl
+                    .viewport(0, 0, i32::from(WideTile::WIDTH), height as i32);
 
-            // Use slot config buffer for rendering to a slot texture.
-            self.gl.bind_buffer_base(
-                WebGl2RenderingContext::UNIFORM_BUFFER,
-                self.programs.strip_uniforms.config_vs_block_index,
-                Some(&self.programs.resources.slot_config_buffer),
-            );
-            self.gl.bind_buffer_base(
-                WebGl2RenderingContext::UNIFORM_BUFFER,
-                self.programs.strip_uniforms.config_fs_block_index,
-                Some(&self.programs.resources.slot_config_buffer),
-            );
+                // Use slot config buffer for rendering to a slot texture.
+                self.gl.bind_buffer_base(
+                    WebGl2RenderingContext::UNIFORM_BUFFER,
+                    self.programs.strip_uniforms.config_vs_block_index,
+                    Some(&self.programs.resources.slot_config_buffer),
+                );
+                self.gl.bind_buffer_base(
+                    WebGl2RenderingContext::UNIFORM_BUFFER,
+                    self.programs.strip_uniforms.config_fs_block_index,
+                    Some(&self.programs.resources.slot_config_buffer),
+                );
+            }
         }
 
         // Clear framebuffer if requested.
@@ -1835,11 +1843,12 @@ impl WebGlRendererContext<'_> {
         self.gl
             .uniform1i(Some(&self.programs.strip_uniforms.alphas_texture), 0);
 
-        // Bound clip textures are dependent on `ix`:
-        // - ix=0 or ix=2: use slot_texture[1]
-        // - ix=1: use slot_texture[0]
         self.gl.active_texture(WebGl2RenderingContext::TEXTURE1);
-        let clip_texture_idx = if ix == 1 { 0 } else { 1 };
+        let clip_texture_idx = if matches!(target, RenderTarget::SlotTexture(1)) {
+            0
+        } else {
+            1
+        };
         self.gl.bind_texture(
             WebGl2RenderingContext::TEXTURE_2D,
             Some(&self.programs.resources.slot_textures[clip_texture_idx]),
@@ -1956,14 +1965,21 @@ impl WebGlRendererContext<'_> {
 }
 
 impl RendererBackend for WebGlRendererContext<'_> {
+    type View = WebGlFramebuffer;
+
     /// Clear specific slots in a texture
     fn clear_slots(&mut self, texture_index: usize, slots: &[u32]) {
         self.do_clear_slots_render_pass(texture_index, slots);
     }
 
     /// Execute a render pass for strips.
-    fn render_strips(&mut self, strips: &[GpuStrip], target_index: usize, load_op: LoadOp) {
-        self.do_strip_render_pass(strips, target_index, load_op);
+    fn render_strips(
+        &mut self,
+        strips: &[GpuStrip],
+        target: RenderTarget<&WebGlFramebuffer>,
+        load_op: LoadOp,
+    ) {
+        self.do_strip_render_pass(strips, target, load_op);
     }
 }
 
@@ -2178,6 +2194,13 @@ struct WebGlTextureSize {
     height: u32,
     /// The number of layers in the texture array.
     depth_or_array_layers: u32,
+}
+
+/// Clear a framebuffer.
+fn clear_framebuffer(frame_buffer: &WebGlFramebuffer, gl: &WebGl2RenderingContext) {
+    gl.bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, Some(frame_buffer));
+    gl.clear_color(0.0, 0.0, 0.0, 0.0);
+    gl.clear(WebGl2RenderingContext::COLOR_BUFFER_BIT);
 }
 
 /// Helper function to copy from a source texture/framebuffer to a destination texture array layer.

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -177,8 +177,8 @@ impl WebGlRenderer {
             "Render size must match drawing buffer size"
         );
 
-        let view_fb = &self.programs.resources.view_framebuffer;
-        self.render_scene(scene, render_size, OutputTarget::FinalView(view_fb), true)?;
+        let view_fb = &self.programs.resources.view_framebuffer.clone();
+        self.render_scene(scene, render_size, OutputTarget::FinalView(&view_fb), true)?;
 
         // Blit the view framebuffer to the default framebuffer (canvas element), reflecting the
         // image along the Y axis to complete the WebGPU to WebGL2 coordinate transform.

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -34,7 +34,9 @@ use crate::{
         },
     },
     scene::Scene,
-    schedule::{LoadOp, OutputTarget, RenderTarget, RendererBackend, Scheduler, SchedulerState},
+    schedule::{
+        LoadOp, OutputTarget, RendererBackend, Scheduler, SchedulerState, StripPassRenderTarget,
+    },
 };
 use alloc::sync::Arc;
 use alloc::vec;
@@ -1760,7 +1762,7 @@ impl WebGlRendererContext<'_> {
     fn do_strip_render_pass(
         &mut self,
         strips: &[GpuStrip],
-        target: RenderTarget<&WebGlFramebuffer>,
+        target: StripPassRenderTarget<&WebGlFramebuffer>,
         load: LoadOp,
     ) {
         if strips.is_empty() {
@@ -1770,7 +1772,7 @@ impl WebGlRendererContext<'_> {
 
         // Bind the appropriate framebuffer.
         match target {
-            RenderTarget::Output(output) => {
+            StripPassRenderTarget::Output(output) => {
                 let framebuffer = match output {
                     OutputTarget::FinalView(fb) | OutputTarget::IntermediateTexture(fb) => fb,
                 };
@@ -1793,7 +1795,7 @@ impl WebGlRendererContext<'_> {
                     Some(&self.programs.resources.view_config_buffer),
                 );
             }
-            RenderTarget::SlotTexture(idx) => {
+            StripPassRenderTarget::SlotTexture(idx) => {
                 self.gl.bind_framebuffer(
                     WebGl2RenderingContext::FRAMEBUFFER,
                     Some(&self.programs.resources.slot_framebuffers[idx as usize]),
@@ -1844,7 +1846,7 @@ impl WebGlRendererContext<'_> {
             .uniform1i(Some(&self.programs.strip_uniforms.alphas_texture), 0);
 
         self.gl.active_texture(WebGl2RenderingContext::TEXTURE1);
-        let clip_texture_idx = if matches!(target, RenderTarget::SlotTexture(1)) {
+        let clip_texture_idx = if matches!(target, StripPassRenderTarget::SlotTexture(1)) {
             0
         } else {
             1
@@ -1976,7 +1978,7 @@ impl RendererBackend for WebGlRendererContext<'_> {
     fn render_strips(
         &mut self,
         strips: &[GpuStrip],
-        target: RenderTarget<&WebGlFramebuffer>,
+        target: StripPassRenderTarget<&WebGlFramebuffer>,
         load_op: LoadOp,
     ) {
         self.do_strip_render_pass(strips, target, load_op);

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -177,7 +177,7 @@ impl WebGlRenderer {
             "Render size must match drawing buffer size"
         );
 
-        let view_fb = &self.programs.resources.view_framebuffer.clone();
+        let view_fb = self.programs.resources.view_framebuffer.clone();
         self.render_scene(scene, render_size, OutputTarget::FinalView(&view_fb), true)?;
 
         // Blit the view framebuffer to the default framebuffer (canvas element), reflecting the

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -32,7 +32,9 @@ use crate::{
         },
     },
     scene::Scene,
-    schedule::{LoadOp, OutputTarget, RenderTarget, RendererBackend, Scheduler, SchedulerState},
+    schedule::{
+        LoadOp, OutputTarget, RendererBackend, Scheduler, SchedulerState, StripPassRenderTarget,
+    },
 };
 use alloc::vec::Vec;
 use alloc::{sync::Arc, vec};
@@ -1730,7 +1732,7 @@ impl RendererContext<'_> {
     fn do_strip_render_pass(
         &mut self,
         strips: &[GpuStrip],
-        target: RenderTarget<&TextureView>,
+        target: StripPassRenderTarget<&TextureView>,
         load: wgpu::LoadOp<wgpu::Color>,
     ) {
         if strips.is_empty() {
@@ -1741,9 +1743,9 @@ impl RendererContext<'_> {
         self.programs.upload_strips(self.device, self.queue, strips);
 
         let (view, bind_group_index, pipeline_index) = match target {
-            RenderTarget::Output(OutputTarget::FinalView(view)) => (view, 2, 0),
-            RenderTarget::Output(OutputTarget::IntermediateTexture(view)) => (view, 2, 1),
-            RenderTarget::SlotTexture(idx) => (
+            StripPassRenderTarget::Output(OutputTarget::FinalView(view)) => (view, 2, 0),
+            StripPassRenderTarget::Output(OutputTarget::IntermediateTexture(view)) => (view, 2, 1),
+            StripPassRenderTarget::SlotTexture(idx) => (
                 &self.programs.resources.slot_texture_views[idx as usize],
                 idx as usize,
                 0,
@@ -1839,7 +1841,7 @@ impl RendererBackend for RendererContext<'_> {
     fn render_strips(
         &mut self,
         strips: &[GpuStrip],
-        target: RenderTarget<&TextureView>,
+        target: StripPassRenderTarget<&TextureView>,
         load_op: LoadOp,
     ) {
         let wgpu_load_op = match load_op {

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -32,7 +32,7 @@ use crate::{
         },
     },
     scene::Scene,
-    schedule::{LoadOp, RendererBackend, Scheduler, SchedulerState},
+    schedule::{LoadOp, OutputTarget, RenderTarget, RendererBackend, Scheduler, SchedulerState},
 };
 use alloc::vec::Vec;
 use alloc::{sync::Arc, vec};
@@ -140,7 +140,15 @@ impl Renderer {
         render_size: &RenderSize,
         view: &TextureView,
     ) -> Result<(), RenderError> {
-        self.render_scene(scene, device, queue, encoder, render_size, view, true)
+        self.render_scene(
+            scene,
+            device,
+            queue,
+            encoder,
+            render_size,
+            OutputTarget::FinalView(view),
+            true,
+        )
     }
 
     /// Render a `scene` directly into an atlas layer.
@@ -210,17 +218,13 @@ impl Renderer {
             &mut self.programs.resources.stub_atlas_bind_group,
         );
 
-        // TODO: The atlas is always RGBA8; when the surface uses a different format (e.g. BGRA on
-        // macOS), we may need a dedicated RGBA8 render pipeline for atlas rendering. Adopt the
-        // fix from the filters/native-format pipeline work when available.
-
         let result = self.render_scene(
             scene,
             device,
             queue,
             &mut encoder,
             &atlas_render_size,
-            &layer_view,
+            OutputTarget::IntermediateTexture(&layer_view),
             false,
         );
 
@@ -249,7 +253,7 @@ impl Renderer {
         queue: &Queue,
         encoder: &mut CommandEncoder,
         render_size: &RenderSize,
-        view: &TextureView,
+        output_target: OutputTarget<&TextureView>,
         // See https://github.com/linebender/vello/pull/1458/changes#r2851077556
         // TODO: Fix this ASAP!
         _clear: bool,
@@ -272,10 +276,14 @@ impl Renderer {
             device,
             queue,
             encoder,
-            view,
         };
-        self.scheduler
-            .do_scene(&mut self.scheduler_state, &mut ctx, scene, &self.paint_idxs)?;
+        self.scheduler.do_scene(
+            &mut self.scheduler_state,
+            &mut ctx,
+            scene,
+            &self.paint_idxs,
+            output_target,
+        )?;
         self.gradient_cache.maintain();
 
         Ok(())
@@ -585,8 +593,10 @@ impl Renderer {
 /// Defines the GPU resources and pipelines for rendering.
 #[derive(Debug)]
 struct Programs {
-    /// Pipeline for rendering wide tile commands.
-    strip_pipeline: RenderPipeline,
+    /// Pipelines for rendering wide tile commands.
+    /// Index 0: native surface format (for final view and slot textures).
+    /// Index 1: `Rgba8Unorm` (for intermediate textures).
+    strip_pipelines: [RenderPipeline; 2],
     /// Bind group layout for strip draws
     strip_bind_group_layout: BindGroupLayout,
     /// Bind group layout for encoded paints
@@ -812,37 +822,40 @@ impl Programs {
                 push_constant_ranges: &[],
             });
 
-        let strip_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-            label: Some("Strip Pipeline"),
-            layout: Some(&strip_pipeline_layout),
-            vertex: wgpu::VertexState {
-                module: &strip_shader,
-                entry_point: Some("vs_main"),
-                buffers: &[wgpu::VertexBufferLayout {
-                    array_stride: size_of::<GpuStrip>() as u64,
-                    step_mode: wgpu::VertexStepMode::Instance,
-                    attributes: &GpuStrip::vertex_attributes(),
-                }],
-                compilation_options: PipelineCompilationOptions::default(),
-            },
-            fragment: Some(wgpu::FragmentState {
-                module: &strip_shader,
-                entry_point: Some("fs_main"),
-                targets: &[Some(ColorTargetState {
-                    format: render_target_config.format,
-                    blend: Some(BlendState::PREMULTIPLIED_ALPHA_BLENDING),
-                    write_mask: ColorWrites::ALL,
-                })],
-                compilation_options: PipelineCompilationOptions::default(),
-            }),
-            primitive: wgpu::PrimitiveState {
-                topology: wgpu::PrimitiveTopology::TriangleStrip,
-                ..Default::default()
-            },
-            depth_stencil: None,
-            multisample: wgpu::MultisampleState::default(),
-            multiview: None,
-            cache: None,
+        let strip_formats = [render_target_config.format, wgpu::TextureFormat::Rgba8Unorm];
+        let strip_pipelines: [RenderPipeline; 2] = core::array::from_fn(|i| {
+            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("Strip Pipeline"),
+                layout: Some(&strip_pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &strip_shader,
+                    entry_point: Some("vs_main"),
+                    buffers: &[wgpu::VertexBufferLayout {
+                        array_stride: size_of::<GpuStrip>() as u64,
+                        step_mode: wgpu::VertexStepMode::Instance,
+                        attributes: &GpuStrip::vertex_attributes(),
+                    }],
+                    compilation_options: PipelineCompilationOptions::default(),
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &strip_shader,
+                    entry_point: Some("fs_main"),
+                    targets: &[Some(ColorTargetState {
+                        format: strip_formats[i],
+                        blend: Some(BlendState::PREMULTIPLIED_ALPHA_BLENDING),
+                        write_mask: ColorWrites::ALL,
+                    })],
+                    compilation_options: PipelineCompilationOptions::default(),
+                }),
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleStrip,
+                    ..Default::default()
+                },
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState::default(),
+                multiview: None,
+                cache: None,
+            })
         });
 
         let clear_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
@@ -1072,7 +1085,7 @@ impl Programs {
         };
 
         Self {
-            strip_pipeline,
+            strip_pipelines,
             strip_bind_group_layout,
             encoded_paints_bind_group_layout,
             gradient_bind_group_layout,
@@ -1710,18 +1723,16 @@ struct RendererContext<'a> {
     device: &'a Device,
     queue: &'a Queue,
     encoder: &'a mut CommandEncoder,
-    view: &'a TextureView,
 }
 
 impl RendererContext<'_> {
-    /// Render the strips to either the view or a slot texture (depending on `ix`).
+    /// Render the strips to the given target.
     fn do_strip_render_pass(
         &mut self,
         strips: &[GpuStrip],
-        ix: usize,
+        target: RenderTarget<&TextureView>,
         load: wgpu::LoadOp<wgpu::Color>,
     ) {
-        debug_assert!(ix < 3, "Invalid texture index");
         if strips.is_empty() {
             return;
         }
@@ -1729,14 +1740,20 @@ impl RendererContext<'_> {
         // approach would be to re-use buffers or slices of a larger buffer.
         self.programs.upload_strips(self.device, self.queue, strips);
 
+        let (view, bind_group_index, pipeline_index) = match target {
+            RenderTarget::Output(OutputTarget::FinalView(view)) => (view, 2, 0),
+            RenderTarget::Output(OutputTarget::IntermediateTexture(view)) => (view, 2, 1),
+            RenderTarget::SlotTexture(idx) => (
+                &self.programs.resources.slot_texture_views[idx as usize],
+                idx as usize,
+                0,
+            ),
+        };
+
         let mut render_pass = self.encoder.begin_render_pass(&RenderPassDescriptor {
             label: Some("Render to Texture Pass"),
             color_attachments: &[Some(RenderPassColorAttachment {
-                view: if ix == 2 {
-                    self.view
-                } else {
-                    &self.programs.resources.slot_texture_views[ix]
-                },
+                view,
                 depth_slice: None,
                 resolve_target: None,
                 ops: wgpu::Operations {
@@ -1748,8 +1765,12 @@ impl RendererContext<'_> {
             occlusion_query_set: None,
             timestamp_writes: None,
         });
-        render_pass.set_pipeline(&self.programs.strip_pipeline);
-        render_pass.set_bind_group(0, &self.programs.resources.slot_bind_groups[ix], &[]);
+        render_pass.set_pipeline(&self.programs.strip_pipelines[pipeline_index]);
+        render_pass.set_bind_group(
+            0,
+            &self.programs.resources.slot_bind_groups[bind_group_index],
+            &[],
+        );
         render_pass.set_bind_group(1, &self.programs.resources.atlas_bind_group, &[]);
         render_pass.set_bind_group(2, &self.programs.resources.encoded_paints_bind_group, &[]);
         render_pass.set_bind_group(3, &self.programs.resources.gradient_bind_group, &[]);
@@ -1807,19 +1828,26 @@ impl RendererContext<'_> {
 }
 
 impl RendererBackend for RendererContext<'_> {
+    type View = TextureView;
+
     /// Execute the render pass for clearing slots.
     fn clear_slots(&mut self, texture_index: usize, slots: &[u32]) {
         self.do_clear_slots_render_pass(texture_index, slots);
     }
 
     /// Execute the render pass for rendering strips.
-    fn render_strips(&mut self, strips: &[GpuStrip], target_index: usize, load_op: LoadOp) {
+    fn render_strips(
+        &mut self,
+        strips: &[GpuStrip],
+        target: RenderTarget<&TextureView>,
+        load_op: LoadOp,
+    ) {
         let wgpu_load_op = match load_op {
             LoadOp::Load => wgpu::LoadOp::Load,
             LoadOp::Clear => wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
         };
 
-        self.do_strip_render_pass(strips, target_index, wgpu_load_op);
+        self.do_strip_render_pass(strips, target, wgpu_load_op);
     }
 }
 

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -218,7 +218,7 @@ pub(crate) enum OutputTarget<V> {
 
 /// The render target for a strip rendering pass.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum RenderTarget<V> {
+pub(crate) enum StripPassRenderTarget<V> {
     /// Render to the current output target.
     Output(OutputTarget<V>),
     /// Render to one of the two slot textures used for clipping/blending.
@@ -237,7 +237,7 @@ pub(crate) trait RendererBackend {
     fn render_strips(
         &mut self,
         strips: &[GpuStrip],
-        target: RenderTarget<&Self::View>,
+        target: StripPassRenderTarget<&Self::View>,
         load_op: LoadOp,
     );
 }
@@ -721,9 +721,9 @@ impl Scheduler {
             }
 
             let target = if i == 2 {
-                RenderTarget::Output(output_target)
+                StripPassRenderTarget::Output(output_target)
             } else {
-                RenderTarget::SlotTexture(i as u8)
+                StripPassRenderTarget::SlotTexture(i as u8)
             };
             renderer.render_strips(&draw.0, target, load);
         }

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -205,13 +205,41 @@ const PAINT_TYPE_SWEEP_GRADIENT: u32 = 4;
 // The sentinel tile index representing the surface.
 const SENTINEL_SLOT_IDX: usize = usize::MAX;
 
+/// The output target for a draw operation.
+///
+/// Either the final user-provided surface or an intermediate texture.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OutputTarget<V> {
+    /// Render to the final, user-provided output view/surface.
+    FinalView(V),
+    /// Render to an intermediate texture.
+    IntermediateTexture(V),
+}
+
+/// The render target for a strip rendering pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RenderTarget<V> {
+    /// Render to the current output target.
+    Output(OutputTarget<V>),
+    /// Render to one of the two slot textures used for clipping/blending.
+    SlotTexture(u8),
+}
+
 /// Trait for abstracting the renderer backend from the scheduler.
 pub(crate) trait RendererBackend {
+    /// The backend-specific texture view type used for intermediate render targets.
+    type View;
+
     /// Clear specific slots in a texture.
     fn clear_slots(&mut self, texture_index: usize, slots: &[u32]);
 
     /// Execute a render pass for strips.
-    fn render_strips(&mut self, strips: &[GpuStrip], target_index: usize, load_op: LoadOp);
+    fn render_strips(
+        &mut self,
+        strips: &[GpuStrip],
+        target: RenderTarget<&Self::View>,
+        load_op: LoadOp,
+    );
 }
 
 /// Backend agnostic enum that specifies the operation to perform to the output attachment at the
@@ -424,12 +452,13 @@ impl Scheduler {
         &mut self,
         texture: usize,
         renderer: &mut R,
+        output_target: OutputTarget<&R::View>,
     ) -> Result<ClaimedSlot, RenderError> {
         while self.free[texture].is_empty() {
             if self.rounds_queue.is_empty() {
                 return Err(RenderError::SlotsExhausted);
             }
-            self.flush(renderer);
+            self.flush(renderer, output_target);
         }
 
         let slot_ix = self.free[texture].pop().unwrap();
@@ -470,6 +499,7 @@ impl Scheduler {
         renderer: &mut R,
         scene: &Scene,
         paint_idxs: &[u32],
+        output_target: OutputTarget<&R::View>,
     ) -> Result<(), RenderError> {
         let wide = &scene.wide;
         let rows = wide.height_tiles();
@@ -498,6 +528,7 @@ impl Scheduler {
                     cols,
                     &mut cmd_offsets,
                     paint_idxs,
+                    output_target,
                 )?;
             }
             StripPathMode::Interleaved => {
@@ -520,6 +551,7 @@ impl Scheduler {
                         cols,
                         &mut cmd_offsets,
                         paint_idxs,
+                        output_target,
                     )?;
 
                     prev_split = split;
@@ -538,7 +570,7 @@ impl Scheduler {
         self.cmd_offsets = cmd_offsets;
 
         while !self.rounds_queue.is_empty() {
-            self.flush(renderer);
+            self.flush(renderer, output_target);
         }
 
         // Restore state to reuse allocations.
@@ -583,6 +615,7 @@ impl Scheduler {
         cols: u16,
         cmd_offsets: &mut [usize],
         paint_idxs: &[u32],
+        output_target: OutputTarget<&R::View>,
     ) -> Result<(), RenderError> {
         for row in 0..rows {
             for col in 0..cols {
@@ -626,6 +659,7 @@ impl Scheduler {
                     tile.surface_is_blend_target(),
                     paint_idxs,
                     &wide.attrs,
+                    output_target,
                 )?;
                 let end = relative_end + start_offset;
 
@@ -640,7 +674,11 @@ impl Scheduler {
     /// Flush one round.
     ///
     /// The rounds queue must not be empty.
-    fn flush<R: RendererBackend>(&mut self, renderer: &mut R) {
+    fn flush<R: RendererBackend>(
+        &mut self,
+        renderer: &mut R,
+        output_target: OutputTarget<&R::View>,
+    ) {
         let round = self.rounds_queue.pop_front().unwrap();
         for (i, draw) in round.draws.iter().enumerate() {
             #[cfg(debug_assertions)]
@@ -682,7 +720,12 @@ impl Scheduler {
                 continue;
             }
 
-            renderer.render_strips(&draw.0, i, load);
+            let target = if i == 2 {
+                RenderTarget::Output(output_target)
+            } else {
+                RenderTarget::SlotTexture(i as u8)
+            };
+            renderer.render_strips(&draw.0, target, load);
         }
         for i in 0..2 {
             self.free[i].extend(&round.free[i]);
@@ -778,6 +821,7 @@ impl Scheduler {
         surface_is_blend_target: bool,
         paint_idxs: &[u32],
         attrs: &CommandAttrs,
+        output_target: OutputTarget<&R::View>,
     ) -> Result<usize, RenderError> {
         // What is going on with the `surface_is_blend_target` and `is_blend_target` variables in
         // `PushBuf`?
@@ -802,7 +846,7 @@ impl Scheduler {
         // in this case we need to "wrap" _everything_ into a push/pop layer operation.
 
         if surface_is_blend_target {
-            self.do_push_buf(state, renderer, true)?;
+            self.do_push_buf(state, renderer, true, output_target)?;
         }
 
         for (idx, cmd) in wide_tile_cmds.iter().enumerate() {
@@ -869,7 +913,7 @@ impl Scheduler {
                     );
                 }
                 Cmd::PushBuf(_, is_blend_target) => {
-                    self.do_push_buf(state, renderer, *is_blend_target)?;
+                    self.do_push_buf(state, renderer, *is_blend_target, output_target)?;
                 }
                 Cmd::PopBuf => {
                     self.do_pop_buf(state);
@@ -1009,6 +1053,7 @@ impl Scheduler {
         state: &mut SchedulerState,
         renderer: &mut R,
         needs_temporary_slot: bool,
+        output_target: OutputTarget<&R::View>,
     ) -> Result<(), RenderError> {
         let depth = state.tile_state.stack.len();
 
@@ -1062,9 +1107,9 @@ impl Scheduler {
 
         // Push a new tile.
         let ix = depth % 2;
-        let slot = self.claim_free_slot(ix, renderer)?;
+        let slot = self.claim_free_slot(ix, renderer, output_target)?;
         let temporary_slot = if needs_temporary_slot {
-            let temp_slot = self.claim_free_slot((ix + 1) % 2, renderer)?;
+            let temp_slot = self.claim_free_slot((ix + 1) % 2, renderer, output_target)?;
             debug_assert_ne!(
                 slot.get_texture(),
                 temp_slot.get_texture(),


### PR DESCRIPTION
I haven't tested this and unfortunately cannot backport this to my filter branch because they diverge too much, but I think this should work.

Note also that the current `mem::replace` things we have in WebGL don't seem ideal, but this can be figured out in a future PR.