### PR TITLE
vello_cpu: Don't use rectangle fast path if anti-aliasing is disabled

### DIFF
--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -212,8 +212,10 @@ impl RenderContext {
         self.with_optional_filter(|ctx| {
             let paint = ctx.encode_current_paint();
 
-            // Fast path: Use optimized rect filling if we have no skew in the path transform.
-            if is_axis_aligned(&ctx.state.transform) {
+            // Fast path: Use optimized rect filling if we have no skew in the path transform
+            // and anti-aliasing is enabled.
+            // TODO: Maybe also support no anti-aliasing in the fast path
+            if is_axis_aligned(&ctx.state.transform) && ctx.aliasing_threshold.is_none() {
                 // Transform the rect to screen coordinates.
                 let transformed_rect = ctx.state.transform.transform_rect_bbox(*rect);
                 ctx.dispatcher.fill_rect_fast(


### PR DESCRIPTION
Sorry, I only noticed this now after trying the release branch with my PDF library. Would be great to fix before I make the release, since it represents a regression. 😦 