### PR TITLE
Update `png` to 0.18.1 and `oxipng` to 10.1.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,7 +1401,7 @@ dependencies = [
  "clap",
  "env_logger",
  "futures-intrusive",
- "png 0.17.16",
+ "png",
  "pollster",
  "scenes",
  "vello",
@@ -1570,7 +1570,7 @@ dependencies = [
  "byteorder-lite",
  "moxcms",
  "num-traits",
- "png 0.18.1",
+ "png",
  "zune-core",
  "zune-jpeg",
 ]
@@ -1749,7 +1749,7 @@ source = "git+https://github.com/linebender/kompari.git?rev=4b851413e1b17307064a
 dependencies = [
  "image",
  "log",
- "oxipng",
+ "oxipng 9.1.5",
  "rayon",
  "thiserror 2.0.18",
  "walkdir",
@@ -2606,6 +2606,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxipng"
+version = "10.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efc4ea5566cd49b80c4b5e8eac2167d137d2ca3007ec8976d4cd9fe8b654ba2b"
+dependencies = [
+ "bitvec",
+ "crossbeam-channel",
+ "indexmap",
+ "libdeflater",
+ "log",
+ "rayon",
+ "rgb",
+ "rustc-hash 2.1.1",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2727,19 +2743,6 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
-name = "png"
-version = "0.17.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
-dependencies = [
- "bitflags 1.3.2",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
-]
 
 [[package]]
 name = "png"
@@ -3946,7 +3949,7 @@ dependencies = [
  "futures-intrusive",
  "log",
  "peniko 0.6.0",
- "png 0.17.16",
+ "png",
  "skrifa 0.40.0",
  "static_assertions",
  "thiserror 2.0.18",
@@ -3962,7 +3965,7 @@ version = "0.7.0"
 dependencies = [
  "bytemuck",
  "peniko 0.6.0",
- "png 0.17.16",
+ "png",
 ]
 
 [[package]]
@@ -3990,7 +3993,7 @@ dependencies = [
  "libm",
  "log",
  "peniko 0.6.0",
- "png 0.17.16",
+ "png",
  "roxmltree",
  "skrifa 0.40.0",
  "smallvec",
@@ -4070,7 +4073,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "js-sys",
  "log",
- "png 0.17.16",
+ "png",
  "pollster",
  "roxmltree",
  "thiserror 2.0.18",
@@ -4118,7 +4121,7 @@ dependencies = [
  "bytemuck",
  "fearless_simd",
  "image",
- "oxipng",
+ "oxipng 10.1.0",
  "pollster",
  "serde",
  "serde_json",
@@ -4145,8 +4148,8 @@ dependencies = [
  "futures-intrusive",
  "image",
  "nv-flip",
- "oxipng",
- "png 0.17.16",
+ "oxipng 10.1.0",
+ "png",
  "pollster",
  "scenes",
  "vello",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,8 +110,8 @@ hashbrown = { version = "0.16.1", default-features = false, features = ["default
 smallvec = "1.15.1"
 static_assertions = "1.1.0"
 thiserror = { version = "2.0.18", default-features = false }
-oxipng = { version = "9.1.5", default-features = false }
-png = "0.17.16"
+oxipng = { version = "10.1.0", default-features = false }
+png = "0.18.1"
 rayon = { version = "1.11.0" }
 thread_local = "1.1.9"
 crossbeam-channel = "0.5.15"

--- a/sparse_strips/vello_bench/src/fine/image.rs
+++ b/sparse_strips/vello_bench/src/fine/image.rs
@@ -3,6 +3,7 @@
 
 use crate::fine::{default_blend, fill_single};
 use criterion::{Bencher, Criterion};
+use std::io::Cursor;
 use std::sync::Arc;
 use vello_common::coarse::WideTile;
 use vello_common::encode::EncodeExt;
@@ -147,7 +148,7 @@ mod transform {
 fn get_colr_image(extend: peniko::Extend, quality: ImageQuality) -> Image {
     let data = include_bytes!("../../../../vello_tests/snapshots/big_colr.png");
 
-    let pixmap = Pixmap::from_png(&data[..]).unwrap();
+    let pixmap = Pixmap::from_png(Cursor::new(data)).unwrap();
     Image {
         image: ImageSource::Pixmap(Arc::new(pixmap)),
         sampler: ImageSampler {
@@ -162,7 +163,7 @@ fn get_colr_image(extend: peniko::Extend, quality: ImageQuality) -> Image {
 fn get_small_image(extend: peniko::Extend, quality: ImageQuality) -> Image {
     let data = include_bytes!("../../../vello_sparse_tests/tests/assets/rgb_image_2x2.png");
 
-    let pixmap = Pixmap::from_png(&data[..]).unwrap();
+    let pixmap = Pixmap::from_png(Cursor::new(data)).unwrap();
     Image {
         image: ImageSource::Pixmap(Arc::new(pixmap)),
         sampler: ImageSampler {

--- a/sparse_strips/vello_common/src/glyph.rs
+++ b/sparse_strips/vello_common/src/glyph.rs
@@ -3,13 +3,15 @@
 
 //! Processing and drawing glyphs.
 
-use crate::kurbo::{Affine, BezPath, Vec2};
-use crate::peniko::FontData;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::fmt::{Debug, Formatter};
+#[cfg(feature = "png")]
+use std::io::Cursor;
+
 use hashbrown::hash_map::{Entry, RawEntryMut};
 use hashbrown::{Equivalent, HashMap};
+use skrifa::bitmap::{BitmapData, BitmapFormat, BitmapStrikes, Origin};
 use skrifa::instance::{LocationRef, Size};
 use skrifa::outline::{DrawSettings, OutlineGlyphFormat};
 use skrifa::raw::TableProvider;
@@ -21,12 +23,12 @@ use skrifa::{
 
 use crate::colr::convert_bounding_box;
 use crate::encode::x_y_advances;
-use crate::kurbo::Rect;
+use crate::kurbo::{Affine, BezPath, Rect, Vec2};
+use crate::peniko::FontData;
 use crate::pixmap::Pixmap;
-use skrifa::bitmap::{BitmapData, BitmapFormat, BitmapStrikes, Origin};
 
 #[cfg(not(feature = "std"))]
-use peniko::kurbo::common::FloatFuncs as _;
+use crate::peniko::kurbo::common::FloatFuncs as _;
 
 /// Positioned glyph.
 #[derive(Copy, Clone, Default, Debug)]
@@ -218,7 +220,9 @@ impl<'a, T: GlyphRenderer + 'a> GlyphRunBuilder<'a, T> {
                 .glyph_for_size(Size::new(self.run.font_size), GlyphId::new(glyph.id))
                 .and_then(|g| match g.data {
                     #[cfg(feature = "png")]
-                    BitmapData::Png(data) => Pixmap::from_png(data).ok().map(|d| (g, d)),
+                    BitmapData::Png(data) => {
+                        Pixmap::from_png(Cursor::new(data)).ok().map(|d| (g, d))
+                    }
                     #[cfg(not(feature = "png"))]
                     BitmapData::Png(_) => None,
                     // The others are not worth implementing for now (unless we can find a test case),

--- a/sparse_strips/vello_common/src/pixmap.rs
+++ b/sparse_strips/vello_common/src/pixmap.rs
@@ -5,9 +5,10 @@
 
 use alloc::vec;
 use alloc::vec::Vec;
-use peniko::color::Rgba8;
+#[cfg(feature = "png")]
+use std::io::{BufRead, Seek};
 
-use crate::peniko::color::PremulRgba8;
+use crate::peniko::color::{PremulRgba8, Rgba8};
 
 #[cfg(feature = "png")]
 extern crate std;
@@ -185,7 +186,7 @@ impl Pixmap {
 
     /// Create a pixmap from a PNG file.
     #[cfg(feature = "png")]
-    pub fn from_png(data: impl std::io::Read) -> Result<Self, png::DecodingError> {
+    pub fn from_png(data: impl BufRead + Seek) -> Result<Self, png::DecodingError> {
         let mut decoder = png::Decoder::new(data);
         decoder.set_transformations(
             png::Transformations::normalize_to_color8() | png::Transformations::ALPHA,
@@ -223,7 +224,7 @@ impl Pixmap {
             }
             png::ColorType::Rgba => {
                 debug_assert_eq!(
-                    pixmap.data_as_u8_slice().len(),
+                    Some(pixmap.data_as_u8_slice().len()),
                     reader.output_buffer_size(),
                     "The pixmap buffer should have the same number of bytes as the image."
                 );
@@ -231,11 +232,11 @@ impl Pixmap {
             }
             png::ColorType::GrayscaleAlpha => {
                 debug_assert_eq!(
-                    pixmap.data().len() * 2,
+                    Some(pixmap.data().len() * 2),
                     reader.output_buffer_size(),
                     "The pixmap buffer should have twice the number of bytes of the grayscale image."
                 );
-                let mut grayscale_data = vec![0; reader.output_buffer_size()];
+                let mut grayscale_data = vec![0; reader.output_buffer_size().unwrap_or_default()];
                 reader.next_frame(&mut grayscale_data)?;
 
                 for (grayscale_pixel, pixmap_pixel) in

--- a/sparse_strips/vello_cpu/examples/paints.rs
+++ b/sparse_strips/vello_cpu/examples/paints.rs
@@ -3,8 +3,8 @@
 
 //! Using gradients and patterns paints using Vello CPU.
 
-use std::path::Path;
 use std::sync::Arc;
+use std::{io::Cursor, path::Path};
 use vello_cpu::{
     Image, ImageSource, Pixmap, RenderContext,
     color::palette::css::{BLUE, CYAN, DEEP_PINK, MAGENTA, NAVY, ORANGE, PURPLE, WHITE, YELLOW},
@@ -118,7 +118,7 @@ fn pattern() -> Image {
     let path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../vello_sparse_tests/tests/assets/rgb_image_2x2.png");
     let file = std::fs::read(path).unwrap();
-    let pixmap = Pixmap::from_png(file.as_slice()).unwrap();
+    let pixmap = Pixmap::from_png(Cursor::new(file)).unwrap();
 
     Image {
         // Note that only ImageSource::Pixmap is currently supported. Don't

--- a/sparse_strips/vello_example_scenes/src/image.rs
+++ b/sparse_strips/vello_example_scenes/src/image.rs
@@ -3,6 +3,7 @@
 
 //! Image rendering example scene.
 use std::f64::consts::PI;
+use std::io::Cursor;
 
 use vello_common::color::PremulRgba8;
 use vello_common::kurbo::{BezPath, Point, Shape, Vec2};
@@ -204,7 +205,7 @@ impl ImageScene {
     /// Read the cowboy image
     pub fn read_cowboy_image() -> Pixmap {
         let data = include_bytes!("../../vello_sparse_tests/tests/assets/cowboy.png");
-        Pixmap::from_png(&data[..]).unwrap()
+        Pixmap::from_png(Cursor::new(data)).unwrap()
     }
 }
 

--- a/sparse_strips/vello_sparse_tests/tests/util.rs
+++ b/sparse_strips/vello_sparse_tests/tests/util.rs
@@ -83,15 +83,18 @@ macro_rules! load_image {
         #[cfg(target_arch = "wasm32")]
         {
             let bytes = include_bytes!(concat!("../tests/assets/", $name, ".png"));
-            std::sync::Arc::new(vello_common::pixmap::Pixmap::from_png(&bytes[..]).unwrap())
+            std::sync::Arc::new(
+                vello_common::pixmap::Pixmap::from_png(std::io::Cursor::new(bytes)).unwrap(),
+            )
         }
 
         #[cfg(not(target_arch = "wasm32"))]
         {
             let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
                 .join(format!("tests/assets/{}.png", $name));
+            let bytes = std::fs::read(path).unwrap();
             std::sync::Arc::new(
-                vello_common::pixmap::Pixmap::from_png(std::fs::File::open(path).unwrap()).unwrap(),
+                vello_common::pixmap::Pixmap::from_png(std::io::Cursor::new(bytes)).unwrap(),
             )
         }
     }};

--- a/vello/src/scene.rs
+++ b/vello/src/scene.rs
@@ -1,6 +1,7 @@
 // Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use std::io::Cursor;
 use std::sync::Arc;
 
 use peniko::{
@@ -719,7 +720,7 @@ impl<'a> DrawGlyphs<'a> {
                             }
                         }
                         bitmap::BitmapData::Png(data) => {
-                            let mut decoder = png::Decoder::new(data);
+                            let mut decoder = png::Decoder::new(Cursor::new(data));
                             decoder.set_transformations(
                                 Transformations::ALPHA | Transformations::STRIP_16,
                             );
@@ -732,7 +733,8 @@ impl<'a> DrawGlyphs<'a> {
                                 log::error!("Unsupported `output_color_type`");
                                 continue;
                             }
-                            let mut buf = vec![0; reader.output_buffer_size()].into_boxed_slice();
+                            let mut buf = vec![0; reader.output_buffer_size().unwrap_or_default()]
+                                .into_boxed_slice();
 
                             let info = reader.next_frame(&mut buf).unwrap();
                             if info.width != bitmap.width || info.height != bitmap.height {


### PR DESCRIPTION
These both had breaking changes but luckily only minimal impact to Vello code.

Both updates bring performance and correctness improvements.
* [`png` changelog](https://github.com/image-rs/image-png/blob/master/CHANGES.md)
* [`oxipng` changelog](https://github.com/oxipng/oxipng/blob/master/CHANGELOG.md)