### PR TITLE
Update skrifa to 0.41 (and add support for Varc glyphs)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1087,9 +1087,9 @@ dependencies = [
 
 [[package]]
 name = "font-types"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4d2d0cf79d38430cc9dc9aadec84774bff2e1ba30ae2bf6c16cfce9385a23"
+checksum = "73829a7b5c91198af28a99159b7ae4afbb252fb906159ff7f189f3a2ceaa3df2"
 dependencies = [
  "bytemuck",
 ]
@@ -2976,13 +2976,13 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
+checksum = "70eac20eeee8bd51247a0c2f349f657563fffd19d041cd12988cc2801ec2ebef"
 dependencies = [
  "bytemuck",
  "core_maths",
- "font-types 0.11.0",
+ "font-types 0.11.1",
 ]
 
 [[package]]
@@ -3163,7 +3163,7 @@ dependencies = [
  "image",
  "rand",
  "roxmltree",
- "skrifa 0.40.0",
+ "skrifa 0.41.0",
  "vello",
  "web-time",
 ]
@@ -3369,13 +3369,13 @@ dependencies = [
 
 [[package]]
 name = "skrifa"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
+checksum = "77c3bef975c2f5f07c0a780f95e1f5002deafb716f8e0484816cc08b1a823d2f"
 dependencies = [
  "bytemuck",
  "core_maths",
- "read-fonts 0.37.0",
+ "read-fonts 0.38.0",
 ]
 
 [[package]]
@@ -3950,7 +3950,7 @@ dependencies = [
  "log",
  "peniko 0.6.0",
  "png",
- "skrifa 0.40.0",
+ "skrifa 0.41.0",
  "static_assertions",
  "thiserror 2.0.18",
  "vello_encoding",
@@ -3996,7 +3996,7 @@ dependencies = [
  "peniko 0.6.0",
  "png",
  "roxmltree",
- "skrifa 0.40.0",
+ "skrifa 0.41.0",
  "smallvec",
  "thiserror 2.0.18",
 ]
@@ -4042,7 +4042,7 @@ dependencies = [
  "bytemuck",
  "guillotiere",
  "peniko 0.6.0",
- "skrifa 0.40.0",
+ "skrifa 0.41.0",
  "smallvec",
 ]
 
@@ -4126,7 +4126,7 @@ dependencies = [
  "pollster",
  "serde",
  "serde_json",
- "skrifa 0.40.0",
+ "skrifa 0.41.0",
  "smallvec",
  "vello_api",
  "vello_common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ vello = { version = "0.8.0", path = "vello" }
 vello_encoding = { version = "0.8.0", path = "vello_encoding" }
 vello_shaders = { version = "0.8.0", path = "vello_shaders" }
 bytemuck = { version = "1.25.0", features = ["derive"] }
-skrifa = { version = "0.40.0", default-features = false, features = ["autohint_shaping"] }
+skrifa = { version = "0.41.0", default-features = false, features = ["autohint_shaping"] }
 # The version of kurbo used below should be kept in sync
 # with the version of kurbo used by peniko.
 peniko = { version = "0.6.0", default-features = false }

--- a/sparse_strips/vello_common/src/glyph.rs
+++ b/sparse_strips/vello_common/src/glyph.rs
@@ -926,6 +926,7 @@ struct HintCache {
     // internal memory when reconfigured for the same format.
     glyf_entries: Vec<HintEntry>,
     cff_entries: Vec<HintEntry>,
+    varc_entries: Vec<HintEntry>,
     serial: u64,
 }
 
@@ -934,6 +935,7 @@ impl Debug for HintCache {
         f.debug_struct("HintCache")
             .field("glyf_entries", &self.glyf_entries.len())
             .field("cff_entries", &self.cff_entries.len())
+            .field("varc_entries", &self.varc_entries.len())
             .field("serial", &self.serial)
             .finish()
     }
@@ -944,6 +946,7 @@ impl HintCache {
         let entries = match key.outlines.format()? {
             OutlineGlyphFormat::Glyf => &mut self.glyf_entries,
             OutlineGlyphFormat::Cff | OutlineGlyphFormat::Cff2 => &mut self.cff_entries,
+            OutlineGlyphFormat::Varc => &mut self.varc_entries,
         };
         let (entry_ix, is_current) = find_hint_entry(entries, key)?;
         let entry = entries.get_mut(entry_ix)?;
@@ -963,6 +966,7 @@ impl HintCache {
     fn clear(&mut self) {
         self.glyf_entries.clear();
         self.cff_entries.clear();
+        self.varc_entries.clear();
         self.serial = 0;
     }
 }

--- a/vello_encoding/src/glyph_cache.rs
+++ b/vello_encoding/src/glyph_cache.rs
@@ -270,6 +270,7 @@ struct HintCache {
     // internal memory when reconfigured for the same format.
     glyf_entries: Vec<HintEntry>,
     cff_entries: Vec<HintEntry>,
+    varc_entries: Vec<HintEntry>,
     serial: u64,
 }
 
@@ -278,6 +279,7 @@ impl HintCache {
         let entries = match key.outlines.format()? {
             OutlineGlyphFormat::Glyf => &mut self.glyf_entries,
             OutlineGlyphFormat::Cff | OutlineGlyphFormat::Cff2 => &mut self.cff_entries,
+            OutlineGlyphFormat::Varc => &mut self.varc_entries,
         };
         let (entry_ix, is_current) = find_hint_entry(entries, key)?;
         let entry = entries.get_mut(entry_ix)?;


### PR DESCRIPTION
Main point was to update skrifa, but it turns out that Varc glyphs are now supported.

Made an attempt, assuming that it works similar to the rest, but not sure how to test it (nor if it actually works).