### PR TITLE
Fix half-pixel offset when sampling images using pixel centers not corners

### DIFF
--- a/vello_shaders/shader/fine.wgsl
+++ b/vello_shaders/shader/fine.wgsl
@@ -1220,7 +1220,8 @@ fn main(
                         for (var i = 0u; i < PIXELS_PER_THREAD; i += 1u) {
                             // We only need to load from the textures if the value will be used.
                             if area[i] != 0.0 {
-                                let my_xy = vec2(xy.x + f32(i), xy.y);
+                                // Use pixel centers (+0.5) rather than pixel corners for correct sampling
+                                let my_xy = vec2(xy.x + f32(i) + 0.5, xy.y + 0.5);
                                 var atlas_uv = image.matrx.xy * my_xy.x + image.matrx.zw * my_xy.y + image.xlat;
                                 atlas_uv.x = extend_mode(atlas_uv.x, image.x_extend_mode, image.extents.x);
                                 atlas_uv.y = extend_mode(atlas_uv.y, image.y_extend_mode, image.extents.y);
@@ -1239,7 +1240,8 @@ fn main(
                         for (var i = 0u; i < PIXELS_PER_THREAD; i += 1u) {
                             // We only need to load from the textures if the value will be used.
                             if area[i] != 0.0 {
-                                let my_xy = vec2(xy.x + f32(i), xy.y);
+                                // Use pixel centers (+0.5) rather than pixel corners for correct sampling
+                                let my_xy = vec2(xy.x + f32(i) + 0.5, xy.y + 0.5);
                                 var atlas_uv = image.matrx.xy * my_xy.x + image.matrx.zw * my_xy.y + image.xlat;
                                 atlas_uv.x = extend_mode(atlas_uv.x, image.x_extend_mode, image.extents.x);
                                 atlas_uv.y = extend_mode(atlas_uv.y, image.y_extend_mode, image.extents.y);


### PR DESCRIPTION
Fixes #972 in Vello and https://github.com/GraphiteEditor/Graphite/issues/3018 in Graphite.

Here are some screenshots (view them at exactly 100% scale) from the Graphite viewport.

Blurry (currently in Vello):

<img width="491" height="434" alt="image" src="https://github.com/user-attachments/assets/2cae7f9f-aeb0-423d-ad3e-24d8bc544005" />

Pixel-perfect (this fix):

<img width="491" height="434" alt="image" src="https://github.com/user-attachments/assets/2754e73b-9461-4b2e-9198-2e3674c9c739" />

Ground truth pixel-perfect (Graphite's SVG renderer, not Vello):

<img width="491" height="434" alt="image" src="https://github.com/user-attachments/assets/5be378e8-191e-41f7-b85e-9afa9d2bfe5f" />

Disclosure: this is discovered and fixed with the help of Claude Code, but tested in Graphite. I have not, however, tested this in isolation outside of Graphite, but that might be something a reviewer could help with.