### PR TITLE
vello_hybrid: Faster bilinear image rendering

### DIFF
--- a/sparse_strips/vello_common/src/encode.rs
+++ b/sparse_strips/vello_common/src/encode.rs
@@ -516,6 +516,8 @@ impl EncodeExt for Image {
             x_advance,
             y_advance,
             tint,
+            // If needed, this will be updated by backends afterward.
+            custom: 0,
         };
 
         paints.push(EncodedPaint::Image(encoded));
@@ -564,6 +566,23 @@ pub struct EncodedImage {
     pub y_advance: Vec2,
     /// Optional tint applied to the image.
     pub tint: Option<Tint>,
+    /// A custom field that can be used by rendering backends to
+    /// attach additional information to the image.
+    pub custom: u8,
+}
+
+impl EncodedImage {
+    const GPU_FAST_PATH: u8 = 1 << 0;
+
+    /// Indicate that the GPU fast path should be used for this image.
+    pub fn set_use_gpu_fast_path(&mut self) {
+        self.custom |= Self::GPU_FAST_PATH;
+    }
+
+    /// Whether to use the GPU fast path.
+    pub fn use_gpu_fast_path(&self) -> bool {
+        self.custom & Self::GPU_FAST_PATH != 0
+    }
 }
 
 /// Computed properties of a linear gradient.

--- a/sparse_strips/vello_dev_macros/src/test.rs
+++ b/sparse_strips/vello_dev_macros/src/test.rs
@@ -42,6 +42,8 @@ struct Arguments {
     /// Whether no reference image should actually be created (for tests that only check
     /// for panics, but are not interested in the actual output).
     no_ref: bool,
+    /// Whether the hybrid renderer should create reference images instead of the CPU renderer.
+    hybrid_ref: bool,
     /// A reason for ignoring a test.
     ignore_reason: Option<String>,
 }
@@ -59,6 +61,7 @@ impl Default for Arguments {
             skip_hybrid: false,
             skip_hybrid_constrained: false,
             no_ref: false,
+            hybrid_ref: false,
             diff_pixels: 0,
             ignore_reason: None,
         }
@@ -157,6 +160,7 @@ pub(crate) fn vello_test_inner(attr: TokenStream, item: TokenStream) -> TokenStr
         mut skip_hybrid_constrained,
         ignore_reason,
         no_ref,
+        hybrid_ref,
         diff_pixels,
     } = parse_args(&attrs);
 
@@ -467,7 +471,7 @@ pub(crate) fn vello_test_inner(attr: TokenStream, item: TokenStream) -> TokenStr
             #input_fn_name(&mut ctx);
             ctx.flush();
             if !#no_ref {
-                check_ref(&ctx, #input_fn_name_str, #hybrid_fn_name_str, #hybrid_tolerance, #diff_pixels, false, #reference_image_name);
+                check_ref(&ctx, #input_fn_name_str, #hybrid_fn_name_str, #hybrid_tolerance, #diff_pixels, #hybrid_ref, #reference_image_name);
             }
         }
 
@@ -546,6 +550,7 @@ fn parse_args(attribute_input: &AttributeInput) -> Arguments {
                     "skip_hybrid" => args.skip_hybrid = true,
                     "skip_hybrid_constrained" => args.skip_hybrid_constrained = true,
                     "no_ref" => args.no_ref = true,
+                    "hybrid_ref" => args.hybrid_ref = true,
                     "ignore" => {
                         args.skip_cpu = true;
                         args.skip_multithreaded = true;

--- a/sparse_strips/vello_hybrid/src/filter.rs
+++ b/sparse_strips/vello_hybrid/src/filter.rs
@@ -792,6 +792,7 @@ impl FilterContext {
                     x_advance: Vec2::new(1.0, 0.0),
                     y_advance: Vec2::new(0.0, 1.0),
                     tint: None,
+                    custom: 0,
                 });
 
                 let idx = encoded_paints.len();

--- a/sparse_strips/vello_hybrid/src/render/common.rs
+++ b/sparse_strips/vello_hybrid/src/render/common.rs
@@ -18,9 +18,10 @@ pub(crate) const GPU_RADIAL_GRADIENT_SIZE_TEXELS: u32 =
     (size_of::<GpuRadialGradient>() / 16) as u32;
 pub(crate) const GPU_SWEEP_GRADIENT_SIZE_TEXELS: u32 = (size_of::<GpuSweepGradient>() / 16) as u32;
 
-// TODO: If we want to use native bilinear sampling for uploaded images,
-// we can pass 1 instead of 0 here.
-pub(crate) const IMAGE_PADDING: u16 = 0;
+// One pixel padding to account for bilinear filtering.
+pub(crate) const IMAGE_PADDING: u16 = 1;
+
+pub(crate) const IMAGE_QUALITY_GPU_FAST_PATH: u32 = 3;
 
 /// Dimensions of the rendering target.
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -20,7 +20,7 @@
 only break in edge cases, and some of them are also only related to conversions from f64 to f32."
 )]
 
