### PR TITLE
vello_hybrid: Use scissor rect when rendering into intermediate layers

### DIFF
--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -1995,7 +1995,7 @@ impl WebGlRendererContext<'_> {
         }
         self.programs.upload_strips(self.gl, strips);
 
-        match &target {
+        let scissor_rect = match &target {
             StripPassRenderTarget::Output(OutputTarget::IntermediateTexture(layer_id)) => {
                 let image_id = self
                     .filter_context
@@ -2057,6 +2057,13 @@ impl WebGlRendererContext<'_> {
                     self.programs.strip_uniforms.config_fs_block_index,
                     Some(buf),
                 );
+
+                Some([
+                    resources.offset[0] as i32,
+                    resources.offset[1] as i32,
+                    resources.width as i32,
+                    resources.height as i32,
+                ])
             }
             StripPassRenderTarget::Output(OutputTarget::FinalView) => {
                 self.gl.bind_framebuffer(
@@ -2077,6 +2084,8 @@ impl WebGlRendererContext<'_> {
                     self.programs.strip_uniforms.config_fs_block_index,
                     Some(&self.programs.resources.view_config_buffer),
                 );
+
+                None
             }
             StripPassRenderTarget::SlotTexture(ix) => {
                 self.gl.bind_framebuffer(
@@ -2103,7 +2112,16 @@ impl WebGlRendererContext<'_> {
                     self.programs.strip_uniforms.config_fs_block_index,
                     Some(&self.programs.resources.slot_config_buffer),
                 );
+
+                None
             }
+        };
+
+        if let Some([x, y, width, height]) = scissor_rect {
+            self.gl.enable(WebGl2RenderingContext::SCISSOR_TEST);
+            self.gl.scissor(x, y, width, height);
+        } else {
+            self.gl.disable(WebGl2RenderingContext::SCISSOR_TEST);
         }
 
         // Clear framebuffer if requested.

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -2241,10 +2241,15 @@ impl RendererContext<'_> {
             }
         }
 
-        let (view, bind_group): (&TextureView, MaybeOwned<'_, BindGroup>) = match target {
+        let (view, bind_group, scissor_rect): (
+            &TextureView,
+            MaybeOwned<'_, BindGroup>,
+            Option<[u32; 4]>,
+        ) = match target {
             StripPassRenderTarget::Output(OutputTarget::FinalView) => (
                 self.view,
                 MaybeOwned::Borrowed(&self.programs.resources.slot_bind_groups[2]),
+                None,
             ),
             StripPassRenderTarget::Output(OutputTarget::IntermediateTexture(layer_id)) => {
                 let image_id = self
@@ -2329,11 +2334,18 @@ impl RendererContext<'_> {
                 (
                     &filter_atlas.views[atlas_idx],
                     MaybeOwned::Owned(bind_group),
+                    Some([
+                        resources.offset[0] as u32,
+                        resources.offset[1] as u32,
+                        resources.width as u32,
+                        resources.height as u32,
+                    ]),
                 )
             }
             StripPassRenderTarget::SlotTexture(idx) => (
                 &self.programs.resources.slot_texture_views[idx as usize],
                 MaybeOwned::Borrowed(&self.programs.resources.slot_bind_groups[idx as usize]),
+                None,
             ),
         };
 
@@ -2358,6 +2370,9 @@ impl RendererContext<'_> {
             timestamp_writes: None,
             multiview_mask: None,
         });
+        if let Some([x, y, width, height]) = scissor_rect {
+            render_pass.set_scissor_rect(x, y, width, height);
+        }
         render_pass.set_pipeline(&self.programs.strip_pipelines[pipeline_idx]);
         render_pass.set_bind_group(0, bind_group.as_ref(), &[]);
         render_pass.set_bind_group(1, &self.programs.resources.atlas_bind_group, &[]);


### PR DESCRIPTION
Stacked on top of #1566. Basically the same as there, but instead when rendering the original contents of the filter layer.

I'm not sure why it helps, because it shouldn't be the case that we are actually rendering any content outside of the targeted region. But it consistently gives me 1-3 additional FPS on my Samsung tablet when rendering scenes that contain filters. Are there any disadvantages I should be aware of?