### PR TITLE
[INVESTIGATION]: Front to back rendering of opaque strips

### DIFF
--- a/sparse_strips/vello_hybrid/Cargo.toml
+++ b/sparse_strips/vello_hybrid/Cargo.toml
@@ -36,6 +36,7 @@ web-sys = { version = "0.3.91", features = [
     "WebGlShader",
     "WebGlTexture",
     "WebGlFramebuffer",
+    "WebGlRenderbuffer",
     "WebGlVertexArrayObject",
 ], optional = true }
 

--- a/sparse_strips/vello_hybrid/src/render/common.rs
+++ b/sparse_strips/vello_hybrid/src/render/common.rs
@@ -93,6 +93,9 @@ pub struct GpuStrip {
     pub payload: u32,
     /// See `StripInstance::paint_and_rect_flag` documentation in `render_strips.wgsl`.
     pub paint_and_rect_flag: u32,
+    /// Painter's-order index used to compute z-depth for early-z rejection on TBDR GPUs.
+    /// Monotonically increasing in back-to-front order within a frame.
+    pub layer_index: u32,
 }
 
 /// Different types of GPU encoded paints.

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -306,6 +306,7 @@ impl WebGlRenderer {
         if clear {
             self.programs.clear_view_framebuffer(&self.gl);
         }
+        self.programs.resources.depth_cleared_this_frame = false;
         let mut ctx = WebGlRendererContext {
             programs: &mut self.programs,
             gl: &self.gl,
@@ -700,6 +701,8 @@ struct WebGlResources {
     clear_config_buffer: WebGlBuffer,
 
     view_framebuffer_override: Option<WebGlFramebuffer>,
+    /// Whether the depth buffer has been cleared this frame.
+    depth_cleared_this_frame: bool,
 
     /// Slot textures.
     slot_textures: [WebGlTexture; 2],
@@ -1833,6 +1836,7 @@ fn create_webgl_resources(
         slot_textures,
         slot_framebuffers,
         view_framebuffer_override: None,
+        depth_cleared_this_frame: false,
         max_texture_dimension_2d,
         stub_atlas_texture_array,
         atlas_render_framebuffer: None,
@@ -1924,11 +1928,11 @@ fn initialize_strip_vao(gl: &WebGl2RenderingContext, resources: &WebGlResources)
     );
 
     const STRIDE: i32 = size_of::<GpuStrip>() as i32;
-    const { assert!(STRIDE == 20, "expected stride of 20") };
+    const { assert!(STRIDE == 24, "expected stride of 24") };
     let stride = STRIDE;
 
     // Configure attributes.
-    for i in 0..5 {
+    for i in 0..6 {
         let location = i as u32;
         let offset = i * 4;
 
@@ -1986,14 +1990,14 @@ impl WebGlRendererContext<'_> {
     /// Render strips to the specified render target.
     fn do_strip_render_pass(
         &mut self,
-        strips: &[GpuStrip],
+        opaque_strips: &[GpuStrip],
+        alpha_strips: &[GpuStrip],
         target: StripPassRenderTarget,
         load: LoadOp,
     ) {
-        if strips.is_empty() {
+        if opaque_strips.is_empty() && alpha_strips.is_empty() {
             return;
         }
-        self.programs.upload_strips(self.gl, strips);
 
         match &target {
             StripPassRenderTarget::Output(OutputTarget::IntermediateTexture(layer_id)) => {
@@ -2173,13 +2177,67 @@ impl WebGlRendererContext<'_> {
         self.gl
             .uniform1i(Some(&self.programs.strip_uniforms.gradient_texture), 4);
 
-        // Draw.
-        self.gl.draw_arrays_instanced(
-            WebGl2RenderingContext::TRIANGLE_STRIP,
-            0,
-            4,
-            strips.len() as i32,
-        );
+        let is_final_view =
+            matches!(target, StripPassRenderTarget::Output(OutputTarget::FinalView));
+
+        if is_final_view {
+            // Clear depth buffer on first use per frame.
+            if !self.programs.resources.depth_cleared_this_frame {
+                self.programs.resources.depth_cleared_this_frame = true;
+                self.gl.clear_depth(1.0);
+                self.gl
+                    .clear(WebGl2RenderingContext::DEPTH_BUFFER_BIT);
+            }
+
+            self.gl.enable(WebGl2RenderingContext::DEPTH_TEST);
+            self.gl.depth_func(WebGl2RenderingContext::LEQUAL);
+
+            // Opaque pass: front-to-back, depth write ON, blend OFF.
+            if !opaque_strips.is_empty() {
+                self.programs.upload_strips(self.gl, opaque_strips);
+                self.gl.depth_mask(true);
+                self.gl.disable(WebGl2RenderingContext::BLEND);
+                self.gl.draw_arrays_instanced(
+                    WebGl2RenderingContext::TRIANGLE_STRIP,
+                    0,
+                    4,
+                    opaque_strips.len() as i32,
+                );
+            }
+
+            // Alpha pass: back-to-front, depth test ON, depth write OFF, blend ON.
+            if !alpha_strips.is_empty() {
+                self.programs.upload_strips(self.gl, alpha_strips);
+                self.gl.depth_mask(false);
+                self.gl.enable(WebGl2RenderingContext::BLEND);
+                self.gl.draw_arrays_instanced(
+                    WebGl2RenderingContext::TRIANGLE_STRIP,
+                    0,
+                    4,
+                    alpha_strips.len() as i32,
+                );
+            }
+
+            // Restore state.
+            self.gl.disable(WebGl2RenderingContext::DEPTH_TEST);
+            self.gl.depth_mask(true);
+            self.gl.enable(WebGl2RenderingContext::BLEND);
+        } else {
+            // Slot texture / intermediate: single draw with blending, no depth.
+            // Combine both lists for upload.
+            let all_strips: Vec<GpuStrip> = opaque_strips
+                .iter()
+                .chain(alpha_strips.iter())
+                .copied()
+                .collect();
+            self.programs.upload_strips(self.gl, &all_strips);
+            self.gl.draw_arrays_instanced(
+                WebGl2RenderingContext::TRIANGLE_STRIP,
+                0,
+                4,
+                all_strips.len() as i32,
+            );
+        }
 
         // Clean up.
         self.gl.bind_vertex_array(None);
@@ -2257,11 +2315,12 @@ impl RendererBackend for WebGlRendererContext<'_> {
     /// Execute a render pass for strips.
     fn render_strips(
         &mut self,
-        strips: &[GpuStrip],
+        opaque_strips: &[GpuStrip],
+        alpha_strips: &[GpuStrip],
         target: StripPassRenderTarget,
         load_op: LoadOp,
     ) {
-        self.do_strip_render_pass(strips, target, load_op);
+        self.do_strip_render_pass(opaque_strips, alpha_strips, target, load_op);
     }
 
     fn apply_filter(&mut self, layer_id: LayerId) {

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -1285,9 +1285,15 @@ impl WebGlPrograms {
         gl.clear(WebGl2RenderingContext::COLOR_BUFFER_BIT);
     }
 
-    /// Upload strip data to GPU.
-    fn upload_strips(&mut self, gl: &WebGl2RenderingContext, strips: &[GpuStrip]) {
-        if strips.is_empty() {
+    /// Upload two strip slices (opaque then alpha) into a single GPU buffer,
+    /// avoiding multiple `bufferData` calls.
+    fn upload_strip_pair(
+        &mut self,
+        gl: &WebGl2RenderingContext,
+        first: &[GpuStrip],
+        second: &[GpuStrip],
+    ) {
+        if first.is_empty() && second.is_empty() {
             return;
         }
 
@@ -1295,12 +1301,32 @@ impl WebGlPrograms {
             WebGl2RenderingContext::ARRAY_BUFFER,
             Some(&self.resources.strips_buffer),
         );
-        let strips_data = bytemuck::cast_slice(strips);
-        gl.buffer_data_with_u8_array(
+
+        let first_bytes: &[u8] = bytemuck::cast_slice(first);
+        let second_bytes: &[u8] = bytemuck::cast_slice(second);
+        let total_len = first_bytes.len() + second_bytes.len();
+
+        // Allocate buffer, then write both slices via bufferSubData to avoid
+        // a temporary concatenation Vec.
+        gl.buffer_data_with_i32(
             WebGl2RenderingContext::ARRAY_BUFFER,
-            strips_data,
+            total_len as i32,
             WebGl2RenderingContext::DYNAMIC_DRAW,
         );
+        if !first_bytes.is_empty() {
+            gl.buffer_sub_data_with_i32_and_u8_array(
+                WebGl2RenderingContext::ARRAY_BUFFER,
+                0,
+                first_bytes,
+            );
+        }
+        if !second_bytes.is_empty() {
+            gl.buffer_sub_data_with_i32_and_u8_array(
+                WebGl2RenderingContext::ARRAY_BUFFER,
+                first_bytes.len() as i32,
+                second_bytes,
+            );
+        }
     }
 }
 
@@ -1919,6 +1945,11 @@ fn create_framebuffer_for_texture(
     framebuffer
 }
 
+const STRIP_STRIDE: i32 = size_of::<GpuStrip>() as i32;
+const STRIP_ATTR_COUNT: i32 = STRIP_STRIDE / 4;
+const _: () = assert!(STRIP_STRIDE == 24, "expected stride of 24");
+const _: () = assert!(STRIP_ATTR_COUNT == 6);
+
 /// Initialize strip VAO.
 fn initialize_strip_vao(gl: &WebGl2RenderingContext, resources: &WebGlResources) {
     gl.bind_vertex_array(Some(&resources.strip_vao));
@@ -1927,12 +1958,7 @@ fn initialize_strip_vao(gl: &WebGl2RenderingContext, resources: &WebGlResources)
         Some(&resources.strips_buffer),
     );
 
-    const STRIDE: i32 = size_of::<GpuStrip>() as i32;
-    const { assert!(STRIDE == 24, "expected stride of 24") };
-    let stride = STRIDE;
-
-    // Configure attributes.
-    for i in 0..6 {
+    for i in 0..STRIP_ATTR_COUNT {
         let location = i as u32;
         let offset = i * 4;
 
@@ -1941,7 +1967,7 @@ fn initialize_strip_vao(gl: &WebGl2RenderingContext, resources: &WebGlResources)
             location,
             1,
             WebGl2RenderingContext::UNSIGNED_INT,
-            stride,
+            STRIP_STRIDE,
             offset,
         );
 
@@ -2180,6 +2206,13 @@ impl WebGlRendererContext<'_> {
         let is_final_view =
             matches!(target, StripPassRenderTarget::Output(OutputTarget::FinalView));
 
+        // Single upload for all strip data (opaque then alpha) to avoid
+        // multiple bufferData calls which are more expensive than attribute rebinding.
+        self.programs
+            .upload_strip_pair(self.gl, opaque_strips, alpha_strips);
+        let opaque_count = opaque_strips.len() as i32;
+        let alpha_count = alpha_strips.len() as i32;
+
         if is_final_view {
             // Clear depth buffer on first use per frame.
             if !self.programs.resources.depth_cleared_this_frame {
@@ -2193,29 +2226,51 @@ impl WebGlRendererContext<'_> {
             self.gl.depth_func(WebGl2RenderingContext::LEQUAL);
 
             // Opaque pass: front-to-back, depth write ON, blend OFF.
-            if !opaque_strips.is_empty() {
-                self.programs.upload_strips(self.gl, opaque_strips);
+            // Instances 0..opaque_count are already at offset 0 in the buffer.
+            if opaque_count > 0 {
                 self.gl.depth_mask(true);
                 self.gl.disable(WebGl2RenderingContext::BLEND);
                 self.gl.draw_arrays_instanced(
                     WebGl2RenderingContext::TRIANGLE_STRIP,
                     0,
                     4,
-                    opaque_strips.len() as i32,
+                    opaque_count,
                 );
             }
 
             // Alpha pass: back-to-front, depth test ON, depth write OFF, blend ON.
-            if !alpha_strips.is_empty() {
-                self.programs.upload_strips(self.gl, alpha_strips);
+            // Rebind attribute pointers with offset to start at the alpha portion.
+            if alpha_count > 0 {
+                let alpha_byte_offset = opaque_count * STRIP_STRIDE;
+                for i in 0..STRIP_ATTR_COUNT {
+                    self.gl.vertex_attrib_i_pointer_with_i32(
+                        i as u32,
+                        1,
+                        WebGl2RenderingContext::UNSIGNED_INT,
+                        STRIP_STRIDE,
+                        i as i32 * 4 + alpha_byte_offset,
+                    );
+                }
+
                 self.gl.depth_mask(false);
                 self.gl.enable(WebGl2RenderingContext::BLEND);
                 self.gl.draw_arrays_instanced(
                     WebGl2RenderingContext::TRIANGLE_STRIP,
                     0,
                     4,
-                    alpha_strips.len() as i32,
+                    alpha_count,
                 );
+
+                // Restore attribute offsets to base for subsequent passes.
+                for i in 0..STRIP_ATTR_COUNT {
+                    self.gl.vertex_attrib_i_pointer_with_i32(
+                        i as u32,
+                        1,
+                        WebGl2RenderingContext::UNSIGNED_INT,
+                        STRIP_STRIDE,
+                        i as i32 * 4,
+                    );
+                }
             }
 
             // Restore state.
@@ -2224,18 +2279,11 @@ impl WebGlRendererContext<'_> {
             self.gl.enable(WebGl2RenderingContext::BLEND);
         } else {
             // Slot texture / intermediate: single draw with blending, no depth.
-            // Combine both lists for upload.
-            let all_strips: Vec<GpuStrip> = opaque_strips
-                .iter()
-                .chain(alpha_strips.iter())
-                .copied()
-                .collect();
-            self.programs.upload_strips(self.gl, &all_strips);
             self.gl.draw_arrays_instanced(
                 WebGl2RenderingContext::TRIANGLE_STRIP,
                 0,
                 4,
-                all_strips.len() as i32,
+                opaque_count + alpha_count,
             );
         }
 

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -2312,19 +2312,28 @@ impl Programs {
         }
     }
 
-    /// Upload the strip data by creating and assigning a new `self.resources.strips_buffer`.
-    fn upload_strips(&mut self, device: &Device, queue: &Queue, strips: &[GpuStrip]) {
-        let required_strips_size = size_of_val(strips) as u64;
-        self.resources.strips_buffer = Self::create_strips_buffer(device, required_strips_size);
-        // TODO: Consider using a staging belt to avoid an extra staging buffer allocation.
+    /// Upload two strip slices (opaque then alpha) into a single GPU buffer,
+    /// avoiding an intermediate Vec allocation.
+    fn upload_strip_pair(
+        &mut self,
+        device: &Device,
+        queue: &Queue,
+        first: &[GpuStrip],
+        second: &[GpuStrip],
+    ) {
+        let first_bytes = size_of_val(first) as u64;
+        let second_bytes = size_of_val(second) as u64;
+        let total = first_bytes + second_bytes;
+        self.resources.strips_buffer = Self::create_strips_buffer(device, total);
         let mut buffer = queue
             .write_buffer_with(
                 &self.resources.strips_buffer,
                 0,
-                required_strips_size.try_into().unwrap(),
+                total.try_into().unwrap(),
             )
             .expect("Capacity handled in creation");
-        buffer.copy_from_slice(bytemuck::cast_slice(strips));
+        buffer[..first_bytes as usize].copy_from_slice(bytemuck::cast_slice(first));
+        buffer[first_bytes as usize..].copy_from_slice(bytemuck::cast_slice(second));
     }
 }
 
@@ -2353,11 +2362,8 @@ impl RendererContext<'_> {
         if opaque_strips.is_empty() && alpha_strips.is_empty() {
             return;
         }
-        // Upload all strips (opaque first, then alpha) into a single buffer.
-        let total_strips: Vec<GpuStrip> =
-            opaque_strips.iter().chain(alpha_strips.iter()).copied().collect();
         self.programs
-            .upload_strips(self.device, self.queue, &total_strips);
+            .upload_strip_pair(self.device, self.queue, opaque_strips, alpha_strips);
         let opaque_count = u32::try_from(opaque_strips.len()).unwrap();
         let alpha_count = u32::try_from(alpha_strips.len()).unwrap();
 

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -344,6 +344,7 @@ impl Renderer {
         encoded_paints: &[EncodedPaint],
         clear: bool,
     ) -> Result<(), RenderError> {
+        self.programs.depth_cleared_this_frame = false;
         self.prepare_gpu_encoded_paints(encoded_paints);
         // TODO: For the time being, we upload the entire alpha buffer as one big chunk. As a future
         // refinement, we could have a bounded alpha buffer, and break draws when the alpha
@@ -722,10 +723,20 @@ impl Renderer {
 /// Defines the GPU resources and pipelines for rendering.
 #[derive(Debug)]
 struct Programs {
-    /// Pipelines for rendering strips.
+    /// Pipelines for rendering strips to slot textures (no depth, blending ON).
     /// The first pipeline should be used for color attachments in the native pixel format,
     /// the second for color attachments in RGBA8.
-    strip_pipelines: [RenderPipeline; 2],
+    slot_strip_pipelines: [RenderPipeline; 2],
+    /// Alpha pipelines for rendering strips to Output targets (depth test ON, depth write OFF, blending ON).
+    alpha_strip_pipelines: [RenderPipeline; 2],
+    /// Opaque pipelines for rendering strips to Output targets (depth test ON, depth write ON, blending OFF).
+    opaque_strip_pipelines: [RenderPipeline; 2],
+    /// Depth texture for early-z rejection on the Output target.
+    depth_texture: Texture,
+    /// View for the depth texture.
+    depth_texture_view: TextureView,
+    /// Whether the depth buffer has been cleared this frame.
+    depth_cleared_this_frame: bool,
     /// Bind group layout for strip draws
     strip_bind_group_layout: BindGroupLayout,
     /// Bind group layout for encoded paints
@@ -901,13 +912,14 @@ struct ClearSlotsConfig {
 
 impl GpuStrip {
     /// Vertex attributes for the strip
-    pub fn vertex_attributes() -> [wgpu::VertexAttribute; 5] {
+    pub fn vertex_attributes() -> [wgpu::VertexAttribute; 6] {
         wgpu::vertex_attr_array![
             0 => Uint32,
             1 => Uint32,
             2 => Uint32,
             3 => Uint32,
             4 => Uint32,
+            5 => Uint32,
         ]
     }
 }
@@ -1047,19 +1059,24 @@ impl Programs {
                 immediate_size: 0,
             });
 
+        let depth_format = wgpu::TextureFormat::Depth24Plus;
         let strip_formats = [render_target_config.format, wgpu::TextureFormat::Rgba8Unorm];
-        let strip_pipelines: [RenderPipeline; 2] = core::array::from_fn(|i| {
+
+        let strip_vertex_state = wgpu::VertexBufferLayout {
+            array_stride: size_of::<GpuStrip>() as u64,
+            step_mode: wgpu::VertexStepMode::Instance,
+            attributes: &GpuStrip::vertex_attributes(),
+        };
+
+        // Slot pipelines: no depth, blending ON (for slot textures without depth attachment).
+        let slot_strip_pipelines: [RenderPipeline; 2] = core::array::from_fn(|i| {
             device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-                label: Some("Strip Pipeline"),
+                label: Some("Strip Slot Pipeline"),
                 layout: Some(&strip_pipeline_layout),
                 vertex: wgpu::VertexState {
                     module: &strip_shader,
                     entry_point: Some("vs_main"),
-                    buffers: &[wgpu::VertexBufferLayout {
-                        array_stride: size_of::<GpuStrip>() as u64,
-                        step_mode: wgpu::VertexStepMode::Instance,
-                        attributes: &GpuStrip::vertex_attributes(),
-                    }],
+                    buffers: core::slice::from_ref(&strip_vertex_state),
                     compilation_options: PipelineCompilationOptions::default(),
                 },
                 fragment: Some(wgpu::FragmentState {
@@ -1077,6 +1094,82 @@ impl Programs {
                     ..Default::default()
                 },
                 depth_stencil: None,
+                multisample: wgpu::MultisampleState::default(),
+                multiview_mask: None,
+                cache: None,
+            })
+        });
+
+        // Alpha pipelines: blending ON, depth test ON (LessEqual), depth write OFF.
+        let alpha_strip_pipelines: [RenderPipeline; 2] = core::array::from_fn(|i| {
+            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("Strip Alpha Pipeline"),
+                layout: Some(&strip_pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &strip_shader,
+                    entry_point: Some("vs_main"),
+                    buffers: core::slice::from_ref(&strip_vertex_state),
+                    compilation_options: PipelineCompilationOptions::default(),
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &strip_shader,
+                    entry_point: Some("fs_main"),
+                    targets: &[Some(ColorTargetState {
+                        format: strip_formats[i],
+                        blend: Some(BlendState::PREMULTIPLIED_ALPHA_BLENDING),
+                        write_mask: ColorWrites::ALL,
+                    })],
+                    compilation_options: PipelineCompilationOptions::default(),
+                }),
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleStrip,
+                    ..Default::default()
+                },
+                depth_stencil: Some(wgpu::DepthStencilState {
+                    format: depth_format,
+                    depth_write_enabled: false,
+                    depth_compare: wgpu::CompareFunction::LessEqual,
+                    stencil: wgpu::StencilState::default(),
+                    bias: wgpu::DepthBiasState::default(),
+                }),
+                multisample: wgpu::MultisampleState::default(),
+                multiview_mask: None,
+                cache: None,
+            })
+        });
+
+        // Opaque pipelines: blending OFF, depth test ON (LessEqual), depth write ON.
+        let opaque_strip_pipelines: [RenderPipeline; 2] = core::array::from_fn(|i| {
+            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("Strip Opaque Pipeline"),
+                layout: Some(&strip_pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &strip_shader,
+                    entry_point: Some("vs_main"),
+                    buffers: core::slice::from_ref(&strip_vertex_state),
+                    compilation_options: PipelineCompilationOptions::default(),
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &strip_shader,
+                    entry_point: Some("fs_main"),
+                    targets: &[Some(ColorTargetState {
+                        format: strip_formats[i],
+                        blend: None,
+                        write_mask: ColorWrites::ALL,
+                    })],
+                    compilation_options: PipelineCompilationOptions::default(),
+                }),
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleStrip,
+                    ..Default::default()
+                },
+                depth_stencil: Some(wgpu::DepthStencilState {
+                    format: depth_format,
+                    depth_write_enabled: true,
+                    depth_compare: wgpu::CompareFunction::LessEqual,
+                    stencil: wgpu::StencilState::default(),
+                    bias: wgpu::DepthBiasState::default(),
+                }),
                 multisample: wgpu::MultisampleState::default(),
                 multiview_mask: None,
                 cache: None,
@@ -1441,8 +1534,20 @@ impl Programs {
             view_config_buffer,
         };
 
+        let depth_texture = Self::create_depth_texture(
+            device,
+            render_target_config.width,
+            render_target_config.height,
+        );
+        let depth_texture_view = depth_texture.create_view(&TextureViewDescriptor::default());
+
         Self {
-            strip_pipelines,
+            slot_strip_pipelines,
+            alpha_strip_pipelines,
+            opaque_strip_pipelines,
+            depth_texture,
+            depth_texture_view,
+            depth_cleared_this_frame: false,
             strip_bind_group_layout,
             encoded_paints_bind_group_layout,
             gradient_bind_group_layout,
@@ -1460,6 +1565,23 @@ impl Programs {
             clear_pipeline,
             atlas_clear_pipeline,
         }
+    }
+
+    fn create_depth_texture(device: &Device, width: u32, height: u32) -> Texture {
+        device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("Depth Texture"),
+            size: Extent3d {
+                width: width.max(1),
+                height: height.max(1),
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Depth24Plus,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        })
     }
 
     fn create_strips_buffer(device: &Device, required_strips_size: u64) -> Buffer {
@@ -1763,7 +1885,7 @@ impl Programs {
         self.maybe_resize_alphas_tex(device, max_texture_dimension_2d, alphas.len());
         self.maybe_resize_encoded_paints_tex(device, max_texture_dimension_2d, paint_idxs);
         self.maybe_resize_filter_tex(device, max_texture_dimension_2d, filter_context);
-        self.maybe_update_config_buffer(queue, max_texture_dimension_2d, new_render_size);
+        self.maybe_update_config_buffer(device, queue, max_texture_dimension_2d, new_render_size);
 
         self.upload_alpha_texture(queue, alphas);
         self.upload_encoded_paints_texture(queue, encoded_paints);
@@ -1942,6 +2064,7 @@ impl Programs {
     /// Update config buffer if dimensions changed.
     fn maybe_update_config_buffer(
         &mut self,
+        device: &Device,
         queue: &Queue,
         max_texture_dimension_2d: u32,
         new_render_size: &RenderSize,
@@ -1961,6 +2084,12 @@ impl Programs {
                 .write_buffer_with(&self.resources.view_config_buffer, 0, SIZE_OF_CONFIG)
                 .expect("Buffer only ever holds `Config`");
             buffer.copy_from_slice(bytemuck::bytes_of(&config));
+
+            self.depth_texture =
+                Self::create_depth_texture(device, new_render_size.width, new_render_size.height);
+            self.depth_texture_view =
+                self.depth_texture
+                    .create_view(&TextureViewDescriptor::default());
 
             self.render_size = new_render_size.clone();
         }
@@ -2216,16 +2345,21 @@ impl RendererContext<'_> {
     /// Render the strips to the specified render target.
     fn do_strip_render_pass(
         &mut self,
-        strips: &[GpuStrip],
+        opaque_strips: &[GpuStrip],
+        alpha_strips: &[GpuStrip],
         target: StripPassRenderTarget,
         load: wgpu::LoadOp<wgpu::Color>,
     ) {
-        if strips.is_empty() {
+        if opaque_strips.is_empty() && alpha_strips.is_empty() {
             return;
         }
-        // TODO: We currently allocate a new strips buffer for each render pass. A more efficient
-        // approach would be to re-use buffers or slices of a larger buffer.
-        self.programs.upload_strips(self.device, self.queue, strips);
+        // Upload all strips (opaque first, then alpha) into a single buffer.
+        let total_strips: Vec<GpuStrip> =
+            opaque_strips.iter().chain(alpha_strips.iter()).copied().collect();
+        self.programs
+            .upload_strips(self.device, self.queue, &total_strips);
+        let opaque_count = u32::try_from(opaque_strips.len()).unwrap();
+        let alpha_count = u32::try_from(alpha_strips.len()).unwrap();
 
         enum MaybeOwned<'a, T> {
             Borrowed(&'a T),
@@ -2342,6 +2476,28 @@ impl RendererContext<'_> {
             _ => 0,
         };
 
+        let is_final_view =
+            matches!(target, StripPassRenderTarget::Output(OutputTarget::FinalView));
+
+        let depth_stencil_attachment = if is_final_view {
+            let depth_load = if self.programs.depth_cleared_this_frame {
+                wgpu::LoadOp::Load
+            } else {
+                self.programs.depth_cleared_this_frame = true;
+                wgpu::LoadOp::Clear(1.0)
+            };
+            Some(wgpu::RenderPassDepthStencilAttachment {
+                view: &self.programs.depth_texture_view,
+                depth_ops: Some(wgpu::Operations {
+                    load: depth_load,
+                    store: wgpu::StoreOp::Store,
+                }),
+                stencil_ops: None,
+            })
+        } else {
+            None
+        };
+
         let mut render_pass = self.encoder.begin_render_pass(&RenderPassDescriptor {
             label: Some("Render to Texture Pass"),
             color_attachments: &[Some(RenderPassColorAttachment {
@@ -2353,18 +2509,34 @@ impl RendererContext<'_> {
                     store: wgpu::StoreOp::Store,
                 },
             })],
-            depth_stencil_attachment: None,
+            depth_stencil_attachment,
             occlusion_query_set: None,
             timestamp_writes: None,
             multiview_mask: None,
         });
-        render_pass.set_pipeline(&self.programs.strip_pipelines[pipeline_idx]);
+
         render_pass.set_bind_group(0, bind_group.as_ref(), &[]);
         render_pass.set_bind_group(1, &self.programs.resources.atlas_bind_group, &[]);
         render_pass.set_bind_group(2, &self.programs.resources.encoded_paints_bind_group, &[]);
         render_pass.set_bind_group(3, &self.programs.resources.gradient_bind_group, &[]);
         render_pass.set_vertex_buffer(0, self.programs.resources.strips_buffer.slice(..));
-        render_pass.draw(0..4, 0..u32::try_from(strips.len()).unwrap());
+
+        if is_final_view {
+            // Opaque pass: front-to-back, depth write ON, no blend.
+            if opaque_count > 0 {
+                render_pass.set_pipeline(&self.programs.opaque_strip_pipelines[pipeline_idx]);
+                render_pass.draw(0..4, 0..opaque_count);
+            }
+            // Alpha pass: back-to-front, depth test ON, depth write OFF, blend ON.
+            if alpha_count > 0 {
+                render_pass.set_pipeline(&self.programs.alpha_strip_pipelines[pipeline_idx]);
+                render_pass.draw(0..4, opaque_count..opaque_count + alpha_count);
+            }
+        } else {
+            // Slot texture / intermediate: single draw, no depth pipeline.
+            render_pass.set_pipeline(&self.programs.slot_strip_pipelines[pipeline_idx]);
+            render_pass.draw(0..4, 0..opaque_count + alpha_count);
+        }
     }
 
     /// Clear specific slots from a slot texture.
@@ -2426,7 +2598,8 @@ impl RendererBackend for RendererContext<'_> {
     /// Execute the render pass for rendering strips.
     fn render_strips(
         &mut self,
-        strips: &[GpuStrip],
+        opaque_strips: &[GpuStrip],
+        alpha_strips: &[GpuStrip],
         target: StripPassRenderTarget,
         load_op: LoadOp,
     ) {
@@ -2434,7 +2607,7 @@ impl RendererBackend for RendererContext<'_> {
             LoadOp::Load => wgpu::LoadOp::Load,
             LoadOp::Clear => wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
         };
-        self.do_strip_render_pass(strips, target, wgpu_load_op);
+        self.do_strip_render_pass(opaque_strips, alpha_strips, target, wgpu_load_op);
     }
 
     fn apply_filter(&mut self, layer_id: LayerId) {

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -493,6 +493,10 @@ impl Scene {
         self.fill_path(&rect.to_path(DEFAULT_TOLERANCE));
     }
 
+    pub fn paint_transform(&self) -> &Affine {
+        &self.render_state.paint_transform
+    }
+
     #[expect(
         clippy::cast_possible_truncation,
         reason = "f64→f32 truncation is acceptable for pixel coordinates"

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -1007,8 +1007,11 @@ impl Scheduler {
             let layer_index = self.next_layer_index();
             let draw = self.draw_mut(self.round, 2);
             draw.push_opaque(
-                GpuStripBuilder::at_surface(wide_tile_x, wide_tile_y, WideTile::WIDTH)
-                    .paint(payload, paint, layer_index),
+                GpuStripBuilder::at_surface(wide_tile_x, wide_tile_y, WideTile::WIDTH).paint(
+                    payload,
+                    paint,
+                    layer_index,
+                ),
             );
         }
     }
@@ -1413,13 +1416,11 @@ impl Scheduler {
             // `BlendState::PREMULTIPLIED_ALPHA_BLENDING`). This is the whole reason
             // why for default blend modes, we don't need to rely on temporary slots
             // to achieve blending.
-            draw.push_alpha(
-                gpu_strip_builder.copy_from_slot(
-                    tos.dest_slot.get_idx(),
-                    (tos.opacity * 255.0) as u8,
-                    layer_index,
-                ),
-            );
+            draw.push_alpha(gpu_strip_builder.copy_from_slot(
+                tos.dest_slot.get_idx(),
+                (tos.opacity * 255.0) as u8,
+                layer_index,
+            ));
         }
     }
 
@@ -1465,11 +1466,11 @@ impl Scheduler {
         };
 
         let draw = self.draw_mut(el_round, draw_texture);
-        draw.push_alpha(
-            gpu_strip_builder
-                .with_sparse(cmd.width, col_idx)
-                .paint(payload, paint, layer_index),
-        );
+        draw.push_alpha(gpu_strip_builder.with_sparse(cmd.width, col_idx).paint(
+            payload,
+            paint,
+            layer_index,
+        ));
     }
 
     #[inline]
@@ -1553,6 +1554,7 @@ impl Scheduler {
                             && img.sampler.alpha == 1.0
                             && img.tint.is_none_or(|t| t.color.components[3] >= 1.0)
                     }
+                    Some(EncodedPaint::Gradient(g)) => !g.may_have_opacities,
                     _ => false,
                 }
             }
@@ -1616,9 +1618,11 @@ impl Scheduler {
         } else {
             GpuStripBuilder::at_slot(nos.dest_slot.get_idx(), cmd.x, cmd.width)
         };
-        draw.push_alpha(
-            gpu_strip_builder.copy_from_slot(tos.dest_slot.get_idx(), 0xFF, layer_index),
-        );
+        draw.push_alpha(gpu_strip_builder.copy_from_slot(
+            tos.dest_slot.get_idx(),
+            0xFF,
+            layer_index,
+        ));
 
         let nos_ptr = state.tile_state.stack.len() - 2;
         state.tile_state.stack[nos_ptr].temporary_slot.invalidate();
@@ -2014,9 +2018,7 @@ fn emit_rect_strips(
     // Edge strips: 1px wide/tall strips carrying fractional coverage.
     // Top edge (full width, 1px tall).
     if has_top {
-        let frac = u32::from(frac_l)
-            | (u32::from(frac_t) << 8)
-            | (u32::from(frac_r) << 16);
+        let frac = u32::from(frac_l) | (u32::from(frac_t) << 8) | (u32::from(frac_r) << 16);
         let (payload, paint_packed) =
             Scheduler::process_paint(&rect.paint, encoded_paints, (base_x, base_y), paint_idxs);
         draw.push_alpha(GpuStrip {
@@ -2034,15 +2036,9 @@ fn emit_rect_strips(
     // Bottom edge (full width, 1px tall).
     if has_bottom {
         let bottom_y = base_y + snapped_h - 1;
-        let frac = u32::from(frac_l)
-            | (u32::from(frac_r) << 16)
-            | (u32::from(frac_b) << 24);
-        let (payload, paint_packed) = Scheduler::process_paint(
-            &rect.paint,
-            encoded_paints,
-            (base_x, bottom_y),
-            paint_idxs,
-        );
+        let frac = u32::from(frac_l) | (u32::from(frac_r) << 16) | (u32::from(frac_b) << 24);
+        let (payload, paint_packed) =
+            Scheduler::process_paint(&rect.paint, encoded_paints, (base_x, bottom_y), paint_idxs);
         draw.push_alpha(GpuStrip {
             x: base_x,
             y: bottom_y,

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -1964,8 +1964,11 @@ fn emit_rect_strips(
     let interior_h = snapped_h.saturating_sub(top_inset + bottom_inset);
 
     const MIN_SPLIT_SIZE: u16 = 20;
-    if snapped_w < MIN_SPLIT_SIZE || snapped_h < MIN_SPLIT_SIZE
-        || interior_w == 0 || interior_h == 0
+    if snapped_w < MIN_SPLIT_SIZE
+        || snapped_h < MIN_SPLIT_SIZE
+        || interior_w == 0
+        || interior_h == 0
+        || !is_opaque
     {
         let frac = pack_unorm4x8([rect.x0 - sx0, rect.y0 - sy0, sx1 - rect.x1, sy1 - rect.y1]);
         let (payload, paint_packed) =

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -239,10 +239,15 @@ pub(crate) trait RendererBackend {
     /// Clear specific slots in a texture.
     fn clear_slots(&mut self, texture_index: usize, slots: &[u32]);
 
-    /// Execute a render pass for strips.
+    /// Execute a render pass for strips, split into opaque and alpha sub-passes.
+    ///
+    /// For Output targets: `opaque_strips` are rendered front-to-back with depth writes
+    /// and no blending; `alpha_strips` are rendered back-to-front with depth testing
+    /// and alpha blending. For `SlotTexture` targets: only `alpha_strips` are used.
     fn render_strips(
         &mut self,
-        strips: &[GpuStrip],
+        opaque_strips: &[GpuStrip],
+        alpha_strips: &[GpuStrip],
         target: StripPassRenderTarget,
         load_op: LoadOp,
     );
@@ -278,6 +283,9 @@ pub(crate) struct Scheduler {
     round_pool: RoundPool,
     /// The output target for the main rendering operations.
     output_target: OutputTarget,
+    /// Monotonically increasing counter for assigning `layer_index` to strips.
+    /// Drives z-depth computation for TBDR early-z rejection. Reset per frame.
+    layer_counter: u32,
 }
 
 #[derive(Debug, Default)]
@@ -430,16 +438,33 @@ impl TileEl {
 }
 
 #[derive(Debug, Default)]
-struct Draw(Vec<GpuStrip>);
+struct Draw {
+    /// Opaque strips: interior fills with fully opaque paint at surface level.
+    /// Rendered front-to-back with depth writes and no blending for TBDR early-z.
+    opaque: Vec<GpuStrip>,
+    /// Alpha strips: boundary strips, transparent paints, blend/clip ops.
+    /// Rendered back-to-front with depth testing and alpha blending.
+    alpha: Vec<GpuStrip>,
+}
 
 impl Draw {
     #[inline(always)]
-    fn push(&mut self, gpu_strip: GpuStrip) {
-        self.0.push(gpu_strip);
+    fn push_opaque(&mut self, gpu_strip: GpuStrip) {
+        self.opaque.push(gpu_strip);
+    }
+
+    #[inline(always)]
+    fn push_alpha(&mut self, gpu_strip: GpuStrip) {
+        self.alpha.push(gpu_strip);
+    }
+
+    fn is_empty(&self) -> bool {
+        self.opaque.is_empty() && self.alpha.is_empty()
     }
 
     fn clear(&mut self) {
-        self.0.clear();
+        self.opaque.clear();
+        self.alpha.clear();
     }
 }
 
@@ -456,6 +481,7 @@ impl Scheduler {
             rounds_queue: VecDeque::new(),
             round_pool: RoundPool::default(),
             output_target: OutputTarget::FinalView,
+            layer_counter: 0,
         }
     }
 
@@ -499,6 +525,7 @@ impl Scheduler {
         filter_context: &FilterContext,
         encoded_paints: &[EncodedPaint],
     ) -> Result<(), RenderError> {
+        self.layer_counter = 0;
         for node_id in scene.render_graph.execution_order() {
             let node = &scene.render_graph.nodes[node_id];
 
@@ -757,6 +784,7 @@ impl Scheduler {
         let strip_storage = scene.strip_storage.borrow();
         // Always choose the draw of the final surface, since direct strips are only ever
         // rendered to the final surface.
+        let mut layer_counter = self.layer_counter;
         let draw = self.draw_mut(round, 2);
 
         for cmd in &scene.fast_strips_buffer.commands[range] {
@@ -768,16 +796,19 @@ impl Scheduler {
                         scene,
                         encoded_paints,
                         paint_idxs,
-                        &mut draw.0,
+                        &mut layer_counter,
+                        draw,
                     );
                 }
                 FastStripCommand::Rect(r) => {
-                    let strip = pack_rectangle_into_gpu(r, encoded_paints, paint_idxs);
-
-                    draw.0.push(strip);
+                    let layer_index = layer_counter;
+                    layer_counter += 1;
+                    let is_opaque = Self::is_paint_opaque(&r.paint, encoded_paints);
+                    emit_rect_strips(r, encoded_paints, paint_idxs, layer_index, is_opaque, draw);
                 }
             }
         }
+        self.layer_counter = layer_counter;
     }
 
     /// Process one batch of coarse-rasterized wide tile commands.
@@ -858,8 +889,8 @@ impl Scheduler {
     ///
     /// The rounds queue must not be empty.
     fn flush<R: RendererBackend>(&mut self, renderer: &mut R) {
-        let round = self.rounds_queue.pop_front().unwrap();
-        for (i, draw) in round.draws.iter().enumerate() {
+        let mut round = self.rounds_queue.pop_front().unwrap();
+        for (i, draw) in round.draws.iter_mut().enumerate() {
             #[cfg(debug_assertions)]
             {
                 // This is an expensive O(n²) debug only check that enforces that there are no
@@ -895,7 +926,7 @@ impl Scheduler {
                 }
             };
 
-            if draw.0.is_empty() {
+            if draw.is_empty() {
                 if load == LoadOp::Clear {
                     // There are no strips to render, so `render_strips` will not run and won't clear
                     // the texture. We still have slots to clear this round so explicitly clear
@@ -905,7 +936,20 @@ impl Scheduler {
                 continue;
             }
 
-            renderer.render_strips(&draw.0, target, load);
+            if i == 2 {
+                // Output target: reverse opaque for front-to-back rendering.
+                // Alpha strips stay in natural back-to-front order.
+                let mut opaque = core::mem::take(&mut draw.opaque);
+                opaque.reverse();
+                renderer.render_strips(&opaque, &draw.alpha, target, load);
+            } else {
+                // Slot textures: no depth optimization, everything in alpha list.
+                debug_assert!(
+                    draw.opaque.is_empty(),
+                    "slot texture draws should not contain opaque strips"
+                );
+                renderer.render_strips(&[], &draw.alpha, target, load);
+            }
         }
         for i in 0..2 {
             self.free[i].extend(&round.free[i]);
@@ -913,6 +957,14 @@ impl Scheduler {
         self.round += 1;
 
         self.round_pool.return_to_pool(round);
+    }
+
+    /// Allocate and return the next layer index for z-depth ordering.
+    #[inline(always)]
+    fn next_layer_index(&mut self) -> u32 {
+        let idx = self.layer_counter;
+        self.layer_counter += 1;
+        idx
     }
 
     // Find the appropriate draw call for rendering.
@@ -952,10 +1004,11 @@ impl Scheduler {
                 idxs,
             );
 
+            let layer_index = self.next_layer_index();
             let draw = self.draw_mut(self.round, 2);
-            draw.push(
+            draw.push_opaque(
                 GpuStripBuilder::at_surface(wide_tile_x, wide_tile_y, WideTile::WIDTH)
-                    .paint(payload, paint),
+                    .paint(payload, paint, layer_index),
             );
         }
     }
@@ -1106,6 +1159,7 @@ impl Scheduler {
                                 wide_tile_y,
                                 payload,
                                 paint,
+                                false,
                             );
                         };
 
@@ -1206,10 +1260,11 @@ impl Scheduler {
             if let TemporarySlot::Invalid(temp_slot) = tos.temporary_slot {
                 let next_round = depth.is_multiple_of(2);
                 let el_round = tos.round + usize::from(next_round);
+                let layer_index = self.next_layer_index();
                 let draw = self.draw_mut(el_round, temp_slot.get_texture());
-                draw.push(
+                draw.push_alpha(
                     GpuStripBuilder::at_slot(temp_slot.get_idx(), 0, WideTile::WIDTH)
-                        .copy_from_slot(tos.dest_slot.get_idx(), 0xFF),
+                        .copy_from_slot(tos.dest_slot.get_idx(), 0xFF, layer_index),
                 );
 
                 tos.temporary_slot = TemporarySlot::Valid(temp_slot);
@@ -1315,33 +1370,32 @@ impl Scheduler {
 
         let next_round: bool = depth.is_multiple_of(2) && depth > 2;
         let round = nos.round.max(tos.round + usize::from(next_round));
+        let layer_index = self.next_layer_index();
 
-        let draw = self.draw_mut(
-            round,
-            if depth <= 2 {
-                2
-            } else {
-                nos.dest_slot.get_texture()
-            },
-        );
+        let draw_texture = if depth <= 2 {
+            2
+        } else {
+            nos.dest_slot.get_texture()
+        };
+        let draw = self.draw_mut(round, draw_texture);
 
         let gpu_strip_builder = if depth <= 2 {
             GpuStripBuilder::at_surface(wide_tile_x, wide_tile_y, WideTile::WIDTH)
         } else {
             GpuStripBuilder::at_slot(nos.dest_slot.get_idx(), 0, WideTile::WIDTH)
         };
-
         if let TemporarySlot::Valid(temp_slot) = nos.temporary_slot {
             let opacity_u8 = (tos.opacity * 255.0) as u8;
             let mix_mode = mode.mix as u8;
             let compose_mode = mode.compose as u8;
 
-            draw.push(gpu_strip_builder.blend(
+            draw.push_alpha(gpu_strip_builder.blend(
                 tos.dest_slot.get_idx(),
                 temp_slot.get_idx(),
                 opacity_u8,
                 mix_mode,
                 compose_mode,
+                layer_index,
             ));
             // Invalidate the temporary slot after use
             let nos_ptr = state.tile_state.stack.len() - 2;
@@ -1359,9 +1413,12 @@ impl Scheduler {
             // `BlendState::PREMULTIPLIED_ALPHA_BLENDING`). This is the whole reason
             // why for default blend modes, we don't need to rely on temporary slots
             // to achieve blending.
-            draw.push(
-                gpu_strip_builder
-                    .copy_from_slot(tos.dest_slot.get_idx(), (tos.opacity * 255.0) as u8),
+            draw.push_alpha(
+                gpu_strip_builder.copy_from_slot(
+                    tos.dest_slot.get_idx(),
+                    (tos.opacity * 255.0) as u8,
+                    layer_index,
+                ),
             );
         }
     }
@@ -1378,9 +1435,9 @@ impl Scheduler {
         attrs: &CommandAttrs,
     ) {
         let depth = state.tile_state.stack.len();
-
         let el = state.tile_state.stack.last_mut().unwrap();
-        let draw = self.draw_mut(el.round, el.get_draw_texture(depth));
+        let el_round = el.round;
+        let draw_texture = el.get_draw_texture(depth);
 
         let fill_attrs = &attrs.fill[cmd.attrs_idx as usize];
         let alpha_idx = fill_attrs.alpha_idx(cmd.alpha_offset);
@@ -1393,9 +1450,12 @@ impl Scheduler {
             paint_idxs,
         );
 
+        let layer_index = self.next_layer_index();
+
         let gpu_strip_builder = if depth == 1 {
             GpuStripBuilder::at_surface(scene_strip_x, scene_strip_y, cmd.width)
         } else {
+            let el = state.tile_state.stack.last().unwrap();
             let slot_idx = if let TemporarySlot::Valid(temp_slot) = el.temporary_slot {
                 temp_slot.get_idx()
             } else {
@@ -1404,10 +1464,11 @@ impl Scheduler {
             GpuStripBuilder::at_slot(slot_idx, cmd.x, cmd.width)
         };
 
-        draw.push(
+        let draw = self.draw_mut(el_round, draw_texture);
+        draw.push_alpha(
             gpu_strip_builder
                 .with_sparse(cmd.width, col_idx)
-                .paint(payload, paint),
+                .paint(payload, paint, layer_index),
         );
     }
 
@@ -1431,7 +1492,16 @@ impl Scheduler {
             paint_idxs,
         );
 
-        self.do_fill_with(state, cmd, scene_strip_x, scene_strip_y, payload, paint);
+        let is_opaque = Self::is_paint_opaque(&fill_attrs.paint, encoded_paints);
+        self.do_fill_with(
+            state,
+            cmd,
+            scene_strip_x,
+            scene_strip_y,
+            payload,
+            paint,
+            is_opaque,
+        );
     }
 
     #[inline]
@@ -1443,9 +1513,11 @@ impl Scheduler {
         scene_strip_y: u16,
         payload: u32,
         paint: u32,
+        is_opaque: bool,
     ) {
         let depth = state.tile_state.stack.len();
 
+        let layer_index = self.next_layer_index();
         let el = state.tile_state.stack.last_mut().unwrap();
         let draw = self.draw_mut(el.round, el.get_draw_texture(depth));
 
@@ -1460,7 +1532,31 @@ impl Scheduler {
             GpuStripBuilder::at_slot(slot_idx, cmd.x, cmd.width)
         };
 
-        draw.push(gpu_strip_builder.paint(payload, paint));
+        let strip = gpu_strip_builder.paint(payload, paint, layer_index);
+        if depth == 1 && is_opaque {
+            draw.push_opaque(strip);
+        } else {
+            draw.push_alpha(strip);
+        }
+    }
+
+    /// Determine if a paint is fully opaque (no transparency).
+    #[inline]
+    fn is_paint_opaque(paint: &Paint, encoded_paints: &[EncodedPaint]) -> bool {
+        match paint {
+            Paint::Solid(color) => color.is_opaque(),
+            Paint::Indexed(indexed_paint) => {
+                let paint_id = indexed_paint.index();
+                match encoded_paints.get(paint_id) {
+                    Some(EncodedPaint::Image(img)) => {
+                        !img.may_have_opacities
+                            && img.sampler.alpha == 1.0
+                            && img.tint.is_none_or(|t| t.color.components[3] >= 1.0)
+                    }
+                    _ => false,
+                }
+            }
+        }
     }
 
     #[inline]
@@ -1497,14 +1593,16 @@ impl Scheduler {
         // enough "ping-ponging" to resolve all dependencies.
         let next_round = depth.is_multiple_of(2) && depth > 2;
         let round = nos.round.max(tos.round + usize::from(next_round));
+        let layer_index = self.next_layer_index();
         if let TemporarySlot::Valid(temp_slot) = nos.temporary_slot {
             let draw = self.draw_mut(round, nos.dest_slot.get_texture());
-            draw.push(
+            draw.push_alpha(
                 GpuStripBuilder::at_slot(nos.dest_slot.get_idx(), 0, WideTile::WIDTH)
-                    .copy_from_slot(temp_slot.get_idx(), 0xFF),
+                    .copy_from_slot(temp_slot.get_idx(), 0xFF, layer_index),
             );
         }
 
+        let layer_index = self.next_layer_index();
         let draw = self.draw_mut(
             round,
             if (depth - 1) <= 1 {
@@ -1518,7 +1616,9 @@ impl Scheduler {
         } else {
             GpuStripBuilder::at_slot(nos.dest_slot.get_idx(), cmd.x, cmd.width)
         };
-        draw.push(gpu_strip_builder.copy_from_slot(tos.dest_slot.get_idx(), 0xFF));
+        draw.push_alpha(
+            gpu_strip_builder.copy_from_slot(tos.dest_slot.get_idx(), 0xFF, layer_index),
+        );
 
         let nos_ptr = state.tile_state.stack.len() - 2;
         state.tile_state.stack[nos_ptr].temporary_slot.invalidate();
@@ -1539,15 +1639,17 @@ impl Scheduler {
         let next_round = depth.is_multiple_of(2) && depth > 2;
         let round = nos.round.max(tos.round + usize::from(next_round));
 
+        let layer_index = self.next_layer_index();
         // If nos has a temporary slot, copy it to `dest_slot` first
         if let TemporarySlot::Valid(temp_slot) = nos.temporary_slot {
             let draw = self.draw_mut(round, nos.dest_slot.get_texture());
-            draw.push(
+            draw.push_alpha(
                 GpuStripBuilder::at_slot(nos.dest_slot.get_idx(), 0, WideTile::WIDTH)
-                    .copy_from_slot(temp_slot.get_idx(), 0xFF),
+                    .copy_from_slot(temp_slot.get_idx(), 0xFF, layer_index),
             );
         }
 
+        let layer_index = self.next_layer_index();
         let draw = self.draw_mut(
             round,
             if (depth - 1) <= 1 {
@@ -1566,10 +1668,10 @@ impl Scheduler {
         let alpha_idx = clip_attrs.alpha_idx(cmd.alpha_offset);
         let col_idx = alpha_idx / u32::from(Tile::HEIGHT);
 
-        draw.push(
+        draw.push_alpha(
             gpu_strip_builder
                 .with_sparse(cmd.width, col_idx)
-                .copy_from_slot(tos.dest_slot.get_idx(), 0xFF),
+                .copy_from_slot(tos.dest_slot.get_idx(), 0xFF, layer_index),
         );
         let nos_ptr = state.tile_state.stack.len() - 2;
         state.tile_state.stack[nos_ptr].temporary_slot.invalidate();
@@ -1682,7 +1784,7 @@ impl GpuStripBuilder {
     }
 
     /// Paint into strip.
-    fn paint(self, payload: u32, paint: u32) -> GpuStrip {
+    fn paint(self, payload: u32, paint: u32, layer_index: u32) -> GpuStrip {
         GpuStrip {
             x: self.x,
             y: self.y,
@@ -1691,11 +1793,12 @@ impl GpuStripBuilder {
             col_idx_or_rect_frac: self.col_idx_or_rect_frac,
             payload,
             paint_and_rect_flag: paint,
+            layer_index,
         }
     }
 
     /// Copy from slot.
-    fn copy_from_slot(self, from_slot: usize, opacity: u8) -> GpuStrip {
+    fn copy_from_slot(self, from_slot: usize, opacity: u8, layer_index: u32) -> GpuStrip {
         GpuStrip {
             x: self.x,
             y: self.y,
@@ -1704,6 +1807,7 @@ impl GpuStripBuilder {
             col_idx_or_rect_frac: self.col_idx_or_rect_frac,
             payload: u32::try_from(from_slot).unwrap(),
             paint_and_rect_flag: (COLOR_SOURCE_SLOT << 29) | (opacity as u32),
+            layer_index,
         }
     }
 
@@ -1715,6 +1819,7 @@ impl GpuStripBuilder {
         opacity: u8,
         mix_mode: u8,
         compose_mode: u8,
+        layer_index: u32,
     ) -> GpuStrip {
         GpuStrip {
             x: self.x,
@@ -1728,6 +1833,7 @@ impl GpuStripBuilder {
                 | ((opacity as u32) << 16)
                 | ((mix_mode as u32) << 8)
                 | (compose_mode as u32),
+            layer_index,
         }
     }
 }
@@ -1743,13 +1849,16 @@ fn generate_gpu_strips_for_fast_path(
     scene: &Scene,
     encoded_paints: &[EncodedPaint],
     paint_idxs: &[u32],
-    gpu_strips: &mut Vec<GpuStrip>,
+    layer_counter: &mut u32,
+    draw: &mut Draw,
 ) {
     let strips = &strip_storage.strips[path.strips.clone()];
 
     if strips.is_empty() {
         return;
     }
+
+    let is_opaque = Scheduler::is_paint_opaque(&path.paint, encoded_paints);
 
     // Note: Some of this logic is similar to current coarse rasterization code, but
     // the coarse rasterization code is more complex due to clip paths and other factors.
@@ -1769,14 +1878,16 @@ fn generate_gpu_strips_for_fast_path(
         let x0 = strip.x;
         let y = strip.y;
 
-        // Alpha fill for the strip's coverage region.
+        // Alpha fill for the strip's coverage region (always alpha — has AA).
         if strip_width > 0 {
+            let layer_index = *layer_counter;
+            *layer_counter += 1;
             let (payload, paint) =
                 Scheduler::process_paint(&path.paint, encoded_paints, (x0, y), paint_idxs);
-            gpu_strips.push(
+            draw.push_alpha(
                 GpuStripBuilder::at_surface(x0, y, strip_width)
                     .with_sparse(strip_width, col)
-                    .paint(payload, paint),
+                    .paint(payload, paint, layer_index),
             );
         }
 
@@ -1790,45 +1901,198 @@ fn generate_gpu_strips_for_fast_path(
                     .unwrap_or(u16::MAX),
             );
             if x2 > x1 {
+                let layer_index = *layer_counter;
+                *layer_counter += 1;
                 let (payload, paint) =
                     Scheduler::process_paint(&path.paint, encoded_paints, (x1, y), paint_idxs);
-                gpu_strips.push(GpuStripBuilder::at_surface(x1, y, x2 - x1).paint(payload, paint));
+                let strip =
+                    GpuStripBuilder::at_surface(x1, y, x2 - x1).paint(payload, paint, layer_index);
+                if is_opaque {
+                    draw.push_opaque(strip);
+                } else {
+                    draw.push_alpha(strip);
+                }
             }
         }
     }
 }
 
-fn pack_rectangle_into_gpu(
+/// Decompose a rectangle into a pixel-aligned opaque interior plus thin AA edge
+/// strips. The interior has `rect_frac=0` so the fragment shader skips the AA
+/// coverage math entirely; when the paint is opaque this quad goes to the opaque
+/// draw list for TBDR early-z. The 1px edge strips carry fractional coverage and
+/// always go to the alpha list.
+///
+/// For small rects (under 20px in either dimension, or where the interior would be
+/// empty), we fall back to a single rect instance with full AA fracs — the overhead
+/// of 5 draw instances outweighs the per-fragment savings at small sizes.
+fn emit_rect_strips(
     rect: &FastPathRect,
     encoded_paints: &[EncodedPaint],
     paint_idxs: &[u32],
-) -> GpuStrip {
+    layer_index: u32,
+    is_opaque: bool,
+    draw: &mut Draw,
+) {
     let sx0 = rect.x0.floor();
     let sy0 = rect.y0.floor();
     let sx1 = rect.x1.ceil();
     let sy1 = rect.y1.ceil();
 
-    let x = sx0 as u16;
-    let y = sy0 as u16;
-    // Are guaranteed to be > 0 since we rejected negative rectangles.
-    let width = (sx1 - sx0) as u16;
-    let height = (sy1 - sy0) as u16;
+    let base_x = sx0 as u16;
+    let base_y = sy0 as u16;
+    let snapped_w = (sx1 - sx0) as u16;
+    let snapped_h = (sy1 - sy0) as u16;
 
-    let (payload, paint_packed) =
-        Scheduler::process_paint(&rect.paint, encoded_paints, (x, y), paint_idxs);
+    let q = |f: f32| -> u8 { (f * 255.0 + 0.5) as u8 };
+    let frac_l = q(rect.x0 - sx0);
+    let frac_t = q(rect.y0 - sy0);
+    let frac_r = q(sx1 - rect.x1);
+    let frac_b = q(sy1 - rect.y1);
 
-    // Determine the fractional offsets for anti-aliasing and quantize so it
-    // fits into u8.
-    let frac = pack_unorm4x8([rect.x0 - sx0, rect.y0 - sy0, sx1 - rect.x1, sy1 - rect.y1]);
+    let has_left = frac_l > 0;
+    let has_top = frac_t > 0;
+    let has_right = frac_r > 0;
+    let has_bottom = frac_b > 0;
 
-    GpuStrip {
-        x,
-        y,
-        width,
-        dense_width_or_rect_height: height,
-        col_idx_or_rect_frac: frac,
+    let left_inset: u16 = u16::from(has_left);
+    let top_inset: u16 = u16::from(has_top);
+    let right_inset: u16 = u16::from(has_right);
+    let bottom_inset: u16 = u16::from(has_bottom);
+
+    let interior_w = snapped_w.saturating_sub(left_inset + right_inset);
+    let interior_h = snapped_h.saturating_sub(top_inset + bottom_inset);
+
+    const MIN_SPLIT_SIZE: u16 = 20;
+    if snapped_w < MIN_SPLIT_SIZE || snapped_h < MIN_SPLIT_SIZE
+        || interior_w == 0 || interior_h == 0
+    {
+        let frac = pack_unorm4x8([rect.x0 - sx0, rect.y0 - sy0, sx1 - rect.x1, sy1 - rect.y1]);
+        let (payload, paint_packed) =
+            Scheduler::process_paint(&rect.paint, encoded_paints, (base_x, base_y), paint_idxs);
+        draw.push_alpha(GpuStrip {
+            x: base_x,
+            y: base_y,
+            width: snapped_w,
+            dense_width_or_rect_height: snapped_h,
+            col_idx_or_rect_frac: frac,
+            payload,
+            paint_and_rect_flag: paint_packed | RECT_STRIP_FLAG,
+            layer_index,
+        });
+        return;
+    }
+
+    // Interior: pixel-aligned, rect_frac=0 → no AA in fragment shader.
+    let interior_x = base_x + left_inset;
+    let interior_y = base_y + top_inset;
+    let (payload, paint_packed) = Scheduler::process_paint(
+        &rect.paint,
+        encoded_paints,
+        (interior_x, interior_y),
+        paint_idxs,
+    );
+    let interior_strip = GpuStrip {
+        x: interior_x,
+        y: interior_y,
+        width: interior_w,
+        dense_width_or_rect_height: interior_h,
+        col_idx_or_rect_frac: 0,
         payload,
         paint_and_rect_flag: paint_packed | RECT_STRIP_FLAG,
+        layer_index,
+    };
+    if is_opaque {
+        draw.push_opaque(interior_strip);
+    } else {
+        draw.push_alpha(interior_strip);
+    }
+
+    // Edge strips: 1px wide/tall strips carrying fractional coverage.
+    // Top edge (full width, 1px tall).
+    if has_top {
+        let frac = u32::from(frac_l)
+            | (u32::from(frac_t) << 8)
+            | (u32::from(frac_r) << 16);
+        let (payload, paint_packed) =
+            Scheduler::process_paint(&rect.paint, encoded_paints, (base_x, base_y), paint_idxs);
+        draw.push_alpha(GpuStrip {
+            x: base_x,
+            y: base_y,
+            width: snapped_w,
+            dense_width_or_rect_height: 1,
+            col_idx_or_rect_frac: frac,
+            payload,
+            paint_and_rect_flag: paint_packed | RECT_STRIP_FLAG,
+            layer_index,
+        });
+    }
+
+    // Bottom edge (full width, 1px tall).
+    if has_bottom {
+        let bottom_y = base_y + snapped_h - 1;
+        let frac = u32::from(frac_l)
+            | (u32::from(frac_r) << 16)
+            | (u32::from(frac_b) << 24);
+        let (payload, paint_packed) = Scheduler::process_paint(
+            &rect.paint,
+            encoded_paints,
+            (base_x, bottom_y),
+            paint_idxs,
+        );
+        draw.push_alpha(GpuStrip {
+            x: base_x,
+            y: bottom_y,
+            width: snapped_w,
+            dense_width_or_rect_height: 1,
+            col_idx_or_rect_frac: frac,
+            payload,
+            paint_and_rect_flag: paint_packed | RECT_STRIP_FLAG,
+            layer_index,
+        });
+    }
+
+    // Left edge (1px wide, interior height only — corners handled by top/bottom).
+    if has_left {
+        let frac = u32::from(frac_l);
+        let (payload, paint_packed) = Scheduler::process_paint(
+            &rect.paint,
+            encoded_paints,
+            (base_x, interior_y),
+            paint_idxs,
+        );
+        draw.push_alpha(GpuStrip {
+            x: base_x,
+            y: interior_y,
+            width: 1,
+            dense_width_or_rect_height: interior_h,
+            col_idx_or_rect_frac: frac,
+            payload,
+            paint_and_rect_flag: paint_packed | RECT_STRIP_FLAG,
+            layer_index,
+        });
+    }
+
+    // Right edge (1px wide, interior height only).
+    if has_right {
+        let right_x = base_x + snapped_w - 1;
+        let frac = u32::from(frac_r) << 16;
+        let (payload, paint_packed) = Scheduler::process_paint(
+            &rect.paint,
+            encoded_paints,
+            (right_x, interior_y),
+            paint_idxs,
+        );
+        draw.push_alpha(GpuStrip {
+            x: right_x,
+            y: interior_y,
+            width: 1,
+            dense_width_or_rect_height: interior_h,
+            col_idx_or_rect_frac: frac,
+            payload,
+            paint_and_rect_flag: paint_packed | RECT_STRIP_FLAG,
+            layer_index,
+        });
     }
 }
 

--- a/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
@@ -211,6 +211,9 @@ struct StripInstance {
     @location(3) payload: u32,
     // See StripInstance documentation above.
     @location(4) paint_and_rect_flag: u32,
+    // Painter's-order index for z-depth computation (TBDR early-z).
+    // Monotonically increasing in back-to-front order within a frame.
+    @location(5) layer_index: u32,
 }
 
 struct VertexOutput {
@@ -306,9 +309,10 @@ fn vs_main(
     let col_offset = select(f32(instance.col_idx_or_rect_frac), 0.0, is_rect);
     out.tex_coord = vec2<f32>(col_offset + x * f32(width), y * f32(height));
 
+    let z = 1.0 - f32(instance.layer_index) / f32(1u << 24u);
     // Flip it based on the flag.
     let final_ndc_y = select(ndc_y, -ndc_y, config.ndc_y_negate != 0u);
-    out.position = vec4<f32>(ndc_x, final_ndc_y, 0.0, 1.0);
+    out.position = vec4<f32>(ndc_x, final_ndc_y, z, 1.0);
     out.payload = instance.payload;
     out.paint_and_rect_flag = instance.paint_and_rect_flag;
 


### PR DESCRIPTION
I'm seeing very promising performance results on low tier devices from front to back rendering of opaque strips (owing to early z culling):

Benchmarks were amended to be opaque. The current Vello bench suites largely have alpha.

![1000000070](https://github.com/user-attachments/assets/9b0827e2-2d4c-466a-b68d-99a70af9145a)

![1000000076](https://github.com/user-attachments/assets/d171cfcb-488b-42c8-b286-da1bde20642a)

![1000000074](https://github.com/user-attachments/assets/4652231c-499a-49ea-9dd7-470c4a869bcb)
