### PR TITLE
Increase hybrid tolerance for nested layer filter tests.

### DIFF
--- a/sparse_strips/vello_sparse_tests/tests/filter.rs
+++ b/sparse_strips/vello_sparse_tests/tests/filter.rs
@@ -1190,7 +1190,7 @@ fn filter_with_nested_opacity(ctx: &mut impl Renderer) {
     ctx.pop_layer();
 }
 
-#[vello_test(skip_multithreaded)]
+#[vello_test(skip_multithreaded, hybrid_tolerance = 1)]
 fn filter_in_nested_layer(ctx: &mut impl Renderer) {
     let filter = Filter::from_primitive(FilterPrimitive::GaussianBlur {
         std_deviation: 2.0,
@@ -1207,7 +1207,7 @@ fn filter_in_nested_layer(ctx: &mut impl Renderer) {
     ctx.pop_layer();
 }
 
-#[vello_test(skip_multithreaded)]
+#[vello_test(skip_multithreaded, hybrid_tolerance = 1)]
 fn filter_in_double_nested_layer(ctx: &mut impl Renderer) {
     let filter = Filter::from_primitive(FilterPrimitive::GaussianBlur {
         std_deviation: 2.0,


### PR DESCRIPTION
On my Windows 11 25H2 26200.8037 setup with Nvidia RTX 4090 @ 595.79 there are four new tests that fail with four pixels being slightly different.

```
FAIL [   3.228s] vello_sparse_tests::tests filter::filter_in_double_nested_layer_hybrid
FAIL [   3.401s] vello_sparse_tests::tests filter::filter_in_double_nested_layer_hybrid_constrained
FAIL [   3.534s] vello_sparse_tests::tests filter::filter_in_nested_layer_hybrid
FAIL [   3.537s] vello_sparse_tests::tests filter::filter_in_nested_layer_hybrid_constrained
```

This PR increases the tolerance to make these tests pass on my setup as well.