### PR TITLE
Small bug in `tex_parameteri` - use provided target

### DIFF
--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -1546,11 +1546,7 @@ fn create_texture_inner(gl: &WebGl2RenderingContext, target: u32) -> WebGlTextur
     );
     // Also only to be defensive, in theory this shouldn't be necessary since we use
     // `NEAREST` for both filters.
-    gl.tex_parameteri(
-        WebGl2RenderingContext::TEXTURE_2D,
-        WebGl2RenderingContext::TEXTURE_MAX_LEVEL,
-        0,
-    );
+    gl.tex_parameteri(target, WebGl2RenderingContext::TEXTURE_MAX_LEVEL, 0);
 
     texture
 }


### PR DESCRIPTION
Per title - this call into `tex_parameteri` didn't honour the passed in target.