### PR TITLE
vello_hybrid: Use scissor rects for filter pass aplication

### DIFF
--- a/sparse_strips/vello_hybrid/src/filter.rs
+++ b/sparse_strips/vello_hybrid/src/filter.rs
@@ -423,7 +423,7 @@ impl FilterInstanceData {
         // between each pass always stays the same; only the width/height can vary.
         //
         // TODO: Explore whether we can not use scissor rects and instead adjust the vertex shader
-        // to cover the reduced area. Unfortunately, this seemed to caused other non-obvious test
+        // to cover the reduced area. Unfortunately, this seemed to cause other non-obvious test
         // failures, hence why we just use this approach for now.
         let x = self.dest.offset.0[0];
         let y = self.dest.offset.0[1];

--- a/sparse_strips/vello_hybrid/src/filter.rs
+++ b/sparse_strips/vello_hybrid/src/filter.rs
@@ -400,6 +400,48 @@ pub(crate) struct FilterInstanceData {
     pub pass_kind: u32,
 }
 
+impl FilterInstanceData {
+    /// The scissor rect that should be applied when applying this filter
+    /// pass.
+    pub(crate) fn scissor_rect(&self, target_size: [u32; 2]) -> [u32; 4] {
+        // See the comment in `filters.wgsl`. In general, when applying a filter it's not enough
+        // to just cover the destination region of the (possibly downsized) filter area. We also
+        // need to include some padding such that stale border pixels are set back to a fully
+        // transparent color. In the shader, we always use the original size (e.g. if the original
+        // filter layer was 700x700 pixels but the downsized area only 15x15, we would still have fragment
+        // shader invocations for the whole 700x700 area, even if the vast majority just shortcut to
+        // yielding a transparent color).
+        //
+        // However, we can actually further reduce this area: In the bottom/right, we only need to
+        // cover as many additional pixels as are necessary for padding. So in the above case,
+        // we only need to cover (15 + FILTER_ATLAS_PADDING) in each direction. Therefore, when
+        // rendering filters we apply a scissor rect to further reduce the area to only the part
+        // that really needs to be cleared out. Experiments have shown that especially on low-tier
+        // devices, doing this leads to very huge speedups.
+        //
+        // Note that we never need to clear the top/left area, since the origin of a filter
+        // between each pass always stays the same; only the width/height can vary.
+        //
+        // TODO: Explore whether we can not use scissor rects and instead adjust the vertex shader
+        // to cover the reduced area. Unfortunately, this seemed to caused other non-obvious test
+        // failures, hence why we just use this approach for now.
+        let x = self.dest.offset.0[0];
+        let y = self.dest.offset.0[1];
+        let width = self.dest.size.0[0];
+        let height = self.dest.size.0[1];
+        let padding = u32::from(FILTER_ATLAS_PADDING);
+        let x1 = x
+            .saturating_add(width)
+            .saturating_add(padding)
+            .min(target_size[0]);
+        let y1 = y
+            .saturating_add(height)
+            .saturating_add(padding)
+            .min(target_size[1]);
+        [x, y, x1 - x, y1 - y]
+    }
+}
+
 /// Where a filter pass writes its output.
 #[derive(Debug)]
 pub(crate) enum FilterPassTarget {

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -2287,6 +2287,7 @@ impl RendererBackend for WebGlRendererContext<'_> {
         }
 
         self.gl.disable(WebGl2RenderingContext::BLEND);
+        self.gl.enable(WebGl2RenderingContext::SCISSOR_TEST);
 
         let instances = self.filter_pass_state.instances();
         self.programs.upload_filter_instances(self.gl, instances);
@@ -2317,13 +2318,14 @@ impl RendererBackend for WebGlRendererContext<'_> {
                 );
             }
 
-            match &pass.output {
+            let (target_width, target_height) = match &pass.output {
                 FilterPassTarget::FilterAtlas(idx) => {
                     let fb = &self.programs.resources.filter_atlas_framebuffers[*idx as usize];
                     self.gl
                         .bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, Some(fb));
                     self.gl
                         .viewport(0, 0, filter_atlas_width as i32, filter_atlas_height as i32);
+                    (filter_atlas_width as i32, filter_atlas_height as i32)
                 }
                 FilterPassTarget::MainAtlas(idx) => {
                     let fb = self
@@ -2340,14 +2342,18 @@ impl RendererBackend for WebGlRendererContext<'_> {
                         0,
                         *idx as i32,
                     );
-                    self.gl.viewport(
-                        0,
-                        0,
-                        self.programs.resources.atlas_texture_array.size.width as i32,
-                        self.programs.resources.atlas_texture_array.size.height as i32,
-                    );
+                    let width = self.programs.resources.atlas_texture_array.size.width as i32;
+                    let height = self.programs.resources.atlas_texture_array.size.height as i32;
+                    self.gl.viewport(0, 0, width, height);
+                    (width, height)
                 }