-use crate::render::common::IMAGE_PADDING;
+use crate::render::common::{IMAGE_PADDING, IMAGE_QUALITY_GPU_FAST_PATH};
 use crate::{
     GpuStrip, RenderError, RenderSettings, RenderSize,
     filter::{FilterContext, FilterInstanceData, FilterPassState, FilterPassTarget},
@@ -583,8 +583,16 @@ impl WebGlRenderer {
         let transform = image.transform.as_coeffs().map(|x| x as f32);
         let image_size = pack_image_size(image_resource.width, image_resource.height);
         let image_offset = pack_image_offset(image_resource.offset[0], image_resource.offset[1]);
+
+        // See the comment in the wgpu backend.
+        let quality = if image.use_gpu_fast_path() {
+            IMAGE_QUALITY_GPU_FAST_PATH
+        } else {
+            image.sampler.quality as u32
+        };
+
         let image_params = pack_image_params(
-            image.sampler.quality as u32,
+            quality,
             image.sampler.x_extend as u32,
             image.sampler.y_extend as u32,
             image_resource.atlas_id.as_u32(),
@@ -717,8 +725,10 @@ struct StripUniforms {
     alphas_texture: WebGlUniformLocation,
     /// Clip input texture location.
     clip_input_texture: WebGlUniformLocation,
-    /// Atlas texture location.
-    atlas_texture_array: WebGlUniformLocation,
+    /// Atlas texture location for fragment shader.
+    atlas_texture_array_fs: WebGlUniformLocation,
+    /// Atlas texture location for vertex shader.
+    atlas_texture_array_vs: WebGlUniformLocation,
     /// Encoded paints texture location for fragment shader.
     encoded_paints_texture_fs: WebGlUniformLocation,
     /// Encoded paints texture location for vertex shader.
@@ -1671,7 +1681,8 @@ fn get_strip_uniforms(gl: &WebGl2RenderingContext, program: &WebGlProgram) -> St
     // Get texture uniform locations.
     let alphas_texture_name = render_strips::fragment::ALPHAS_TEXTURE;
     let clip_input_texture_name = render_strips::fragment::CLIP_INPUT_TEXTURE;
-    let atlas_texture_array_name = render_strips::fragment::ATLAS_TEXTURE_ARRAY;
+    let atlas_texture_array_fs_name = render_strips::fragment::ATLAS_TEXTURE_ARRAY;
+    let atlas_texture_array_vs_name = render_strips::vertex::ATLAS_TEXTURE_ARRAY;
     let encoded_paints_texture_fs_name = render_strips::fragment::ENCODED_PAINTS_TEXTURE;
     let encoded_paints_texture_vs_name = render_strips::vertex::ENCODED_PAINTS_TEXTURE;
     let gradient_texture_name = render_strips::fragment::GRADIENT_TEXTURE;
@@ -1685,8 +1696,11 @@ fn get_strip_uniforms(gl: &WebGl2RenderingContext, program: &WebGlProgram) -> St
         clip_input_texture: gl
             .get_uniform_location(program, clip_input_texture_name)
             .unwrap(),
-        atlas_texture_array: gl
-            .get_uniform_location(program, atlas_texture_array_name)
+        atlas_texture_array_fs: gl
+            .get_uniform_location(program, atlas_texture_array_fs_name)
+            .unwrap(),
+        atlas_texture_array_vs: gl
+            .get_uniform_location(program, atlas_texture_array_vs_name)
             .unwrap(),
         encoded_paints_texture_fs: gl
             .get_uniform_location(program, encoded_paints_texture_fs_name)
@@ -1823,10 +1837,37 @@ fn create_texture(gl: &WebGl2RenderingContext) -> WebGlTexture {
     create_texture_inner(gl, WebGl2RenderingContext::TEXTURE_2D)
 }
 
-/// Create a texture array with nearest neighbor sampling and
-/// clamp-to-edge wrapping.
+/// Create a texture array with bilinear sampling and clamp-to-edge wrapping.
 fn create_texture_array(gl: &WebGl2RenderingContext) -> WebGlTexture {
-    create_texture_inner(gl, WebGl2RenderingContext::TEXTURE_2D_ARRAY)
+    let texture = gl.create_texture().unwrap();
+    gl.active_texture(WebGl2RenderingContext::TEXTURE0);
+    gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D_ARRAY, Some(&texture));
+    gl.tex_parameteri(
+        WebGl2RenderingContext::TEXTURE_2D_ARRAY,
+        WebGl2RenderingContext::TEXTURE_MIN_FILTER,
+        WebGl2RenderingContext::LINEAR as i32,
+    );
+    gl.tex_parameteri(
+        WebGl2RenderingContext::TEXTURE_2D_ARRAY,
+        WebGl2RenderingContext::TEXTURE_MAG_FILTER,
+        WebGl2RenderingContext::LINEAR as i32,
+    );
+    gl.tex_parameteri(
+        WebGl2RenderingContext::TEXTURE_2D_ARRAY,
+        WebGl2RenderingContext::TEXTURE_WRAP_S,
+        WebGl2RenderingContext::CLAMP_TO_EDGE as i32,
+    );
+    gl.tex_parameteri(
+        WebGl2RenderingContext::TEXTURE_2D_ARRAY,
+        WebGl2RenderingContext::TEXTURE_WRAP_T,
+        WebGl2RenderingContext::CLAMP_TO_EDGE as i32,
+    );
+    gl.tex_parameteri(
+        WebGl2RenderingContext::TEXTURE_2D_ARRAY,
+        WebGl2RenderingContext::TEXTURE_MAX_LEVEL,
+        0,
+    );
+    texture
 }
 
 fn create_texture_inner(gl: &WebGl2RenderingContext, target: u32) -> WebGlTexture {
@@ -2260,8 +2301,14 @@ impl WebGlRendererContext<'_> {
             WebGl2RenderingContext::TEXTURE_2D_ARRAY,
             Some(&self.programs.resources.atlas_texture_array.texture),
         );
-        self.gl
-            .uniform1i(Some(&self.programs.strip_uniforms.atlas_texture_array), 2);
+        self.gl.uniform1i(
+            Some(&self.programs.strip_uniforms.atlas_texture_array_fs),
+            2,
+        );
+        self.gl.uniform1i(
+            Some(&self.programs.strip_uniforms.atlas_texture_array_vs),
+            2,
+        );
 
         // Bind encoded paints texture for image metadata
         self.gl.active_texture(WebGl2RenderingContext::TEXTURE3);

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -18,7 +18,7 @@
 only break in edge cases, and some of them are also only related to conversions from f64 to f32."
 )]
 
-use crate::render::common::IMAGE_PADDING;
+use crate::render::common::{IMAGE_PADDING, IMAGE_QUALITY_GPU_FAST_PATH};
 use crate::{
     GpuStrip, RenderError, RenderSettings, RenderSize,
     filter::{FilterContext, FilterInstanceData, FilterPassState, FilterPassTarget},
@@ -628,8 +628,19 @@ impl Renderer {
         let transform = image.transform.as_coeffs().map(|x| x as f32);
         let image_size = pack_image_size(image_resource.width, image_resource.height);
         let image_offset = pack_image_offset(image_resource.offset[0], image_resource.offset[1]);
+
+        // Values 0-2 represent the peniko `ImageQuality` variants, value 3 (IMAGE_QUALITY_GPU_BILINEAR)
+        // stands for "GPU-native bilinear sampling with transparent padding".
+        // Meaning that if quality is 3, the extend modes will be ignored and are instead used
+        // to distinguish between bilinear sampling and nearest-neighbor sampling.
+        let quality = if image.use_gpu_fast_path() {
+            IMAGE_QUALITY_GPU_FAST_PATH
+        } else {
+            image.sampler.quality as u32
+        };
+
         let image_params = pack_image_params(
-            image.sampler.quality as u32,
+            quality,
             image.sampler.x_extend as u32,
             image.sampler.y_extend as u32,
             image_resource.atlas_id.as_u32(),
@@ -843,6 +854,8 @@ struct GpuResources {
     atlas_texture_array: Texture,
     /// View for atlas texture array
     atlas_texture_array_view: TextureView,
+    /// Bilinear sampler for GPU-native image sampling
+    atlas_sampler: Sampler,
     /// Bind group for atlas textures (as texture array)
     atlas_bind_group: BindGroup,
     /// Filter atlas textures and their associated views/bind groups.
@@ -960,16 +973,24 @@ impl Programs {
         let atlas_bind_group_layout =
             device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
                 label: Some("Atlas Texture Bind Group Layout"),
-                entries: &[wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Texture {
-                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
-                        view_dimension: wgpu::TextureViewDimension::D2Array,
-                        multisampled: false,
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                            view_dimension: wgpu::TextureViewDimension::D2Array,
+                            multisampled: false,
+                        },
+                        count: None,
                     },
-                    count: None,
-                }],
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                ],
             });
 
         let encoded_paints_bind_group_layout =
@@ -1340,10 +1361,17 @@ impl Programs {
             *atlas_height,
             *initial_atlas_count as u32,
         );
+        let atlas_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("Atlas Bilinear Sampler"),
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            ..Default::default()
+        });
         let atlas_bind_group = Self::create_atlas_bind_group(
             device,
             &atlas_bind_group_layout,
             &atlas_texture_array_view,
+            &atlas_sampler,
         );
 
         // Create a 1x1 stub atlas texture array for use during render_to_atlas.
