### PR TITLE
Re attach texture to re-trigger framebuffer completeness

### DIFF
--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -1060,6 +1060,16 @@ impl WebGlPrograms {
                 0,
             );
 
+            #[cfg(debug_assertions)]
+            {
+                let status = gl.check_framebuffer_status(WebGl2RenderingContext::FRAMEBUFFER);
+                debug_assert_eq!(
+                    status,
+                    WebGl2RenderingContext::FRAMEBUFFER_COMPLETE,
+                    "view framebuffer incomplete"
+                );
+            }
+
             self.render_size = new_render_size.clone();
         }
     }


### PR DESCRIPTION
Last week, I did some checking of Vello on a handful of low end devices. This is a bug I found while testing on a Samsung A05s, which uses very old drivers.

(I tested manually on A05s).