### PR TITLE
vello_hybrid: Fix slow scenes with many changing gradients

### DIFF
--- a/sparse_strips/vello_hybrid/src/gradient_cache.rs
+++ b/sparse_strips/vello_hybrid/src/gradient_cache.rs
@@ -165,12 +165,15 @@ impl GradientRampCache {
                 .map(|(key, (_, last_used))| (key, *last_used)),
         );
 
-        // Sort by last_used (ascending) to get LRU entries first
-        entries.sort_by_key(|(_, last_used)| *last_used);
+        let (lesser, median, _) =
+            entries.select_nth_unstable_by_key(count - 1, |(_, last_used)| *last_used);
 
+        // Note that since we use `select_nth_unstable`, the entries themselves are not guaranteed
+        // to be sorted.
         let mut removed = core::mem::take(&mut self.scratch.removed);
         removed.clear();
-        removed.extend(entries.iter().take(count).map(|(key, _)| (*key).clone()));
+        removed.extend(lesser.iter().map(|(key, _)| (*key).clone()));
+        removed.push(median.0.clone());
         self.scratch.entries = reuse_vec(entries);
 
         for key in removed.drain(..) {
@@ -191,7 +194,8 @@ impl GradientRampCache {
             return;
         }
 
-        // Sort by lut_start position (ascending) for efficient processing
+        // See comment in `remove_lru_entries`, the entries are not sorted yet but need to be
+        // for the prefix sum to work correctly.
         ramps_to_remove.sort_by_key(|(_, ramp)| ramp.lut_start);
 
         // Compute a prefix sum of how much the `lut_start` entry of a given cached ramp needs


### PR DESCRIPTION
Closes #1413.

There were two problems in the old implementation:
1) When compacting the LUTs, we had a doubly-nested loop that, for each gradient existing in the cache we iterated over ALL removed gradients to compute the new `lut_start` position for that gradient.
2) When copying LUT data, we would do so pixel-by-pixel instead of copying the whole range at once.

This PR addresses both points by 1) computing a prefix sum for how much `lut_start` needs to be adjusted for a given cached ramp and 2) copying whole ranges at once using `copy_within`.

Before:
As you can see, the scene quickly gets laggy once we hit the compaction code path.

https://github.com/user-attachments/assets/319b7c80-a152-4239-9bea-ecf47f259f28



<img width="1419" height="729" alt="image" src="https://github.com/user-attachments/assets/4802f7fc-9fbd-41c3-9f39-b32a17e21c18" />

After:
Now, the bottleneck is basically only uploading the texture and computing the LUT on the CPU. Which is still not ideal, but much better than before.


https://github.com/user-attachments/assets/b159b47d-a4ee-4f10-aac3-8909cf0a4d91



https://github.com/user-attachments/assets/f58db4b4-2a46-4c14-a225-6fea11cd1314
<img width="1413" height="707" alt="image" src="https://github.com/user-attachments/assets/6457f8b1-a2cd-4615-908f-8d2ff876adc2" />

