### PR TITLE
Clear hybrid render targets before drawing

### DIFF
--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -278,9 +278,6 @@ impl Renderer {
             &mut encoded_paints,
         )?;
 
-        // TODO: Passing `false` here because wgpu swapchain textures likely have
-        // undefined initial content, making an explicit clear redundant in the common
-        // case. Verify whether there are scenarios where wgpu would need a clear.
         let result = self.render_scene(
             scene,
             device,
@@ -290,7 +287,7 @@ impl Renderer {
             view,
             &resources.image_cache,
             &encoded_paints,
-            false,
+            true,
             RootRenderTarget::UserSurface,
         );
 

--- a/sparse_strips/vello_sparse_tests/snapshots/render_target_cleared_between_frames.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/render_target_cleared_between_frames.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c11aee7bb3bee9ad6989dfb37efd9b5b90be406082a9b03e2fe4998ae723eca9
+size 109

--- a/sparse_strips/vello_sparse_tests/tests/issues.rs
+++ b/sparse_strips/vello_sparse_tests/tests/issues.rs
@@ -5,6 +5,7 @@
 
 use crate::renderer::Renderer;
 use crate::util::layout_glyphs_noto_cbtf;
+use crate::util::render_pixmap;
 use crate::util::stops_blue_green_red_yellow;
 use std::sync::Arc;
 use vello_api::peniko::GradientKind::Radial;
@@ -371,6 +372,20 @@ fn clip_clear(ctx: &mut impl Renderer) {
         None,
     );
     ctx.pop_layer();
+}
+
+/// Reproduces stale pixels when the hybrid WGPU path reuses a render target without clearing it.
+#[vello_test(width = 64, height = 64, transparent)]
+fn render_target_cleared_between_frames(ctx: &mut impl Renderer) {
+    ctx.set_paint(RED);
+    ctx.fill_rect(&Rect::new(0.0, 0.0, 64.0, 64.0));
+    ctx.flush();
+    let _ = render_pixmap(ctx);
+
+    ctx.reset();
+
+    ctx.set_paint(LIME);
+    ctx.fill_rect(&Rect::new(16.0, 16.0, 48.0, 48.0));
 }
 
 /// <https://github.com/web-platform-tests/wpt/blob/18c64a74b1/html/canvas/element/fill-and-stroke-styles/2d.gradient.interpolate.coloralpha.html>

--- a/sparse_strips/vello_sparse_tests/tests/renderer.rs
+++ b/sparse_strips/vello_sparse_tests/tests/renderer.rs
@@ -68,6 +68,7 @@ pub(crate) trait Renderer: Sized {
     fn set_blend_mode(&mut self, blend_mode: BlendMode);
     fn set_filter_effect(&mut self, filter: Filter);
     fn reset_filter_effect(&mut self);
+    fn reset(&mut self);
     fn render_to_pixmap(&mut self, pixmap: &mut Pixmap);
     fn width(&self) -> u16;
     fn height(&self) -> u16;
@@ -222,6 +223,10 @@ impl Renderer for CpuRenderer {
 
     fn reset_filter_effect(&mut self) {
         self.ctx.reset_filter_effect();
+    }
+
+    fn reset(&mut self) {
+        self.ctx.reset();
     }
 
     fn render_to_pixmap(&mut self, pixmap: &mut Pixmap) {
@@ -488,6 +493,10 @@ impl Renderer for HybridRenderer {
 
     fn reset_filter_effect(&mut self) {
         self.scene.reset_filter_effect();
+    }
+
+    fn reset(&mut self) {
+        self.scene.reset();
     }
 
     // This method creates device resources every time it is called. This does not matter much for
@@ -809,6 +818,10 @@ impl Renderer for HybridRenderer {
 
     fn reset_filter_effect(&mut self) {
         self.scene.reset_filter_effect();
+    }
+
+    fn reset(&mut self) {
+        self.scene.reset();
     }
 
     // vello_hybrid WebGL renderer backend.


### PR DESCRIPTION
This clears the hybrid WGPU render target before normal scene rendering.

The previous behavior assumed that the target contents were either undefined or irrelevant, which is often true for fresh swapchain images. But `Renderer::render` accepts an arbitrary `TextureView`, and in practice it is also used with reused offscreen targets. In that case, transparent or otherwise untouched regions can retain pixels from an earlier frame.

This PR does two things:

* adds a regression test that renders a full frame, resets the scene, then renders a smaller second frame into the same target
* clears the user-surface render path before drawing so the second frame starts from transparent black

The atlas render path is left unchanged. This fix is only for the normal user-facing render target path.