@@ -1351,8 +1379,12 @@ impl Programs {
         // a shader input (bind group) and render target in the same pass.
         let (_stub_atlas_texture, stub_atlas_view) =
             Self::create_atlas_texture_array(device, 1, 1, 1);
-        let stub_atlas_bind_group =
-            Self::create_atlas_bind_group(device, &atlas_bind_group_layout, &stub_atlas_view);
+        let stub_atlas_bind_group = Self::create_atlas_bind_group(
+            device,
+            &atlas_bind_group_layout,
+            &stub_atlas_view,
+            &atlas_sampler,
+        );
 
         const INITIAL_ENCODED_PAINTS_TEXTURE_HEIGHT: u32 = 1;
         let encoded_paints_data = vec![
@@ -1429,6 +1461,7 @@ impl Programs {
             alphas_texture,
             atlas_texture_array,
             atlas_texture_array_view,
+            atlas_sampler,
             atlas_bind_group,
             filter_atlas,
             stub_atlas_bind_group,
@@ -1609,14 +1642,21 @@ impl Programs {
         device: &Device,
         atlas_bind_group_layout: &BindGroupLayout,
         atlas_texture_array_view: &TextureView,
+        atlas_sampler: &Sampler,
     ) -> BindGroup {
         device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("Atlas Bind Group"),
             layout: atlas_bind_group_layout,
-            entries: &[wgpu::BindGroupEntry {
-                binding: 0,
-                resource: wgpu::BindingResource::TextureView(atlas_texture_array_view),
-            }],
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(atlas_texture_array_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(atlas_sampler),
+                },
+            ],
         })
     }
 
