### PR TITLE
vello_hybrid: Faster rotated rectangles (PoC)

### DIFF
--- a/sparse_strips/vello_example_scenes/src/lib.rs
+++ b/sparse_strips/vello_example_scenes/src/lib.rs
@@ -10,6 +10,7 @@ pub mod gradient;
 pub mod image;
 pub mod multi_image;
 pub mod path;
+pub mod rotated_rects;
 pub mod simple;
 pub mod svg;
 pub mod text;
@@ -444,6 +445,7 @@ pub fn get_example_scenes<T: RenderingContext + 'static>(
     scenes.push(AnyScene::new(path::TrickyStrokesScene::new()));
     scenes.push(AnyScene::new(path::FunkyPathsScene::new()));
     scenes.push(AnyScene::new(path::RobustPathsScene::new()));
+    scenes.push(AnyScene::new(rotated_rects::RotatedRectsScene::new()));
 
     scenes.into_boxed_slice()
 }
@@ -472,6 +474,7 @@ pub fn get_example_scenes<T: RenderingContext + 'static>(
         AnyScene::new(path::TrickyStrokesScene::new()),
         AnyScene::new(path::FunkyPathsScene::new()),
         AnyScene::new(path::RobustPathsScene::new()),
+        AnyScene::new(rotated_rects::RotatedRectsScene::new()),
     ];
     scenes.into_boxed_slice()
 }

--- a/sparse_strips/vello_example_scenes/src/rotated_rects.rs
+++ b/sparse_strips/vello_example_scenes/src/rotated_rects.rs
@@ -1,0 +1,194 @@
+// Copyright 2025 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Scene with bouncing, rotating, semi-transparent rectangles.
+//! Press "a"/"d" to add/remove 100 rects, "r" to toggle rotation.
+
+use crate::{ExampleScene, RenderingContext};
+use vello_common::color::{AlphaColor, Srgb};
+use vello_common::kurbo::{Affine, Rect};
+
+const BATCH_SIZE: usize = 100;
+const MIN_SIZE: f64 = 20.0;
+const MAX_SIZE: f64 = 100.0;
+const MIN_SPEED: f64 = 0.5;
+const MAX_SPEED: f64 = 3.0;
+const ALPHA: f32 = 0.6;
+
+struct RectState {
+    x: f64,
+    y: f64,
+    vx: f64,
+    vy: f64,
+    w: f64,
+    h: f64,
+    angle: f64,
+    angular_vel: f64,
+    color: [u8; 3],
+}
+
+/// Interactive scene with bouncing, rotating, semi-transparent rectangles.
+pub struct RotatedRectsScene {
+    rng: Rng,
+    rects: Vec<RectState>,
+    rotated: bool,
+}
+
+impl std::fmt::Debug for RotatedRectsScene {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RotatedRectsScene")
+            .field("count", &self.rects.len())
+            .field("rotated", &self.rotated)
+            .finish_non_exhaustive()
+    }
+}
+
+impl RotatedRectsScene {
+    /// Create a new scene with an initial batch of rectangles.
+    pub fn new() -> Self {
+        let mut scene = Self {
+            rng: Rng::new(0xCAFE_BABE_DEAD_BEEF),
+            rects: Vec::new(),
+            rotated: false,
+        };
+        scene.add_batch();
+        scene
+    }
+
+    fn add_one(&mut self, vw: f64, vh: f64) {
+        let w = self.rng.range_f64(MIN_SIZE, MAX_SIZE);
+        let h = self.rng.range_f64(MIN_SIZE, MAX_SIZE);
+        self.rects.push(RectState {
+            x: self.rng.range_f64(0.0, (vw - w).max(1.0)),
+            y: self.rng.range_f64(0.0, (vh - h).max(1.0)),
+            vx: self.rng.range_f64(MIN_SPEED, MAX_SPEED) * self.rng.sign(),
+            vy: self.rng.range_f64(MIN_SPEED, MAX_SPEED) * self.rng.sign(),
+            w,
+            h,
+            angle: self.rng.range_f64(0.0, std::f64::consts::TAU),
+            angular_vel: self.rng.range_f64(0.005, 0.03) * self.rng.sign(),
+            color: [self.rng.range_u8(), self.rng.range_u8(), self.rng.range_u8()],
+        });
+    }
+
+    fn add_batch(&mut self) {
+        for _ in 0..BATCH_SIZE {
+            // Use a default viewport size; positions will clamp on first render.
+            self.add_one(1920.0, 1080.0);
+        }
+    }
+
+    fn step(&mut self, vw: f64, vh: f64) {
+        for r in &mut self.rects {
+            r.x += r.vx;
+            r.y += r.vy;
+            r.angle += r.angular_vel;
+
+            if r.x < 0.0 {
+                r.x = 0.0;
+                r.vx = r.vx.abs();
+            } else if r.x + r.w > vw {
+                r.x = vw - r.w;
+                r.vx = -r.vx.abs();
+            }
+
+            if r.y < 0.0 {
+                r.y = 0.0;
+                r.vy = r.vy.abs();
+            } else if r.y + r.h > vh {
+                r.y = vh - r.h;
+                r.vy = -r.vy.abs();
+            }
+        }
+    }
+}
+
+impl ExampleScene for RotatedRectsScene {
+    fn render(&mut self, ctx: &mut impl RenderingContext, root_transform: Affine) {
+        let vw = ctx.width() as f64;
+        let vh = ctx.height() as f64;
+
+        self.step(vw, vh);
+
+        for r in &self.rects {
+            let cx = r.x + r.w / 2.0;
+            let cy = r.y + r.h / 2.0;
+
+            let transform = if self.rotated {
+                root_transform
+                    * Affine::translate((cx, cy))
+                    * Affine::rotate(r.angle)
+                    * Affine::translate((-r.w / 2.0, -r.h / 2.0))
+            } else {
+                root_transform * Affine::translate((r.x, r.y))
+            };
+
+            ctx.set_transform(transform);
+            ctx.set_paint(AlphaColor::<Srgb>::new([
+                r.color[0] as f32 / 255.0,
+                r.color[1] as f32 / 255.0,
+                r.color[2] as f32 / 255.0,
+                ALPHA,
+            ]));
+            ctx.fill_rect(&Rect::new(0.0, 0.0, r.w, r.h));
+        }
+    }
+
+    fn handle_key(&mut self, key: &str) -> bool {
+        match key {
+            "a" => {
+                self.add_batch();
+                true
+            }
+            "d" => {
+                let new_len = self.rects.len().saturating_sub(BATCH_SIZE);
+                self.rects.truncate(new_len);
+                true
+            }
+            "r" => {
+                self.rotated = !self.rotated;
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn status(&self) -> Option<String> {
+        Some(format!(
+            "{} rects{}",
+            self.rects.len(),
+            if self.rotated { " (rotated)" } else { "" }
+        ))
+    }
+}
+
+struct Rng(u64);
+
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Self(seed)
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+
+    fn range_f64(&mut self, lo: f64, hi: f64) -> f64 {
+        let t =
+            (self.next_u64() & 0x000F_FFFF_FFFF_FFFF) as f64 / (0x0010_0000_0000_0000_u64 as f64);
+        lo + t * (hi - lo)
+    }
+
+    fn range_u8(&mut self) -> u8 {
+        (self.next_u64() & 0xFF) as u8
+    }
+
+    fn sign(&mut self) -> f64 {
+        if self.next_u64() & 1 == 0 { 1.0 } else { -1.0 }
+    }
+}

--- a/sparse_strips/vello_example_scenes/src/rotated_rects.rs
+++ b/sparse_strips/vello_example_scenes/src/rotated_rects.rs
@@ -8,7 +8,7 @@ use crate::{ExampleScene, RenderingContext};
 use vello_common::color::{AlphaColor, Srgb};
 use vello_common::kurbo::{Affine, Rect};
 
-const BATCH_SIZE: usize = 100;
+const BATCH_SIZE: usize = 500;
 const MIN_SIZE: f64 = 20.0;
 const MAX_SIZE: f64 = 100.0;
 const MIN_SPEED: f64 = 0.5;

--- a/sparse_strips/vello_hybrid/examples/winit/src/main.rs
+++ b/sparse_strips/vello_hybrid/examples/winit/src/main.rs
@@ -141,7 +141,7 @@ impl ApplicationHandler for App<'_> {
             window.clone(),
             size.width,
             size.height,
-            wgpu::PresentMode::Immediate, // Unlimited FPS mode
+            wgpu::PresentMode::Fifo,
             wgpu::TextureFormat::Bgra8Unorm,
         ));
 

--- a/sparse_strips/vello_hybrid/src/render/common.rs
+++ b/sparse_strips/vello_hybrid/src/render/common.rs
@@ -69,8 +69,6 @@ pub struct GpuStrip {
     /// See `StripInstance::paint_and_rect_flag` documentation in `render_strips.wgsl`.
     pub paint_and_rect_flag: u32,
     /// See `StripInstance::rotation` documentation in `render_strips.wgsl`.
-    /// Packed sin/cos for rotated rects: u16(sin) in low bits, u16(cos) in high bits.
-    /// Zero for non-rotated strips/rects.
     pub rotation: u32,
 }
 

--- a/sparse_strips/vello_hybrid/src/render/common.rs
+++ b/sparse_strips/vello_hybrid/src/render/common.rs
@@ -68,6 +68,10 @@ pub struct GpuStrip {
     pub payload: u32,
     /// See `StripInstance::paint_and_rect_flag` documentation in `render_strips.wgsl`.
     pub paint_and_rect_flag: u32,
+    /// See `StripInstance::rotation` documentation in `render_strips.wgsl`.
+    /// Packed sin/cos for rotated rects: u16(sin) in low bits, u16(cos) in high bits.
+    /// Zero for non-rotated strips/rects.
+    pub rotation: u32,
 }
 
 /// Different types of GPU encoded paints.

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -1712,10 +1712,10 @@ fn initialize_strip_vao(gl: &WebGl2RenderingContext, resources: &WebGlResources)
     );
 
     let stride = size_of::<GpuStrip>() as i32;
-    debug_assert_eq!(stride, 20, "expected stride of 20");
+    debug_assert_eq!(stride, 24, "expected stride of 24");
 
     // Configure attributes.
