### PR TITLE
vello_hybrid: Only encode paint in fast rectangle path if we are really taking it

### DIFF
--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -508,7 +508,6 @@ impl Scene {
             return false;
         }
 
-        let paint = self.encode_current_paint();
         let transformed_rect = self.render_state.transform.transform_rect_bbox(*rect);
 
         let x0 = transformed_rect.x0.max(0.0).min(f64::from(self.width));
@@ -520,6 +519,8 @@ impl Scene {
         if x1 <= x0 || y1 <= y0 {
             return false;
         }
+
+        let paint = self.encode_current_paint();
 
         self.fast_strips_buffer
             .commands


### PR DESCRIPTION
Move it after the very last if condition where it cannot happen anymore that we reject it. Otherwise, if it fails afterwards we end up encoding the same paint twice: Once in the (failed) fast rect path, and a second time when painting it as a normal path.