### PR TITLE
fix: clamp sparse bicubic samples

### DIFF
--- a/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
@@ -1017,13 +1017,9 @@ fn bicubic_sample(
     // Interpolate in y direction
     let result = cy.x * row0 + cy.y * row1 + cy.z * row2 + cy.w * row3;
     
-    // Clamp each component to [0,1] and ensure color components don't exceed alpha
-    return vec4<f32>(
-        min(clamp(result.r, 0.0, 1.0), result.a),
-        min(clamp(result.g, 0.0, 1.0), result.a),
-        min(clamp(result.b, 0.0, 1.0), result.a),
-        min(clamp(result.a, 0.0, 1.0), result.a)
-    );
+    // Clamp alpha first, then clamp premultiplied color channels against it.
+    let a = clamp(result.a, 0.0, 1.0);
+    return vec4<f32>(clamp(result.rgb, vec3(0.0), vec3(a)), a);
 }
 
 // Cubic resampler logic borrowed from Skia (same as CPU cubic_resampler function)


### PR DESCRIPTION
This brings the sparse bicubic clamp logic into parity with the earlier change in 1ba466801a3112e58dc7d1c68abf16108a099201.

Because sparse WebGL is generated from the same WGSL source, it also picks up the same fix.