### PR TITLE
fix: hanging in mmark example

### DIFF
--- a/examples/scenes/src/mmark.rs
+++ b/examples/scenes/src/mmark.rs
@@ -81,9 +81,13 @@ impl TestScene for MMark {
         let mut path = BezPath::new();
         let len = self.elements.len();
         for (i, element) in self.elements.iter_mut().enumerate() {
-            if path.is_empty() {
-                path.move_to(element.seg.start());
+            // Delete old path events.
+            if !path.is_empty() {
+                path.truncate(0); // Should have clear method, to avoid allocations.
             }
+
+            path.move_to(element.seg.start());
+
             match element.seg {
                 PathSeg::Line(l) => path.line_to(l.p1),
                 PathSeg::Quad(q) => path.quad_to(q.p1, q.p2),
@@ -99,7 +103,6 @@ impl TestScene for MMark {
                     None,
                     &path,
                 );
-                path.truncate(0); // Should have clear method, to avoid allocations.
             }
             if rng.random::<f32>() > 0.995 {
                 element.is_split ^= true;


### PR DESCRIPTION
In my Mac mini M4, when the path elements reached at `70000`, its hanging.

### Before

https://github.com/user-attachments/assets/6889f717-86c8-43d5-8267-632c4584f9d0

### After

https://github.com/user-attachments/assets/22104d62-8889-4d75-b299-4e27ad646f2f

