### PR TITLE
Streamline handling of pixel center offsets

### DIFF
--- a/sparse_strips/vello_bench/src/fine/gradient.rs
+++ b/sparse_strips/vello_bench/src/fine/gradient.rs
@@ -10,7 +10,7 @@ use smallvec::{SmallVec, smallvec};
 use vello_common::coarse::WideTile;
 use vello_common::color::palette::css::{BLUE, GREEN, RED, YELLOW};
 use vello_common::color::{AlphaColor, DynamicColor, Srgb};
-use vello_common::encode::{EncodeExt, PixelSampling};
+use vello_common::encode::EncodeExt;
 use vello_common::fearless_simd::Simd;
 use vello_common::kurbo::{Affine, Point};
 use vello_common::peniko;
@@ -244,7 +244,7 @@ fn gradient_base<S: Simd, N: FineKernel<S>>(
         ..Default::default()
     };
 
-    let paint = grad.encode_into(&mut paints, Affine::IDENTITY, None, PixelSampling::Corner);
+    let paint = grad.encode_into(&mut paints, Affine::IDENTITY, None);
     fill_single(
         &paint,
         &paints,

--- a/sparse_strips/vello_bench/src/fine/image.rs
+++ b/sparse_strips/vello_bench/src/fine/image.rs
@@ -5,7 +5,7 @@ use crate::fine::{default_blend, fill_single};
 use criterion::{Bencher, Criterion};
 use std::sync::Arc;
 use vello_common::coarse::WideTile;
-use vello_common::encode::{EncodeExt, PixelSampling};
+use vello_common::encode::EncodeExt;
 use vello_common::fearless_simd::Simd;
 use vello_common::kurbo::Affine;
 use vello_common::paint::{Image, ImageSource};
@@ -182,7 +182,7 @@ fn image_base<S: Simd, T: FineKernel<S>>(
 ) {
     let mut paints = vec![];
 
-    let paint = image.encode_into(&mut paints, transform, None, PixelSampling::Corner);
+    let paint = image.encode_into(&mut paints, transform, None);
 
     fill_single(
         &paint,

--- a/sparse_strips/vello_bench/src/fine/rounded_blurred_rect.rs
+++ b/sparse_strips/vello_bench/src/fine/rounded_blurred_rect.rs
@@ -6,7 +6,7 @@ use criterion::{Bencher, Criterion};
 use vello_common::blurred_rounded_rect::BlurredRoundedRectangle;
 use vello_common::coarse::WideTile;
 use vello_common::color::palette::css::GREEN;
-use vello_common::encode::{EncodeExt, PixelSampling};
+use vello_common::encode::EncodeExt;
 use vello_common::fearless_simd::Simd;
 use vello_common::kurbo::{Affine, Point, Rect};
 use vello_common::tile::Tile;
@@ -40,7 +40,7 @@ fn base<S: Simd, N: FineKernel<S>>(b: &mut Bencher<'_>, fine: &mut Fine<S, N>, t
         std_dev: 10.0,
     };
 
-    let paint = rect.encode_into(&mut paints, transform, None, PixelSampling::Corner);
+    let paint = rect.encode_into(&mut paints, transform, None);
     fill_single(
         &paint,
         &paints,

--- a/sparse_strips/vello_common/src/encode.rs
+++ b/sparse_strips/vello_common/src/encode.rs
@@ -35,22 +35,6 @@ use peniko::kurbo::common::FloatFuncs as _;
 
 const DEGENERATE_THRESHOLD: f32 = 1.0e-6;
 const NUDGE_VAL: f32 = 1.0e-7;
-const PIXEL_CENTER_OFFSET: f64 = 0.5;
-
-/// How the client performs pixel sampling.
-///
-/// For complex paints like images and gradients, it's important that the value is always sampled
-/// at the center of the pixel. In case the client code uses sampling based on the top-left corner
-/// instead, an additional correctional shift will be encoded in the transform of the paint to
-/// account for that.
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
-pub enum PixelSampling {
-    /// Assume that the client does sampling from the pixel center by default.
-    Center,
-    /// Assume that the client does sampling from the top-left pixel corner by default.
-    Corner,
-}
-
 #[cfg(feature = "std")]
 fn exp(val: f32) -> f32 {
     val.exp()
@@ -73,13 +57,6 @@ pub trait EncodeExt: private::Sealed {
         paints: &mut Vec<EncodedPaint>,
         transform: Affine,
         tint: Option<Tint>,
-        // Note: We make this configurable because different backends have different requirements.
-        // For vello_cpu, it makes sense to apply the center shift _once_ during encoding, so that
-        // we don't have to manually apply the shift for each wide tile command (since by default,
-        // we will sample from the top-left corner).
-        // However, for vello_hybrid, the fragment shader already calculates the positions such
-        // that they are centered in the pixel, so there is no need to apply an additional shift.
-        pixel_sampling: PixelSampling,
     ) -> Paint;
 }
 
@@ -90,7 +67,6 @@ impl EncodeExt for Gradient {
         paints: &mut Vec<EncodedPaint>,
         transform: Affine,
         _tint: Option<Tint>,
-        pixel_sampling: PixelSampling,
     ) -> Paint {
         // First make sure that the gradient is valid and not degenerate.
         if let Err(paint) = validate(self) {
@@ -218,14 +194,9 @@ impl EncodeExt for Gradient {
         // This represents the transform that needs to be applied to the starting point of a
         // command before starting with the rendering.
         // First we need to account for the base transform of the shader, then
-        // we (optionally) account for the fact that we want to sample in the center of a pixel and not
-        // in the corner by adding `PIXEL_CENTER_OFFSET`.
-        // Finally, we need to apply the _inverse_ paint transform to the point so that we can account
+        // we need to apply the _inverse_ paint transform to the point so that we can account
         // for the paint transform of the render context.
-        let mut transform = base_transform * transform.inverse();
-        if pixel_sampling == PixelSampling::Corner {
-            transform *= Affine::translate((PIXEL_CENTER_OFFSET, PIXEL_CENTER_OFFSET));
-        }
+        let transform = base_transform * transform.inverse();
 
         // One possible approach of calculating the positions would be to apply the above
         // transform to _each_ pixel that we render in the wide tile. However, a much better
@@ -505,7 +476,6 @@ impl EncodeExt for Image {
         paints: &mut Vec<EncodedPaint>,
         transform: Affine,
         tint: Option<Tint>,
-        pixel_sampling: PixelSampling,
     ) -> Paint {
         let idx = paints.len();
 
@@ -530,13 +500,7 @@ impl EncodeExt for Image {
             sampler.quality = ImageQuality::Low;
         }
 
-        // Similarly to gradients, optionally apply the `PIXEL_CENTER_OFFSET` offset so we sample
-        // at the center of a pixel.
-        let mut transform = transform.inverse();
-
-        if pixel_sampling == PixelSampling::Corner {
-            transform *= Affine::translate((PIXEL_CENTER_OFFSET, PIXEL_CENTER_OFFSET));
-        }
+        let transform = transform.inverse();
 
         let (x_advance, y_advance) = x_y_advances(&transform);
 
@@ -874,7 +838,6 @@ impl EncodeExt for BlurredRoundedRectangle {
         paints: &mut Vec<EncodedPaint>,
         transform: Affine,
         _tint: Option<Tint>,
-        pixel_sampling: PixelSampling,
     ) -> Paint {
         let rect = {
             // Ensure rectangle has positive width/height.
@@ -891,11 +854,7 @@ impl EncodeExt for BlurredRoundedRectangle {
             rect
         };
 
-        let mut transform = Affine::translate((-rect.x0, -rect.y0)) * transform.inverse();
-
-        if pixel_sampling == PixelSampling::Corner {
-            transform *= Affine::translate((PIXEL_CENTER_OFFSET, PIXEL_CENTER_OFFSET));
-        }
+        let transform = Affine::translate((-rect.x0, -rect.y0)) * transform.inverse();
 
         let (x_advance, y_advance) = x_y_advances(&transform);
 
@@ -1181,14 +1140,13 @@ mod private {
 
 #[cfg(test)]
 mod tests {
-    use super::{EncodeExt, EncodedPaint, Gradient, PixelSampling};
+    use super::{EncodeExt, Gradient};
     use crate::color::DynamicColor;
     use crate::color::palette::css::{BLACK, BLUE, GREEN};
     use crate::kurbo::{Affine, Point};
-    use crate::paint::{Image, ImageId, ImageSource};
     use crate::peniko::{ColorStop, ColorStops};
     use alloc::vec;
-    use peniko::{ImageSampler, LinearGradientPosition, RadialGradientPosition};
+    use peniko::{LinearGradientPosition, RadialGradientPosition};
     use smallvec::smallvec;
 
     #[test]
@@ -1205,7 +1163,7 @@ mod tests {
         };
 
         assert_eq!(
-            gradient.encode_into(&mut buf, Affine::IDENTITY, None, PixelSampling::Center),
+            gradient.encode_into(&mut buf, Affine::IDENTITY, None),
             BLACK.into()
         );
     }
@@ -1229,7 +1187,7 @@ mod tests {
 
         // Should return the color of the first stop.
         assert_eq!(
-            gradient.encode_into(&mut buf, Affine::IDENTITY, None, PixelSampling::Center),
+            gradient.encode_into(&mut buf, Affine::IDENTITY, None),
             GREEN.into()
         );
     }
@@ -1258,7 +1216,7 @@ mod tests {
         };
 
         assert_eq!(
-            gradient.encode_into(&mut buf, Affine::IDENTITY, None, PixelSampling::Center),
+            gradient.encode_into(&mut buf, Affine::IDENTITY, None),
             GREEN.into()
         );
     }
@@ -1287,70 +1245,9 @@ mod tests {
         };
 
         assert_eq!(
-            gradient.encode_into(&mut buf, Affine::IDENTITY, None, PixelSampling::Center),
+            gradient.encode_into(&mut buf, Affine::IDENTITY, None),
             GREEN.into()
         );
-    }
-
-    #[test]
-    fn gradient_encode_sampling_offset() {
-        let mut buf = vec![];
-
-        let gradient = Gradient {
-            kind: LinearGradientPosition {
-                start: Point::new(0.0, 0.0),
-                end: Point::new(1.0, 0.0),
-            }
-            .into(),
-            stops: ColorStops(smallvec![
-                ColorStop {
-                    offset: 0.0,
-                    color: DynamicColor::from_alpha_color(GREEN),
-                },
-                ColorStop {
-                    offset: 1.0,
-                    color: DynamicColor::from_alpha_color(BLUE),
-                },
-            ]),
-            ..Default::default()
-        };
-
-        gradient.encode_into(&mut buf, Affine::IDENTITY, None, PixelSampling::Center);
-        gradient.encode_into(&mut buf, Affine::IDENTITY, None, PixelSampling::Corner);
-
-        let EncodedPaint::Gradient(g) = &buf[0] else {
-            unreachable!()
-        };
-        assert_eq!(g.transform, Affine::IDENTITY);
-        let EncodedPaint::Gradient(g) = &buf[1] else {
-            unreachable!()
-        };
-        assert_eq!(g.transform, Affine::translate((0.5, 0.5)));
-    }
-
-    #[test]
-    fn image_encode_sampling_offset() {
-        let mut buf = vec![];
-
-        let image = Image {
-            image: ImageSource::OpaqueId {
-                id: ImageId::new(0),
-                may_have_opacities: false,
-            },
-            sampler: ImageSampler::default(),
-        };
-
-        image.encode_into(&mut buf, Affine::IDENTITY, None, PixelSampling::Center);
-        image.encode_into(&mut buf, Affine::IDENTITY, None, PixelSampling::Corner);
-
-        let EncodedPaint::Image(i) = &buf[0] else {
-            unreachable!()
-        };
-        assert_eq!(i.transform, Affine::IDENTITY);
-        let EncodedPaint::Image(i) = &buf[1] else {
-            unreachable!()
-        };
-        assert_eq!(i.transform, Affine::translate((0.5, 0.5)));
     }
 
     #[test]
@@ -1379,7 +1276,7 @@ mod tests {
         };
 
         assert_eq!(
-            gradient.encode_into(&mut buf, Affine::IDENTITY, None, PixelSampling::Center),
+            gradient.encode_into(&mut buf, Affine::IDENTITY, None),
             GREEN.into()
         );
     }

--- a/sparse_strips/vello_cpu/src/fine/common/gradient/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/common/gradient/mod.rs
@@ -17,14 +17,13 @@ pub(crate) fn calculate_t_vals<S: Simd, U: SimdGradientKind<S>>(
     kind: U,
     buf: &mut [f32],
     gradient: &EncodedGradient,
-    start_x: u16,
-    start_y: u16,
+    start_x: f64,
+    start_y: f64,
 ) {
     simd.vectorize(
         #[inline(always)]
         || {
-            let mut cur_pos =
-                gradient.transform * Point::new(f64::from(start_x), f64::from(start_y));
+            let mut cur_pos = gradient.transform * Point::new(start_x, start_y);
             let x_advances = (gradient.x_advance.x as f32, gradient.x_advance.y as f32);
             let y_advances = (gradient.y_advance.x as f32, gradient.y_advance.y as f32);
 

--- a/sparse_strips/vello_cpu/src/fine/common/image.rs
+++ b/sparse_strips/vello_cpu/src/fine/common/image.rs
@@ -24,8 +24,8 @@ impl<'a, S: Simd> PlainNNImagePainter<'a, S> {
         simd: S,
         image: &'a EncodedImage,
         pixmap: &'a Pixmap,
-        start_x: u16,
-        start_y: u16,
+        start_x: f64,
+        start_y: f64,
     ) -> Self {
         let data = ImagePainterData::new(simd, image, pixmap, start_x, start_y);
 
@@ -94,8 +94,8 @@ impl<'a, S: Simd> NNImagePainter<'a, S> {
         simd: S,
         image: &'a EncodedImage,
         pixmap: &'a Pixmap,
-        start_x: u16,
-        start_y: u16,
+        start_x: f64,
+        start_y: f64,
     ) -> Self {
         let data = ImagePainterData::new(simd, image, pixmap, start_x, start_y);
 
@@ -163,8 +163,8 @@ impl<'a, S: Simd, const QUALITY: u8> FilteredImagePainter<'a, S, QUALITY> {
         simd: S,
         image: &'a EncodedImage,
         pixmap: &'a Pixmap,
-        start_x: u16,
-        start_y: u16,
+        start_x: f64,
+        start_y: f64,
     ) -> Self {
         let data = ImagePainterData::new(simd, image, pixmap, start_x, start_y);
 
@@ -363,12 +363,12 @@ impl<'a, S: Simd> ImagePainterData<'a, S> {
         simd: S,
         image: &'a EncodedImage,
         pixmap: &'a Pixmap,
-        start_x: u16,
-        start_y: u16,
+        start_x: f64,
+        start_y: f64,
     ) -> Self {
         let width = pixmap.width() as f32;
         let height = pixmap.height() as f32;
-        let start_pos = image.transform * Point::new(f64::from(start_x), f64::from(start_y));
+        let start_pos = image.transform * Point::new(start_x, start_y);
 
         let width_inv = f32x4::splat(simd, 1.0 / width);
         let height_inv = f32x4::splat(simd, 1.0 / height);

--- a/sparse_strips/vello_cpu/src/fine/common/rounded_blurred_rect.rs
+++ b/sparse_strips/vello_cpu/src/fine/common/rounded_blurred_rect.rs
@@ -26,10 +26,10 @@ impl<S: Simd> BlurredRoundedRectFiller<S> {
     pub(crate) fn new(
         simd: S,
         rect: &EncodedBlurredRoundedRectangle,
-        start_x: u16,
-        start_y: u16,
+        start_x: f64,
+        start_y: f64,
     ) -> Self {
-        let start_pos = rect.transform * Point::new(f64::from(start_x), f64::from(start_y));
+        let start_pos = rect.transform * Point::new(start_x, start_y);
         let color_components = rect.color.as_premul_f32().components;
         let r = f32x8::splat(simd, color_components[0]);
         let g = f32x8::splat(simd, color_components[1]);

--- a/sparse_strips/vello_cpu/src/fine/lowp/image.rs
+++ b/sparse_strips/vello_cpu/src/fine/lowp/image.rs
@@ -22,8 +22,8 @@ impl<'a, S: Simd> BilinearImagePainter<'a, S> {
         simd: S,
         image: &'a EncodedImage,
         pixmap: &'a Pixmap,
-        start_x: u16,
-        start_y: u16,
+        start_x: f64,
+        start_y: f64,
     ) -> Self {
         let data = ImagePainterData::new(simd, image, pixmap, start_x, start_y);
 
@@ -140,8 +140,8 @@ impl<'a, S: Simd> PlainBilinearImagePainter<'a, S> {
         simd: S,
         image: &'a EncodedImage,
         pixmap: &'a Pixmap,
-        start_x: u16,
-        start_y: u16,
+        start_x: f64,
+        start_y: f64,
     ) -> Self {
         let data = ImagePainterData::new(simd, image, pixmap, start_x, start_y);
 

--- a/sparse_strips/vello_cpu/src/fine/lowp/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/lowp/mod.rs
@@ -138,8 +138,8 @@ impl<S: Simd> FineKernel<S> for U8Kernel {
         simd: S,
         image: &'a EncodedImage,
         pixmap: &'a Pixmap,
-        start_x: u16,
-        start_y: u16,
+        start_x: f64,
+        start_y: f64,
     ) -> impl Painter + 'a {
         simd.vectorize(
             #[inline(always)]
@@ -155,8 +155,8 @@ impl<S: Simd> FineKernel<S> for U8Kernel {
         simd: S,
         image: &'a EncodedImage,
         pixmap: &'a Pixmap,
-        start_x: u16,
-        start_y: u16,
+        start_x: f64,
+        start_y: f64,
     ) -> impl Painter + 'a {
         simd.vectorize(
             #[inline(always)]

--- a/sparse_strips/vello_cpu/src/fine/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/mod.rs
@@ -45,6 +45,9 @@ use vello_common::util::f32_to_u8;
 pub use highp::F32Kernel;
 pub use lowp::U8Kernel;
 
+/// Offset to shift from pixel corner to pixel center for sampling.
+const PIXEL_CENTER_OFFSET: f64 = 0.5;
+
 /// Number of color components per pixel (RGBA).
 pub(crate) const COLOR_COMPONENTS: usize = 4;
 
@@ -297,8 +300,8 @@ pub trait FineKernel<S: Simd>: Send + Sync + 'static {
         simd: S,
         image: &'a EncodedImage,
         pixmap: &'a Pixmap,
-        start_x: u16,
-        start_y: u16,
+        start_x: f64,
+        start_y: f64,
     ) -> impl Painter + 'a {
         simd.vectorize(
             #[inline(always)]
@@ -314,8 +317,8 @@ pub trait FineKernel<S: Simd>: Send + Sync + 'static {
         simd: S,
         image: &'a EncodedImage,
         pixmap: &'a Pixmap,
-        start_x: u16,
-        start_y: u16,
+        start_x: f64,
+        start_y: f64,
     ) -> impl Painter + 'a {
         simd.vectorize(
             #[inline(always)]
@@ -330,8 +333,8 @@ pub trait FineKernel<S: Simd>: Send + Sync + 'static {
         simd: S,
         image: &'a EncodedImage,
         pixmap: &'a Pixmap,
-        start_x: u16,
-        start_y: u16,
+        start_x: f64,
+        start_y: f64,
     ) -> impl Painter + 'a {
         simd.vectorize(
             #[inline(always)]
@@ -346,8 +349,8 @@ pub trait FineKernel<S: Simd>: Send + Sync + 'static {
         simd: S,
         image: &'a EncodedImage,
         pixmap: &'a Pixmap,
-        start_x: u16,
-        start_y: u16,
+        start_x: f64,
+        start_y: f64,
     ) -> impl Painter + 'a {
         simd.vectorize(
             #[inline(always)]
@@ -362,8 +365,8 @@ pub trait FineKernel<S: Simd>: Send + Sync + 'static {
         simd: S,
         image: &'a EncodedImage,
         pixmap: &'a Pixmap,
-        start_x: u16,
-        start_y: u16,
+        start_x: f64,
+        start_y: f64,
     ) -> impl Painter + 'a {
         simd.vectorize(
             #[inline(always)]
@@ -378,8 +381,8 @@ pub trait FineKernel<S: Simd>: Send + Sync + 'static {
     fn blurred_rounded_rectangle_painter(
         simd: S,
         rect: &EncodedBlurredRoundedRectangle,
-        start_x: u16,
-        start_y: u16,
+        start_x: f64,
+        start_y: f64,
     ) -> impl Painter {
         simd.vectorize(
             #[inline(always)]
@@ -723,6 +726,10 @@ impl<S: Simd, T: FineKernel<S>> Fine<S, T> {
                 let start_x = self.wide_coords.0 * WideTile::WIDTH + x as u16;
                 let start_y = self.wide_coords.1 * Tile::HEIGHT;
 
+                // Make sure sampling happens at the center of the pixel.
+                let sampler_x = start_x as f64 + PIXEL_CENTER_OFFSET;
+                let sampler_y = start_y as f64 + PIXEL_CENTER_OFFSET;
+
                 // We need to have this as a macro because closures cannot take generic arguments, and
                 // we would have to repeatedly provide all arguments if we made it a function.
                 macro_rules! fill_complex_paint {
@@ -767,7 +774,9 @@ impl<S: Simd, T: FineKernel<S>> Fine<S, T> {
                     EncodedPaint::BlurredRoundedRect(b) => {
                         fill_complex_paint!(
                             true,
-                            T::blurred_rounded_rectangle_painter(self.simd, b, start_x, start_y)
+                            T::blurred_rounded_rectangle_painter(
+                                self.simd, b, sampler_x, sampler_y
+                            )
                         );
                     }
                     EncodedPaint::Gradient(g) => {
@@ -785,8 +794,8 @@ impl<S: Simd, T: FineKernel<S>> Fine<S, T> {
                                     SimdLinearKind::new(self.simd, *l),
                                     f32_buf,
                                     g,
-                                    start_x,
-                                    start_y,
+                                    sampler_x,
+                                    sampler_y,
                                 );
 
                                 fill_complex_paint!(
@@ -800,8 +809,8 @@ impl<S: Simd, T: FineKernel<S>> Fine<S, T> {
                                     SimdSweepKind::new(self.simd, s),
                                     f32_buf,
                                     g,
-                                    start_x,
-                                    start_y,
+                                    sampler_x,
+                                    sampler_y,
                                 );
 
                                 fill_complex_paint!(
@@ -815,8 +824,8 @@ impl<S: Simd, T: FineKernel<S>> Fine<S, T> {
                                     SimdRadialKind::new(self.simd, r),
                                     f32_buf,
                                     g,
-                                    start_x,
-                                    start_y,
+                                    sampler_x,
+                                    sampler_y,
                                 );
 
                                 if r.has_undefined() {
@@ -850,7 +859,7 @@ impl<S: Simd, T: FineKernel<S>> Fine<S, T> {
                                     fill_complex_paint!(
                                         i.may_have_opacities,
                                         T::plain_medium_quality_image_painter(
-                                            self.simd, i, &pixmap, start_x, start_y
+                                            self.simd, i, &pixmap, sampler_x, sampler_y
                                         ),
                                         tint
                                     );
@@ -858,7 +867,7 @@ impl<S: Simd, T: FineKernel<S>> Fine<S, T> {
                                     fill_complex_paint!(
                                         i.may_have_opacities,
                                         T::high_quality_image_painter(
-                                            self.simd, i, &pixmap, start_x, start_y
+                                            self.simd, i, &pixmap, sampler_x, sampler_y
                                         ),
                                         tint
                                     );
@@ -870,7 +879,7 @@ impl<S: Simd, T: FineKernel<S>> Fine<S, T> {
                                     fill_complex_paint!(
                                         i.may_have_opacities,
                                         T::medium_quality_image_painter(
-                                            self.simd, i, &pixmap, start_x, start_y
+                                            self.simd, i, &pixmap, sampler_x, sampler_y
                                         ),
                                         tint
                                     );
@@ -878,7 +887,7 @@ impl<S: Simd, T: FineKernel<S>> Fine<S, T> {
                                     fill_complex_paint!(
                                         i.may_have_opacities,
                                         T::high_quality_image_painter(
-                                            self.simd, i, &pixmap, start_x, start_y
+                                            self.simd, i, &pixmap, sampler_x, sampler_y
                                         ),
                                         tint
                                     );
@@ -888,7 +897,7 @@ impl<S: Simd, T: FineKernel<S>> Fine<S, T> {
                                 fill_complex_paint!(
                                     i.may_have_opacities,
                                     T::plain_nn_image_painter(
-                                        self.simd, i, &pixmap, start_x, start_y
+                                        self.simd, i, &pixmap, sampler_x, sampler_y
                                     ),
                                     tint
                                 );
@@ -896,7 +905,9 @@ impl<S: Simd, T: FineKernel<S>> Fine<S, T> {
                             (true, true) => {
                                 fill_complex_paint!(
                                     i.may_have_opacities,
-                                    T::nn_image_painter(self.simd, i, &pixmap, start_x, start_y),
+                                    T::nn_image_painter(
+                                        self.simd, i, &pixmap, sampler_x, sampler_y
+                                    ),
                                     tint
                                 );
                             }

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -16,7 +16,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 use hashbrown::HashMap;
 use vello_common::blurred_rounded_rect::BlurredRoundedRectangle;
-use vello_common::encode::{EncodeExt, EncodedPaint, PixelSampling};
+use vello_common::encode::{EncodeExt, EncodedPaint};
 use vello_common::fearless_simd::Level;
 use vello_common::filter_effects::Filter;
 use vello_common::kurbo::{Affine, BezPath, Rect, Stroke};
@@ -163,14 +163,12 @@ impl RenderContext {
                     &mut self.encoded_paints,
                     self.state.transform * self.state.paint_transform,
                     None,
-                    PixelSampling::Corner,
                 )
             }
             PaintType::Image(i) => i.encode_into(
                 &mut self.encoded_paints,
                 self.state.transform * self.state.paint_transform,
                 self.state.tint,
-                PixelSampling::Corner,
             ),
         }
     }
@@ -310,12 +308,7 @@ impl RenderContext {
 
         self.rect_to_temp_path(&inflated_rect);
 
-        let paint = blurred_rect.encode_into(
-            &mut self.encoded_paints,
-            transform,
-            None,
-            PixelSampling::Corner,
-        );
+        let paint = blurred_rect.encode_into(&mut self.encoded_paints, transform, None);
         self.dispatcher.fill_path(
             &self.temp_path,
             Fill::NonZero,

--- a/sparse_strips/vello_hybrid/src/gradient_cache.rs
+++ b/sparse_strips/vello_hybrid/src/gradient_cache.rs
@@ -290,7 +290,7 @@ mod tests {
     use super::*;
     use alloc::vec;
     use vello_common::color::{ColorSpaceTag, DynamicColor, HueDirection};
-    use vello_common::encode::{EncodeExt, EncodedPaint, PixelSampling};
+    use vello_common::encode::{EncodeExt, EncodedPaint};
     use vello_common::kurbo::{Affine, Point};
     use vello_common::peniko::{Color, ColorStop, ColorStops, Gradient, LinearGradientPosition};
 
@@ -310,12 +310,7 @@ mod tests {
 
     fn create_encoded_gradient(gradient: Gradient) -> EncodedGradient {
         let mut encoded_paints = vec![];
-        gradient.encode_into(
-            &mut encoded_paints,
-            Affine::IDENTITY,
-            None,
-            PixelSampling::Center,
-        );
+        gradient.encode_into(&mut encoded_paints, Affine::IDENTITY, None);
         match encoded_paints.into_iter().last().unwrap() {
             EncodedPaint::Gradient(encoded_gradient) => encoded_gradient,
             _ => panic!("Expected a gradient paint"),

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -9,7 +9,7 @@ use core::cell::RefCell;
 use core::ops::Range;
 use vello_common::clip::ClipContext;
 use vello_common::coarse::{MODE_HYBRID, Wide, WideTilesBbox};
-use vello_common::encode::{EncodeExt, EncodedPaint, PixelSampling};
+use vello_common::encode::{EncodeExt, EncodedPaint};
 use vello_common::fearless_simd::Level;
 use vello_common::filter_effects::Filter;
 #[cfg(feature = "text")]
@@ -330,19 +330,21 @@ impl Scene {
     /// a `Paint` that references that data. The combined transform (geometry + paint)
     /// is applied during encoding.
     fn encode_current_paint(&mut self) -> Paint {
+        // Note: In vello_cpu, during fine rasterization we apply a 0.5 offset to the location
+        // to account for the fact that we want to sample the pixel center instead of the top-left
+        // corner. For vello_hybrid, we don't need this, because the GPU itself already applies
+        // this shift automatically.
         match self.render_state.paint.clone() {
             PaintType::Solid(s) => s.into(),
             PaintType::Gradient(g) => g.encode_into(
                 &mut self.encoded_paints.borrow_mut(),
                 self.render_state.transform * self.render_state.paint_transform,
                 None,
-                PixelSampling::Center,
             ),
             PaintType::Image(i) => i.encode_into(
                 &mut self.encoded_paints.borrow_mut(),
                 self.render_state.transform * self.render_state.paint_transform,
                 self.render_state.tint,
-                PixelSampling::Center,
             ),
         }
     }


### PR DESCRIPTION
This resolves a TODO, such that we don't need "do and then undo" the  center shift transform in vello_hybrid. It's not entirely clear to me why it doesn't work for blurred rounded rectangles, but unfortunately I don't really understand the algorithm in the first place, so I can't explore this further in the short term.