### PR TITLE
Prepare to release Vello 0.8.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,14 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 # Changelog
 
-The latest published Vello release is [0.7.0](#070---2026-01-13) which was released on 2026-01-13.
-You can find its changes [documented below](#070---2026-01-13).
+The latest published Vello release is [0.8.0](#080---2026-03-20) which was released on 2026-03-20.
+You can find its changes [documented below](#080---2026-03-20).
 
 ## [Unreleased]
+
+This release has an [MSRV][] of 1.92.
+
+## [0.8.0][] - 2026-03-20
 
 This release has an [MSRV][] of 1.92.
 
@@ -402,7 +406,8 @@ This release has an [MSRV][] of 1.75.
 [#1349]: https://github.com/linebender/vello/pull/1349
 [#1492]: https://github.com/linebender/vello/pull/1492
 
-[Unreleased]: https://github.com/linebender/vello/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/linebender/vello/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/linebender/vello/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/linebender/vello/compare/v0.6.0...v0.7.0
 <!-- Note that this still comparing against 0.5.0, because 0.5.1 is a cherry-picked patch -->
 [0.6.0]: https://github.com/linebender/vello/compare/v0.5.0...v0.6.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2093,7 +2093,7 @@ dependencies = [
 
 [[package]]
 name = "native_webgl"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "console_error_panic_hook",
  "console_log",
@@ -3940,7 +3940,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vello"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bytemuck",
  "futures-intrusive",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "vello_api"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bytemuck",
  "peniko 0.6.0",
@@ -4034,7 +4034,7 @@ dependencies = [
 
 [[package]]
 name = "vello_encoding"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bytemuck",
  "guillotiere",
@@ -4061,7 +4061,7 @@ dependencies = [
 
 [[package]]
 name = "vello_filters_cpu"
-version = "0.7.0"
+version = "0.8.0"
 
 [[package]]
 name = "vello_hybrid"
@@ -4096,7 +4096,7 @@ dependencies = [
 
 [[package]]
 name = "vello_shaders"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bytemuck",
  "log",
@@ -4354,7 +4354,7 @@ dependencies = [
 
 [[package]]
 name = "wasm_cpu"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bytemuck",
  "console_error_panic_hook",
@@ -4713,7 +4713,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu_webgl"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ members = [
 # NOTE: When bumping this, remember to also bump the aforementioned other packages'
 #       version in the dependencies section at the bottom of this file.
 #       Additionally, bump the Vello dependency version in the 'simple' example.
-version = "0.7.0"
+version = "0.8.0"
 
 edition = "2024"
 # Keep in sync with RUST_MIN_VER in .github/workflows/ci.yml, with the relevant README.md files
@@ -95,9 +95,9 @@ clippy.wildcard_dependencies = "warn"
 # END LINEBENDER LINT SET
 
 [workspace.dependencies]
-vello = { version = "0.7.0", path = "vello" }
-vello_encoding = { version = "0.7.0", path = "vello_encoding" }
-vello_shaders = { version = "0.7.0", path = "vello_shaders" }
+vello = { version = "0.8.0", path = "vello" }
+vello_encoding = { version = "0.8.0", path = "vello_encoding" }
+vello_shaders = { version = "0.8.0", path = "vello_shaders" }
 bytemuck = { version = "1.25.0", features = ["derive"] }
 skrifa = { version = "0.40.0", default-features = false, features = ["autohint_shaping"] }
 # The version of kurbo used below should be kept in sync

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 # When using this example outside of the original Vello workspace,
 # remove the path property of the following Vello dependency requirement.
-vello = { version = "0.7.0", path = "../../vello" }
+vello = { version = "0.8.0", path = "../../vello" }
 anyhow = "1.0.102"
 pollster = "0.4.0"
 winit = "0.30.13"

--- a/examples/simple_sdl2/Cargo.toml
+++ b/examples/simple_sdl2/Cargo.toml
@@ -12,6 +12,6 @@ workspace = true
 [dependencies]
 # When using this example outside of the original Vello workspace,
 # remove the path property of the following Vello dependency requirement.
-vello = { version = "0.7.0", path = "../../vello" }
+vello = { version = "0.8.0", path = "../../vello" }
 pollster = "0.4.0"
 sdl2 = { version = "0.37.0", features = ["raw-window-handle", "bundled"] }


### PR DESCRIPTION
With wgpu 29 now out already, it's time to get a Vello release out with wgpu 28 before updating wgpu.