-    for i in 0..5 {
+    for i in 0..6 {
         let location = i as u32;
         let offset = i * 4;
 

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -683,13 +683,14 @@ struct ClearSlotsConfig {
 
 impl GpuStrip {
     /// Vertex attributes for the strip
-    pub fn vertex_attributes() -> [wgpu::VertexAttribute; 5] {
+    pub fn vertex_attributes() -> [wgpu::VertexAttribute; 6] {
         wgpu::vertex_attr_array![
             0 => Uint32,
             1 => Uint32,
             2 => Uint32,
             3 => Uint32,
             4 => Uint32,
+            5 => Uint32,
         ]
     }
 }

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -495,7 +495,6 @@ impl Scene {
         let sin = decomp.sin as f32;
 
         if sin.abs().is_nearly_zero() {
-            // Axis-aligned: transform bounds directly and clamp to viewport.
             let transformed_rect = self.render_state.transform.transform_rect_bbox(*rect);
 
             let x0 = transformed_rect.x0.max(0.0).min(f64::from(self.width)) as f32;

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -520,39 +520,31 @@ impl Scene {
                     paint,
                 }));
         } else {
-            // Rotated: compute screen-space bounds from center + scaled dimensions.
-            let scaled_w = (rect.width() * decomp.sx) as f32;
-            let scaled_h = (rect.height() * decomp.sy) as f32;
-
-            // Same as above, for simplicity don't support mirroring for now.
-            if scaled_w <= 0.0 || scaled_h <= 0.0 {
+            // If the rectangle has a rotation, we need to make sure that after applying the whole
+            // transform, the bounding box of the rectangle is still fully within the viewport. This
+            // is necessary because later on, rects are clamped to u16 coordinates. This works fine
+            // if we just have a scaling/translation component, but if we have an additional rotation,
+            // this might cut off parts of the rectangle that should actually be visible.
+            let viewport = Rect::new(0.0, 0.0, self.width as f64, self.height as f64);
+            let aabb = self.render_state.transform.transform_rect_bbox(*rect);
+            if !viewport.contains_rect(aabb) {
                 return false;
             }
 
-            let [a, b, c, d, e, f] = self.render_state.transform.as_coeffs();
-            let rect_cx = rect.x0 + rect.width() / 2.0;
-            let rect_cy = rect.y0 + rect.height() / 2.0;
-            let cx = (a * rect_cx + c * rect_cy + e) as f32;
-            let cy = (b * rect_cx + d * rect_cy + f) as f32;
+            let center = self.render_state.transform * rect.center();
+            let scale_only = Affine::scale_non_uniform(decomp.sx, decomp.sy);
+            let scaled_rect = scale_only.transform_rect_bbox(*rect);
 
-            let x0 = cx - scaled_w / 2.0;
-            let y0 = cy - scaled_h / 2.0;
-            let x1 = cx + scaled_w / 2.0;
-            let y1 = cy + scaled_h / 2.0;
-
-            // Check AABB against viewport.
-            let hw = scaled_w / 2.0;
-            let hh = scaled_h / 2.0;
-            let aabb_hw = hw * cos.abs() + hh * sin.abs();
-            let aabb_hh = hw * sin.abs() + hh * cos.abs();
-
-            if cx + aabb_hw <= 0.0
-                || cy + aabb_hh <= 0.0
-                || cx - aabb_hw >= self.width as f32
-                || cy - aabb_hh >= self.height as f32
-            {
+            // Similarly to above, don't support mirrored rectangles for simplicity for now.
+            if scaled_rect.width() <= 0.0 || scaled_rect.height() <= 0.0 {
                 return false;
             }
+
+            // Local-frame bounds centered at the screen-space center.
+            let x0 = (center.x - scaled_rect.width() / 2.0) as f32;
+            let y0 = (center.y - scaled_rect.height() / 2.0) as f32;
+            let x1 = (center.x + scaled_rect.width() / 2.0) as f32;
+            let y1 = (center.y + scaled_rect.height() / 2.0) as f32;
 
             self.fast_strips_buffer
                 .commands

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -531,20 +531,22 @@ impl Scene {
                 return false;
             }
 
-            let center = self.render_state.transform * rect.center();
-            let scale_only = Affine::scale_non_uniform(decomp.sx, decomp.sy);
-            let scaled_rect = scale_only.transform_rect_bbox(*rect);
+            // Apply scale + translation (without rotation) to get the local-frame bounds.
+            let transformed_center = self.render_state.transform * rect.center();
+            let local_rect = (Affine::translate((transformed_center.x, transformed_center.y))
+                * Affine::scale_non_uniform(decomp.sx, decomp.sy)
+                * Affine::translate((-rect.center().x, -rect.center().y)))
+            .transform_rect_bbox(*rect);
 
             // Similarly to above, don't support mirrored rectangles for simplicity for now.
-            if scaled_rect.width() <= 0.0 || scaled_rect.height() <= 0.0 {
+            if local_rect.width() <= 0.0 || local_rect.height() <= 0.0 {
                 return false;
             }
 
-            // Local-frame bounds centered at the screen-space center.
-            let x0 = (center.x - scaled_rect.width() / 2.0) as f32;
-            let y0 = (center.y - scaled_rect.height() / 2.0) as f32;
-            let x1 = (center.x + scaled_rect.width() / 2.0) as f32;
-            let y1 = (center.y + scaled_rect.height() / 2.0) as f32;
+            let x0 = local_rect.x0 as f32;
+            let y0 = local_rect.y0 as f32;
+            let x1 = local_rect.x1 as f32;
+            let y1 = local_rect.y1 as f32;
 
             self.fast_strips_buffer
                 .commands

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -71,30 +71,21 @@ pub(crate) struct FastStripsPath {
     pub(crate) paint: Paint,
 }
 
-/// An axis-aligned rectangle stored in the fast-path buffer.
+/// A rectangle stored in the fast-path buffer, defined by center, half-extents, and rotation.
+/// Axis-aligned rects use sin=0, cos=1.
 #[derive(Debug)]
 pub(crate) struct FastPathRect {
-    pub(crate) x0: f32,
-    pub(crate) y0: f32,
-    pub(crate) x1: f32,
-    pub(crate) y1: f32,
-    pub(crate) paint: Paint,
-}
-
-/// A rotated rectangle stored in the fast-path buffer.
-#[derive(Debug)]
-pub(crate) struct FastPathRotatedRect {
     /// Center x in pixel coordinates.
     pub(crate) cx: f32,
     /// Center y in pixel coordinates.
     pub(crate) cy: f32,
-    /// Half-width of the original (unrotated) rectangle.
+    /// Half-width of the (unrotated) rectangle in screen pixels.
     pub(crate) half_width: f32,
-    /// Half-height of the original (unrotated) rectangle.
+    /// Half-height of the (unrotated) rectangle in screen pixels.
     pub(crate) half_height: f32,
-    /// Sine of the rotation angle.
+    /// Sine of the rotation angle (0 for axis-aligned).
     pub(crate) sin: f32,
-    /// Cosine of the rotation angle.
+    /// Cosine of the rotation angle (1 for axis-aligned).
     pub(crate) cos: f32,
     pub(crate) paint: Paint,
 }
@@ -104,10 +95,8 @@ pub(crate) struct FastPathRotatedRect {
 pub(crate) enum FastStripCommand {
     /// A path rendered via the normal strip pipeline.
     Path(FastStripsPath),
-    /// An axis-aligned rectangle.
+    /// A rectangle (axis-aligned or rotated).
     Rect(FastPathRect),
-    /// A rotated rectangle.
-    RotatedRect(FastPathRotatedRect),
 }
 
 /// A buffer that collects strips from paths that are rendered directly to the surface,
@@ -525,86 +514,57 @@ impl Scene {
 
         let paint = self.encode_current_paint();
 
-        if is_axis_aligned {
-            let transformed_rect = self.render_state.transform.transform_rect_bbox(*rect);
+        // Extract scale factors from column lengths.
+        // Column 1 = (a, b), Column 2 = (c, d).
+        let sx = (a * a + b * b).sqrt();
+        let sy = (c * c + d * d).sqrt();
 
-            let x0 = transformed_rect.x0.max(0.0).min(f64::from(self.width));
-            let y0 = transformed_rect.y0.max(0.0).min(f64::from(self.height));
-            let x1 = transformed_rect.x1.max(0.0).min(f64::from(self.width));
-            let y1 = transformed_rect.y1.max(0.0).min(f64::from(self.height));
-
-            // Can't handle mirrored or zero-sized rectangles.
-            if x1 <= x0 || y1 <= y0 {
-                return false;
-            }
-
-            self.fast_strips_buffer
-                .commands
-                .push(FastStripCommand::Rect(FastPathRect {
-                    x0: x0 as f32,
-                    y0: y0 as f32,
-                    x1: x1 as f32,
-                    y1: y1 as f32,
-                    paint,
-                }));
-        } else {
-            // Rotated rectangle. Extract scale factors from column lengths.
-            // Column 1 = (a, b), Column 2 = (c, d).
-            let sx = (a * a + b * b).sqrt();
-            let sy = (c * c + d * d).sqrt();
-
-            // Reject degenerate or reflected transforms.
-            let det = a * d - b * c;
-            if det.abs() <= 1e-10 {
-                return false;
-            }
-
-            let half_width = (rect.width() * sx / 2.0) as f32;
-            let half_height = (rect.height() * sy / 2.0) as f32;
-
-            if half_width <= 0.0 || half_height <= 0.0 {
-                return false;
-            }
-
-            // Extract rotation angle from column 1: (a, b) = sx * (cos θ, sin θ)
-            let cos = (a / sx) as f32;
-            let sin = (b / sx) as f32;
-
-            // Transform the rect center: x' = a*x + c*y + e, y' = b*x + d*y + f
-            let rect_cx = rect.x0 + rect.width() / 2.0;
-            let rect_cy = rect.y0 + rect.height() / 2.0;
-            let cx = (a * rect_cx + c * rect_cy + e) as f32;
-            let cy = (b * rect_cx + d * rect_cy + f) as f32;
-
-            // Compute the AABB and check it's within the viewport.
-            let aabb_hw = half_width * cos.abs() + half_height * sin.abs();
-            let aabb_hh = half_width * sin.abs() + half_height * cos.abs();
-            let aabb_x0 = cx - aabb_hw;
-            let aabb_y0 = cy - aabb_hh;
-            let aabb_x1 = cx + aabb_hw;
-            let aabb_y1 = cy + aabb_hh;
-
-            // Reject if entirely outside the viewport.
-            if aabb_x1 <= 0.0
-                || aabb_y1 <= 0.0
-                || aabb_x0 >= self.width as f32
-                || aabb_y0 >= self.height as f32
-            {
-                return false;
-            }
-
-            self.fast_strips_buffer
-                .commands
-                .push(FastStripCommand::RotatedRect(FastPathRotatedRect {
-                    cx,
-                    cy,
-                    half_width,
-                    half_height,
-                    sin,
-                    cos,
-                    paint,
-                }));
+        // Reject degenerate transforms.
+        if sx <= 1e-10 || sy <= 1e-10 {
+            return false;
         }
+
+        let half_width = (rect.width() * sx / 2.0) as f32;
+        let half_height = (rect.height() * sy / 2.0) as f32;
+
+        if half_width <= 0.0 || half_height <= 0.0 {
+            return false;
+        }
+
+        // Extract rotation from column 1: (a, b) = sx * (cos θ, sin θ).
+        // For axis-aligned transforms, sin ≈ 0 and cos ≈ ±1.
+        let cos = (a / sx) as f32;
+        let sin = (b / sx) as f32;
+
+        // Transform the rect center: x' = a*x + c*y + e, y' = b*x + d*y + f
+        let rect_cx = rect.x0 + rect.width() / 2.0;
+        let rect_cy = rect.y0 + rect.height() / 2.0;
+        let cx = (a * rect_cx + c * rect_cy + e) as f32;
+        let cy = (b * rect_cx + d * rect_cy + f) as f32;
+
+        // Compute the AABB and check it's within the viewport.
+        let aabb_hw = half_width * cos.abs() + half_height * sin.abs();
+        let aabb_hh = half_width * sin.abs() + half_height * cos.abs();
+
+        if cx + aabb_hw <= 0.0
+            || cy + aabb_hh <= 0.0
+            || cx - aabb_hw >= self.width as f32
+            || cy - aabb_hh >= self.height as f32
+        {
+            return false;
+        }
+
+        self.fast_strips_buffer
+            .commands
+            .push(FastStripCommand::Rect(FastPathRect {
+                cx,
+                cy,
+                half_width,
+                half_height,
+                sin,
+                cos,
+                paint,
+            }));
 
         true
     }
@@ -645,27 +605,9 @@ impl Scene {
                     );
                 }
                 FastStripCommand::Rect(r) => {
-                    let rect = Rect::new(
-                        f64::from(r.x0),
-                        f64::from(r.y0),
-                        f64::from(r.x1),
-                        f64::from(r.y1),
-                    );
-                    let strip_start = strip_storage.strips.len();
-                    self.strip_generator
-                        .generate_filled_rect_fast(&rect, &mut strip_storage, None);
-                    self.wide.generate(
-                        &strip_storage.strips[strip_start..],
-                        r.paint,
-                        BlendMode::default(),
-                        0,
-                        None,
-                        &self.encoded_paints,
-                    );
-                }
-                FastStripCommand::RotatedRect(r) => {
-                    // For the coarse path fallback, generate the rotated rect as a
-                    // regular path through the flatten → tiles → strips pipeline.
+                    // For the coarse path fallback, generate the rect as a
+                    // path through the flatten → tiles → strips pipeline.
+                    // TODO: Add tests for this
                     let angle = f64::from(r.sin).atan2(f64::from(r.cos));
                     let rect = Rect::new(
                         f64::from(-r.half_width),

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -531,22 +531,19 @@ impl Scene {
                 return false;
             }
 
-            // Apply scale + translation (without rotation) to get the local-frame bounds.
+            // Build the new rectangle at the right center point and with the scaled size.
             let transformed_center = self.render_state.transform * rect.center();
-            let local_rect = (Affine::translate((transformed_center.x, transformed_center.y))
-                * Affine::scale_non_uniform(decomp.sx, decomp.sy)
-                * Affine::translate((-rect.center().x, -rect.center().y)))
-            .transform_rect_bbox(*rect);
+            let rect = Rect::from_center_size(transformed_center, (decomp.sx * rect.width(), decomp.sy * rect.height()));
 
             // Similarly to above, don't support mirrored rectangles for simplicity for now.
-            if local_rect.width() <= 0.0 || local_rect.height() <= 0.0 {
+            if rect.width() <= 0.0 || rect.height() <= 0.0 {
                 return false;
             }
 
-            let x0 = local_rect.x0 as f32;
-            let y0 = local_rect.y0 as f32;
-            let x1 = local_rect.x1 as f32;
-            let y1 = local_rect.y1 as f32;
+            let x0 = rect.x0 as f32;
+            let y0 = rect.y0 as f32;
+            let x1 = rect.x1 as f32;
+            let y1 = rect.y1 as f32;
 
             self.fast_strips_buffer
                 .commands

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -72,18 +72,13 @@ pub(crate) struct FastStripsPath {
     pub(crate) paint: Paint,
 }
 
-/// A rectangle stored in the fast-path buffer, defined by center, half-extents, and rotation.
-/// Axis-aligned rects use sin=0, cos=1.
+/// A rectangle stored in the fast-path buffer.
 #[derive(Debug)]
 pub(crate) struct FastPathRect {
-    /// Center x in pixel coordinates.
-    pub(crate) cx: f32,
-    /// Center y in pixel coordinates.
-    pub(crate) cy: f32,
-    /// Half-width of the (unrotated) rectangle in screen pixels.
-    pub(crate) half_width: f32,
-    /// Half-height of the (unrotated) rectangle in screen pixels.
-    pub(crate) half_height: f32,
+    pub(crate) x0: f32,
+    pub(crate) y0: f32,
+    pub(crate) x1: f32,
+    pub(crate) y1: f32,
     /// Sine of the rotation angle (0 for axis-aligned).
     pub(crate) sin: f32,
     /// Cosine of the rotation angle (1 for axis-aligned).
@@ -497,10 +492,10 @@ impl Scene {
 
         let paint = self.encode_current_paint();
 
-        let half_width = (rect.width() * decomp.sx / 2.0) as f32;
-        let half_height = (rect.height() * decomp.sy / 2.0) as f32;
+        let scaled_w = (rect.width() * decomp.sx) as f32;
+        let scaled_h = (rect.height() * decomp.sy) as f32;
 
-        if half_width <= 0.0 || half_height <= 0.0 {
+        if scaled_w <= 0.0 || scaled_h <= 0.0 {
             return false;
         }
 
@@ -514,9 +509,17 @@ impl Scene {
         let cx = (a * rect_cx + c * rect_cy + e) as f32;
         let cy = (b * rect_cx + d * rect_cy + f) as f32;
 
+        // Store as screen-space bounds centered at (cx, cy).
+        let x0 = cx - scaled_w / 2.0;
+        let y0 = cy - scaled_h / 2.0;
+        let x1 = cx + scaled_w / 2.0;
+        let y1 = cy + scaled_h / 2.0;
+
         // Compute the AABB and check it's within the viewport.
-        let aabb_hw = half_width * cos.abs() + half_height * sin.abs();
-        let aabb_hh = half_width * sin.abs() + half_height * cos.abs();
+        let hw = scaled_w / 2.0;
+        let hh = scaled_h / 2.0;
+        let aabb_hw = hw * cos.abs() + hh * sin.abs();
+        let aabb_hh = hw * sin.abs() + hh * cos.abs();
 
         if cx + aabb_hw <= 0.0
             || cy + aabb_hh <= 0.0
@@ -529,10 +532,10 @@ impl Scene {
         self.fast_strips_buffer
             .commands
             .push(FastStripCommand::Rect(FastPathRect {
-                cx,
-                cy,
-                half_width,
-                half_height,
+                x0,
+                y0,
+                x1,
+                y1,
                 sin,
                 cos,
                 paint,
@@ -579,15 +582,18 @@ impl Scene {
                 FastStripCommand::Rect(r) => {
                     // For the coarse path fallback, generate the rect as a
                     // path through the flatten → tiles → strips pipeline.
-                    // TODO: Add tests for this
+                    let hw = (r.x1 - r.x0) / 2.0;
+                    let hh = (r.y1 - r.y0) / 2.0;
+                    let cx = (r.x0 + r.x1) / 2.0;
+                    let cy = (r.y0 + r.y1) / 2.0;
                     let angle = f64::from(r.sin).atan2(f64::from(r.cos));
                     let rect = Rect::new(
-                        f64::from(-r.half_width),
-                        f64::from(-r.half_height),
-                        f64::from(r.half_width),
-                        f64::from(r.half_height),
+                        f64::from(-hw),
+                        f64::from(-hh),
+                        f64::from(hw),
+                        f64::from(hh),
                     );
-                    let transform = Affine::translate((f64::from(r.cx), f64::from(r.cy)))
+                    let transform = Affine::translate((f64::from(cx), f64::from(cy)))
                         * Affine::rotate(angle);
                     let path = rect.to_path(DEFAULT_TOLERANCE);
                     let strip_start = strip_storage.strips.len();

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -71,7 +71,7 @@ pub(crate) struct FastStripsPath {
     pub(crate) paint: Paint,
 }
 
-/// A rectangle stored in the fast-path buffer.
+/// An axis-aligned rectangle stored in the fast-path buffer.
 #[derive(Debug)]
 pub(crate) struct FastPathRect {
     pub(crate) x0: f32,
@@ -81,13 +81,33 @@ pub(crate) struct FastPathRect {
     pub(crate) paint: Paint,
 }
 
+/// A rotated rectangle stored in the fast-path buffer.
+#[derive(Debug)]
+pub(crate) struct FastPathRotatedRect {
+    /// Center x in pixel coordinates.
+    pub(crate) cx: f32,
+    /// Center y in pixel coordinates.
+    pub(crate) cy: f32,
+    /// Half-width of the original (unrotated) rectangle.
+    pub(crate) half_width: f32,
+    /// Half-height of the original (unrotated) rectangle.
+    pub(crate) half_height: f32,
+    /// Sine of the rotation angle.
+    pub(crate) sin: f32,
+    /// Cosine of the rotation angle.
+    pub(crate) cos: f32,
+    pub(crate) paint: Paint,
+}
+
 /// A command in the fast strips buffer.
 #[derive(Debug)]
 pub(crate) enum FastStripCommand {
     /// A path rendered via the normal strip pipeline.
     Path(FastStripsPath),
-    /// A rectangle.
+    /// An axis-aligned rectangle.
     Rect(FastPathRect),
+    /// A rotated rectangle.
+    RotatedRect(FastPathRotatedRect),
 }
 
 /// A buffer that collects strips from paths that are rendered directly to the surface,
@@ -482,33 +502,109 @@ impl Scene {
 
         // We can't handle skewed rectangles.
         let coeffs = self.render_state.transform.as_coeffs();
-        // TODO: Maybe support rotated rectangles (https://github.com/linebender/vello/pull/1482#discussion_r2881223621)
-        if coeffs[1].abs() > 1e-5 || coeffs[2].abs() > 1e-5 {
+        let [a, b, c, d, e, f] = coeffs;
+
+        // Kurbo Affine layout: [a, b, c, d, e, f] where
+        //   x' = a*x + c*y + e
+        //   y' = b*x + d*y + f
+        // Column 1 (local x-axis): (a, b)
+        // Column 2 (local y-axis): (c, d)
+        // Translation: (e, f)
+
+        // Check if the transform is axis-aligned (no rotation/skew).
+        // Axis-aligned means both off-diagonal elements of each column are ~0.
+        let is_axis_aligned = b.abs() <= 1e-5 && c.abs() <= 1e-5;
+
+        // Check if the transform is a rotation+scale (columns are perpendicular).
+        // Column 1 · Column 2 = a*c + b*d
+        let is_rotation = !is_axis_aligned && (a * c + b * d).abs() <= 1e-5;
+
+        if !is_axis_aligned && !is_rotation {
             return false;
         }
 
         let paint = self.encode_current_paint();
-        let transformed_rect = self.render_state.transform.transform_rect_bbox(*rect);
 
-        let x0 = transformed_rect.x0.max(0.0).min(f64::from(self.width));
-        let y0 = transformed_rect.y0.max(0.0).min(f64::from(self.height));
-        let x1 = transformed_rect.x1.max(0.0).min(f64::from(self.width));
-        let y1 = transformed_rect.y1.max(0.0).min(f64::from(self.height));
+        if is_axis_aligned {
+            let transformed_rect = self.render_state.transform.transform_rect_bbox(*rect);
 
-        // Can't handle mirrored or zero-sized rectangles.
-        if x1 <= x0 || y1 <= y0 {
-            return false;
+            let x0 = transformed_rect.x0.max(0.0).min(f64::from(self.width));
+            let y0 = transformed_rect.y0.max(0.0).min(f64::from(self.height));
+            let x1 = transformed_rect.x1.max(0.0).min(f64::from(self.width));
+            let y1 = transformed_rect.y1.max(0.0).min(f64::from(self.height));
+
+            // Can't handle mirrored or zero-sized rectangles.
+            if x1 <= x0 || y1 <= y0 {
+                return false;
+            }
+
+            self.fast_strips_buffer
+                .commands
+                .push(FastStripCommand::Rect(FastPathRect {
+                    x0: x0 as f32,
+                    y0: y0 as f32,
+                    x1: x1 as f32,
+                    y1: y1 as f32,
+                    paint,
+                }));
+        } else {
+            // Rotated rectangle. Extract scale factors from column lengths.
+            // Column 1 = (a, b), Column 2 = (c, d).
+            let sx = (a * a + b * b).sqrt();
+            let sy = (c * c + d * d).sqrt();
+
+            // Reject degenerate or reflected transforms.
+            let det = a * d - b * c;
+            if det.abs() <= 1e-10 {
+                return false;
+            }
+
+            let half_width = (rect.width() * sx / 2.0) as f32;
+            let half_height = (rect.height() * sy / 2.0) as f32;
+
+            if half_width <= 0.0 || half_height <= 0.0 {
+                return false;
+            }
+
+            // Extract rotation angle from column 1: (a, b) = sx * (cos θ, sin θ)
+            let cos = (a / sx) as f32;
+            let sin = (b / sx) as f32;
+
+            // Transform the rect center: x' = a*x + c*y + e, y' = b*x + d*y + f
+            let rect_cx = rect.x0 + rect.width() / 2.0;
+            let rect_cy = rect.y0 + rect.height() / 2.0;
+            let cx = (a * rect_cx + c * rect_cy + e) as f32;
+            let cy = (b * rect_cx + d * rect_cy + f) as f32;
+
+            // Compute the AABB and check it's within the viewport.
+            let aabb_hw = half_width * cos.abs() + half_height * sin.abs();
+            let aabb_hh = half_width * sin.abs() + half_height * cos.abs();
+            let aabb_x0 = cx - aabb_hw;
+            let aabb_y0 = cy - aabb_hh;
+            let aabb_x1 = cx + aabb_hw;
+            let aabb_y1 = cy + aabb_hh;
+
+            // Reject if entirely outside the viewport.
+            if aabb_x1 <= 0.0
+                || aabb_y1 <= 0.0
+                || aabb_x0 >= self.width as f32
+                || aabb_y0 >= self.height as f32
+            {
+                return false;
+            }
+
+            self.fast_strips_buffer
+                .commands
+                .push(FastStripCommand::RotatedRect(FastPathRotatedRect {
+                    cx,
+                    cy,
+                    half_width,
+                    half_height,
+                    sin,
+                    cos,
+                    paint,
+                }));
         }
-
-        self.fast_strips_buffer
-            .commands
-            .push(FastStripCommand::Rect(FastPathRect {
-                x0: x0 as f32,
-                y0: y0 as f32,
-                x1: x1 as f32,
-                y1: y1 as f32,
-                paint,
-            }));
 
         true
     }
@@ -558,6 +654,37 @@ impl Scene {
                     let strip_start = strip_storage.strips.len();
                     self.strip_generator
                         .generate_filled_rect_fast(&rect, &mut strip_storage, None);
+                    self.wide.generate(
+                        &strip_storage.strips[strip_start..],
+                        r.paint,
+                        BlendMode::default(),
+                        0,
+                        None,
+                        &self.encoded_paints,
+                    );
+                }
+                FastStripCommand::RotatedRect(r) => {
+                    // For the coarse path fallback, generate the rotated rect as a
+                    // regular path through the flatten → tiles → strips pipeline.
+                    let angle = f64::from(r.sin).atan2(f64::from(r.cos));
+                    let rect = Rect::new(
+                        f64::from(-r.half_width),
+                        f64::from(-r.half_height),
+                        f64::from(r.half_width),
+                        f64::from(r.half_height),
+                    );
+                    let transform = Affine::translate((f64::from(r.cx), f64::from(r.cy)))
+                        * Affine::rotate(angle);
+                    let path = rect.to_path(DEFAULT_TOLERANCE);
+                    let strip_start = strip_storage.strips.len();
+                    self.strip_generator.generate_filled_path(
+                        &path,
+                        Fill::NonZero,
+                        transform,
+                        None,
+                        &mut strip_storage,
+                        None,
+                    );
                     self.wide.generate(
                         &strip_storage.strips[strip_start..],
                         r.paint,

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -494,7 +494,7 @@ impl Scene {
         let cos = decomp.cos as f32;
         let sin = decomp.sin as f32;
 
-        if sin.abs() <= 1e-5 {
+        if sin.abs().is_nearly_zero() {
             // Axis-aligned: transform bounds directly and clamp to viewport.
             let transformed_rect = self.render_state.transform.transform_rect_bbox(*rect);
 
@@ -503,6 +503,7 @@ impl Scene {
             let x1 = transformed_rect.x1.max(0.0).min(f64::from(self.width)) as f32;
             let y1 = transformed_rect.y1.max(0.0).min(f64::from(self.height)) as f32;
 
+            // For now we don't support mirroring (and zero-sized rectangles).
             if x1 <= x0 || y1 <= y0 {
                 return false;
             }
@@ -523,6 +524,7 @@ impl Scene {
             let scaled_w = (rect.width() * decomp.sx) as f32;
             let scaled_h = (rect.height() * decomp.sy) as f32;
 
+            // Same as above, for simplicity don't support mirroring for now.
             if scaled_w <= 0.0 || scaled_h <= 0.0 {
                 return false;
             }

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -475,6 +475,11 @@ impl Scene {
             return false;
         }
 
+        // Could be made to work in the future, but for now we don't support this.
+        if self.aliasing_threshold.is_some() {
+            return false;
+        }
+
         // We can't handle skewed rectangles.
         let coeffs = self.render_state.transform.as_coeffs();
         // TODO: Maybe support rotated rectangles (https://github.com/linebender/vello/pull/1482#discussion_r2881223621)

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -79,9 +79,9 @@ pub(crate) struct FastPathRect {
     pub(crate) y0: f32,
     pub(crate) x1: f32,
     pub(crate) y1: f32,
-    /// Sine of the rotation angle (0 for axis-aligned).
+    /// Sine of the rotation angle.
     pub(crate) sin: f32,
-    /// Cosine of the rotation angle (1 for axis-aligned).
+    /// Cosine of the rotation angle.
     pub(crate) cos: f32,
     pub(crate) paint: Paint,
 }
@@ -91,7 +91,7 @@ pub(crate) struct FastPathRect {
 pub(crate) enum FastStripCommand {
     /// A path rendered via the normal strip pipeline.
     Path(FastStripsPath),
-    /// A rectangle (axis-aligned or rotated).
+    /// A rectangle.
     Rect(FastPathRect),
 }
 
@@ -491,55 +491,79 @@ impl Scene {
         };
 
         let paint = self.encode_current_paint();
-
-        let scaled_w = (rect.width() * decomp.sx) as f32;
-        let scaled_h = (rect.height() * decomp.sy) as f32;
-
-        if scaled_w <= 0.0 || scaled_h <= 0.0 {
-            return false;
-        }
-
         let cos = decomp.cos as f32;
         let sin = decomp.sin as f32;
 
-        // Transform the rect center using the full affine.
-        let [a, b, c, d, e, f] = self.render_state.transform.as_coeffs();
-        let rect_cx = rect.x0 + rect.width() / 2.0;
-        let rect_cy = rect.y0 + rect.height() / 2.0;
-        let cx = (a * rect_cx + c * rect_cy + e) as f32;
-        let cy = (b * rect_cx + d * rect_cy + f) as f32;
+        if sin.abs() <= 1e-5 {
+            // Axis-aligned: transform bounds directly and clamp to viewport.
+            let transformed_rect = self.render_state.transform.transform_rect_bbox(*rect);
 
-        // Store as screen-space bounds centered at (cx, cy).
-        let x0 = cx - scaled_w / 2.0;
-        let y0 = cy - scaled_h / 2.0;
-        let x1 = cx + scaled_w / 2.0;
-        let y1 = cy + scaled_h / 2.0;
+            let x0 = transformed_rect.x0.max(0.0).min(f64::from(self.width)) as f32;
+            let y0 = transformed_rect.y0.max(0.0).min(f64::from(self.height)) as f32;
+            let x1 = transformed_rect.x1.max(0.0).min(f64::from(self.width)) as f32;
+            let y1 = transformed_rect.y1.max(0.0).min(f64::from(self.height)) as f32;
 
-        // Compute the AABB and check it's within the viewport.
-        let hw = scaled_w / 2.0;
-        let hh = scaled_h / 2.0;
-        let aabb_hw = hw * cos.abs() + hh * sin.abs();
-        let aabb_hh = hw * sin.abs() + hh * cos.abs();
+            if x1 <= x0 || y1 <= y0 {
+                return false;
+            }
 
-        if cx + aabb_hw <= 0.0
-            || cy + aabb_hh <= 0.0
-            || cx - aabb_hw >= self.width as f32
-            || cy - aabb_hh >= self.height as f32
-        {
-            return false;
+            self.fast_strips_buffer
+                .commands
+                .push(FastStripCommand::Rect(FastPathRect {
+                    x0,
+                    y0,
+                    x1,
+                    y1,
+                    sin: 0.0,
+                    cos: 1.0,
+                    paint,
+                }));
+        } else {
+            // Rotated: compute screen-space bounds from center + scaled dimensions.
+            let scaled_w = (rect.width() * decomp.sx) as f32;
+            let scaled_h = (rect.height() * decomp.sy) as f32;
+
+            if scaled_w <= 0.0 || scaled_h <= 0.0 {
+                return false;
+            }
+
+            let [a, b, c, d, e, f] = self.render_state.transform.as_coeffs();
+            let rect_cx = rect.x0 + rect.width() / 2.0;
+            let rect_cy = rect.y0 + rect.height() / 2.0;
+            let cx = (a * rect_cx + c * rect_cy + e) as f32;
+            let cy = (b * rect_cx + d * rect_cy + f) as f32;
+
+            let x0 = cx - scaled_w / 2.0;
+            let y0 = cy - scaled_h / 2.0;
+            let x1 = cx + scaled_w / 2.0;
+            let y1 = cy + scaled_h / 2.0;
+
+            // Check AABB against viewport.
+            let hw = scaled_w / 2.0;
+            let hh = scaled_h / 2.0;
+            let aabb_hw = hw * cos.abs() + hh * sin.abs();
+            let aabb_hh = hw * sin.abs() + hh * cos.abs();
+
+            if cx + aabb_hw <= 0.0
+                || cy + aabb_hh <= 0.0
+                || cx - aabb_hw >= self.width as f32
+                || cy - aabb_hh >= self.height as f32
+            {
+                return false;
+            }
+
+            self.fast_strips_buffer
+                .commands
+                .push(FastStripCommand::Rect(FastPathRect {
+                    x0,
+                    y0,
+                    x1,
+                    y1,
+                    sin,
+                    cos,
+                    paint,
+                }));
         }
-
-        self.fast_strips_buffer
-            .commands
-            .push(FastStripCommand::Rect(FastPathRect {
-                x0,
-                y0,
-                x1,
-                y1,
-                sin,
-                cos,
-                paint,
-            }));
 
         true
     }
@@ -580,6 +604,7 @@ impl Scene {
                     );
                 }
                 FastStripCommand::Rect(r) => {
+                    // TODO: Add tests for this.
                     // For the coarse path fallback, generate the rect as a
                     // path through the flatten → tiles → strips pipeline.
                     let hw = (r.x1 - r.x0) / 2.0;

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -16,6 +16,7 @@ use vello_common::filter_effects::Filter;
 use vello_common::glyph::{GlyphCaches, GlyphRenderer, GlyphRunBuilder, GlyphType, PreparedGlyph};
 use vello_common::kurbo::{Affine, BezPath, Rect, Shape, Stroke};
 use vello_common::mask::Mask;
+use vello_common::math::FloatExt;
 use vello_common::multi_atlas::AtlasConfig;
 use vello_common::paint::{Paint, PaintType, Tint};
 #[cfg(feature = "text")]
@@ -489,54 +490,25 @@ impl Scene {
             return false;
         }
 
-        // We can't handle skewed rectangles.
-        let coeffs = self.render_state.transform.as_coeffs();
-        let [a, b, c, d, e, f] = coeffs;
-
-        // Kurbo Affine layout: [a, b, c, d, e, f] where
-        //   x' = a*x + c*y + e
-        //   y' = b*x + d*y + f
-        // Column 1 (local x-axis): (a, b)
-        // Column 2 (local y-axis): (c, d)
-        // Translation: (e, f)
-
-        // Check if the transform is axis-aligned (no rotation/skew).
-        // Axis-aligned means both off-diagonal elements of each column are ~0.
-        let is_axis_aligned = b.abs() <= 1e-5 && c.abs() <= 1e-5;
-
-        // Check if the transform is a rotation+scale (columns are perpendicular).
-        // Column 1 · Column 2 = a*c + b*d
-        let is_rotation = !is_axis_aligned && (a * c + b * d).abs() <= 1e-5;
-
-        if !is_axis_aligned && !is_rotation {
-            return false;
-        }
+        let decomp = match decompose_affine_rotation(&self.render_state.transform) {
+            Some(d) => d,
+            None => return false,
+        };
 
         let paint = self.encode_current_paint();
 
-        // Extract scale factors from column lengths.
-        // Column 1 = (a, b), Column 2 = (c, d).
-        let sx = (a * a + b * b).sqrt();
-        let sy = (c * c + d * d).sqrt();
-
-        // Reject degenerate transforms.
-        if sx <= 1e-10 || sy <= 1e-10 {
-            return false;
-        }
-
-        let half_width = (rect.width() * sx / 2.0) as f32;
-        let half_height = (rect.height() * sy / 2.0) as f32;
+        let half_width = (rect.width() * decomp.sx / 2.0) as f32;
+        let half_height = (rect.height() * decomp.sy / 2.0) as f32;
 
         if half_width <= 0.0 || half_height <= 0.0 {
             return false;
         }
 
-        // Extract rotation from column 1: (a, b) = sx * (cos θ, sin θ).
-        // For axis-aligned transforms, sin ≈ 0 and cos ≈ ±1.
-        let cos = (a / sx) as f32;
-        let sin = (b / sx) as f32;
+        let cos = decomp.cos as f32;
+        let sin = decomp.sin as f32;
 
-        // Transform the rect center: x' = a*x + c*y + e, y' = b*x + d*y + f
+        // Transform the rect center using the full affine.
+        let [a, b, c, d, e, f] = self.render_state.transform.as_coeffs();
         let rect_cx = rect.x0 + rect.width() / 2.0;
         let rect_cy = rect.y0 + rect.height() / 2.0;
         let cx = (a * rect_cx + c * rect_cy + e) as f32;
@@ -1227,5 +1199,116 @@ impl Scene {
                 adjusted_strip
             })
             .collect()
+    }
+}
+
+/// Result of decomposing an affine transform into rotation + scale.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct AffineDecomposition {
+    /// Scale factor along the local x-axis.
+    pub sx: f64,
+    /// Scale factor along the local y-axis.
+    pub sy: f64,
+    /// Cosine of the rotation angle.
+    pub cos: f64,
+    /// Sine of the rotation angle.
+    pub sin: f64,
+}
+
+/// Decompose an affine transform into rotation + non-uniform scale, if possible.
+pub(crate) fn decompose_affine_rotation(affine: &Affine) -> Option<AffineDecomposition> {
+    // For now, we don't support flipping. Should be possible to add in the future, though.
+    if affine.determinant() <= 0.0 {
+        return None;
+    }
+
+    let [a, b, c, d, _, _] = affine.as_coeffs();
+
+    // Ensure that the axes are perpendicular, since we don't support raw skewing.
+    if !(a * c + b * d).abs().is_nearly_zero() {
+        return None;
+    }
+
+    // Extract the scale factor in each direction.
+    let sx = (a * a + b * b).sqrt();
+    let sy = (c * c + d * d).sqrt();
+
+    let cos = a / sx;
+    let sin = b / sx;
+
+    Some(AffineDecomposition { sx, sy, cos, sin })
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn check_decompose_exhaustively(sx: f64, sy: f64) {
+        let mut angle = 0.0_f64;
+
+        while angle < 360.0 {
+            let theta = angle.to_radians();
+            let affine = Affine::scale_non_uniform(sx, sy).then_rotate(theta);
+            let decomp = decompose_affine_rotation(&affine).unwrap();
+            let expected_cos = theta.cos();
+            let expected_sin = theta.sin();
+
+            assert!(
+                (decomp.cos - expected_cos).abs() < 1e-10,
+                "cos mismatch at {angle}°: expected {expected_cos}, got {}",
+                decomp.cos
+            );
+            assert!(
+                (decomp.sin - expected_sin).abs() < 1e-10,
+                "sin mismatch at {angle}°: expected {expected_sin}, got {}",
+                decomp.sin
+            );
+            assert!(
+                (decomp.sx - sx).abs() < 1e-10,
+                "sx mismatch at {angle}°: expected {sx}, got {}",
+                decomp.sx
+            );
+            assert!(
+                (decomp.sy - sy).abs() < 1e-10,
+                "sy mismatch at {angle}°: expected {sy}, got {}",
+                decomp.sy
+            );
+
+            angle += 0.375;
+        }
+    }
+
+    #[test]
+    fn decompose_uniform_scale_1() {
+        check_decompose_exhaustively(1.0, 1.0);
+    }
+
+    #[test]
+    fn decompose_uniform_scale_2_5() {
+        check_decompose_exhaustively(2.5, 2.5);
+    }
+
+    #[test]
+    fn decompose_non_uniform_scale() {
+        check_decompose_exhaustively(3.75, 2.39);
+    }
+
+    #[test]
+    fn decompose_affine_rejects_skew() {
+        let affine = Affine::skew(0.3, 0.0);
+        assert!(decompose_affine_rotation(&affine).is_none());
+
+        let affine = Affine::skew(0.0, 0.3);
+        assert!(decompose_affine_rotation(&affine).is_none());
+    }
+
+    #[test]
+    fn decompose_affine_identity() {
+        let decomp = decompose_affine_rotation(&Affine::IDENTITY).unwrap();
+        assert!((decomp.cos - 1.0).abs() < 1e-10);
+        assert!(decomp.sin.abs() < 1e-10);
+        assert!((decomp.sx - 1.0).abs() < 1e-10);
+        assert!((decomp.sy - 1.0).abs() < 1e-10);
     }
 }

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -1432,11 +1432,14 @@ fn generate_gpu_strips_for_fast_path(
 fn pack_rect_into_gpu(rect: &FastPathRect, scene: &Scene, paint_idxs: &[u32]) -> GpuStrip {
     let is_axis_aligned = rect.sin.abs() <= 1e-5;
 
+    let vw = f32::from(scene.width);
+    let vh = f32::from(scene.height);
+
     if is_axis_aligned {
-        let x0 = rect.cx - rect.half_width;
-        let y0 = rect.cy - rect.half_height;
-        let x1 = rect.cx + rect.half_width;
-        let y1 = rect.cy + rect.half_height;
+        let x0 = (rect.cx - rect.half_width).max(0.0).min(vw);
+        let y0 = (rect.cy - rect.half_height).max(0.0).min(vh);
+        let x1 = (rect.cx + rect.half_width).max(0.0).min(vw);
+        let y1 = (rect.cy + rect.half_height).max(0.0).min(vh);
 
         let sx0 = x0.floor();
         let sy0 = y0.floor();
@@ -1445,7 +1448,6 @@ fn pack_rect_into_gpu(rect: &FastPathRect, scene: &Scene, paint_idxs: &[u32]) ->
 
         let x = sx0 as u16;
         let y = sy0 as u16;
-        // Are guaranteed to be > 0 since we rejected negative rectangles.
         let width = (sx1 - sx0) as u16;
         let height = (sy1 - sy0) as u16;
 
@@ -1470,11 +1472,11 @@ fn pack_rect_into_gpu(rect: &FastPathRect, scene: &Scene, paint_idxs: &[u32]) ->
         let aabb_hw = rect.half_width * rect.cos.abs() + rect.half_height * rect.sin.abs();
         let aabb_hh = rect.half_width * rect.sin.abs() + rect.half_height * rect.cos.abs();
 
-        // Snap AABB outward with 1px margin for AA.
-        let aabb_x0 = (rect.cx - aabb_hw - 1.0).floor().max(0.0);
-        let aabb_y0 = (rect.cy - aabb_hh - 1.0).floor().max(0.0);
-        let aabb_x1 = (rect.cx + aabb_hw + 1.0).ceil();
-        let aabb_y1 = (rect.cy + aabb_hh + 1.0).ceil();
+        // Snap AABB outward with 1px margin for AA, clamped to viewport.
+        let aabb_x0 = (rect.cx - aabb_hw - 1.0).floor().max(0.0).min(vw);
+        let aabb_y0 = (rect.cy - aabb_hh - 1.0).floor().max(0.0).min(vh);
+        let aabb_x1 = (rect.cx + aabb_hw + 1.0).ceil().max(0.0).min(vw);
+        let aabb_y1 = (rect.cy + aabb_hh + 1.0).ceil().max(0.0).min(vh);
 
         let x = aabb_x0 as u16;
         let y = aabb_y0 as u16;

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -1486,19 +1486,8 @@ fn pack_rect_into_gpu(rect: &FastPathRect, scene: &Scene, paint_idxs: &[u32]) ->
         let width = sw as u16;
         let height = sh as u16;
 
-        // For non-solid paints, payload encodes the scene position for sampling.
-        // Use the AABB top-left, computed from center + half-extents + rotation.
-        let hw = w / 2.0;
-        let hh = h / 2.0;
-        let cx = rect.x0 + hw;
-        let cy = rect.y0 + hh;
-        let aabb_hw = hw * rect.cos.abs() + hh * rect.sin.abs();
-        let aabb_hh = hw * rect.sin.abs() + hh * rect.cos.abs();
-        let aabb_x = (cx - aabb_hw - 1.0).floor().max(0.0) as u16;
-        let aabb_y = (cy - aabb_hh - 1.0).floor().max(0.0) as u16;
-
         let (payload, paint_packed) =
-            Scheduler::process_paint(&rect.paint, scene, (aabb_x, aabb_y), paint_idxs);
+            Scheduler::process_paint(&rect.paint, scene, (x, y), paint_idxs);
 
         // Pack fractional parts of x0, y0, width, height as 4 × u8 (unorm).
         let frac = pack_unorm4x8([

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -1436,10 +1436,11 @@ fn pack_rect_into_gpu(rect: &FastPathRect, scene: &Scene, paint_idxs: &[u32]) ->
     let vh = f32::from(scene.height);
 
     if is_axis_aligned {
-        let x0 = (rect.cx - rect.half_width).max(0.0).min(vw);
-        let y0 = (rect.cy - rect.half_height).max(0.0).min(vh);
-        let x1 = (rect.cx + rect.half_width).max(0.0).min(vw);
-        let y1 = (rect.cy + rect.half_height).max(0.0).min(vh);
+        // Axis-aligned: same encoding as original — store bounds directly.
+        let x0 = rect.x0.max(0.0).min(vw);
+        let y0 = rect.y0.max(0.0).min(vh);
+        let x1 = rect.x1.max(0.0).min(vw);
+        let y1 = rect.y1.max(0.0).min(vh);
 
         let sx0 = x0.floor();
         let sy0 = y0.floor();
@@ -1448,6 +1449,7 @@ fn pack_rect_into_gpu(rect: &FastPathRect, scene: &Scene, paint_idxs: &[u32]) ->
 
         let x = sx0 as u16;
         let y = sy0 as u16;
+        // Are guaranteed to be > 0 since we rejected negative rectangles.
         let width = (sx1 - sx0) as u16;
         let height = (sy1 - sy0) as u16;
 
@@ -1469,13 +1471,18 @@ fn pack_rect_into_gpu(rect: &FastPathRect, scene: &Scene, paint_idxs: &[u32]) ->
         }
     } else {
         // Rotated: store center in x/y, half-extents in width/height,
-        // fractional parts in col_idx_or_rect_frac (4 × u8, same layout as
-        // axis-aligned rects), and sin/cos in rotation.
-        // The vertex shader reconstructs precise values and computes the AABB.
-        let cx_floor = rect.cx.floor().max(0.0).min(vw);
-        let cy_floor = rect.cy.floor().max(0.0).min(vh);
-        let hw_floor = rect.half_width.floor();
-        let hh_floor = rect.half_height.floor();
+        // fractional parts in col_idx_or_rect_frac (4 × u8: cx, cy, hw, hh),
+        // and sin/cos in rotation. The vertex shader reconstructs precise
+        // values and computes the AABB on-the-fly.
+        let cx = (rect.x0 + rect.x1) / 2.0;
+        let cy = (rect.y0 + rect.y1) / 2.0;
+        let hw = (rect.x1 - rect.x0) / 2.0;
+        let hh = (rect.y1 - rect.y0) / 2.0;
+
+        let cx_floor = cx.floor().max(0.0).min(vw);
+        let cy_floor = cy.floor().max(0.0).min(vh);
+        let hw_floor = hw.floor();
+        let hh_floor = hh.floor();
 
         let x = cx_floor as u16;
         let y = cy_floor as u16;
@@ -1484,20 +1491,20 @@ fn pack_rect_into_gpu(rect: &FastPathRect, scene: &Scene, paint_idxs: &[u32]) ->
 
         // For non-solid paints, payload encodes the scene position for sampling.
         // Use the AABB top-left for this, computed from center + half-extents + rotation.
-        let aabb_hw = rect.half_width * rect.cos.abs() + rect.half_height * rect.sin.abs();
-        let aabb_hh = rect.half_width * rect.sin.abs() + rect.half_height * rect.cos.abs();
-        let aabb_x = (rect.cx - aabb_hw - 1.0).floor().max(0.0) as u16;
-        let aabb_y = (rect.cy - aabb_hh - 1.0).floor().max(0.0) as u16;
+        let aabb_hw = hw * rect.cos.abs() + hh * rect.sin.abs();
+        let aabb_hh = hw * rect.sin.abs() + hh * rect.cos.abs();
+        let aabb_x = (cx - aabb_hw - 1.0).floor().max(0.0) as u16;
+        let aabb_y = (cy - aabb_hh - 1.0).floor().max(0.0) as u16;
 
         let (payload, paint_packed) =
             Scheduler::process_paint(&rect.paint, scene, (aabb_x, aabb_y), paint_idxs);
 
         // Pack fractional parts of center and half-extents as 4 × u8 (unorm).
         let frac = pack_unorm4x8([
-            rect.cx - cx_floor,
-            rect.cy - cy_floor,
-            rect.half_width - hw_floor,
-            rect.half_height - hh_floor,
+            cx - cx_floor,
+            cy - cy_floor,
+            hw - hw_floor,
+            hh - hh_floor,
         ]);
 
         // Pack sin and cos as u16 values: [-1, 1] → [0, 65535].

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -1433,8 +1433,6 @@ fn pack_rect_into_gpu(rect: &FastPathRect, scene: &Scene, paint_idxs: &[u32]) ->
     let is_axis_aligned = rect.sin.abs() <= 1e-5;
 
     if is_axis_aligned {
-        // Axis-aligned: use the efficient encoding with sub-pixel fractional AA.
-        // Reconstruct the axis-aligned rect bounds from center + half-extents.
         let x0 = rect.cx - rect.half_width;
         let y0 = rect.cy - rect.half_height;
         let x1 = rect.cx + rect.half_width;
@@ -1445,20 +1443,17 @@ fn pack_rect_into_gpu(rect: &FastPathRect, scene: &Scene, paint_idxs: &[u32]) ->
         let sx1 = x1.ceil();
         let sy1 = y1.ceil();
 
-        let x = sx0.max(0.0) as u16;
-        let y = sy0.max(0.0) as u16;
-        let width = (sx1 - sx0.max(0.0)) as u16;
-        let height = (sy1 - sy0.max(0.0)) as u16;
+        let x = sx0 as u16;
+        let y = sy0 as u16;
+        // Are guaranteed to be > 0 since we rejected negative rectangles.
+        let width = (sx1 - sx0) as u16;
+        let height = (sy1 - sy0) as u16;
 
-        let (payload, paint_packed) =
-            Scheduler::process_paint(&rect.paint, scene, (x, y), paint_idxs);
+        let (payload, paint_packed) = Scheduler::process_paint(&rect.paint, scene, (x, y), paint_idxs);
 
-        let frac = pack_unorm4x8([
-            x0 - sx0.max(0.0),
-            y0 - sy0.max(0.0),
-            sx1 - x1,
-            sy1 - y1,
-        ]);
+        // Determine the fractional offsets for anti-aliasing and quantize so it
+        // fits into u8.
+        let frac = pack_unorm4x8([x0 - sx0, y0 - sy0, sx1 - x1, sy1 - y1]);
 
         GpuStrip {
             x,

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -1468,28 +1468,37 @@ fn pack_rect_into_gpu(rect: &FastPathRect, scene: &Scene, paint_idxs: &[u32]) ->
             rotation: 0,
         }
     } else {
-        // Rotated: use AABB + half-extents + sin/cos encoding.
+        // Rotated: store center in x/y, half-extents in width/height,
+        // fractional parts in col_idx_or_rect_frac (4 × u8, same layout as
+        // axis-aligned rects), and sin/cos in rotation.
+        // The vertex shader reconstructs precise values and computes the AABB.
+        let cx_floor = rect.cx.floor().max(0.0).min(vw);
+        let cy_floor = rect.cy.floor().max(0.0).min(vh);
+        let hw_floor = rect.half_width.floor();
+        let hh_floor = rect.half_height.floor();
+
+        let x = cx_floor as u16;
+        let y = cy_floor as u16;
+        let width = hw_floor as u16;
+        let height = hh_floor as u16;
+
+        // For non-solid paints, payload encodes the scene position for sampling.
+        // Use the AABB top-left for this, computed from center + half-extents + rotation.
         let aabb_hw = rect.half_width * rect.cos.abs() + rect.half_height * rect.sin.abs();
         let aabb_hh = rect.half_width * rect.sin.abs() + rect.half_height * rect.cos.abs();
-
-        // Snap AABB outward with 1px margin for AA, clamped to viewport.
-        let aabb_x0 = (rect.cx - aabb_hw - 1.0).floor().max(0.0).min(vw);
-        let aabb_y0 = (rect.cy - aabb_hh - 1.0).floor().max(0.0).min(vh);
-        let aabb_x1 = (rect.cx + aabb_hw + 1.0).ceil().max(0.0).min(vw);
-        let aabb_y1 = (rect.cy + aabb_hh + 1.0).ceil().max(0.0).min(vh);
-
-        let x = aabb_x0 as u16;
-        let y = aabb_y0 as u16;
-        let width = (aabb_x1 - aabb_x0) as u16;
-        let height = (aabb_y1 - aabb_y0) as u16;
+        let aabb_x = (rect.cx - aabb_hw - 1.0).floor().max(0.0) as u16;
+        let aabb_y = (rect.cy - aabb_hh - 1.0).floor().max(0.0) as u16;
 
         let (payload, paint_packed) =
-            Scheduler::process_paint(&rect.paint, scene, (x, y), paint_idxs);
+            Scheduler::process_paint(&rect.paint, scene, (aabb_x, aabb_y), paint_idxs);
 
-        // Pack half-extents as 12.4 fixed point.
-        let hw_u16 = (rect.half_width * 16.0) as u16;
-        let hh_u16 = (rect.half_height * 16.0) as u16;
-        let half_extents_packed = u32::from(hw_u16) | (u32::from(hh_u16) << 16);
+        // Pack fractional parts of center and half-extents as 4 × u8 (unorm).
+        let frac = pack_unorm4x8([
+            rect.cx - cx_floor,
+            rect.cy - cy_floor,
+            rect.half_width - hw_floor,
+            rect.half_height - hh_floor,
+        ]);
 
         // Pack sin and cos as u16 values: [-1, 1] → [0, 65535].
         let sin_u16 = ((rect.sin * 0.5 + 0.5) * 65535.0) as u16;
@@ -1501,7 +1510,7 @@ fn pack_rect_into_gpu(rect: &FastPathRect, scene: &Scene, paint_idxs: &[u32]) ->
             y,
             width,
             dense_width_or_rect_height: height,
-            col_idx_or_rect_frac: half_extents_packed,
+            col_idx_or_rect_frac: frac,
             payload,
             paint_and_rect_flag: paint_packed | RECT_STRIP_FLAG,
             rotation,

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -176,9 +176,7 @@
 only break in edge cases, and some of them are also only related to conversions from f64 to f32."
 )]
 
-use crate::scene::{
-    FastPathRect, FastPathRotatedRect, FastStripCommand, FastStripsPath, StripPathMode,
-};
+use crate::scene::{FastPathRect, FastStripCommand, FastStripsPath, StripPathMode};
 use crate::{GpuStrip, RenderError, Scene};
 use alloc::collections::VecDeque;
 use alloc::vec::Vec;
@@ -586,11 +584,7 @@ impl Scheduler {
                     );
                 }
                 FastStripCommand::Rect(r) => {
-                    let strip = pack_rectangle_into_gpu(r, scene, paint_idxs);
-                    draw.0.push(strip);
-                }
-                FastStripCommand::RotatedRect(r) => {
-                    let strip = pack_rotated_rectangle_into_gpu(r, scene, paint_idxs);
+                    let strip = pack_rect_into_gpu(r, scene, paint_idxs);
                     draw.0.push(strip);
                 }
             }
@@ -1435,80 +1429,86 @@ fn generate_gpu_strips_for_fast_path(
     }
 }
 
-fn pack_rectangle_into_gpu(rect: &FastPathRect, scene: &Scene, paint_idxs: &[u32]) -> GpuStrip {
-    let sx0 = rect.x0.floor();
-    let sy0 = rect.y0.floor();
-    let sx1 = rect.x1.ceil();
-    let sy1 = rect.y1.ceil();
+fn pack_rect_into_gpu(rect: &FastPathRect, scene: &Scene, paint_idxs: &[u32]) -> GpuStrip {
+    let is_axis_aligned = rect.sin.abs() <= 1e-5;
 
-    let x = sx0 as u16;
-    let y = sy0 as u16;
-    // Are guaranteed to be > 0 since we rejected negative rectangles.
-    let width = (sx1 - sx0) as u16;
-    let height = (sy1 - sy0) as u16;
+    if is_axis_aligned {
+        // Axis-aligned: use the efficient encoding with sub-pixel fractional AA.
+        // Reconstruct the axis-aligned rect bounds from center + half-extents.
+        let x0 = rect.cx - rect.half_width;
+        let y0 = rect.cy - rect.half_height;
+        let x1 = rect.cx + rect.half_width;
+        let y1 = rect.cy + rect.half_height;
 
-    let (payload, paint_packed) = Scheduler::process_paint(&rect.paint, scene, (x, y), paint_idxs);
+        let sx0 = x0.floor();
+        let sy0 = y0.floor();
+        let sx1 = x1.ceil();
+        let sy1 = y1.ceil();
 
-    // Determine the fractional offsets for anti-aliasing and quantize so it
-    // fits into u8.
-    let frac = pack_unorm4x8([rect.x0 - sx0, rect.y0 - sy0, sx1 - rect.x1, sy1 - rect.y1]);
+        let x = sx0.max(0.0) as u16;
+        let y = sy0.max(0.0) as u16;
+        let width = (sx1 - sx0.max(0.0)) as u16;
+        let height = (sy1 - sy0.max(0.0)) as u16;
 
-    GpuStrip {
-        x,
-        y,
-        width,
-        dense_width_or_rect_height: height,
-        col_idx_or_rect_frac: frac,
-        payload,
-        paint_and_rect_flag: paint_packed | RECT_STRIP_FLAG,
-        rotation: 0,
-    }
-}
+        let (payload, paint_packed) =
+            Scheduler::process_paint(&rect.paint, scene, (x, y), paint_idxs);
 
-fn pack_rotated_rectangle_into_gpu(
-    rect: &FastPathRotatedRect,
-    scene: &Scene,
-    paint_idxs: &[u32],
-) -> GpuStrip {
-    // Compute the AABB of the rotated rectangle.
-    let aabb_hw = rect.half_width * rect.cos.abs() + rect.half_height * rect.sin.abs();
-    let aabb_hh = rect.half_width * rect.sin.abs() + rect.half_height * rect.cos.abs();
+        let frac = pack_unorm4x8([
+            x0 - sx0.max(0.0),
+            y0 - sy0.max(0.0),
+            sx1 - x1,
+            sy1 - y1,
+        ]);
 
-    // Snap AABB outward to integer pixels, with 1px margin for AA.
-    // The AA region extends 0.5px beyond the rect edge in local space, which
-    // maps to up to 0.5*(|cos|+|sin|) extra pixels in screen space.
-    let aabb_x0 = (rect.cx - aabb_hw - 1.0).floor().max(0.0);
-    let aabb_y0 = (rect.cy - aabb_hh - 1.0).floor().max(0.0);
-    let aabb_x1 = (rect.cx + aabb_hw + 1.0).ceil();
-    let aabb_y1 = (rect.cy + aabb_hh + 1.0).ceil();
+        GpuStrip {
+            x,
+            y,
+            width,
+            dense_width_or_rect_height: height,
+            col_idx_or_rect_frac: frac,
+            payload,
+            paint_and_rect_flag: paint_packed | RECT_STRIP_FLAG,
+            rotation: 0,
+        }
+    } else {
+        // Rotated: use AABB + half-extents + sin/cos encoding.
+        let aabb_hw = rect.half_width * rect.cos.abs() + rect.half_height * rect.sin.abs();
+        let aabb_hh = rect.half_width * rect.sin.abs() + rect.half_height * rect.cos.abs();
 
-    let x = aabb_x0 as u16;
-    let y = aabb_y0 as u16;
-    let width = (aabb_x1 - aabb_x0) as u16;
-    let height = (aabb_y1 - aabb_y0) as u16;
+        // Snap AABB outward with 1px margin for AA.
+        let aabb_x0 = (rect.cx - aabb_hw - 1.0).floor().max(0.0);
+        let aabb_y0 = (rect.cy - aabb_hh - 1.0).floor().max(0.0);
+        let aabb_x1 = (rect.cx + aabb_hw + 1.0).ceil();
+        let aabb_y1 = (rect.cy + aabb_hh + 1.0).ceil();
 
-    let (payload, paint_packed) =
-        Scheduler::process_paint(&rect.paint, scene, (x, y), paint_idxs);
+        let x = aabb_x0 as u16;
+        let y = aabb_y0 as u16;
+        let width = (aabb_x1 - aabb_x0) as u16;
+        let height = (aabb_y1 - aabb_y0) as u16;
 
-    // Pack half-extents as 12.4 fixed point (max ~4095 pixels, 1/16 sub-pixel precision).
-    let hw_u16 = (rect.half_width * 16.0) as u16;
-    let hh_u16 = (rect.half_height * 16.0) as u16;
-    let half_extents_packed = u32::from(hw_u16) | (u32::from(hh_u16) << 16);
+        let (payload, paint_packed) =
+            Scheduler::process_paint(&rect.paint, scene, (x, y), paint_idxs);
 
-    // Pack sin and cos as u16 values: [-1, 1] → [0, 65535].
-    let sin_u16 = ((rect.sin * 0.5 + 0.5) * 65535.0) as u16;
-    let cos_u16 = ((rect.cos * 0.5 + 0.5) * 65535.0) as u16;
-    let rotation = u32::from(sin_u16) | (u32::from(cos_u16) << 16);
+        // Pack half-extents as 12.4 fixed point.
+        let hw_u16 = (rect.half_width * 16.0) as u16;
+        let hh_u16 = (rect.half_height * 16.0) as u16;
+        let half_extents_packed = u32::from(hw_u16) | (u32::from(hh_u16) << 16);
 
-    GpuStrip {
-        x,
-        y,
-        width,
-        dense_width_or_rect_height: height,
-        col_idx_or_rect_frac: half_extents_packed,
-        payload,
-        paint_and_rect_flag: paint_packed | RECT_STRIP_FLAG,
-        rotation,
+        // Pack sin and cos as u16 values: [-1, 1] → [0, 65535].
+        let sin_u16 = ((rect.sin * 0.5 + 0.5) * 65535.0) as u16;
+        let cos_u16 = ((rect.cos * 0.5 + 0.5) * 65535.0) as u16;
+        let rotation = u32::from(sin_u16) | (u32::from(cos_u16) << 16);
+
+        GpuStrip {
+            x,
+            y,
+            width,
+            dense_width_or_rect_height: height,
+            col_idx_or_rect_frac: half_extents_packed,
+            payload,
+            paint_and_rect_flag: paint_packed | RECT_STRIP_FLAG,
+            rotation,
+        }
     }
 }
 

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -176,7 +176,9 @@
 only break in edge cases, and some of them are also only related to conversions from f64 to f32."
 )]
 
-use crate::scene::{FastPathRect, FastStripCommand, FastStripsPath, StripPathMode};
+use crate::scene::{
+    FastPathRect, FastPathRotatedRect, FastStripCommand, FastStripsPath, StripPathMode,
+};
 use crate::{GpuStrip, RenderError, Scene};
 use alloc::collections::VecDeque;
 use alloc::vec::Vec;
@@ -205,6 +207,7 @@ const PAINT_TYPE_SWEEP_GRADIENT: u32 = 4;
 /// Bit 31 of [`GpuStrip::paint_and_rect_flag`] signals that the strip
 /// represents a full rectangle.
 const RECT_STRIP_FLAG: u32 = 1 << 31;
+
 
 // The sentinel tile index representing the surface.
 const SENTINEL_SLOT_IDX: usize = usize::MAX;
@@ -584,7 +587,10 @@ impl Scheduler {
                 }
                 FastStripCommand::Rect(r) => {
                     let strip = pack_rectangle_into_gpu(r, scene, paint_idxs);
-
+                    draw.0.push(strip);
+                }
+                FastStripCommand::RotatedRect(r) => {
+                    let strip = pack_rotated_rectangle_into_gpu(r, scene, paint_idxs);
                     draw.0.push(strip);
                 }
             }
@@ -1320,6 +1326,7 @@ impl GpuStripBuilder {
             col_idx_or_rect_frac: self.col_idx_or_rect_frac,
             payload,
             paint_and_rect_flag: paint,
+            rotation: 0,
         }
     }
 
@@ -1333,6 +1340,7 @@ impl GpuStripBuilder {
             col_idx_or_rect_frac: self.col_idx_or_rect_frac,
             payload: u32::try_from(from_slot).unwrap(),
             paint_and_rect_flag: (COLOR_SOURCE_SLOT << 29) | (opacity as u32),
+            rotation: 0,
         }
     }
 
@@ -1357,6 +1365,7 @@ impl GpuStripBuilder {
                 | ((opacity as u32) << 16)
                 | ((mix_mode as u32) << 8)
                 | (compose_mode as u32),
+            rotation: 0,
         }
     }
 }
@@ -1452,6 +1461,54 @@ fn pack_rectangle_into_gpu(rect: &FastPathRect, scene: &Scene, paint_idxs: &[u32
         col_idx_or_rect_frac: frac,
         payload,
         paint_and_rect_flag: paint_packed | RECT_STRIP_FLAG,
+        rotation: 0,
+    }
+}
+
+fn pack_rotated_rectangle_into_gpu(
+    rect: &FastPathRotatedRect,
+    scene: &Scene,
+    paint_idxs: &[u32],
+) -> GpuStrip {
+    // Compute the AABB of the rotated rectangle.
+    let aabb_hw = rect.half_width * rect.cos.abs() + rect.half_height * rect.sin.abs();
+    let aabb_hh = rect.half_width * rect.sin.abs() + rect.half_height * rect.cos.abs();
+
+    // Snap AABB outward to integer pixels, with 1px margin for AA.
+    // The AA region extends 0.5px beyond the rect edge in local space, which
+    // maps to up to 0.5*(|cos|+|sin|) extra pixels in screen space.
+    let aabb_x0 = (rect.cx - aabb_hw - 1.0).floor().max(0.0);
+    let aabb_y0 = (rect.cy - aabb_hh - 1.0).floor().max(0.0);
+    let aabb_x1 = (rect.cx + aabb_hw + 1.0).ceil();
+    let aabb_y1 = (rect.cy + aabb_hh + 1.0).ceil();
+
+    let x = aabb_x0 as u16;
+    let y = aabb_y0 as u16;
+    let width = (aabb_x1 - aabb_x0) as u16;
+    let height = (aabb_y1 - aabb_y0) as u16;
+
+    let (payload, paint_packed) =
+        Scheduler::process_paint(&rect.paint, scene, (x, y), paint_idxs);
+
+    // Pack half-extents as 12.4 fixed point (max ~4095 pixels, 1/16 sub-pixel precision).
+    let hw_u16 = (rect.half_width * 16.0) as u16;
+    let hh_u16 = (rect.half_height * 16.0) as u16;
+    let half_extents_packed = u32::from(hw_u16) | (u32::from(hh_u16) << 16);
+
+    // Pack sin and cos as u16 values: [-1, 1] → [0, 65535].
+    let sin_u16 = ((rect.sin * 0.5 + 0.5) * 65535.0) as u16;
+    let cos_u16 = ((rect.cos * 0.5 + 0.5) * 65535.0) as u16;
+    let rotation = u32::from(sin_u16) | (u32::from(cos_u16) << 16);
+
+    GpuStrip {
+        x,
+        y,
+        width,
+        dense_width_or_rect_height: height,
+        col_idx_or_rect_frac: half_extents_packed,
+        payload,
+        paint_and_rect_flag: paint_packed | RECT_STRIP_FLAG,
+        rotation,
     }
 }
 

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -1430,88 +1430,41 @@ fn generate_gpu_strips_for_fast_path(
 }
 
 fn pack_rect_into_gpu(rect: &FastPathRect, scene: &Scene, paint_idxs: &[u32]) -> GpuStrip {
-    let is_axis_aligned = rect.sin.abs() <= 1e-5;
+    let sx0 = rect.x0.floor();
+    let sy0 = rect.y0.floor();
+    let sx1 = rect.x1.ceil();
+    let sy1 = rect.y1.ceil();
 
-    let vw = f32::from(scene.width);
-    let vh = f32::from(scene.height);
+    let x = sx0.max(0.0) as u16;
+    let y = sy0.max(0.0) as u16;
+    let width = (sx1 - sx0) as u16;
+    let height = (sy1 - sy0) as u16;
 
-    if is_axis_aligned {
-        // Axis-aligned: same encoding as original — store bounds directly.
-        let x0 = rect.x0.max(0.0).min(vw);
-        let y0 = rect.y0.max(0.0).min(vh);
-        let x1 = rect.x1.max(0.0).min(vw);
-        let y1 = rect.y1.max(0.0).min(vh);
+    let (payload, paint_packed) =
+        Scheduler::process_paint(&rect.paint, scene, (x, y), paint_idxs);
 
-        let sx0 = x0.floor();
-        let sy0 = y0.floor();
-        let sx1 = x1.ceil();
-        let sy1 = y1.ceil();
+    // Fractional offsets for anti-aliasing: how far each edge is from the
+    // snapped pixel boundary.
+    let frac = pack_unorm4x8([
+        rect.x0 - sx0,
+        rect.y0 - sy0,
+        sx1 - rect.x1,
+        sy1 - rect.y1,
+    ]);
 
-        let x = sx0 as u16;
-        let y = sy0 as u16;
-        // Are guaranteed to be > 0 since we rejected negative rectangles.
-        let width = (sx1 - sx0) as u16;
-        let height = (sy1 - sy0) as u16;
+    let sin_u16 = ((rect.sin * 0.5 + 0.5) * 65535.0) as u16;
+    let cos_u16 = ((rect.cos * 0.5 + 0.5) * 65535.0) as u16;
+    let rotation = u32::from(sin_u16) | (u32::from(cos_u16) << 16);
 
-        let (payload, paint_packed) = Scheduler::process_paint(&rect.paint, scene, (x, y), paint_idxs);
-
-        // Determine the fractional offsets for anti-aliasing and quantize so it
-        // fits into u8.
-        let frac = pack_unorm4x8([x0 - sx0, y0 - sy0, sx1 - x1, sy1 - y1]);
-
-        GpuStrip {
-            x,
-            y,
-            width,
-            dense_width_or_rect_height: height,
-            col_idx_or_rect_frac: frac,
-            payload,
-            paint_and_rect_flag: paint_packed | RECT_STRIP_FLAG,
-            rotation: 0,
-        }
-    } else {
-        // Rotated: store local rect bounds in x/y/width/height (same layout as
-        // axis-aligned), with 4 × u8 fractional parts, plus sin/cos in rotation.
-        // The vertex shader reconstructs precise bounds, derives center and
-        // half-extents, and computes the AABB on-the-fly.
-        let sx0 = rect.x0.floor();
-        let sy0 = rect.y0.floor();
-        let w = rect.x1 - rect.x0;
-        let h = rect.y1 - rect.y0;
-        let sw = w.floor();
-        let sh = h.floor();
-
-        let x = sx0.max(0.0) as u16;
-        let y = sy0.max(0.0) as u16;
-        let width = sw as u16;
-        let height = sh as u16;
-
-        let (payload, paint_packed) =
-            Scheduler::process_paint(&rect.paint, scene, (x, y), paint_idxs);
-
-        // Pack fractional parts of x0, y0, width, height as 4 × u8 (unorm).
-        let frac = pack_unorm4x8([
-            rect.x0 - sx0,
-            rect.y0 - sy0,
-            w - sw,
-            h - sh,
-        ]);
-
-        // Pack sin and cos as u16 values: [-1, 1] → [0, 65535].
-        let sin_u16 = ((rect.sin * 0.5 + 0.5) * 65535.0) as u16;
-        let cos_u16 = ((rect.cos * 0.5 + 0.5) * 65535.0) as u16;
-        let rotation = u32::from(sin_u16) | (u32::from(cos_u16) << 16);
-
-        GpuStrip {
-            x,
-            y,
-            width,
-            dense_width_or_rect_height: height,
-            col_idx_or_rect_frac: frac,
-            payload,
-            paint_and_rect_flag: paint_packed | RECT_STRIP_FLAG,
-            rotation,
-        }
+    GpuStrip {
+        x,
+        y,
+        width,
+        dense_width_or_rect_height: height,
+        col_idx_or_rect_frac: frac,
+        payload,
+        paint_and_rect_flag: paint_packed | RECT_STRIP_FLAG,
+        rotation,
     }
 }
 

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -1470,27 +1470,28 @@ fn pack_rect_into_gpu(rect: &FastPathRect, scene: &Scene, paint_idxs: &[u32]) ->
             rotation: 0,
         }
     } else {
-        // Rotated: store center in x/y, half-extents in width/height,
-        // fractional parts in col_idx_or_rect_frac (4 × u8: cx, cy, hw, hh),
-        // and sin/cos in rotation. The vertex shader reconstructs precise
-        // values and computes the AABB on-the-fly.
-        let cx = (rect.x0 + rect.x1) / 2.0;
-        let cy = (rect.y0 + rect.y1) / 2.0;
-        let hw = (rect.x1 - rect.x0) / 2.0;
-        let hh = (rect.y1 - rect.y0) / 2.0;
+        // Rotated: store local rect bounds in x/y/width/height (same layout as
+        // axis-aligned), with 4 × u8 fractional parts, plus sin/cos in rotation.
+        // The vertex shader reconstructs precise bounds, derives center and
+        // half-extents, and computes the AABB on-the-fly.
+        let sx0 = rect.x0.floor();
+        let sy0 = rect.y0.floor();
+        let w = rect.x1 - rect.x0;
+        let h = rect.y1 - rect.y0;
+        let sw = w.floor();
+        let sh = h.floor();
 
-        let cx_floor = cx.floor().max(0.0).min(vw);
-        let cy_floor = cy.floor().max(0.0).min(vh);
-        let hw_floor = hw.floor();
-        let hh_floor = hh.floor();
-
-        let x = cx_floor as u16;
-        let y = cy_floor as u16;
-        let width = hw_floor as u16;
-        let height = hh_floor as u16;
+        let x = sx0.max(0.0) as u16;
+        let y = sy0.max(0.0) as u16;
+        let width = sw as u16;
+        let height = sh as u16;
 
         // For non-solid paints, payload encodes the scene position for sampling.
-        // Use the AABB top-left for this, computed from center + half-extents + rotation.
+        // Use the AABB top-left, computed from center + half-extents + rotation.
+        let hw = w / 2.0;
+        let hh = h / 2.0;
+        let cx = rect.x0 + hw;
+        let cy = rect.y0 + hh;
         let aabb_hw = hw * rect.cos.abs() + hh * rect.sin.abs();
         let aabb_hh = hw * rect.sin.abs() + hh * rect.cos.abs();
         let aabb_x = (cx - aabb_hw - 1.0).floor().max(0.0) as u16;
@@ -1499,12 +1500,12 @@ fn pack_rect_into_gpu(rect: &FastPathRect, scene: &Scene, paint_idxs: &[u32]) ->
         let (payload, paint_packed) =
             Scheduler::process_paint(&rect.paint, scene, (aabb_x, aabb_y), paint_idxs);
 
-        // Pack fractional parts of center and half-extents as 4 × u8 (unorm).
+        // Pack fractional parts of x0, y0, width, height as 4 × u8 (unorm).
         let frac = pack_unorm4x8([
-            cx - cx_floor,
-            cy - cy_floor,
-            hw - hw_floor,
-            hh - hh_floor,
+            rect.x0 - sx0,
+            rect.y0 - sy0,
+            w - sw,
+            h - sh,
         ]);
 
         // Pack sin and cos as u16 values: [-1, 1] → [0, 65535].

--- a/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
@@ -264,25 +264,27 @@ fn vs_main(
     let dense_width = instance.widths_or_rect_height >> 16u;
 
     let is_rect = (instance.paint_and_rect_flag & RECT_STRIP_FLAG) != 0u;
-    let is_rotated_rect = is_rect && instance.rotation != 0u;
+    // Unpack sin to detect rotated vs axis-aligned rects.
+    let sin_t = f32(instance.rotation & 0xffffu) / 65535.0 * 2.0 - 1.0;
+    let is_rotated_rect = is_rect && abs(sin_t) > 0.001;
     out.rotation = instance.rotation;
 
     var pix_x: f32;
     var pix_y: f32;
 
     if is_rotated_rect {
-        // For rotated rects, x/y/width/height store the local rect bounds (same
-        // layout as axis-aligned rects). col_idx_or_rect_frac = 4 × u8 fractional
-        // parts (x0, y0, w, h). rotation = packed sin/cos.
+        // For rotated rects, same encoding as axis-aligned: x/y = floor(x0, y0),
+        // width/height = ceil(x1)-floor(x0), ceil(y1)-floor(y0).
+        // col_idx_or_rect_frac = 4 × u8 edge fracs (x0, y0, x1, y1).
         let frac = unpack4x8unorm(instance.col_idx_or_rect_frac);
         let rect_x0 = f32(x0) + frac.x;
         let rect_y0 = f32(y0) + frac.y;
-        let rect_w = f32(width) + frac.z;
-        let rect_h = f32(dense_width) + frac.w;
-        let hw = rect_w * 0.5;
-        let hh = rect_h * 0.5;
-        let center_x = rect_x0 + hw;
-        let center_y = rect_y0 + hh;
+        let rect_x1 = f32(x0) + f32(width) - frac.z;
+        let rect_y1 = f32(y0) + f32(dense_width) - frac.w;
+        let hw = (rect_x1 - rect_x0) * 0.5;
+        let hh = (rect_y1 - rect_y0) * 0.5;
+        let center_x = (rect_x0 + rect_x1) * 0.5;
+        let center_y = (rect_y0 + rect_y1) * 0.5;
 
         // Unpack sin/cos from rotation field: u16 in [0, 65535] → [-1, 1].
         let sin_t = f32(instance.rotation & 0xffffu) / 65535.0 * 2.0 - 1.0;
@@ -411,7 +413,8 @@ fn halfplane_coverage(d: f32, a: f32, b: f32, inv_2ab: f32) -> f32 {
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     var alpha = 1.0;
     let is_rect = (in.paint_and_rect_flag & RECT_STRIP_FLAG) != 0u;
-    let is_rotated_rect = is_rect && in.rotation != 0u;
+    let sin_t = f32(in.rotation & 0xffffu) / 65535.0 * 2.0 - 1.0;
+    let is_rotated_rect = is_rect && abs(sin_t) > 0.001;
 
     if is_rotated_rect {
         // For rotated rects, tex_coord contains the interpolated local-space coordinates

--- a/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
@@ -205,6 +205,10 @@ struct StripInstance {
     @location(3) payload: u32,
     // See StripInstance documentation above.
     @location(4) paint_and_rect_flag: u32,
+    // For rotated rects: packed sin/cos as u16 pair.
+    // sin = low 16 bits, cos = high 16 bits, each mapped from [-1,1] to [0,65535].
+    // Zero for non-rotated strips/rects.
+    @location(5) rotation: u32,
 }
 
 struct VertexOutput {
@@ -223,6 +227,9 @@ struct VertexOutput {
     // Bits 0-7: x0, 8-15: y0, 16-23: x1, 24-31: y1.
     // Zero for normal strips.
     @location(5) @interpolate(flat) rect_frac: u32,
+    // For rotated rects: packed sin/cos (passed through from instance).
+    // Zero for non-rotated strips/rects.
+    @location(6) @interpolate(flat) rotation: u32,
     // Normalized device coordinates (NDC) for the current vertex
     @builtin(position) position: vec4<f32>,
 };
@@ -257,18 +264,59 @@ fn vs_main(
     let dense_width = instance.widths_or_rect_height >> 16u;
 
     let is_rect = (instance.paint_and_rect_flag & RECT_STRIP_FLAG) != 0u;
-    var height = config.strip_height;
-    if is_rect {
-        height = dense_width;
-        out.dense_end_or_rect_size = width | (dense_width << 16u);
+    let is_rotated_rect = is_rect && instance.rotation != 0u;
+    out.rotation = instance.rotation;
+
+    var pix_x: f32;
+    var pix_y: f32;
+
+    if is_rotated_rect {
+        // For rotated rects, x/y/width/height = AABB (snapped outward).
+        // col_idx_or_rect_frac = packed half-extents as 12.4 fixed point.
+        // rotation = packed sin/cos.
+        let hw = f32(instance.col_idx_or_rect_frac & 0xffffu) / 16.0;
+        let hh = f32(instance.col_idx_or_rect_frac >> 16u) / 16.0;
+
+        // Derive center from AABB center.
+        let center_x = f32(x0) + f32(width) * 0.5;
+        let center_y = f32(y0) + f32(dense_width) * 0.5;
+
+        // Unpack sin/cos from rotation field: u16 in [0, 65535] → [-1, 1].
+        let sin_t = f32(instance.rotation & 0xffffu) / 65535.0 * 2.0 - 1.0;
+        let cos_t = f32(instance.rotation >> 16u) / 65535.0 * 2.0 - 1.0;
+
+        // Use the AABB directly for the quad.
+        pix_x = f32(x0) + x * f32(width);
+        pix_y = f32(y0) + y * f32(dense_width);
+
+        // Rotate (pixel - center) into the rect's local frame for the fragment shader.
+        let pdx = pix_x - center_x;
+        let pdy = pix_y - center_y;
+        let local_x = pdx * cos_t + pdy * sin_t;
+        let local_y = -pdx * sin_t + pdy * cos_t;
+        out.tex_coord = vec2<f32>(local_x, local_y);
+
+        // Pass half-extents to fragment shader.
         out.rect_frac = instance.col_idx_or_rect_frac;
+        out.dense_end_or_rect_size = instance.col_idx_or_rect_frac;
     } else {
-        out.dense_end_or_rect_size = instance.col_idx_or_rect_frac + dense_width;
-        out.rect_frac = 0u;
+        var height = config.strip_height;
+        if is_rect {
+            height = dense_width;
+            out.dense_end_or_rect_size = width | (dense_width << 16u);
+            out.rect_frac = instance.col_idx_or_rect_frac;
+        } else {
+            out.dense_end_or_rect_size = instance.col_idx_or_rect_frac + dense_width;
+            out.rect_frac = 0u;
+        }
+
+        pix_x = f32(x0) + x * f32(width);
+        pix_y = f32(y0) + y * f32(height);
+
+        let col_offset = select(f32(instance.col_idx_or_rect_frac), 0.0, is_rect);
+        out.tex_coord = vec2<f32>(col_offset + x * f32(width), y * f32(height));
     }
-    // Calculate the pixel coordinates of the current vertex within the strip
-    let pix_x = f32(x0) + x * f32(width);
-    let pix_y = f32(y0) + y * f32(height);
+
     // Convert pixel coordinates to normalized device coordinates (NDC)
     // NDC ranges from -1 to 1, with (0,0) at the center of the viewport
     let ndc_x = pix_x * 2.0 / f32(config.width) - 1.0;
@@ -280,28 +328,24 @@ fn vs_main(
         // Unpack view coordinates for image sampling and gradient calculations
         let scene_strip_x = instance.payload & 0xffffu;
         let scene_strip_y = instance.payload >> 16u;
+        let height_for_paint = select(config.strip_height, dense_width, is_rect);
 
         if paint_type == PAINT_TYPE_IMAGE {
             let paint_tex_idx = instance.paint_and_rect_flag & PAINT_TEXTURE_INDEX_MASK;
             let encoded_image = unpack_encoded_image(paint_tex_idx);
-            // Use view coordinates for image sampling (always in global view space)
-            out.sample_xy = encoded_image.translate 
+            out.sample_xy = encoded_image.translate
                 + encoded_image.image_offset
-                + encoded_image.transform.xy * f32(scene_strip_x) 
+                + encoded_image.transform.xy * f32(scene_strip_x)
                 + encoded_image.transform.zw * f32(scene_strip_y)
                 + encoded_image.transform.xy * x * f32(width)
-                + encoded_image.transform.zw * y * f32(height);
+                + encoded_image.transform.zw * y * f32(height_for_paint);
         } else if paint_type == PAINT_TYPE_LINEAR_GRADIENT || paint_type == PAINT_TYPE_RADIAL_GRADIENT || paint_type == PAINT_TYPE_SWEEP_GRADIENT {
-            // Use view coordinates for gradient transform (always in global view space)
             out.sample_xy = vec2<f32>(
                 f32(scene_strip_x) + x * f32(width),
-                f32(scene_strip_y) + y * f32(height)
+                f32(scene_strip_y) + y * f32(height_for_paint)
             );
         }
     }
-
-    let col_offset = select(f32(instance.col_idx_or_rect_frac), 0.0, is_rect);
-    out.tex_coord = vec2<f32>(col_offset + x * f32(width), y * f32(height));
 
     out.position = vec4<f32>(ndc_x, ndc_y, 0.0, 1.0);
     out.payload = instance.payload;
@@ -316,13 +360,70 @@ var alphas_texture: texture_2d<u32>;
 @group(0) @binding(2)
 var clip_input_texture: texture_2d<f32>;
 
+// Exact area coverage of a unit-square pixel by a half-plane at signed distance `d`
+// from the pixel center (positive = inside). The edge normal has components with
+// absolute values `a` = max(|nx|, |ny|) and `b` = min(|nx|, |ny|).
+// `inv_2ab` = 1/(2*a*b), precomputed to avoid repeated division.
+fn halfplane_coverage(d: f32, a: f32, b: f32, inv_2ab: f32) -> f32 {
+    let r = 0.5 * (a + b);
+    if d >= r { return 1.0; }
+    if d <= -r { return 0.0; }
+    let t = d + r;
+    // Near-axis-aligned edge (b ≈ 0): linear transition.
+    if b < 0.001 {
+        return clamp(t / a, 0.0, 1.0);
+    }
+    // Piecewise quadratic/linear coverage function.
+    if t < b {
+        return t * t * inv_2ab;
+    } else if t < a {
+        return (2.0 * t - b) / (2.0 * a);
+    } else {
+        let s = a + b - t;
+        return 1.0 - s * s * inv_2ab;
+    }
+}
+
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     var alpha = 1.0;
     let is_rect = (in.paint_and_rect_flag & RECT_STRIP_FLAG) != 0u;
+    let is_rotated_rect = is_rect && in.rotation != 0u;
+
+    if is_rotated_rect {
+        // For rotated rects, tex_coord contains the interpolated local-space coordinates
+        // (already rotated by the vertex shader). Compute coverage using exact half-plane
+        // area coverage for each of the 4 edges, then take the minimum.
+        let hw = f32(in.dense_end_or_rect_size & 0xffffu) / 16.0;
+        let hh = f32(in.dense_end_or_rect_size >> 16u) / 16.0;
+
+        // Unpack sin/cos for edge normal direction.
+        let sin_t = f32(in.rotation & 0xffffu) / 65535.0 * 2.0 - 1.0;
+        let cos_t = f32(in.rotation >> 16u) / 65535.0 * 2.0 - 1.0;
+
+        // For a unit-square pixel and an edge with normal (cos,sin), the exact coverage
+        // as a function of signed distance d from pixel center is a piecewise function.
+        // Let a = max(|cos|, |sin|), b = min(|cos|, |sin|), r = (a+b)/2.
+        // Both edge pairs of a rectangle have the same a, b values.
+        let a = max(abs(cos_t), abs(sin_t));
+        let b = min(abs(cos_t), abs(sin_t));
+        let inv_2ab = select(1.0 / (2.0 * a * b), 0.0, b < 0.001);
+
+        // Signed distance from pixel center to each edge (positive = inside).
+        let dist_left = in.tex_coord.x + hw;
+        let dist_right = hw - in.tex_coord.x;
+        let dist_top = in.tex_coord.y + hh;
+        let dist_bottom = hh - in.tex_coord.y;
+
+        let cov_left = halfplane_coverage(dist_left, a, b, inv_2ab);
+        let cov_right = halfplane_coverage(dist_right, a, b, inv_2ab);
+        let cov_top = halfplane_coverage(dist_top, a, b, inv_2ab);
+        let cov_bottom = halfplane_coverage(dist_bottom, a, b, inv_2ab);
+
+        alpha = cov_left * cov_right * cov_top * cov_bottom;
     // TODO: Explore doing these calculations only for rectangle parts that actually need anti-aliasing. See
     // https://github.com/linebender/vello/pull/1482#discussion_r2861311034
-    if is_rect && in.rect_frac != 0u {
+    } else if is_rect && in.rect_frac != 0u {
         let frac = unpack4x8unorm(in.rect_frac);
         // Calculate how much of the pixel is actually covered by the rect.
         // We do this by simply calculating the fractions in the x and y direction, and

--- a/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
@@ -234,6 +234,9 @@ struct VertexOutput {
     @builtin(position) position: vec4<f32>,
 };
 
+// NOTE: All of the rotated rect code has been written by Claude
+// and not been reviewed yet!
+
 // TODO: Measure performance of moving to a separate group
 @group(0) @binding(1)
 var<uniform> config: Config;

--- a/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
@@ -306,8 +306,7 @@ fn vs_main(
 
         // Pass half-extents to fragment shader via dense_end_or_rect_size.
         out.dense_end_or_rect_size = u32(hw * 16.0 + 0.5) | (u32(hh * 16.0 + 0.5) << 16u);
-        // Pass center to fragment shader via rect_frac (as two u16 in 8.8 fixed point).
-        out.rect_frac = u32(center_x * 256.0) | (u32(center_y * 256.0) << 16u);
+        out.rect_frac = instance.col_idx_or_rect_frac;
     } else {
         var height = config.strip_height;
         if is_rect {
@@ -457,9 +456,11 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
         let px = floor(in.position.x);
         let py = floor(in.position.y);
 
-        // Unpack center from rect_frac (8.8 fixed point, passed flat from vertex shader).
-        let center_x = f32(in.rect_frac & 0xffffu) / 256.0;
-        let center_y = f32(in.rect_frac >> 16u) / 256.0;
+        // Reconstruct center from pixel position and local-space coords.
+        // local = R^T * (pixel - center), so center = pixel - R * local.
+        let local = in.tex_coord;
+        let center_x = in.position.x - (local.x * cos_r - local.y * sin_r);
+        let center_y = in.position.y - (local.x * sin_r + local.y * cos_r);
 
         // Rect corners in screen space
         let rx = vec2(cos_r, sin_r) * hw;

--- a/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
@@ -271,14 +271,18 @@ fn vs_main(
     var pix_y: f32;
 
     if is_rotated_rect {
-        // For rotated rects, x/y = center (integer), width/height = half-extents (integer).
-        // col_idx_or_rect_frac = 4 × u8 fractional parts (cx, cy, hw, hh).
-        // rotation = packed sin/cos.
+        // For rotated rects, x/y/width/height store the local rect bounds (same
+        // layout as axis-aligned rects). col_idx_or_rect_frac = 4 × u8 fractional
+        // parts (x0, y0, w, h). rotation = packed sin/cos.
         let frac = unpack4x8unorm(instance.col_idx_or_rect_frac);
-        let center_x = f32(x0) + frac.x;
-        let center_y = f32(y0) + frac.y;
-        let hw = f32(width) + frac.z;
-        let hh = f32(dense_width) + frac.w;
+        let rect_x0 = f32(x0) + frac.x;
+        let rect_y0 = f32(y0) + frac.y;
+        let rect_w = f32(width) + frac.z;
+        let rect_h = f32(dense_width) + frac.w;
+        let hw = rect_w * 0.5;
+        let hh = rect_h * 0.5;
+        let center_x = rect_x0 + hw;
+        let center_y = rect_y0 + hh;
 
         // Unpack sin/cos from rotation field: u16 in [0, 65535] → [-1, 1].
         let sin_t = f32(instance.rotation & 0xffffu) / 65535.0 * 2.0 - 1.0;

--- a/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
@@ -305,9 +305,9 @@ fn vs_main(
         out.tex_coord = vec2<f32>(local_x, local_y);
 
         // Pass half-extents to fragment shader via dense_end_or_rect_size.
-        // Pack as 12.4 fixed point (sufficient for the coverage computation).
-        out.dense_end_or_rect_size = u32(hw * 16.0) | (u32(hh * 16.0) << 16u);
-        out.rect_frac = instance.col_idx_or_rect_frac;
+        out.dense_end_or_rect_size = u32(hw * 16.0 + 0.5) | (u32(hh * 16.0 + 0.5) << 16u);
+        // Pass center to fragment shader via rect_frac (as two u16 in 8.8 fixed point).
+        out.rect_frac = u32(center_x * 256.0) | (u32(center_y * 256.0) << 16u);
     } else {
         var height = config.strip_height;
         if is_rect {
@@ -385,28 +385,56 @@ var alphas_texture: texture_2d<u32>;
 @group(0) @binding(2)
 var clip_input_texture: texture_2d<f32>;
 
-// Exact area coverage of a unit-square pixel by a half-plane at signed distance `d`
-// from the pixel center (positive = inside). The edge normal has components with
-// absolute values `a` = max(|nx|, |ny|) and `b` = min(|nx|, |ny|).
-// `inv_2ab` = 1/(2*a*b), precomputed to avoid repeated division.
-fn halfplane_coverage(d: f32, a: f32, b: f32, inv_2ab: f32) -> f32 {
-    let r = 0.5 * (a + b);
-    if d >= r { return 1.0; }
-    if d <= -r { return 0.0; }
-    let t = d + r;
-    // Near-axis-aligned edge (b ≈ 0): linear transition.
-    if b < 0.001 {
-        return clamp(t / a, 0.0, 1.0);
-    }
-    // Piecewise quadratic/linear coverage function.
-    if t < b {
-        return t * t * inv_2ab;
-    } else if t < a {
-        return (2.0 * t - b) / (2.0 * a);
+// Compute ∫_a^b clamp(u, 0, 1) du for a linear variable u.
+// This is the exact integral of a clamped linear function.
+fn integral_clamped_01(a: f32, b: f32) -> f32 {
+    let lo = min(a, b);
+    let hi = max(a, b);
+    let lo_c = clamp(lo, 0.0, 1.0);
+    let hi_c = clamp(hi, 0.0, 1.0);
+    // Quadratic part: ∫_{lo_c}^{hi_c} u du
+    let quadratic = (hi_c * hi_c - lo_c * lo_c) * 0.5;
+    // Saturated part: length where u > 1
+    let saturated = max(hi - max(lo, 1.0), 0.0);
+    let magnitude = quadratic + saturated;
+    return select(-magnitude, magnitude, b >= a);
+}
+
+// Signed area contribution of one edge of a polygon to a pixel at (px, py).
+// Uses the same winding-number area approach as the CPU strip renderer.
+fn edge_area(px: f32, py: f32, x0: f32, y0: f32, x1: f32, y1: f32) -> f32 {
+    let dy = y1 - y0;
+    if abs(dy) < 1e-6 { return 0.0; } // Skip near-horizontal edges
+
+    let dx = x1 - x0;
+
+    // Clip to pixel y-range [py, py+1]
+    let inv_dy = 1.0 / dy;
+    let ta = (py - y0) * inv_dy;
+    let tb = (py + 1.0 - y0) * inv_dy;
+    let t_lo = clamp(min(ta, tb), 0.0, 1.0);
+    let t_hi = clamp(max(ta, tb), 0.0, 1.0);
+
+    if t_lo >= t_hi { return 0.0; }
+
+    // Clipped segment x-coordinates relative to pixel left edge
+    let xa = x0 + t_lo * dx - px;
+    let xb = x0 + t_hi * dx - px;
+
+    // Height of clipped segment
+    let h = (t_hi - t_lo) * abs(dy);
+
+    // Integrate clamp(x(t), 0, 1) over the height
+    let x_diff = xb - xa;
+    var integral: f32;
+    if abs(x_diff) < 1e-6 {
+        integral = h * clamp(xa, 0.0, 1.0);
     } else {
-        let s = a + b - t;
-        return 1.0 - s * s * inv_2ab;
+        integral = h / x_diff * integral_clamped_01(xa, xb);
     }
+
+    // Positive for downward-going edges, negative for upward
+    return select(-integral, integral, dy > 0.0);
 }
 
 @fragment
@@ -417,36 +445,39 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     let is_rotated_rect = is_rect && abs(sin_t) > 0.001;
 
     if is_rotated_rect {
-        // For rotated rects, tex_coord contains the interpolated local-space coordinates
-        // (already rotated by the vertex shader). Compute coverage using exact half-plane
-        // area coverage for each of the 4 edges, then take the minimum.
+        // For rotated rects, compute exact pixel coverage using the same winding-number
+        // area approach as the CPU strip renderer. Sum the signed area contribution of
+        // each of the 4 rect edges to the current pixel.
         let hw = f32(in.dense_end_or_rect_size & 0xffffu) / 16.0;
         let hh = f32(in.dense_end_or_rect_size >> 16u) / 16.0;
 
-        // Unpack sin/cos for edge normal direction.
-        let sin_t = f32(in.rotation & 0xffffu) / 65535.0 * 2.0 - 1.0;
-        let cos_t = f32(in.rotation >> 16u) / 65535.0 * 2.0 - 1.0;
+        let sin_r = f32(in.rotation & 0xffffu) / 65535.0 * 2.0 - 1.0;
+        let cos_r = f32(in.rotation >> 16u) / 65535.0 * 2.0 - 1.0;
 
-        // For a unit-square pixel and an edge with normal (cos,sin), the exact coverage
-        // as a function of signed distance d from pixel center is a piecewise function.
-        // Let a = max(|cos|, |sin|), b = min(|cos|, |sin|), r = (a+b)/2.
-        // Both edge pairs of a rectangle have the same a, b values.
-        let a = max(abs(cos_t), abs(sin_t));
-        let b = min(abs(cos_t), abs(sin_t));
-        let inv_2ab = select(1.0 / (2.0 * a * b), 0.0, b < 0.001);
+        let px = floor(in.position.x);
+        let py = floor(in.position.y);
 
-        // Signed distance from pixel center to each edge (positive = inside).
-        let dist_left = in.tex_coord.x + hw;
-        let dist_right = hw - in.tex_coord.x;
-        let dist_top = in.tex_coord.y + hh;
-        let dist_bottom = hh - in.tex_coord.y;
+        // Unpack center from rect_frac (8.8 fixed point, passed flat from vertex shader).
+        let center_x = f32(in.rect_frac & 0xffffu) / 256.0;
+        let center_y = f32(in.rect_frac >> 16u) / 256.0;
 
-        let cov_left = halfplane_coverage(dist_left, a, b, inv_2ab);
-        let cov_right = halfplane_coverage(dist_right, a, b, inv_2ab);
-        let cov_top = halfplane_coverage(dist_top, a, b, inv_2ab);
-        let cov_bottom = halfplane_coverage(dist_bottom, a, b, inv_2ab);
+        // Rect corners in screen space
+        let rx = vec2(cos_r, sin_r) * hw;
+        let ry = vec2(-sin_r, cos_r) * hh;
+        let c = vec2(center_x, center_y);
+        let p0 = c - rx - ry;
+        let p1 = c + rx - ry;
+        let p2 = c + rx + ry;
+        let p3 = c - rx + ry;
 
-        alpha = cov_left * cov_right * cov_top * cov_bottom;
+        // Sum signed area contributions from all 4 edges
+        var area = 0.0;
+        area += edge_area(px, py, p0.x, p0.y, p1.x, p1.y);
+        area += edge_area(px, py, p1.x, p1.y, p2.x, p2.y);
+        area += edge_area(px, py, p2.x, p2.y, p3.x, p3.y);
+        area += edge_area(px, py, p3.x, p3.y, p0.x, p0.y);
+
+        alpha = clamp(abs(area), 0.0, 1.0);
     // TODO: Explore doing these calculations only for rectangle parts that actually need anti-aliasing. See
     // https://github.com/linebender/vello/pull/1482#discussion_r2861311034
     } else if is_rect && in.rect_frac != 0u {

--- a/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
@@ -271,23 +271,25 @@ fn vs_main(
     var pix_y: f32;
 
     if is_rotated_rect {
-        // For rotated rects, x/y/width/height = AABB (snapped outward).
-        // col_idx_or_rect_frac = packed half-extents as 12.4 fixed point.
+        // For rotated rects, x/y = center (integer), width/height = half-extents (integer).
+        // col_idx_or_rect_frac = 4 × u8 fractional parts (cx, cy, hw, hh).
         // rotation = packed sin/cos.
-        let hw = f32(instance.col_idx_or_rect_frac & 0xffffu) / 16.0;
-        let hh = f32(instance.col_idx_or_rect_frac >> 16u) / 16.0;
-
-        // Derive center from AABB center.
-        let center_x = f32(x0) + f32(width) * 0.5;
-        let center_y = f32(y0) + f32(dense_width) * 0.5;
+        let frac = unpack4x8unorm(instance.col_idx_or_rect_frac);
+        let center_x = f32(x0) + frac.x;
+        let center_y = f32(y0) + frac.y;
+        let hw = f32(width) + frac.z;
+        let hh = f32(dense_width) + frac.w;
 
         // Unpack sin/cos from rotation field: u16 in [0, 65535] → [-1, 1].
         let sin_t = f32(instance.rotation & 0xffffu) / 65535.0 * 2.0 - 1.0;
         let cos_t = f32(instance.rotation >> 16u) / 65535.0 * 2.0 - 1.0;
 
-        // Use the AABB directly for the quad.
-        pix_x = f32(x0) + x * f32(width);
-        pix_y = f32(y0) + y * f32(dense_width);
+        // Compute AABB from center + half-extents + rotation + margin.
+        let aabb_hw = hw * abs(cos_t) + hh * abs(sin_t) + 1.0;
+        let aabb_hh = hw * abs(sin_t) + hh * abs(cos_t) + 1.0;
+
+        pix_x = center_x + (x * 2.0 - 1.0) * aabb_hw;
+        pix_y = center_y + (y * 2.0 - 1.0) * aabb_hh;
 
         // Rotate (pixel - center) into the rect's local frame for the fragment shader.
         let pdx = pix_x - center_x;
@@ -296,9 +298,10 @@ fn vs_main(
         let local_y = -pdx * sin_t + pdy * cos_t;
         out.tex_coord = vec2<f32>(local_x, local_y);
 
-        // Pass half-extents to fragment shader.
+        // Pass half-extents to fragment shader via dense_end_or_rect_size.
+        // Pack as 12.4 fixed point (sufficient for the coverage computation).
+        out.dense_end_or_rect_size = u32(hw * 16.0) | (u32(hh * 16.0) << 16u);
         out.rect_frac = instance.col_idx_or_rect_frac;
-        out.dense_end_or_rect_size = instance.col_idx_or_rect_frac;
     } else {
         var height = config.strip_height;
         if is_rect {
@@ -325,25 +328,41 @@ fn vs_main(
     let color_source = (instance.paint_and_rect_flag >> 29u) & 0x3u;
     if color_source == COLOR_SOURCE_PAYLOAD {
         let paint_type = (instance.paint_and_rect_flag >> 26u) & 0x7u;
-        // Unpack view coordinates for image sampling and gradient calculations
-        let scene_strip_x = instance.payload & 0xffffu;
-        let scene_strip_y = instance.payload >> 16u;
-        let height_for_paint = select(config.strip_height, dense_width, is_rect);
 
-        if paint_type == PAINT_TYPE_IMAGE {
-            let paint_tex_idx = instance.paint_and_rect_flag & PAINT_TEXTURE_INDEX_MASK;
-            let encoded_image = unpack_encoded_image(paint_tex_idx);
-            out.sample_xy = encoded_image.translate
-                + encoded_image.image_offset
-                + encoded_image.transform.xy * f32(scene_strip_x)
-                + encoded_image.transform.zw * f32(scene_strip_y)
-                + encoded_image.transform.xy * x * f32(width)
-                + encoded_image.transform.zw * y * f32(height_for_paint);
-        } else if paint_type == PAINT_TYPE_LINEAR_GRADIENT || paint_type == PAINT_TYPE_RADIAL_GRADIENT || paint_type == PAINT_TYPE_SWEEP_GRADIENT {
-            out.sample_xy = vec2<f32>(
-                f32(scene_strip_x) + x * f32(width),
-                f32(scene_strip_y) + y * f32(height_for_paint)
-            );
+        if is_rotated_rect {
+            // For rotated rects, sample_xy is simply the pixel position in screen space.
+            // pix_x/pix_y already contain the correct screen coordinates.
+            if paint_type == PAINT_TYPE_IMAGE {
+                let paint_tex_idx = instance.paint_and_rect_flag & PAINT_TEXTURE_INDEX_MASK;
+                let encoded_image = unpack_encoded_image(paint_tex_idx);
+                out.sample_xy = encoded_image.translate
+                    + encoded_image.image_offset
+                    + encoded_image.transform.xy * pix_x
+                    + encoded_image.transform.zw * pix_y;
+            } else if paint_type == PAINT_TYPE_LINEAR_GRADIENT || paint_type == PAINT_TYPE_RADIAL_GRADIENT || paint_type == PAINT_TYPE_SWEEP_GRADIENT {
+                out.sample_xy = vec2<f32>(pix_x, pix_y);
+            }
+        } else {
+            // For axis-aligned strips/rects, compute from scene strip position + vertex offset.
+            let scene_strip_x = instance.payload & 0xffffu;
+            let scene_strip_y = instance.payload >> 16u;
+            let height_for_paint = select(config.strip_height, dense_width, is_rect);
+
+            if paint_type == PAINT_TYPE_IMAGE {
+                let paint_tex_idx = instance.paint_and_rect_flag & PAINT_TEXTURE_INDEX_MASK;
+                let encoded_image = unpack_encoded_image(paint_tex_idx);
+                out.sample_xy = encoded_image.translate
+                    + encoded_image.image_offset
+                    + encoded_image.transform.xy * f32(scene_strip_x)
+                    + encoded_image.transform.zw * f32(scene_strip_y)
+                    + encoded_image.transform.xy * x * f32(width)
+                    + encoded_image.transform.zw * y * f32(height_for_paint);
+            } else if paint_type == PAINT_TYPE_LINEAR_GRADIENT || paint_type == PAINT_TYPE_RADIAL_GRADIENT || paint_type == PAINT_TYPE_SWEEP_GRADIENT {
+                out.sample_xy = vec2<f32>(
+                    f32(scene_strip_x) + x * f32(width),
+                    f32(scene_strip_y) + y * f32(height_for_paint)
+                );
+            }
         }
     }
 

--- a/sparse_strips/vello_sparse_tests/snapshots/no_anti_aliasing_2.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/no_anti_aliasing_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c449e423d165678f8283db8dd0255f781ca94625a537b4496caef5fe3e607899
+size 111

--- a/sparse_strips/vello_sparse_tests/snapshots/rect_250deg.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/rect_250deg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c9bc23162a59789ead475b91069e42777e12a27183362ec7019f048ae9c9f3b
+size 541

--- a/sparse_strips/vello_sparse_tests/snapshots/rect_45deg.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/rect_45deg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:023f4d458f29ad6b7ab65f76aee4e87aa0c92e307bdb4ed871688e4dd6e73e7d
+size 268

--- a/sparse_strips/vello_sparse_tests/snapshots/rect_80deg.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/rect_80deg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:789e23388eece55587355529572a6db78c02590f3875a9e665c90591009154bf
+size 478

--- a/sparse_strips/vello_sparse_tests/snapshots/rect_no_rotation.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/rect_no_rotation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3eaf0202a94d482dfc475a6f273644b3c00d4b1e7e703fe43fb88034b5f64689
+size 103

--- a/sparse_strips/vello_sparse_tests/snapshots/rect_nonsquare_45deg.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/rect_nonsquare_45deg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39e491bf2286c76a28ee0c3c53910afeddeff7d6b209c172bf9a427078d5fb1e
+size 310

--- a/sparse_strips/vello_sparse_tests/snapshots/rect_nonuniform_150deg.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/rect_nonuniform_150deg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4b77a305a7a33bdf4867b387a6de4a28cf0589ed31fd119cf2048eb28face44
+size 811

--- a/sparse_strips/vello_sparse_tests/snapshots/rect_nonuniform_45deg.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/rect_nonuniform_45deg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d95bcf6ba9e6e7d346e2203948187c20543d0cd4b4cfa9199346209d4910072
+size 298

--- a/sparse_strips/vello_sparse_tests/snapshots/rect_skew_x.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/rect_skew_x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fcec9f1f62571e9c3c892d69c2a41af3fa51d678d3677bcf8d3b45c8cd74ea7e
+size 134

--- a/sparse_strips/vello_sparse_tests/snapshots/rect_skew_y.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/rect_skew_y.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be6a1088872b08d02b11074137823be69f0c4eca1c4dd75c570dabb429b62084
+size 251

--- a/sparse_strips/vello_sparse_tests/tests/basic.rs
+++ b/sparse_strips/vello_sparse_tests/tests/basic.rs
@@ -306,6 +306,83 @@ fn filled_transformed_rect_4(ctx: &mut impl Renderer) {
     ctx.fill_rect(&rect);
 }
 
+fn fill_centered_rotated_rect(
+    ctx: &mut impl Renderer,
+    rect: &Rect,
+    sx: f64,
+    sy: f64,
+    angle_deg: f64,
+) {
+    let cx = 50.0;
+    let cy = 50.0;
+    let half_w = rect.width() * sx / 2.0;
+    let half_h = rect.height() * sy / 2.0;
+
+    let transform = Affine::translate((cx, cy))
+        * Affine::rotate(angle_deg * PI / 180.0)
+        * Affine::translate((-half_w, -half_h))
+        * Affine::scale_non_uniform(sx, sy);
+
+    ctx.set_transform(transform);
+    ctx.set_paint(BLUE.with_alpha(0.5));
+    ctx.fill_rect(rect);
+}
+
+#[vello_test]
+fn rect_no_rotation(ctx: &mut impl Renderer) {
+    fill_centered_rotated_rect(ctx, &Rect::new(0.0, 0.0, 1.0, 1.0), 40.0, 40.0, 0.0);
+}
+
+#[vello_test]
+fn rect_45deg(ctx: &mut impl Renderer) {
+    fill_centered_rotated_rect(ctx, &Rect::new(0.0, 0.0, 1.0, 1.0), 40.0, 40.0, 45.0);
+}
+
+#[vello_test]
+fn rect_80deg(ctx: &mut impl Renderer) {
+    fill_centered_rotated_rect(ctx, &Rect::new(0.0, 0.0, 1.0, 1.0), 40.0, 40.0, 80.0);
+}
+
+#[vello_test]
+fn rect_250deg(ctx: &mut impl Renderer) {
+    fill_centered_rotated_rect(ctx, &Rect::new(0.0, 0.0, 1.0, 1.0), 40.0, 40.0, 250.0);
+}
+
+#[vello_test]
+fn rect_nonuniform_45deg(ctx: &mut impl Renderer) {
+    fill_centered_rotated_rect(ctx, &Rect::new(0.0, 0.0, 1.0, 1.0), 60.0, 40.0, 45.0);
+}
+
+#[vello_test]
+fn rect_nonuniform_150deg(ctx: &mut impl Renderer) {
+    fill_centered_rotated_rect(ctx, &Rect::new(0.0, 0.0, 1.0, 1.0), 60.0, 40.0, 150.0);
+}
+
+#[vello_test]
+fn rect_nonsquare_45deg(ctx: &mut impl Renderer) {
+    fill_centered_rotated_rect(ctx, &Rect::new(0.0, 0.0, 2.0, 3.0), 20.0, 20.0, 45.0);
+}
+
+#[vello_test]
+fn rect_skew_x(ctx: &mut impl Renderer) {
+    let rect = Rect::new(-1.0, -1.0, 1.0, 1.0);
+    ctx.set_transform(
+        Affine::translate((50.0, 50.0)) * Affine::skew(1.0, 0.0) * Affine::scale(20.0),
+    );
+    ctx.set_paint(BLUE);
+    ctx.fill_rect(&rect);
+}
+
+#[vello_test]
+fn rect_skew_y(ctx: &mut impl Renderer) {
+    let rect = Rect::new(-1.0, -1.0, 1.0, 1.0);
+    ctx.set_transform(
+        Affine::translate((50.0, 50.0)) * Affine::skew(0.0, 1.0) * Affine::scale(20.0),
+    );
+    ctx.set_paint(BLUE);
+    ctx.fill_rect(&rect);
+}
+
 #[vello_test(width = 30, height = 30)]
 fn stroked_transformed_rect_1(ctx: &mut impl Renderer) {
     let rect = Rect::new(0.0, 0.0, 10.0, 10.0);
@@ -401,6 +478,14 @@ fn no_anti_aliasing(ctx: &mut impl Renderer) {
         45.0 * PI / 180.0,
         Point::new(50.0, 50.0),
     ));
+    ctx.set_paint(REBECCA_PURPLE.with_alpha(0.5));
+    ctx.fill_rect(&rect);
+}
+
+#[vello_test(width = 100, height = 100)]
+fn no_anti_aliasing_2(ctx: &mut impl Renderer) {
+    let rect = Rect::new(30.5, 30.5, 69.5, 69.5);
+    ctx.set_aliasing_threshold(Some(128));
     ctx.set_paint(REBECCA_PURPLE.with_alpha(0.5));
     ctx.fill_rect(&rect);
 }

--- a/sparse_strips/vello_sparse_tests/tests/basic.rs
+++ b/sparse_strips/vello_sparse_tests/tests/basic.rs
@@ -324,7 +324,7 @@ fn fill_centered_rotated_rect(
         * Affine::scale_non_uniform(sx, sy);
 
     ctx.set_transform(transform);
-    ctx.set_paint(BLUE.with_alpha(0.5));
+    ctx.set_paint(BLUE);
     ctx.fill_rect(rect);
 }
 

--- a/sparse_strips/vello_sparse_tests/tests/basic.rs
+++ b/sparse_strips/vello_sparse_tests/tests/basic.rs
@@ -632,3 +632,5 @@ fn composite_to_pixmap_at_offset() {
         "composite_to_pixmap_at_offset result should match direct rendering"
     );
 }
+
+// TODO: Add tests for small rectangles, with different rotations


### PR DESCRIPTION
As a disclaimer again, the shader code was AI-generated and I haven't reviewed it deeply yet, I just wanted to get something working that passes all currently existing tests to test the feasibility. So not meant for deep review yet. 

The core idea would be that rectangles get an additional `rotation` attribute (this does unfortunately mean that we need to add an additional field to `GpuStrip`). In case this rotation is non-zero, we do additional work in the shader to compute the alphas, taking the rotation into account. The existing fast rectangle path can basically be left untouched.

It took me a while to prototype this, and during the implementation I encountered a lot of unexpected edge cases (the corner pixels of rotated rectangles yielded different opacities than the CPU version, complex paints didn't work from the get go), so I am a bit concerned about the additional complexity that this implementation brings. It would require us to add a lot more test cases for various interactions (I've added some already, but we will need many more), so I'm a bit hesitant of going down this route, unless we really have a compelling reason to optimize for the rotated rectangle case.

With that said, from my experiments, this does give a good speed boost, but it is significantly slower than drawing non-rotated rectangles (which isn't surprising given that there are a lot of computations happening in the current shader. It's possible this can be optimized further, but I didn't want to spend more time on this before we have a clear answer on whether we want this in the first place).

Here's what I get with current main. As can be seen, after just a few thousand rectangles we already drop below the 120FPS threshold, and it only keeps getting worse from then on:

https://github.com/user-attachments/assets/99e1399b-5b75-4dca-a89d-9955ab7c3a4e

With this current (as mentioned, potentially not optimized) implementation, I can get to 40k rectangles before it slowly starts to drop:

https://github.com/user-attachments/assets/50be270e-1f85-4eda-930b-ee2f2e67c329

However, this is still a lot worse than the non-rotated rectangles case, where we can easily get to 100k+ without really noticing anything:

https://github.com/user-attachments/assets/05bed7a4-448d-430d-a90f-a888ba001ee4

Curious to hear your thoughts @grebmeg @taj-p.