### PR TITLE
vello_example_scenes: Don't try to convert to usize from u64

### DIFF
--- a/sparse_strips/vello_example_scenes/src/filter_elements.rs
+++ b/sparse_strips/vello_example_scenes/src/filter_elements.rs
@@ -264,7 +264,7 @@ impl Rng {
     }
 
     fn range_f64(&mut self, lo: f64, hi: f64) -> f64 {
-        let t = (self.next_u32() >> 8) as f64 / ((1u32 << 24) as f64);
+        let t = (self.next_u32() >> 8) as f64 / ((1_u32 << 24) as f64);
         lo + t * (hi - lo)
     }
 }


### PR DESCRIPTION
This would cause a panic on WASM since a usize can only fit a u32 there.