### PR TITLE
vello: Keep image atlas residency across renders

### DIFF
--- a/examples/scenes/src/test_scenes.rs
+++ b/examples/scenes/src/test_scenes.rs
@@ -111,6 +111,8 @@ export_scenes!(
     fn blurred_rounded_rect(blurred_rounded_rect)
     fn image_sampling(impls::image_sampling(), "image_sampling", false)
     fn image_sampling_bicubic(impls::image_sampling_bicubic(), "image_sampling_bicubic", false)
+    fn image_atlas_residency_demo(image_atlas_residency_demo: animated)
+    fn image_atlas_large_residency_demo(image_atlas_large_residency_demo: animated)
     fn image_extend_modes_bilinear(impls::image_extend_modes(ImageQuality::Medium), "image_extend_modes (bilinear)", false)
     fn image_extend_modes_nearest_neighbor(impls::image_extend_modes(ImageQuality::Low), "image_extend_modes (nearest neighbor)", false)
     fn luminance_mask(luminance_mask)
@@ -121,7 +123,7 @@ export_scenes!(
 /// In a module because the exported [`ExampleScene`] creation functions use the same names.
 mod impls {
     use std::f64::consts::{FRAC_1_SQRT_2, PI};
-    use std::sync::Arc;
+    use std::sync::{Arc, OnceLock};
 
     use crate::SceneParams;
     use kurbo::RoundedRect;
@@ -188,6 +190,83 @@ mod impls {
             height: 16,
             alpha_type: ImageAlphaType::Alpha,
         }
+    }
+
+    fn make_pattern_image(seed: u8, width: u32, height: u32, cell: u32) -> ImageData {
+        let mut data = Vec::with_capacity((width * height * 4) as usize);
+        for y in 0..height {
+            for x in 0..width {
+                let checker = ((x / cell) + (y / cell) + seed as u32).is_multiple_of(2);
+                let diagonal = ((x + y + seed as u32 * 7) % 19) < 4;
+                let cx = (width / 2) as i32;
+                let cy = (height / 2) as i32;
+                let radius = (width.min(height) / 4) as i32;
+                let ring = ((x as i32 - cx).pow(2) + (y as i32 - cy).pow(2)) < radius.pow(2);
+                let [r, g, b, a] = if diagonal {
+                    [
+                        240,
+                        48_u8.saturating_add(seed.saturating_mul(12)),
+                        32_u8.saturating_add(seed.saturating_mul(20)),
+                        255,
+                    ]
+                } else if ring {
+                    [
+                        32_u8.saturating_add(seed.saturating_mul(20)),
+                        120_u8.saturating_add(seed.saturating_mul(24)),
+                        255_u8.saturating_sub(seed.saturating_mul(16)),
+                        220,
+                    ]
+                } else if checker {
+                    [16, 16, 24_u8.saturating_add(seed.saturating_mul(12)), 255]
+                } else {
+                    [
+                        240_u8.saturating_sub(seed.saturating_mul(20)),
+                        240,
+                        248,
+                        255,
+                    ]
+                };
+                data.extend([r, g, b, a]);
+            }
+        }
+        ImageData {
+            data: Blob::new(Arc::new(data)),
+            format: ImageFormat::Rgba8,
+            width,
+            height,
+            alpha_type: ImageAlphaType::Alpha,
+        }
+    }
+
+    fn make_residency_demo_image(seed: u8) -> ImageData {
+        make_pattern_image(seed, 96, 96, 12)
+    }
+
+    fn residency_demo_images() -> &'static [ImageData] {
+        static IMAGES: OnceLock<Vec<ImageData>> = OnceLock::new();
+        IMAGES
+            .get_or_init(|| {
+                vec![
+                    make_residency_demo_image(1),
+                    make_residency_demo_image(5),
+                    make_residency_demo_image(9),
+                ]
+            })
+            .as_slice()
+    }
+
+    fn large_residency_demo_images() -> &'static [ImageData] {
+        static IMAGES: OnceLock<Vec<ImageData>> = OnceLock::new();
+        IMAGES
+            .get_or_init(|| {
+                vec![
+                    make_pattern_image(2, 2048, 2048, 96),
+                    make_pattern_image(4, 2048, 2048, 128),
+                    make_pattern_image(6, 2048, 2048, 160),
+                    make_pattern_image(8, 2048, 2048, 192),
+                ]
+            })
+            .as_slice()
     }
 
     pub(super) fn emoji(scene: &mut Scene, params: &mut SceneParams<'_>) {
@@ -2028,6 +2107,59 @@ mod impls {
                 scene.draw_image(&image_medium, transform.then_translate((420.0, 0.0).into()));
                 scene.draw_image(&image_high, transform.then_translate((840.0, 0.0).into()));
             }
+        }
+    }
+
+    pub(super) fn image_atlas_residency_demo(scene: &mut Scene, params: &mut SceneParams<'_>) {
+        params.resolution = Some(Vec2::new(1400., 900.));
+        params.base_color = Some(palette::css::WHITE);
+
+        let images = residency_demo_images();
+        let columns = 5;
+        let rows = 3;
+        for row in 0..rows {
+            for column in 0..columns {
+                let index = (row * columns + column) % images.len();
+                let image = &images[index];
+                let phase = params.time + (row * columns + column) as f64 * 0.35;
+                let center_x = 180.0 + column as f64 * 240.0 + phase.sin() * 45.0;
+                let center_y = 170.0 + row as f64 * 250.0 + (phase * 0.7).cos() * 30.0;
+                let rotation = (phase * 0.45).sin() * 0.5;
+                let scale = 1.1 + (phase * 1.3).cos() * 0.2;
+                let transform = Affine::translate((center_x, center_y))
+                    * Affine::rotate(rotation)
+                    * Affine::scale(scale)
+                    * Affine::translate((-48.0, -48.0));
+                scene.draw_image(image, transform);
+            }
+        }
+    }
+
+    pub(super) fn image_atlas_large_residency_demo(
+        scene: &mut Scene,
+        params: &mut SceneParams<'_>,
+    ) {
+        params.resolution = Some(Vec2::new(1700., 1100.));
+        params.base_color = Some(palette::css::WHITE);
+
+        let images = large_residency_demo_images();
+        let anchors = [
+            (430.0, 300.0),
+            (1270.0, 310.0),
+            (450.0, 800.0),
+            (1250.0, 780.0),
+        ];
+        for (index, (image, (anchor_x, anchor_y))) in images.iter().zip(anchors).enumerate() {
+            let phase = params.time + index as f64 * 0.8;
+            let offset_x = phase.sin() * 55.0;
+            let offset_y = (phase * 0.7).cos() * 40.0;
+            let rotation = (phase * 0.35).sin() * 0.22;
+            let scale = 0.19 + (phase * 0.45).cos() * 0.015;
+            let transform = Affine::translate((anchor_x + offset_x, anchor_y + offset_y))
+                * Affine::rotate(rotation)
+                * Affine::scale(scale)
+                * Affine::translate((-1024.0, -1024.0));
+            scene.draw_image(image, transform);
         }
     }
 