-            }
+            };
+
+            let instance = &instances[i];
+            let [x, y, width, height] =
+                instance.scissor_rect([target_width as u32, target_height as u32]);
+            self.gl
+                .scissor(x as i32, y as i32, width as i32, height as i32);
 
             let input_tex =
                 &self.programs.resources.filter_atlas_textures[pass.input_atlas_idx as usize];
@@ -2370,6 +2376,7 @@ impl RendererBackend for WebGlRendererContext<'_> {
                 .draw_arrays_instanced(WebGl2RenderingContext::TRIANGLE_STRIP, 0, 4, 1);
         }
         self.gl.bind_vertex_array(None);
+        self.gl.disable(WebGl2RenderingContext::SCISSOR_TEST);
         self.gl.enable(WebGl2RenderingContext::BLEND);
     }
 }

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -2325,7 +2325,7 @@ impl RendererBackend for WebGlRendererContext<'_> {
                         .bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, Some(fb));
                     self.gl
                         .viewport(0, 0, filter_atlas_width as i32, filter_atlas_height as i32);
-                    (filter_atlas_width as i32, filter_atlas_height as i32)
+                    (filter_atlas_width, filter_atlas_height)
                 }
                 FilterPassTarget::MainAtlas(idx) => {
                     let fb = self
@@ -2342,16 +2342,15 @@ impl RendererBackend for WebGlRendererContext<'_> {
                         0,
                         *idx as i32,
                     );
-                    let width = self.programs.resources.atlas_texture_array.size.width as i32;
-                    let height = self.programs.resources.atlas_texture_array.size.height as i32;
-                    self.gl.viewport(0, 0, width, height);
+                    let width = self.programs.resources.atlas_texture_array.size.width;
+                    let height = self.programs.resources.atlas_texture_array.size.height;
+                    self.gl.viewport(0, 0, width as i32, height as i32);
                     (width, height)
                 }
             };
 
             let instance = &instances[i];
-            let [x, y, width, height] =
-                instance.scissor_rect([target_width as u32, target_height as u32]);
+            let [x, y, width, height] = instance.scissor_rect([target_width, target_height]);
             self.gl
                 .scissor(x as i32, y as i32, width as i32, height as i32);
 

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -2479,10 +2479,18 @@ impl RendererBackend for RendererContext<'_> {
             let original_idx = pass.original_atlas_idx.unwrap_or(pass.input_atlas_idx) as usize;
             let original_bg = &filter_atlas.original_bind_groups[original_idx];
 
-            let output_view = match &pass.output {
-                FilterPassTarget::FilterAtlas(idx) => &filter_atlas.views[*idx as usize],
+            let (output_view, target_width, target_height) = match &pass.output {
+                FilterPassTarget::FilterAtlas(idx) => {
+                    let size = filter_atlas.textures[*idx as usize].size();
+                    (&filter_atlas.views[*idx as usize], size.width, size.height)
+                }
                 FilterPassTarget::MainAtlas(idx) => {
-                    &create_atlas_layer_view(&programs.resources.atlas_texture_array, *idx)
+                    let size = programs.resources.atlas_texture_array.size();
+                    (
+                        &create_atlas_layer_view(&programs.resources.atlas_texture_array, *idx),
+                        size.width,
+                        size.height,
+                    )
                 }
             };
 
@@ -2502,6 +2510,9 @@ impl RendererBackend for RendererContext<'_> {
                 timestamp_writes: None,
                 multiview_mask: None,
             });
+            let instance = &instances[i];
+            let [x, y, width, height] = instance.scissor_rect([target_width, target_height]);
+            render_pass.set_scissor_rect(x, y, width, height);
             render_pass.set_pipeline(&programs.filter_pipeline);
             render_pass.set_bind_group(0, &programs.resources.filter_base_bind_group, &[]);
             render_pass.set_bind_group(1, input_bg, &[]);


### PR DESCRIPTION
Not going to add much more in the description of this PR because I've already documented everything using comments.

On current main, rendering a single filtered rectangle on my Samsung Galaxy Tab A6 only yields 3-4FPS. With this change, I get to 13-14FPS, so a pretty huge speedup. If I use Canvas2D, I get 20FPS, so there is definitely more room for improvement, but I think this should be a good start!