### PR TITLE
vello_hybrid: Fix issue that causes mismatch between stored render size and assumed render size

### DIFF
--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -286,8 +286,6 @@ impl WebGlRenderer {
             &mut self.programs.resources.view_framebuffer,
             atlas_framebuffer,
         );
-        let saved_render_size =
-            core::mem::replace(&mut self.programs.render_size, atlas_render_size);
 
         // Swap in the stub atlas texture array to avoid binding the real atlas
         // texture as a shader input while it is also the render target.
@@ -296,7 +294,7 @@ impl WebGlRenderer {
             &mut self.programs.resources.stub_atlas_texture_array,
         );
 
-        let result = self.render_scene(scene, &self.programs.render_size.clone(), false);
+        let result = self.render_scene(scene, &atlas_render_size, false);
 
         // Restore the real atlas texture array.
         core::mem::swap(
@@ -310,8 +308,6 @@ impl WebGlRenderer {
             saved_framebuffer,
         );
         self.programs.resources.atlas_render_framebuffer = Some(atlas_fb);
-
-        self.programs.render_size = saved_render_size;
 
         result
     }


### PR DESCRIPTION
We already [have code](https://github.com/linebender/vello/blob/ea2a935ec79206fb5dd3d367ac8feb79bffc905b/sparse_strips/vello_hybrid/src/render/webgl.rs#L962) that checks whether the currently stored render size (from the last iteration) doesn't match the new render size, and if so updates everything accordingly. Therefore, simply just don't replace the render size in the first place in `render_to_atlas`. I verified that this change also fixes the issue we encountered during the integration.