### PR TITLE
vello_cpu: Fix artifacts for bicubic image rendering on x86

### DIFF
--- a/sparse_strips/vello_common/src/util.rs
+++ b/sparse_strips/vello_common/src/util.rs
@@ -15,6 +15,8 @@ use peniko::kurbo::common::FloatFuncs as _;
 ///
 /// **Important note: The values need to be between 0.0 and 1.0, otherwise you might
 /// get inconsistent results across different platforms.**
+// We can't guarantee correctness for values < 0.0 due to a restriction in fearless_simd:
+// https://github.com/linebender/fearless_simd/blob/3f4489389940b7c3c6ee1847a2d007a22494eeff/fearless_simd/src/generated/simd_types.rs#L1623
 #[inline(always)]
 pub fn f32_to_u8<S: Simd>(val: f32x16<S>) -> u8x16<S> {
     let simd = val.simd;

--- a/sparse_strips/vello_common/src/util.rs
+++ b/sparse_strips/vello_common/src/util.rs
@@ -12,6 +12,9 @@ use peniko::kurbo::Affine;
 use peniko::kurbo::common::FloatFuncs as _;
 
 /// Convert f32x16 to u8x16.
+///
+/// **Important note: The values need to be between 0.0 and 1.0, otherwise you might
+/// get inconsistent results across different platforms.**
 #[inline(always)]
 pub fn f32_to_u8<S: Simd>(val: f32x16<S>) -> u8x16<S> {
     let simd = val.simd;

--- a/sparse_strips/vello_cpu/src/fine/common/image.rs
+++ b/sparse_strips/vello_cpu/src/fine/common/image.rs
@@ -314,9 +314,9 @@ impl<S: Simd, const QUALITY: u8> Iterator for FilteredImagePainter<'_, S, QUALIT
                 // compositing with u8-based values. Because of this, we need to clamp
                 // to the alpha value.
                 interpolated_color = interpolated_color
+                    .min(alphas)
                     .min(f32x16::splat(self.simd, 1.0))
-                    .max(f32x16::splat(self.simd, 0.0))
-                    .min(alphas);
+                    .max(f32x16::splat(self.simd, 0.0));
             }
             _ => panic!(
                 "Unknown value for `FilteredImagePainter`'s const-generic `QUALITY` parameter. Expected `1` for bilinear or `2` for bicubic, got: `{QUALITY}`."

--- a/sparse_strips/vello_sparse_tests/snapshots/issue_bicubic_filtering_clamping.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/issue_bicubic_filtering_clamping.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5abec3e076f454eef4f245ff4a4e822416791dbf6135e392c702c91337bb3ae
+size 232

--- a/sparse_strips/vello_sparse_tests/tests/issues.rs
+++ b/sparse_strips/vello_sparse_tests/tests/issues.rs
@@ -4,6 +4,7 @@
 //! Tests for GitHub issues.
 
 use crate::renderer::Renderer;
+use crate::util::layout_glyphs_noto_cbtf;
 use crate::util::stops_blue_green_red_yellow;
 use std::sync::Arc;
 use vello_api::peniko::GradientKind::Radial;
@@ -764,4 +765,19 @@ fn issue_fast_path_strips_and_coarse_batch_in_later_round(ctx: &mut impl Rendere
     ctx.set_paint(Color::from_rgba8(255, 0, 0, 255));
     ctx.fill_rect(&Rect::new(40.0, 40.0, 90.0, 90.0));
     ctx.pop_layer();
+}
+
+#[vello_test(width = 32, height = 32, skip_hybrid, cpu_u8_tolerance = 1)]
+fn issue_bicubic_filtering_clamping(ctx: &mut impl Renderer) {
+    let font_size = 10.0;
+    let (font, glyphs) = layout_glyphs_noto_cbtf("👀", font_size);
+
+    ctx.set_paint(BLACK);
+    ctx.fill_rect(&Rect::new(0.0, 0.0, 32.0, 32.0));
+
+    ctx.set_transform(Affine::translate((5.0, 19.0)));
+    ctx.glyph_run(&font)
+        .font_size(font_size)
+        .glyph_transform(Affine::scale(2.0))
+        .fill_glyphs(glyphs.into_iter());
 }

--- a/sparse_strips/vello_sparse_tests/tests/issues.rs
+++ b/sparse_strips/vello_sparse_tests/tests/issues.rs
@@ -778,6 +778,5 @@ fn issue_bicubic_filtering_clamping(ctx: &mut impl Renderer) {
     ctx.set_transform(Affine::translate((5.0, 19.0)));
     ctx.glyph_run(&font)
         .font_size(font_size)
-        .glyph_transform(Affine::scale(2.0))
         .fill_glyphs(glyphs.into_iter());
 }


### PR DESCRIPTION
Encountered this while working on #1562.

Basically, the problem is that `f32_to_u8` does not have consistent behavior for negative floating point numbers. Therefore, we need to ensure that the values are always positive. Otherwise, on x86 SIMD, the values will wrap to 255 instead of 0, resulting in artifacts for certain pixels where the pixels would end up as white.

We actually already had a guard for this in the code for bicubic rendering, but the problem is that we were applying `min(alphas)` _after_ clamping. This means that in case the alpha values themselves where negatives, we would end up with negative values again. The solution here is to do the clamping in the very end.

Here is an example of the artifacts that would occur:

<img width="667" height="217" alt="image" src="https://github.com/user-attachments/assets/007e891e-71c8-46d7-809e-7d366f33db24" />