@@ -1999,6 +2039,7 @@ impl Programs {
                 device,
                 atlas_bind_group_layout,
                 &new_atlas_texture_array_view,
+                &resources.atlas_sampler,
             );
 
             // Replace the old resources

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -17,10 +17,11 @@ use vello_common::glyph::{GlyphCaches, GlyphRenderer, GlyphRunBuilder, GlyphType
 use vello_common::kurbo::{Affine, BezPath, Rect, Shape, Stroke};
 use vello_common::mask::Mask;
 use vello_common::multi_atlas::AtlasConfig;
-use vello_common::paint::{Paint, PaintType, Tint};
+use vello_common::paint::{Image, ImageSource, Paint, PaintType, Tint};
 #[cfg(feature = "text")]
 use vello_common::peniko::FontData;
 use vello_common::peniko::{BlendMode, Compose, Fill, Mix};
+use vello_common::peniko::{Extend, ImageQuality, ImageSampler};
 use vello_common::recording::{
     PushLayerCommand, Recordable, Recorder, Recording, RenderCommand, RenderState,
 };
@@ -491,6 +492,50 @@ impl Scene {
         self.fill_path(&rect.to_path(DEFAULT_TOLERANCE));
     }
 
+    /// Draw an image using nearest-neighbor or bilinear filtering.
+    ///
+    /// If you want more room for customization, you can also paint an image by setting
+    /// an image paint via `set_paint` and specifying parameters like extend and filtering quality
+    /// manually. However, if you only want to draw a simple image without bicubic filtering or
+    /// any special extend mode, it is recommended to use this method as it leverages GPU-native
+    /// capabilities and is therefore significantly faster.
+    ///
+    /// This method will respect the current affine transformation in place (set via [`Scene::set_transform`],
+    /// but is not affected by the current paint transform (set via [`Scene::set_paint_transform`] in place.
+    pub fn draw_image(&mut self, image: ImageSource, rect: &Rect, bilinear: bool) {
+        let old_paint_transform = core::mem::take(&mut self.render_state.paint_transform);
+        let old_paint = core::mem::take(&mut self.render_state.paint);
+
+        self.set_paint_transform(Affine::IDENTITY);
+        self.set_paint(Image {
+            image,
+            sampler: ImageSampler {
+                // For the fast path, we always sample transparent pixels outside,
+                // so the extend mode becomes irrelevant. We therefore repurpose the
+                // field to store whether to use bilinear or nearest-neighbor filtering.
+                x_extend: if bilinear {
+                    Extend::Repeat
+                } else {
+                    Extend::Pad
+                },
+                y_extend: Extend::Pad,
+                quality: ImageQuality::Medium,
+                alpha: 1.0,
+            },
+        });
+
+        let paint_idx = self.encoded_paints.borrow().len();
+        self.fill_rect(rect);
+
+        if let Some(EncodedPaint::Image(img)) = self.encoded_paints.borrow_mut().get_mut(paint_idx)
+        {
+            img.set_use_gpu_fast_path();
+        }
+
+        self.set_paint_transform(old_paint_transform);
+        self.set_paint(old_paint);
+    }
+
     #[expect(
         clippy::cast_possible_truncation,
         reason = "f64→f32 truncation is acceptable for pixel coordinates"
@@ -726,6 +771,8 @@ impl Scene {
     }
 
     /// Set the paint for subsequent rendering operations.
+    ///
+    /// For drawing images, see also the [`Scene::draw_image`] method.
     // TODO: This API is not final. Supporting images from a pixmap is explicitly out of scope.
     //       Instead images should be passed via a backend-agnostic opaque id, and be hydrated at
     //       render time into a texture usable by the renderer backend.

--- a/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
@@ -47,6 +47,7 @@ const RECT_STRIP_FLAG: u32 = 0x80000000u;
 const IMAGE_QUALITY_LOW = 0u;
 const IMAGE_QUALITY_MEDIUM = 1u;
 const IMAGE_QUALITY_HIGH = 2u;
+const IMAGE_QUALITY_GPU_FAST_PATH = 3u;
 
 // Gradient types.
 const GRADIENT_TYPE_LINEAR: u32 = 0u;
@@ -65,6 +66,8 @@ const TWO_PI: f32 = 2.0 * PI;
 // Note: This must match SCALAR_NEARLY_ZERO in vello_common/src/math.rs
 // @see {@link https://github.com/linebender/vello/blob/748ba4c7a8973f642f778591b09658d8ee6e1132/sparse_strips/vello_common/src/math.rs#L21}
 const NEARLY_ZERO_TOLERANCE: f32 = 1.0 / 4096.0;
+
+const PIXEL_CENTER_NUDGE: f32 = 0.00001;
 
 // Composite modes.
 const COMPOSE_CLEAR: u32 = 0u;
@@ -240,6 +243,9 @@ var<uniform> config: Config;
 @group(1) @binding(0)
 var atlas_texture_array: texture_2d_array<f32>;
 
+@group(1) @binding(1)
+var atlas_sampler: sampler;
+
 @group(2) @binding(0)
 var encoded_paints_texture: texture_2d<u32>;
 
@@ -294,6 +300,13 @@ fn vs_main(
             // Use view coordinates for image sampling (always in global view space)
             let pos = vec2<f32>(f32(scene_strip_x) + x * f32(width), f32(scene_strip_y) + y * f32(height));
             out.sample_xy = encoded_image.translate + encoded_image.image_offset + encoded_image.transform * pos;
+
+            // In the fast path, for native bilinear sampling, coordinates need to be normalized to [0, 1]
+            // since we use `textureSample` instead of `textureLoad`.
+            if encoded_image.quality == IMAGE_QUALITY_GPU_FAST_PATH && encoded_image.extend_modes.x == 1 {
+                let atlas_dims = vec2<f32>(textureDimensions(atlas_texture_array));
+                out.sample_xy = out.sample_xy / atlas_dims;
+            }
         } else if paint_type == PAINT_TYPE_LINEAR_GRADIENT || paint_type == PAINT_TYPE_RADIAL_GRADIENT || paint_type == PAINT_TYPE_SWEEP_GRADIENT {
             // Use view coordinates for gradient transform (always in global view space)
             out.sample_xy = vec2<f32>(
@@ -379,52 +392,71 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
         } else if paint_type == PAINT_TYPE_IMAGE {
             let paint_tex_idx = in.paint_and_rect_flag & PAINT_TEXTURE_INDEX_MASK;
             let encoded_image = unpack_encoded_image(paint_tex_idx);
-            let image_offset = encoded_image.image_offset;
-            let image_size = encoded_image.image_size;
-            let local_xy = in.sample_xy - image_offset;
-            // This offset doesn't exist in vello_cpu, and we use it because 45 degree skewing seems to cause
-            // artifacts on the GPU. We have something similar in place for gradients. It might be worth revisiting
-            // this to see whether a better approach is possible.
-            let offset = 0.00001;
-            let extended_xy = vec2<f32>(
-                extend_mode(local_xy.x + offset, encoded_image.extend_modes.x, image_size.x),
-                extend_mode(local_xy.y + offset, encoded_image.extend_modes.y, image_size.y)
-            );
-
-            // TODO: add a fast path for images where we are using bilinear sampling and want transparent pixels,
-            // using GPU-native bilinear sampling
-            
             var sample_color: vec4<f32>;
-            if encoded_image.quality == IMAGE_QUALITY_HIGH {
-                let final_xy = image_offset + extended_xy;
-                sample_color = bicubic_sample(
-                    atlas_texture_array,
-                    final_xy,
-                    i32(encoded_image.atlas_index),
-                    image_offset,
-                    image_size,
-                    encoded_image.extend_modes,
-                    encoded_image.image_padding,
-                );
-            } else if encoded_image.quality == IMAGE_QUALITY_MEDIUM {
-                let final_xy = image_offset + extended_xy - vec2(0.5);
-                sample_color = bilinear_sample(
-                    atlas_texture_array,
-                    final_xy,
-                    i32(encoded_image.atlas_index),
-                    image_offset,
-                    image_size,
-                    encoded_image.extend_modes,
-                    encoded_image.image_padding,
-                );
+
+            if encoded_image.quality == IMAGE_QUALITY_GPU_FAST_PATH {
+                if encoded_image.extend_modes.x == 1 {
+                    // Bilinear sampling.
+                    sample_color = textureSample(
+                        atlas_texture_array,
+                        atlas_sampler,
+                        in.sample_xy,
+                        i32(encoded_image.atlas_index),
+                    );
+                } else {
+                    sample_color = textureLoad(
+                        atlas_texture_array,
+                        // See the comment in the else branch for why we have this nudge.
+                        vec2<i32>(in.sample_xy + PIXEL_CENTER_NUDGE),
+                        i32(encoded_image.atlas_index),
+                        0,
+                    );
+                }
             } else {
-                let final_xy = image_offset + extended_xy;
-                sample_color = textureLoad(
-                    atlas_texture_array,
-                    vec2<u32>(final_xy),
-                    i32(encoded_image.atlas_index),
-                    0,
+                let image_offset = encoded_image.image_offset;
+                let image_size = encoded_image.image_size;
+                let local_xy = in.sample_xy - image_offset;
+                // This offset doesn't exist in vello_cpu, and we use it because 45 degree skewing seems to cause
+                // artifacts on the GPU. We have something similar in place for gradients. It might be worth revisiting
+                // this to see whether a better approach is possible.
+                // TODO: This is only really needed for nearest-neighbor sampling, not bilinear/bicubic.
+                let offset = PIXEL_CENTER_NUDGE;
+                let extended_xy = vec2<f32>(
+                    extend_mode(local_xy.x + offset, encoded_image.extend_modes.x, image_size.x),
+                    extend_mode(local_xy.y + offset, encoded_image.extend_modes.y, image_size.y)
                 );
+
+                if encoded_image.quality == IMAGE_QUALITY_HIGH {
+                    let final_xy = image_offset + extended_xy;
+                    sample_color = bicubic_sample(
+                        atlas_texture_array,
+                        final_xy,
+                        i32(encoded_image.atlas_index),
+                        image_offset,
+                        image_size,
+                        encoded_image.extend_modes,
+                        encoded_image.image_padding,
+                    );
+                } else if encoded_image.quality == IMAGE_QUALITY_MEDIUM {
+                    let final_xy = image_offset + extended_xy - vec2(0.5);
+                    sample_color = bilinear_sample(
+                        atlas_texture_array,
+                        final_xy,
+                        i32(encoded_image.atlas_index),
+                        image_offset,
+                        image_size,
+                        encoded_image.extend_modes,
+                        encoded_image.image_padding,
+                    );
+                } else {
+                    let final_xy = image_offset + extended_xy;
+                    sample_color = textureLoad(
+                        atlas_texture_array,
+                        vec2<u32>(final_xy),
+                        i32(encoded_image.atlas_index),
+                        0,
+                    );
+                }
             }
 
             let is_multiply = bool(encoded_image.tint_mode);
@@ -442,7 +474,7 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
             let grad_pos = linear_gradient.transform * fragment_pos + linear_gradient.translate;
             
             // For linear gradient, t-value is just the x coordinate in gradient space
-            let t_value = grad_pos.x + 0.00001;
+            let t_value = grad_pos.x + PIXEL_CENTER_NUDGE;
             let gradient_color = sample_gradient_lut(
                 t_value,
                 linear_gradient.extend_mode,
@@ -878,7 +910,7 @@ fn unpack_encoded_image(paint_tex_idx: u32) -> EncodedImage {
     let image_padding = f32(texel2.w);
 
     return EncodedImage(
-        quality, 
+        quality,
         vec2<u32>(extend_x, extend_y),
         image_size,
         image_offset,
@@ -1179,7 +1211,7 @@ fn unpack_linear_gradient(paint_tex_idx: u32) -> LinearGradient {
         vec2<f32>(bitcast<f32>(texel1.x), bitcast<f32>(texel1.y))
     );
     let translate = vec2<f32>(bitcast<f32>(texel1.z), bitcast<f32>(texel1.w));
-    
+
     return LinearGradient(
         extend_mode, gradient_start, texture_width, transform, translate
     );
@@ -1296,7 +1328,7 @@ fn unpack_radial_gradient(paint_tex_idx: u32) -> RadialGradient {
         vec2<f32>(bitcast<f32>(texel1.x), bitcast<f32>(texel1.y))
     );
     let translate = vec2<f32>(bitcast<f32>(texel1.z), bitcast<f32>(texel1.w));
-    
+
     let kind_and_swapped = unpack_radial_kind_and_swapped(texel2.x);
     let kind = kind_and_swapped.x;
     let f_is_swapped = kind_and_swapped.y;
@@ -1330,7 +1362,7 @@ fn unpack_sweep_gradient(paint_tex_idx: u32) -> SweepGradient {
         vec2<f32>(bitcast<f32>(texel1.x), bitcast<f32>(texel1.y))
     );
     let translate = vec2<f32>(bitcast<f32>(texel1.z), bitcast<f32>(texel1.w));
-    
+
     let start_angle = bitcast<f32>(texel2.x);
     let inv_angle_delta = bitcast<f32>(texel2.y);
 

--- a/sparse_strips/vello_sparse_tests/snapshots/image_draw_image_10x10.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/image_draw_image_10x10.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ef8a6b5fc2ca5b80ce4f291e5c8b626e4009bd7ecadcbac44720f429b81ad25
+size 939

--- a/sparse_strips/vello_sparse_tests/snapshots/image_draw_image_2x2.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/image_draw_image_2x2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5ad6080f1ae9b3a0dbf72b31b94e947c7ba5fa36c608a5e99c2348bbd1fe70a
+size 4140

--- a/sparse_strips/vello_sparse_tests/snapshots/image_draw_image_2x2_rotated.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/image_draw_image_2x2_rotated.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:916d2326d715d42a1d9809bd10d3e85b15adc2be454b2a57faa731a8493acc25
+size 5858

--- a/sparse_strips/vello_sparse_tests/snapshots/image_draw_image_2x3.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/image_draw_image_2x3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b803c4b0098cdcb96b4000c4f5aa882ff077267303c1960b6063d6db57dcdffc
+size 3237

--- a/sparse_strips/vello_sparse_tests/snapshots/image_draw_image_nn_10x10.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/image_draw_image_nn_10x10.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:385122f028251918f717348450dd3369b4cd8f5c695523c3335dfc5cbad3d50d
+size 141

--- a/sparse_strips/vello_sparse_tests/snapshots/image_draw_image_nn_2x2_rotated.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/image_draw_image_nn_2x2_rotated.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bad61daf9b4dc072466909ba3a7107cdd2bb9fbf295876409783eb842c358954
+size 486

--- a/sparse_strips/vello_sparse_tests/snapshots/image_draw_image_nn_2x3.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/image_draw_image_nn_2x3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78b7ed4c455a061d774f8679d66935c4378e8837f97d318b8253a0cebbc89eab
+size 177

--- a/sparse_strips/vello_sparse_tests/snapshots/image_draw_image_preserves_paint.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/image_draw_image_preserves_paint.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a6356b7cd39605fb2b4225125a8368aeaea3837c32bcc7eea12252920d0e7d5
+size 1094

--- a/sparse_strips/vello_sparse_tests/tests/image.rs
+++ b/sparse_strips/vello_sparse_tests/tests/image.rs
@@ -4,7 +4,7 @@
 use crate::gradient::tan_45;
 use crate::load_image;
 use crate::renderer::Renderer;
-use crate::util::crossed_line_star;
+use crate::util::{crossed_line_star, stops_green_blue};
 use std::f64::consts::PI;
 use std::sync::Arc;
 use vello_common::color::palette::css::REBECCA_PURPLE;
@@ -12,8 +12,9 @@ use vello_common::kurbo::{Affine, Point, Rect};
 use vello_common::kurbo::{Shape, Triangle};
 use vello_common::paint::{Image, ImageSource, Tint, TintMode};
 use vello_common::peniko::Color;
-use vello_common::peniko::ImageSampler;
 use vello_common::peniko::{Extend, ImageQuality};
+use vello_common::peniko::{Gradient, ImageSampler};
+use vello_cpu::peniko::LinearGradientPosition;
 use vello_dev_macros::vello_test;
 
 fn rgb_img_10x10(ctx: &mut impl Renderer) -> ImageSource {
@@ -643,6 +644,99 @@ fn render_sprite(
         },
     });
     ctx.fill_rect(&Rect::new(0.0, 0.0, glyph.width, glyph.height));
+}
+
+// Note: Windows CI seems to yield slight differences in native bilinear sampling behavior, so we need
+// an additional tolerance.
+
+#[vello_test(skip_cpu, hybrid_ref, hybrid_tolerance = 1)]
+fn image_draw_image_2x2(ctx: &mut impl Renderer) {
+    let image_source = rgb_img_2x2(ctx);
+    ctx.set_transform(Affine::translate((10.0, 10.0)) * Affine::scale(40.0));
+    ctx.draw_image(image_source, &Rect::new(0.0, 0.0, 2.0, 2.0), true);
+}
+
+#[vello_test(skip_cpu, hybrid_ref, hybrid_tolerance = 1)]
+fn image_draw_image_2x2_rotated(ctx: &mut impl Renderer) {
+    let image_source = rgb_img_2x2(ctx);
+    ctx.set_transform(
+        Affine::rotate_about(45.0_f64.to_radians(), Point::new(50.0, 50.0))
+            * Affine::translate((10.0, 10.0))
+            * Affine::scale(40.0),
+    );
+    ctx.draw_image(image_source, &Rect::new(0.0, 0.0, 2.0, 2.0), true);
+}
+
+#[vello_test(skip_cpu, hybrid_ref, hybrid_tolerance = 1)]
+fn image_draw_image_2x3(ctx: &mut impl Renderer) {
+    let image_source = rgb_img_2x3(ctx);
+
+    // Shouldn't have any effect.
+    ctx.set_paint_transform(Affine::scale(5.0));
+
+    ctx.set_transform(Affine::translate((25.0, 12.5)) * Affine::scale(25.0));
+    ctx.draw_image(image_source, &Rect::new(0.0, 0.0, 2.0, 3.0), true);
+}
+
+#[vello_test(skip_cpu, hybrid_ref, hybrid_tolerance = 1)]
+fn image_draw_image_10x10(ctx: &mut impl Renderer) {
+    let image_source = rgb_img_10x10(ctx);
+    ctx.set_transform(Affine::translate((10.0, 10.0)) * Affine::scale(8.0));
+    ctx.draw_image(image_source, &Rect::new(0.0, 0.0, 10.0, 10.0), true);
+}
+
+#[vello_test(skip_cpu, hybrid_ref)]
+fn image_draw_image_nn_10x10(ctx: &mut impl Renderer) {
+    let image_source = rgb_img_10x10(ctx);
+    ctx.set_transform(Affine::translate((10.0, 10.0)) * Affine::scale(8.0));
+    ctx.draw_image(image_source, &Rect::new(0.0, 0.0, 10.0, 10.0), false);
+}
+
+#[vello_test(skip_cpu, hybrid_ref)]
+fn image_draw_image_nn_2x3(ctx: &mut impl Renderer) {
+    let image_source = rgb_img_2x3(ctx);
+
+    ctx.set_transform(Affine::translate((25.0, 12.5)) * Affine::scale(25.0));
+    ctx.draw_image(image_source, &Rect::new(0.0, 0.0, 2.0, 3.0), false);
+}
+
+#[vello_test(skip_cpu, hybrid_ref)]
+fn image_draw_image_nn_2x2_rotated(ctx: &mut impl Renderer) {
+    let image_source = rgb_img_2x2(ctx);
+    ctx.set_transform(
+        Affine::rotate_about(45.0_f64.to_radians(), Point::new(50.0, 50.0))
+            * Affine::translate((10.0, 10.0))
+            * Affine::scale(40.0),
+    );
+    ctx.draw_image(image_source, &Rect::new(0.0, 0.0, 2.0, 2.0), false);
+}
+
+// Ensures that `draw_image` doesn't pollute the current paint in use.
+#[vello_test(skip_cpu, hybrid_ref)]
+fn image_draw_image_preserves_paint(ctx: &mut impl Renderer) {
+    let strip_left = Rect::new(2.5, 10.0, 7.5, 90.0);
+    let strip_right = Rect::new(92.5, 10.0, 97.5, 90.0);
+
+    let gradient = Gradient {
+        kind: LinearGradientPosition {
+            start: Point::new(0.0, 10.0),
+            end: Point::new(0.0, 90.0),
+        }
+        .into(),
+        stops: stops_green_blue(),
+        ..Default::default()
+    };
+
+    ctx.set_paint(gradient);
+
+    ctx.fill_rect(&strip_left);
+
+    let image_source = rgb_img_10x10(ctx);
+    ctx.set_transform(Affine::translate((10.0, 10.0)) * Affine::scale(8.0));
+    ctx.draw_image(image_source, &Rect::new(0.0, 0.0, 10.0, 10.0), true);
+
+    ctx.set_transform(Affine::IDENTITY);
+    ctx.fill_rect(&strip_right);
 }
 
 /// Same as `image_spritesheet`, but renders "hello world" with a purple tint.

--- a/sparse_strips/vello_sparse_tests/tests/renderer.rs
+++ b/sparse_strips/vello_sparse_tests/tests/renderer.rs
@@ -67,6 +67,7 @@ pub(crate) trait Renderer: Sized {
     fn height(&self) -> u16;
     fn get_image_source(&mut self, pixmap: Arc<Pixmap>) -> ImageSource;
     fn register_image(&mut self, pixmap: Arc<Pixmap>) -> ImageId;
+    fn draw_image(&mut self, image: ImageSource, rect: &Rect, bilinear: bool);
     fn record(&mut self, recording: &mut Recording, f: impl FnOnce(&mut Recorder<'_>));
     fn prepare_recording(&mut self, recording: &mut Recording);
     fn execute_recording(&mut self, recording: &Recording);
@@ -225,6 +226,10 @@ impl Renderer for RenderContext {
 
     fn register_image(&mut self, pixmap: Arc<Pixmap>) -> ImageId {
         Self::register_image(self, pixmap)
+    }
+
+    fn draw_image(&mut self, _image: ImageSource, _rect: &Rect, _bilinear: bool) {
+        unimplemented!()
     }
 
     fn record(&mut self, recording: &mut Recording, f: impl FnOnce(&mut Recorder<'_>)) {
@@ -601,6 +606,10 @@ impl Renderer for HybridRenderer {
         image_id
     }
 
+    fn draw_image(&mut self, image: ImageSource, rect: &Rect, bilinear: bool) {
+        self.scene.draw_image(image, rect, bilinear);
+    }
+
     fn record(&mut self, recording: &mut Recording, f: impl FnOnce(&mut Recorder<'_>)) {
         Recordable::record(&mut self.scene, recording, f);
     }
@@ -840,6 +849,10 @@ impl Renderer for HybridRenderer {
 
     fn register_image(&mut self, pixmap: Arc<Pixmap>) -> ImageId {
         self.renderer.borrow_mut().upload_image(&pixmap)
+    }
+
+    fn draw_image(&mut self, image: ImageSource, rect: &Rect, bilinear: bool) {
+        self.scene.draw_image(image, rect, bilinear);
     }
 
     fn record(&mut self, recording: &mut Recording, f: impl FnOnce(&mut Recorder<'_>)) {


### PR DESCRIPTION
Now that we have the ability to add image padding, we could add a new `draw_image` method that uses the GPU-native bilinear sampler instead of our custom bilinear interpolation method. From my very rough experiment with a single scene of 1k images, this seems to give a pretty good speed boost.

A part of the speed boost also comes from the fact that we need to do less work in the fragment shader itself.

# Zoomed out

https://github.com/user-attachments/assets/5bed74aa-6011-4893-8ae7-f9296766f914

We roughly get the following frame times for each mode:
**Low**: 16.5ms
**Medium (manual bilinear)**: 21.5ms
**Medium (GPU-native bilinear)**: 12.2ms
**High**: 39ms

# Zoomed in

https://github.com/user-attachments/assets/d829c19c-d542-444e-b830-74cdf7974480

**Low**: 27ms
**Medium (manual bilinear)**: 35ms
**Medium (GPU-native bilinear)**: 19.2ms
**High**: 60ms