### PR TITLE
vello_hybrid: Adjust atlas config to actual device capabilities

### DIFF
--- a/sparse_strips/vello_common/src/multi_atlas.rs
+++ b/sparse_strips/vello_common/src/multi_atlas.rs
@@ -461,6 +461,11 @@ pub struct AtlasAllocation {
 }
 
 /// Configuration for multiple atlas support.
+///
+/// Note that any values provided here are recommendations and might not be fully
+/// honored depending on the capabilities of the backend. For example, if you define
+/// the atlas size to be 8192x8192 but the device only supports texture sizes up to 4096x4096,
+/// the backend will likely decide to instead use the value that is compatible with the device.
 #[derive(Debug, Clone, Copy)]
 pub struct AtlasConfig {
     /// Initial number of atlases to create.
@@ -478,14 +483,6 @@ pub struct AtlasConfig {
 impl Default for AtlasConfig {
     fn default() -> Self {
         Self {
-            // NOTE: When targeting wasm32 with a WebGL/GLES backend, you may want to set
-            // `initial_atlas_count` to 2. In WGPU's GLES backend, heuristics are used to decide
-            // whether a texture should be treated as D2 or D2Array. However, this can cause a
-            // mismatch: when depth_or_array_layers == 1, the backend assumes the texture is D2,
-            // even if it was actually created as a D2Array. This issue only occurs with the GLES
-            // backend.
-            //
-            // @see https://github.com/gfx-rs/wgpu/blob/61e5124eb9530d3b3865556a7da4fd320d03ddc5/wgpu-hal/src/gles/mod.rs#L470-L517
             initial_atlas_count: 1,
             max_atlases: 8,
             atlas_size: (4096, 4096),

--- a/sparse_strips/vello_hybrid/src/render/common.rs
+++ b/sparse_strips/vello_hybrid/src/render/common.rs
@@ -9,6 +9,7 @@
 )]
 
 use bytemuck::{Pod, Zeroable};
+use vello_common::multi_atlas::AtlasConfig;
 
 // GPU paint structure sizes in texels (1 texel = 16 bytes for RGBA32Uint texture format).
 pub(crate) const GPU_ENCODED_IMAGE_SIZE_TEXELS: u32 = (size_of::<GpuEncodedImage>() / 16) as u32;
@@ -21,6 +22,62 @@ pub(crate) const GPU_SWEEP_GRADIENT_SIZE_TEXELS: u32 = (size_of::<GpuSweepGradie
 // TODO: If we want to use native bilinear sampling for uploaded images,
 // we can pass 1 instead of 0 here.
 pub(crate) const IMAGE_PADDING: u16 = 0;
+
+pub(crate) fn normalize_atlas_config(
+    config: &mut AtlasConfig,
+    max_texture_dimension_2d: u32,
+    max_texture_array_layers: u32,
+    min_initial_atlas_count: usize,
+) {
+    config.atlas_size.0 = config.atlas_size.0.clamp(1, max_texture_dimension_2d);
+    config.atlas_size.1 = config.atlas_size.1.clamp(1, max_texture_dimension_2d);
+
+    let supported_max_atlases = (max_texture_array_layers as usize).max(min_initial_atlas_count);
+    config.max_atlases = config
+        .max_atlases
+        .clamp(min_initial_atlas_count, supported_max_atlases);
+    config.initial_atlas_count = config
+        .initial_atlas_count
+        .clamp(min_initial_atlas_count, config.max_atlases);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_atlas_config;
+    use vello_common::multi_atlas::AtlasConfig;
+
+    #[test]
+    fn normalize_atlas_config_clamps_to_backend_limits() {
+        let mut config = AtlasConfig {
+            initial_atlas_count: 8,
+            max_atlases: 16,
+            atlas_size: (8192, 2048),
+            ..Default::default()
+        };
+
+        normalize_atlas_config(&mut config, 4096, 4, 1);
+
+        assert_eq!(config.initial_atlas_count, 4);
+        assert_eq!(config.max_atlases, 4);
+        assert_eq!(config.atlas_size, (4096, 2048));
+    }
+
+    #[test]
+    fn normalize_atlas_config_enforces_minimum_initial_count() {
+        let mut config = AtlasConfig {
+            initial_atlas_count: 0,
+            max_atlases: 1,
+            atlas_size: (0, 0),
+            ..Default::default()
+        };
+
+        normalize_atlas_config(&mut config, 4096, 8, 2);
+
+        assert_eq!(config.initial_atlas_count, 2);
+        assert_eq!(config.max_atlases, 2);
+        assert_eq!(config.atlas_size, (1, 1));
+    }
+}
 
 /// Dimensions of the rendering target.
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -31,8 +31,8 @@ use crate::{
             GPU_ENCODED_IMAGE_SIZE_TEXELS, GPU_LINEAR_GRADIENT_SIZE_TEXELS,
             GPU_RADIAL_GRADIENT_SIZE_TEXELS, GPU_SWEEP_GRADIENT_SIZE_TEXELS, GpuEncodedImage,
             GpuEncodedPaint, GpuLinearGradient, GpuRadialGradient, GpuSweepGradient,
-            pack_image_offset, pack_image_params, pack_image_size, pack_radial_kind_and_swapped,
-            pack_texture_width_and_extend_mode, pack_tint,
+            normalize_atlas_config, pack_image_offset, pack_image_params, pack_image_size,
+            pack_radial_kind_and_swapped, pack_texture_width_and_extend_mode, pack_tint,
         },
     },
     scene::Scene,
@@ -73,6 +73,13 @@ const GPU_PAINT_PLACEHOLDER: GpuEncodedPaint = GpuEncodedPaint::LinearGradient(G
 /// Query the WebGL context for the max texture size.
 fn get_max_texture_dimension_2d(gl: &WebGl2RenderingContext) -> u32 {
     gl.get_parameter(WebGl2RenderingContext::MAX_TEXTURE_SIZE)
+        .unwrap()
+        .as_f64()
+        .unwrap() as u32
+}
+
+fn get_max_texture_array_layers(gl: &WebGl2RenderingContext) -> u32 {
+    gl.get_parameter(WebGl2RenderingContext::MAX_ARRAY_TEXTURE_LAYERS)
         .unwrap()
         .as_f64()
         .unwrap() as u32
@@ -142,7 +149,14 @@ impl WebGlRenderer {
             );
         }
 
+        let mut settings = settings;
         let max_texture_dimension_2d = get_max_texture_dimension_2d(&gl);
+        normalize_atlas_config(
+            &mut settings.atlas_config,
+            max_texture_dimension_2d,
+            get_max_texture_array_layers(&gl),
+            1,
+        );
         let total_slots: usize = (max_texture_dimension_2d / u32::from(Tile::HEIGHT)) as usize;
         let image_cache = ImageCache::new_with_config(settings.atlas_config);
         // Estimate the maximum number of gradient cache entries based on the max texture dimension

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -29,8 +29,8 @@ use crate::{
             GPU_ENCODED_IMAGE_SIZE_TEXELS, GPU_LINEAR_GRADIENT_SIZE_TEXELS,
             GPU_RADIAL_GRADIENT_SIZE_TEXELS, GPU_SWEEP_GRADIENT_SIZE_TEXELS, GpuEncodedImage,
             GpuEncodedPaint, GpuLinearGradient, GpuRadialGradient, GpuSweepGradient,
-            pack_image_offset, pack_image_params, pack_image_size, pack_radial_kind_and_swapped,
-            pack_texture_width_and_extend_mode, pack_tint,
+            normalize_atlas_config, pack_image_offset, pack_image_params, pack_image_size,
+            pack_radial_kind_and_swapped, pack_texture_width_and_extend_mode, pack_tint,
         },
     },
     scene::Scene,
@@ -115,7 +115,28 @@ impl Renderer {
     ) -> Self {
         super::common::maybe_warn_about_webgl_feature_conflict();
 
+        let mut settings = settings;
         let max_texture_dimension_2d = device.limits().max_texture_dimension_2d;
+        // When targeting wasm32 with a WebGL/GLES backend, we need to set
+        // `initial_atlas_count` to 2. In WGPU's GLES backend, heuristics are used to decide
+        // whether a texture should be treated as D2 or D2Array. However, this can cause a
+        // mismatch: when depth_or_array_layers == 1, the backend assumes the texture is D2,
+        // even if it was actually created as a D2Array. This issue only occurs with the GLES
+        // backend.
+        //
+        // @see https://github.com/gfx-rs/wgpu/blob/61e5124eb9530d3b3865556a7da4fd320d03ddc5/wgpu-hal/src/gles/mod.rs#L470-L517
+        // TODO: Can we somehow dynamically detect whether the WebGL backend was chosen, so that the
+        // wgpu backend isn't affected by this?
+        #[cfg(target_arch = "wasm32")]
+        let min_initial_atlas_count = 2;
+        #[cfg(not(target_arch = "wasm32"))]
+        let min_initial_atlas_count = 1;
+        normalize_atlas_config(
+            &mut settings.atlas_config,
+            max_texture_dimension_2d,
+            device.limits().max_texture_array_layers,
+            min_initial_atlas_count,
+        );
         let total_slots = (max_texture_dimension_2d / u32::from(Tile::HEIGHT)) as usize;
         let image_cache = ImageCache::new_with_config(settings.atlas_config);
         // Estimate the maximum number of gradient cache entries based on the max texture dimension
@@ -1533,7 +1554,7 @@ impl Programs {
         height: u32,
         atlas_count: u32,
     ) -> (Texture, TextureView) {
-        // See the comment in `AtlasConfig::default`. On WASM, we need to set this to at
+        // See the comment in `Renderer::new_with`. On WASM, we need to set this to at
         // least 2 so it works with the wgpu WebGL backend.
         #[cfg(target_arch = "wasm32")]
         let depth_or_array_layers = atlas_count.max(2);


### PR DESCRIPTION
Right now, `AtlasConfig` implements `Default` with the following configuration:

```rs
impl Default for AtlasConfig {
    fn default() -> Self {
        Self {
            initial_atlas_count: 1,
            max_atlases: 8,
            atlas_size: (4096, 4096),
            auto_grow: true,
            allocation_strategy: AllocationStrategy::FirstFit,
        }
    }
}
```

Given that this is part of `RenderSettings`, users should be able to assume that they can do `RenderSettings::default` and it just works everywhere. However, this is currently not the case, as we will blindly try to allocate the resources without checking the actual device capabilties.

This PR proposes to change this by treating the config as a strong recommendation, but allowing backends to choose different values based on the capabilities of the device it runs on. I experimented with another approach where we instead introduce an `Auto` struct for some fields to allow the users to explicitly opt in for that, and instead let the backend error out in case the user-requested parameters are not compatible with the device. However, this resulted in a much larger code diff, hence why I think just mutating the settings is the easier approach for now.