--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -330,6 +330,7 @@ pub struct Renderer {
     options: RendererOptions,
     engine: WgpuEngine,
     resolver: Resolver,
+    image_atlas: Option<recording::ImageProxy>,
     shaders: FullShaders,
     #[cfg(feature = "debug_layers")]
     debug: debug::DebugRenderer,
@@ -445,6 +446,7 @@ impl Renderer {
             options,
             engine,
             resolver: Resolver::new(),
+            image_atlas: None,
             shaders,
             #[cfg(feature = "debug_layers")]
             debug,
@@ -477,8 +479,13 @@ impl Renderer {
         texture: &TextureView,
         params: &RenderParams,
     ) -> Result<()> {
-        let (recording, target) =
-            render::render_full(scene, &mut self.resolver, &self.shaders, params);
+        let (recording, target) = render::render_full(
+            scene,
+            &mut self.resolver,
+            &self.shaders,
+            &mut self.image_atlas,
+            params,
+        );
         let external_resources = [ExternalResource::Image(
             *target.as_image().unwrap(),
             texture,
@@ -602,6 +609,7 @@ impl Renderer {
             return Err(error.into());
         }
         self.engine = engine;
+        self.image_atlas = None;
         self.shaders = shaders;
         #[cfg(feature = "debug_layers")]
         {
@@ -716,6 +724,7 @@ impl Renderer {
             encoding,
             &mut self.resolver,
             &self.shaders,
+            &mut self.image_atlas,
             params,
             robust,
         );

--- a/vello/src/render.rs
+++ b/vello/src/render.rs
@@ -12,6 +12,13 @@ use crate::Scene;
 
 use vello_encoding::{Encoding, Resolver, WorkgroupSize, make_mask_lut, make_mask_lut_16};
 
+#[derive(Clone, Copy, Debug)]
+enum AtlasProxyAction {
+    Created,
+    Reused,
+    Resized,
+}
+
 /// State for a render in progress.
 pub struct Render {
     fine_wg_count: Option<WorkgroupSize>,
@@ -78,9 +85,10 @@ pub(crate) fn render_full(
     scene: &Scene,
     resolver: &mut Resolver,
     shaders: &FullShaders,
+    image_atlas: &mut Option<ImageProxy>,
     params: &RenderParams,
 ) -> (Recording, ResourceProxy) {
-    render_encoding_full(scene.encoding(), resolver, shaders, params)
+    render_encoding_full(scene.encoding(), resolver, shaders, image_atlas, params)
 }
 
 #[cfg(feature = "wgpu")]
@@ -92,10 +100,12 @@ pub(crate) fn render_encoding_full(
     encoding: &Encoding,
     resolver: &mut Resolver,
     shaders: &FullShaders,
+    image_atlas: &mut Option<ImageProxy>,
     params: &RenderParams,
 ) -> (Recording, ResourceProxy) {
     let mut render = Render::new();
-    let mut recording = render.render_encoding_coarse(encoding, resolver, shaders, params, false);
+    let mut recording =
+        render.render_encoding_coarse(encoding, resolver, shaders, image_atlas, params, false);
     let out_image = render.out_image();
     render.record_fine(shaders, &mut recording);
     (recording, out_image.into())
@@ -127,6 +137,7 @@ impl Render {
         encoding: &Encoding,
         resolver: &mut Resolver,
         shaders: &FullShaders,
+        persistent_image_atlas: &mut Option<ImageProxy>,
         params: &RenderParams,
         robust: bool,
     ) -> Recording {
@@ -146,11 +157,47 @@ impl Render {
                 data,
             ))
         };
-        let image_atlas = if images.images.is_empty() {
-            ImageProxy::new(1, 1, ImageFormat::Rgba8)
-        } else {
-            ImageProxy::new(images.width, images.height, ImageFormat::Rgba8)
+        let atlas_width = images.width.max(1);
+        let atlas_height = images.height.max(1);
+        let (image_atlas, atlas_proxy_action) = match persistent_image_atlas {
+            Some(proxy) if proxy.width == atlas_width && proxy.height == atlas_height => {
+                (*proxy, AtlasProxyAction::Reused)
+            }
+            Some(proxy) => {
+                recording.free_image(*proxy);
+                let new_proxy = ImageProxy::new(atlas_width, atlas_height, ImageFormat::Rgba8);
+                *persistent_image_atlas = Some(new_proxy);
+                (new_proxy, AtlasProxyAction::Resized)
+            }
+            None => {
+                let proxy = ImageProxy::new(atlas_width, atlas_height, ImageFormat::Rgba8);
+                *persistent_image_atlas = Some(proxy);
+                (proxy, AtlasProxyAction::Created)
+            }
         };
+        if !matches!(atlas_proxy_action, AtlasProxyAction::Reused)
+            || !images.images.is_empty()
+            || images.evicted != 0
+        {
+            if images.evicted == 0 {
+                log::debug!(
+                    "image atlas {}x{}: {:?}, {} upload(s)",
+                    atlas_width,
+                    atlas_height,
+                    atlas_proxy_action,
+                    images.images.len()
+                );
+            } else {
+                log::debug!(
+                    "image atlas {}x{}: {:?}, {} upload(s), {} eviction(s)",
+                    atlas_width,
+                    atlas_height,
+                    atlas_proxy_action,
+                    images.images.len(),
+                    images.evicted
+                );
+            }
+        }
         for image in images.images {
             recording.write_image(image_atlas, image.1, image.2, image.0.clone());
         }
@@ -573,7 +620,6 @@ impl Render {
         recording.free_resource(fine.segments_buf);
         recording.free_resource(fine.ptcl_buf);
         recording.free_resource(fine.gradient_image);
-        recording.free_resource(fine.image_atlas);
         recording.free_resource(fine.info_bin_data_buf);
         recording.free_resource(fine.blend_spill_buf);
         // TODO: make mask buf persistent

--- a/vello_encoding/src/image_cache.rs
+++ b/vello_encoding/src/image_cache.rs
@@ -24,6 +24,7 @@ struct ResidentImage {
     alloc_id: AllocId,
     x: u32,
     y: u32,
+    dirty: bool,
     last_seen_generation: u64,
 }
 
@@ -34,7 +35,7 @@ pub(crate) struct ImageCache {
     evicted_in_resolve: usize,
     /// Map from image blob id to atlas residency.
     map: HashMap<u64, ResidentImage>,
-    /// Images referenced in the current resolve pass, with atlas locations.
+    /// Images that must be uploaded in the current resolve pass, with atlas locations.
     images: Vec<(ImageData, u32, u32)>,
 }
 
@@ -102,8 +103,10 @@ impl ImageCache {
                 let xy = (resident.x, resident.y);
                 if resident.last_seen_generation != self.generation {
                     resident.last_seen_generation = self.generation;
-                    self.images
-                        .push((resident.image.clone(), resident.x, resident.y));
+                    if resident.dirty {
+                        self.images
+                            .push((resident.image.clone(), resident.x, resident.y));
+                    }
                 }
                 Some(xy)
             }
@@ -118,11 +121,20 @@ impl ImageCache {
                     alloc_id: alloc.id,
                     x,
                     y,
+                    dirty: true,
                     last_seen_generation: self.generation,
                 };
                 self.images.push((image.clone(), x, y));
                 vacant.insert(resident);
                 Some((x, y))
+            }
+        }
+    }
+
+    pub(crate) fn finish_resolve(&mut self) {
+        for resident in self.map.values_mut() {
+            if resident.last_seen_generation == self.generation {
+                resident.dirty = false;
             }
         }
     }
@@ -167,6 +179,7 @@ impl ImageCache {
             resident.alloc_id = alloc.id;
             resident.x = alloc.rectangle.min.x as u32;
             resident.y = alloc.rectangle.min.y as u32;
+            resident.dirty = true;
             self.map.insert(id, resident);
         }
         self.atlas = atlas;
@@ -208,11 +221,12 @@ mod tests {
         cache.begin_resolve();
         let first = cache.get_or_insert(&image).unwrap();
         assert_eq!(cache.images.len(), 1);
+        cache.finish_resolve();
 
         cache.begin_resolve();
         let second = cache.get_or_insert(&image).unwrap();
         assert_eq!(first, second);
-        assert_eq!(cache.images.len(), 1);
+        assert_eq!(cache.images.len(), 0);
         assert_eq!(cache.map.len(), 1);
     }
 

--- a/vello_encoding/src/image_cache.rs
+++ b/vello_encoding/src/image_cache.rs
@@ -1,26 +1,40 @@
 // Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use guillotiere::{AtlasAllocator, size2};
+use guillotiere::{AllocId, AtlasAllocator, size2};
 use peniko::ImageData;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 
 const DEFAULT_ATLAS_SIZE: i32 = 1024;
 const MAX_ATLAS_SIZE: i32 = 8192;
+const EVICT_AFTER_GENERATIONS: u64 = 2;
 
 #[derive(Default)]
 pub struct Images<'a> {
     pub width: u32,
     pub height: u32,
+    pub evicted: usize,
     pub images: &'a [(ImageData, u32, u32)],
+}
+
+#[derive(Clone)]
+struct ResidentImage {
+    image: ImageData,
+    alloc_id: AllocId,
+    x: u32,
+    y: u32,
+    last_seen_generation: u64,
 }
 
 pub(crate) struct ImageCache {
     atlas: AtlasAllocator,
-    /// Map from image blob id to atlas location.
-    map: HashMap<u64, (u32, u32)>,
-    /// List of all allocated images with associated atlas location.
+    max_size: i32,
+    generation: u64,
+    evicted_in_resolve: usize,
+    /// Map from image blob id to atlas residency.
+    map: HashMap<u64, ResidentImage>,
+    /// Images referenced in the current resolve pass, with atlas locations.
     images: Vec<(ImageData, u32, u32)>,
 }
 
@@ -32,10 +46,33 @@ impl Default for ImageCache {
 
 impl ImageCache {
     pub(crate) fn new() -> Self {
+        Self::new_with_sizes(DEFAULT_ATLAS_SIZE, MAX_ATLAS_SIZE)
+    }
+
+    fn new_with_sizes(initial_size: i32, max_size: i32) -> Self {
         Self {
-            atlas: AtlasAllocator::new(size2(DEFAULT_ATLAS_SIZE, DEFAULT_ATLAS_SIZE)),
+            atlas: AtlasAllocator::new(size2(initial_size, initial_size)),
+            max_size,
+            generation: 0,
+            evicted_in_resolve: 0,
             map: HashMap::default(),
             images: Vec::default(),
+        }
+    }
+
+    pub(crate) fn begin_resolve(&mut self) {
+        self.generation = self.generation.wrapping_add(1);
+        self.evicted_in_resolve = 0;
+        self.images.clear();
+    }
+
+    pub(crate) fn restart_resolve_pass(&mut self) {
+        self.images.clear();
+        let previous_generation = self.generation.wrapping_sub(1);
+        for resident in self.map.values_mut() {
+            if resident.last_seen_generation == self.generation {
+                resident.last_seen_generation = previous_generation;
+            }
         }
     }
 
@@ -43,39 +80,158 @@ impl ImageCache {
         Images {
             width: self.atlas.size().width as u32,
             height: self.atlas.size().height as u32,
+            evicted: self.evicted_in_resolve,
             images: &self.images,
         }
     }
 
     pub(crate) fn bump_size(&mut self) -> bool {
         let new_size = self.atlas.size().width * 2;
-        if new_size > MAX_ATLAS_SIZE {
+        if new_size > self.max_size {
             return false;
         }
-        self.atlas = AtlasAllocator::new(size2(new_size, new_size));
-        self.map.clear();
+        self.repack_to_size(new_size);
         self.images.clear();
         true
     }
 
-    pub(crate) fn clear(&mut self) {
-        self.atlas.clear();
-        self.map.clear();
-        self.images.clear();
-    }
-
     pub(crate) fn get_or_insert(&mut self, image: &ImageData) -> Option<(u32, u32)> {
         match self.map.entry(image.data.id()) {
-            Entry::Occupied(occupied) => Some(*occupied.get()),
+            Entry::Occupied(mut occupied) => {
+                let resident = occupied.get_mut();
+                let xy = (resident.x, resident.y);
+                if resident.last_seen_generation != self.generation {
+                    resident.last_seen_generation = self.generation;
+                    self.images
+                        .push((resident.image.clone(), resident.x, resident.y));
+                }
+                Some(xy)
+            }
             Entry::Vacant(vacant) => {
                 let alloc = self
                     .atlas
                     .allocate(size2(image.width as _, image.height as _))?;
                 let x = alloc.rectangle.min.x as u32;
                 let y = alloc.rectangle.min.y as u32;
+                let resident = ResidentImage {
+                    image: image.clone(),
+                    alloc_id: alloc.id,
+                    x,
+                    y,
+                    last_seen_generation: self.generation,
+                };
                 self.images.push((image.clone(), x, y));
-                Some(*vacant.insert((x, y)))
+                vacant.insert(resident);
+                Some((x, y))
             }
         }
+    }
+
+    pub(crate) fn can_fit_image(&self, image: &ImageData) -> bool {
+        image.width <= self.atlas.size().width as u32
+            && image.height <= self.atlas.size().height as u32
+    }
+
+    pub(crate) fn evict_stale_entries(&mut self) -> bool {
+        let Some(stale_before) = self.generation.checked_sub(EVICT_AFTER_GENERATIONS) else {
+            return false;
+        };
+        let stale_ids: Vec<_> = self
+            .map
+            .iter()
+            .filter_map(|(id, resident)| {
+                (resident.last_seen_generation < stale_before).then_some(*id)
+            })
+            .collect();
+        if stale_ids.is_empty() {
+            return false;
+        }
+        let evicted_count = stale_ids.len();
+        for id in stale_ids {
+            if let Some(resident) = self.map.remove(&id) {
+                self.atlas.deallocate(resident.alloc_id);
+            }
+        }
+        self.evicted_in_resolve += evicted_count;
+        true
+    }
+
+    fn repack_to_size(&mut self, size: i32) {
+        let mut atlas = AtlasAllocator::new(size2(size, size));
+        let mut entries: Vec<_> = self.map.drain().collect();
+        entries.sort_by_key(|(id, _)| *id);
+        for (id, mut resident) in entries {
+            let alloc = atlas
+                .allocate(size2(resident.image.width as _, resident.image.height as _))
+                .expect("resident image must fit after atlas growth");
+            resident.alloc_id = alloc.id;
+            resident.x = alloc.rectangle.min.x as u32;
+            resident.y = alloc.rectangle.min.y as u32;
+            self.map.insert(id, resident);
+        }
+        self.atlas = atlas;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use peniko::{Blob, ImageAlphaType, ImageFormat};
+    use std::sync::Arc;
+
+    fn image(id_byte: u8, width: u32, height: u32) -> ImageData {
+        let len = (width * height * 4) as usize;
+        ImageData {
+            data: Blob::new(Arc::new(vec![id_byte; len])),
+            format: ImageFormat::Rgba8,
+            width,
+            height,
+            alpha_type: ImageAlphaType::Alpha,
+        }
+    }
+
+    #[test]
+    fn atlas_size_persists_after_growth() {
+        let mut cache = ImageCache::new_with_sizes(16, 64);
+        assert_eq!(cache.atlas.size().width, 16);
+        assert!(cache.bump_size());
+        assert_eq!(cache.atlas.size().width, 32);
+        cache.begin_resolve();
+        assert_eq!(cache.atlas.size().width, 32);
+    }
+
+    #[test]
+    fn resident_entries_are_reused_across_resolves() {
+        let mut cache = ImageCache::new_with_sizes(32, 64);
+        let image = image(7, 8, 8);
+
+        cache.begin_resolve();
+        let first = cache.get_or_insert(&image).unwrap();
+        assert_eq!(cache.images.len(), 1);
+
+        cache.begin_resolve();
+        let second = cache.get_or_insert(&image).unwrap();
+        assert_eq!(first, second);
+        assert_eq!(cache.images.len(), 1);
+        assert_eq!(cache.map.len(), 1);
+    }
+
+    #[test]
+    fn stale_entries_can_be_evicted_under_pressure() {
+        let mut cache = ImageCache::new_with_sizes(16, 16);
+        let image_a = image(1, 10, 10);
+        let image_b = image(2, 10, 10);
+
+        cache.begin_resolve();
+        assert!(cache.get_or_insert(&image_a).is_some());
+
+        cache.begin_resolve();
+
+        cache.begin_resolve();
+        cache.begin_resolve();
+        assert!(cache.get_or_insert(&image_b).is_none());
+        assert!(cache.evict_stale_entries());
+        assert!(cache.get_or_insert(&image_b).is_some());
+        assert!(!cache.map.contains_key(&image_a.data.id()));
     }
 }

--- a/vello_encoding/src/image_cache.rs
+++ b/vello_encoding/src/image_cache.rs
@@ -12,9 +12,15 @@ const EVICT_AFTER_GENERATIONS: u64 = 2;
 
 #[derive(Default)]
 pub struct Images<'a> {
+    /// Width of the square image atlas texture.
     pub width: u32,
+    /// Height of the square image atlas texture.
     pub height: u32,
+    /// Number of resident images evicted during the current resolve pass.
+    ///
+    /// This is only used for renderer-side debug logging.
     pub evicted: usize,
+    /// Images that must be uploaded in the current resolve pass, with atlas locations.
     pub images: &'a [(ImageData, u32, u32)],
 }
 
@@ -25,13 +31,19 @@ struct ResidentImage {
     x: u32,
     y: u32,
     dirty: bool,
-    last_seen_generation: u64,
+    last_used_generation: u64,
 }
 
 pub(crate) struct ImageCache {
     atlas: AtlasAllocator,
+    /// Maximum side length for the square image atlas texture.
     max_size: i32,
+    /// Monotonic counter for resolve passes, used to track when resident images were last used.
     generation: u64,
+    /// Number of resident images evicted during the current resolve pass.
+    ///
+    /// This is exposed through [`Images::evicted`] for renderer-side debug logging, and also
+    /// prevents repeated stale-eviction scans during the same resolve pass.
     evicted_in_resolve: usize,
     /// Map from image blob id to atlas residency.
     map: HashMap<u64, ResidentImage>,
@@ -71,8 +83,8 @@ impl ImageCache {
         self.images.clear();
         let previous_generation = self.generation.wrapping_sub(1);
         for resident in self.map.values_mut() {
-            if resident.last_seen_generation == self.generation {
-                resident.last_seen_generation = previous_generation;
+            if resident.last_used_generation == self.generation {
+                resident.last_used_generation = previous_generation;
             }
         }
     }
@@ -87,13 +99,15 @@ impl ImageCache {
     }
 
     pub(crate) fn bump_size(&mut self) -> bool {
-        let new_size = self.atlas.size().width * 2;
-        if new_size > self.max_size {
-            return false;
+        let mut new_size = self.atlas.size().width * 2;
+        while new_size <= self.max_size {
+            if self.repack_to_size(new_size) {
+                self.images.clear();
+                return true;
+            }
+            new_size *= 2;
         }
-        self.repack_to_size(new_size);
-        self.images.clear();
-        true
+        false
     }
 
     pub(crate) fn get_or_insert(&mut self, image: &ImageData) -> Option<(u32, u32)> {
@@ -101,8 +115,8 @@ impl ImageCache {
             Entry::Occupied(mut occupied) => {
                 let resident = occupied.get_mut();
                 let xy = (resident.x, resident.y);
-                if resident.last_seen_generation != self.generation {
-                    resident.last_seen_generation = self.generation;
+                if resident.last_used_generation != self.generation {
+                    resident.last_used_generation = self.generation;
                     if resident.dirty {
                         self.images
                             .push((resident.image.clone(), resident.x, resident.y));
@@ -122,7 +136,7 @@ impl ImageCache {
                     x,
                     y,
                     dirty: true,
-                    last_seen_generation: self.generation,
+                    last_used_generation: self.generation,
                 };
                 self.images.push((image.clone(), x, y));
                 vacant.insert(resident);
@@ -133,7 +147,7 @@ impl ImageCache {
 
     pub(crate) fn finish_resolve(&mut self) {
         for resident in self.map.values_mut() {
-            if resident.last_seen_generation == self.generation {
+            if resident.last_used_generation == self.generation {
                 resident.dirty = false;
             }
         }
@@ -145,44 +159,43 @@ impl ImageCache {
     }
 
     pub(crate) fn evict_stale_entries(&mut self) -> bool {
+        if self.evicted_in_resolve != 0 {
+            return false;
+        }
         let Some(stale_before) = self.generation.checked_sub(EVICT_AFTER_GENERATIONS) else {
             return false;
         };
-        let stale_ids: Vec<_> = self
+        for (_id, resident) in self
             .map
-            .iter()
-            .filter_map(|(id, resident)| {
-                (resident.last_seen_generation < stale_before).then_some(*id)
-            })
-            .collect();
-        if stale_ids.is_empty() {
-            return false;
+            .extract_if(|_, resident| resident.last_used_generation < stale_before)
+        {
+            self.atlas.deallocate(resident.alloc_id);
+            self.evicted_in_resolve += 1;
         }
-        let evicted_count = stale_ids.len();
-        for id in stale_ids {
-            if let Some(resident) = self.map.remove(&id) {
-                self.atlas.deallocate(resident.alloc_id);
-            }
-        }
-        self.evicted_in_resolve += evicted_count;
-        true
+        self.evicted_in_resolve != 0
     }
 
-    fn repack_to_size(&mut self, size: i32) {
+    fn repack_to_size(&mut self, size: i32) -> bool {
         let mut atlas = AtlasAllocator::new(size2(size, size));
-        let mut entries: Vec<_> = self.map.drain().collect();
+        let mut entries: Vec<_> = self.map.iter().collect();
         entries.sort_by_key(|(id, _)| *id);
-        for (id, mut resident) in entries {
-            let alloc = atlas
-                .allocate(size2(resident.image.width as _, resident.image.height as _))
-                .expect("resident image must fit after atlas growth");
+        let mut map = HashMap::with_capacity(self.map.len());
+        for (id, resident) in entries {
+            let Some(alloc) =
+                atlas.allocate(size2(resident.image.width as _, resident.image.height as _))
+            else {
+                return false;
+            };
+            let mut resident = resident.clone();
             resident.alloc_id = alloc.id;
             resident.x = alloc.rectangle.min.x as u32;
             resident.y = alloc.rectangle.min.y as u32;
             resident.dirty = true;
-            self.map.insert(id, resident);
+            map.insert(*id, resident);
         }
         self.atlas = atlas;
+        self.map = map;
+        true
     }
 }
 
@@ -247,5 +260,41 @@ mod tests {
         assert!(cache.evict_stale_entries());
         assert!(cache.get_or_insert(&image_b).is_some());
         assert!(!cache.map.contains_key(&image_a.data.id()));
+    }
+
+    #[test]
+    fn stale_entries_are_evicted_at_most_once_per_resolve() {
+        let mut cache = ImageCache::new_with_sizes(32, 32);
+        let image_a = image(1, 8, 8);
+        let image_b = image(2, 8, 8);
+
+        cache.begin_resolve();
+        assert!(cache.get_or_insert(&image_a).is_some());
+        cache.finish_resolve();
+
+        cache.begin_resolve();
+        assert!(cache.get_or_insert(&image_b).is_some());
+        cache.finish_resolve();
+
+        cache.begin_resolve();
+        cache.begin_resolve();
+        cache.begin_resolve();
+
+        assert!(cache.evict_stale_entries());
+        assert!(!cache.evict_stale_entries());
+    }
+
+    #[test]
+    fn failed_repack_leaves_existing_residency_unchanged() {
+        let mut cache = ImageCache::new_with_sizes(16, 16);
+        let image = image(1, 12, 12);
+
+        cache.begin_resolve();
+        let xy = cache.get_or_insert(&image).unwrap();
+
+        assert!(!cache.repack_to_size(8));
+        assert_eq!(cache.atlas.size().width, 16);
+        assert_eq!(cache.get_or_insert(&image), Some(xy));
+        assert_eq!(cache.map.len(), 1);
     }
 }

--- a/vello_encoding/src/resolve.rs
+++ b/vello_encoding/src/resolve.rs
@@ -390,7 +390,7 @@ impl Resolver {
         self.ramp_cache.maintain();
         self.glyphs.clear();
         self.glyph_cache.maintain();
-        self.image_cache.clear();
+        self.image_cache.begin_resolve();
         self.pending_images.clear();
         self.patches.clear();
         let mut sizes = StreamOffsets::default();
@@ -487,13 +487,21 @@ impl Resolver {
     }
 
     fn resolve_pending_images(&mut self) {
-        self.image_cache.clear();
         'outer: loop {
+            self.image_cache.restart_resolve_pass();
+            for pending_image in &mut self.pending_images {
+                pending_image.xy = None;
+            }
             // Loop over the images, attempting to allocate them all into the atlas.
             for pending_image in &mut self.pending_images {
                 if let Some(xy) = self.image_cache.get_or_insert(&pending_image.image) {
                     pending_image.xy = Some(xy);
                 } else {
+                    if self.image_cache.can_fit_image(&pending_image.image)
+                        && self.image_cache.evict_stale_entries()
+                    {
+                        continue 'outer;
+                    }
                     // We failed to allocate. Try to bump the atlas size.
                     if self.image_cache.bump_size() {
                         // We were able to increase the atlas size. Restart the outer loop.

--- a/vello_encoding/src/resolve.rs
+++ b/vello_encoding/src/resolve.rs
@@ -184,6 +184,7 @@ impl Resolver {
         }
         let patch_sizes = self.resolve_patches(encoding);
         self.resolve_pending_images();
+        self.image_cache.finish_resolve();
         let data = packed;
         data.clear();
         let mut layout = Layout {

--- a/vello_encoding/src/resolve.rs
+++ b/vello_encoding/src/resolve.rs
@@ -490,18 +490,16 @@ impl Resolver {
     fn resolve_pending_images(&mut self) {
         'outer: loop {
             self.image_cache.restart_resolve_pass();
-            for pending_image in &mut self.pending_images {
-                pending_image.xy = None;
-            }
             // Loop over the images, attempting to allocate them all into the atlas.
             for pending_image in &mut self.pending_images {
-                if let Some(xy) = self.image_cache.get_or_insert(&pending_image.image) {
-                    pending_image.xy = Some(xy);
-                } else {
+                pending_image.xy = loop {
+                    if let Some(xy) = self.image_cache.get_or_insert(&pending_image.image) {
+                        break Some(xy);
+                    }
                     if self.image_cache.can_fit_image(&pending_image.image)
                         && self.image_cache.evict_stale_entries()
                     {
-                        continue 'outer;
+                        continue;
                     }
                     // We failed to allocate. Try to bump the atlas size.
                     if self.image_cache.bump_size() {
@@ -511,9 +509,9 @@ impl Resolver {
                         // If the atlas is already maximum size, there's nothing we can do. Set
                         // the xy field to None so this image isn't rendered and then carry on--
                         // other images might still fit.
-                        pending_image.xy = None;
+                        break None;
                     }
-                }
+                };
             }
             // If we made it here, we've either successfully allocated all images or we reached
             // the maximum atlas size.


### PR DESCRIPTION
This changes Vello’s image atlas handling from per-render rebuilds to persistent residency.

Before this series, image atlas placement was recomputed on every resolve, and the renderer recreated and rewrote the atlas texture every render. That meant even steady-state scenes that only moved already-uploaded images still paid repeated atlas upload cost. This series keeps atlas residency metadata alive in `vello_encoding`, keeps the atlas texture proxy alive in `vello`, and only uploads images that are newly inserted or dirtied by atlas growth.

What changed:

* `vello_encoding` now keeps the single-atlas allocator and resident image map across resolves.
* Resident entries are reused by blob id instead of being repacked every render.
* Eviction uses generation-based staleness under allocation pressure before growing the atlas.
* Atlas growth still repacks, but marks residents dirty so only required re-uploads happen afterward.
* The renderer now keeps the atlas texture resident across renders and only recreates it when the atlas size changes.
* Atlas logging is quieter in the steady state, but still reports creation, resize, uploads, and eviction activity.
* Added demo scenes that make residency visible, including a large-image case that roughly fills a 4096x4096 atlas with moving images.

Use this to see the trace log messages:

```
RUST_LOG=vello::render=debug cargo run -p with_winit -- --test-scenes
```
