### PR TITLE
[Vello Hybrid] Opaque Strip Pass

### DIFF
--- a/sparse_strips/vello_hybrid/Cargo.toml
+++ b/sparse_strips/vello_hybrid/Cargo.toml
@@ -37,6 +37,7 @@ web-sys = { version = "0.3.91", features = [
     "WebGlShader",
     "WebGlTexture",
     "WebGlFramebuffer",
+    "WebGlRenderbuffer",
     "WebGlVertexArrayObject",
 ], optional = true }
 

--- a/sparse_strips/vello_hybrid/src/render/common.rs
+++ b/sparse_strips/vello_hybrid/src/render/common.rs
@@ -150,8 +150,9 @@ pub struct GpuStrip {
     pub payload: u32,
     /// See `StripInstance::paint_and_rect_flag` documentation in `render_strips.wgsl`.
     pub paint_and_rect_flag: u32,
-    /// Painter's-order index used to compute z-depth for early-z rejection on TBDR GPUs.
-    /// Monotonically increasing in back-to-front order within a frame.
+    /// Painter's-order index used to compute z-depth for early-z rejection in shader.
+    /// In other words, the back-most layer has index 0 and every additional layer in front 
+    /// has an incrementing index.
     pub layer_index: u32,
 }
 

--- a/sparse_strips/vello_hybrid/src/render/common.rs
+++ b/sparse_strips/vello_hybrid/src/render/common.rs
@@ -150,6 +150,9 @@ pub struct GpuStrip {
     pub payload: u32,
     /// See `StripInstance::paint_and_rect_flag` documentation in `render_strips.wgsl`.
     pub paint_and_rect_flag: u32,
+    /// Painter's-order index used to compute z-depth for early-z rejection on TBDR GPUs.
+    /// Monotonically increasing in back-to-front order within a frame.
+    pub layer_index: u32,
 }
 
 /// Different types of GPU encoded paints.

--- a/sparse_strips/vello_hybrid/src/render/common.rs
+++ b/sparse_strips/vello_hybrid/src/render/common.rs
@@ -151,9 +151,9 @@ pub struct GpuStrip {
     /// See `StripInstance::paint_and_rect_flag` documentation in `render_strips.wgsl`.
     pub paint_and_rect_flag: u32,
     /// Painter's-order index used to compute z-depth for early-z rejection in shader.
-    /// In other words, the back-most layer has index 0 and every additional layer in front
+    /// In other words, the back-most draw has index 0 and every additional draw in front
     /// has an incrementing index.
-    pub layer_index: u32,
+    pub depth_index: u32,
 }
 
 /// Different types of GPU encoded paints.

--- a/sparse_strips/vello_hybrid/src/render/common.rs
+++ b/sparse_strips/vello_hybrid/src/render/common.rs
@@ -151,7 +151,7 @@ pub struct GpuStrip {
     /// See `StripInstance::paint_and_rect_flag` documentation in `render_strips.wgsl`.
     pub paint_and_rect_flag: u32,
     /// Painter's-order index used to compute z-depth for early-z rejection in shader.
-    /// In other words, the back-most layer has index 0 and every additional layer in front 
+    /// In other words, the back-most layer has index 0 and every additional layer in front
     /// has an incrementing index.
     pub layer_index: u32,
 }

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -1995,9 +1995,7 @@ fn create_webgl_resources(
         slot_framebuffers,
         view_framebuffer_override: None,
         depth_cleared_this_frame: false,
-        depth_attachment_array: js_sys::Array::of1(
-            &WebGl2RenderingContext::DEPTH_ATTACHMENT.into(),
-        ),
+        depth_attachment_array: js_sys::Array::of1(&WebGl2RenderingContext::DEPTH.into()),
         max_texture_dimension_2d,
         stub_atlas_texture_array,
         atlas_render_framebuffer: None,

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -1421,10 +1421,10 @@ impl WebGlPrograms {
     fn upload_strip_pair(
         &mut self,
         gl: &WebGl2RenderingContext,
-        first: &[GpuStrip],
-        second: &[GpuStrip],
+        opaque_strips: &[GpuStrip],
+        alpha_strips: &[GpuStrip],
     ) {
-        if first.is_empty() && second.is_empty() {
+        if opaque_strips.is_empty() && alpha_strips.is_empty() {
             return;
         }
 
@@ -1433,9 +1433,9 @@ impl WebGlPrograms {
             Some(&self.resources.strips_buffer),
         );
 
-        let first_bytes: &[u8] = bytemuck::cast_slice(first);
-        let second_bytes: &[u8] = bytemuck::cast_slice(second);
-        let total_len = first_bytes.len() + second_bytes.len();
+        let opaque_bytes: &[u8] = bytemuck::cast_slice(opaque_strips);
+        let alpha_bytes: &[u8] = bytemuck::cast_slice(alpha_strips);
+        let total_len = opaque_bytes.len() + alpha_bytes.len();
 
         // Allocate buffer, then write both slices via bufferSubData.
         // We don't want to pay for concatenating the two slices. It's better to
@@ -1445,18 +1445,18 @@ impl WebGlPrograms {
             total_len as i32,
             WebGl2RenderingContext::DYNAMIC_DRAW,
         );
-        if !first_bytes.is_empty() {
+        if !opaque_bytes.is_empty() {
             gl.buffer_sub_data_with_i32_and_u8_array(
                 WebGl2RenderingContext::ARRAY_BUFFER,
                 0,
-                first_bytes,
+                opaque_bytes,
             );
         }
-        if !second_bytes.is_empty() {
+        if !alpha_bytes.is_empty() {
             gl.buffer_sub_data_with_i32_and_u8_array(
                 WebGl2RenderingContext::ARRAY_BUFFER,
-                first_bytes.len() as i32,
-                second_bytes,
+                opaque_bytes.len() as i32,
+                alpha_bytes,
             );
         }
     }
@@ -2137,7 +2137,7 @@ fn initialize_clear_vao(gl: &WebGl2RenderingContext, resources: &WebGlResources)
 
 /// Context for WebGL rendering operations.
 // TODO: Improve buffer management. Currently a single buffer is used per resource, which means that
-// the GPU must finish drawing before the next `upload_strips` can be executed (effectively pausing
+// the GPU must finish drawing before the next `upload_strip_pair` can be executed (effectively pausing
 // execution). Investigate a buffer pool or creating a new buffer per pass.
 struct WebGlRendererContext<'a> {
     programs: &'a mut WebGlPrograms,

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -1378,9 +1378,15 @@ impl WebGlPrograms {
         gl.clear(WebGl2RenderingContext::COLOR_BUFFER_BIT);
     }
 
-    /// Upload strip data to GPU.
-    fn upload_strips(&mut self, gl: &WebGl2RenderingContext, strips: &[GpuStrip]) {
-        if strips.is_empty() {
+    /// Upload two strip slices (opaque then alpha) into a single GPU buffer,
+    /// avoiding multiple `bufferData` calls.
+    fn upload_strip_pair(
+        &mut self,
+        gl: &WebGl2RenderingContext,
+        first: &[GpuStrip],
+        second: &[GpuStrip],
+    ) {
+        if first.is_empty() && second.is_empty() {
             return;
         }
 
@@ -1388,12 +1394,32 @@ impl WebGlPrograms {
             WebGl2RenderingContext::ARRAY_BUFFER,
             Some(&self.resources.strips_buffer),
         );
-        let strips_data = bytemuck::cast_slice(strips);
-        gl.buffer_data_with_u8_array(
+
+        let first_bytes: &[u8] = bytemuck::cast_slice(first);
+        let second_bytes: &[u8] = bytemuck::cast_slice(second);
+        let total_len = first_bytes.len() + second_bytes.len();
+
+        // Allocate buffer, then write both slices via bufferSubData to avoid
+        // a temporary concatenation Vec.
+        gl.buffer_data_with_i32(
             WebGl2RenderingContext::ARRAY_BUFFER,
-            strips_data,
+            total_len as i32,
             WebGl2RenderingContext::DYNAMIC_DRAW,
         );
+        if !first_bytes.is_empty() {
+            gl.buffer_sub_data_with_i32_and_u8_array(
+                WebGl2RenderingContext::ARRAY_BUFFER,
+                0,
+                first_bytes,
+            );
+        }
+        if !second_bytes.is_empty() {
+            gl.buffer_sub_data_with_i32_and_u8_array(
+                WebGl2RenderingContext::ARRAY_BUFFER,
+                first_bytes.len() as i32,
+                second_bytes,
+            );
+        }
     }
 }
 
@@ -2012,6 +2038,11 @@ fn create_framebuffer_for_texture(
     framebuffer
 }
 
+const STRIP_STRIDE: i32 = size_of::<GpuStrip>() as i32;
+const STRIP_ATTR_COUNT: i32 = STRIP_STRIDE / 4;
+const _: () = assert!(STRIP_STRIDE == 24, "expected stride of 24");
+const _: () = assert!(STRIP_ATTR_COUNT == 6);
+
 /// Initialize strip VAO.
 fn initialize_strip_vao(gl: &WebGl2RenderingContext, resources: &WebGlResources) {
     gl.bind_vertex_array(Some(&resources.strip_vao));
@@ -2020,12 +2051,7 @@ fn initialize_strip_vao(gl: &WebGl2RenderingContext, resources: &WebGlResources)
         Some(&resources.strips_buffer),
     );
 
-    const STRIDE: i32 = size_of::<GpuStrip>() as i32;
-    const { assert!(STRIDE == 24, "expected stride of 24") };
-    let stride = STRIDE;
-
-    // Configure attributes.
-    for i in 0..6 {
+    for i in 0..STRIP_ATTR_COUNT {
         let location = i as u32;
         let offset = i * 4;
 
@@ -2034,7 +2060,7 @@ fn initialize_strip_vao(gl: &WebGl2RenderingContext, resources: &WebGlResources)
             location,
             1,
             WebGl2RenderingContext::UNSIGNED_INT,
-            stride,
+            STRIP_STRIDE,
             offset,
         );
 
@@ -2291,6 +2317,13 @@ impl WebGlRendererContext<'_> {
         let is_final_view =
             matches!(target, StripPassRenderTarget::Output(OutputTarget::FinalView));
 
+        // Single upload for all strip data (opaque then alpha) to avoid
+        // multiple bufferData calls which are more expensive than attribute rebinding.
+        self.programs
+            .upload_strip_pair(self.gl, opaque_strips, alpha_strips);
+        let opaque_count = opaque_strips.len() as i32;
+        let alpha_count = alpha_strips.len() as i32;
+
         if is_final_view {
             // Clear depth buffer on first use per frame.
             if !self.programs.resources.depth_cleared_this_frame {
@@ -2304,29 +2337,51 @@ impl WebGlRendererContext<'_> {
             self.gl.depth_func(WebGl2RenderingContext::LEQUAL);
 
             // Opaque pass: front-to-back, depth write ON, blend OFF.
-            if !opaque_strips.is_empty() {
-                self.programs.upload_strips(self.gl, opaque_strips);
+            // Instances 0..opaque_count are already at offset 0 in the buffer.
+            if opaque_count > 0 {
                 self.gl.depth_mask(true);
                 self.gl.disable(WebGl2RenderingContext::BLEND);
                 self.gl.draw_arrays_instanced(
                     WebGl2RenderingContext::TRIANGLE_STRIP,
                     0,
                     4,
-                    opaque_strips.len() as i32,
+                    opaque_count,
                 );
             }
 
             // Alpha pass: back-to-front, depth test ON, depth write OFF, blend ON.
-            if !alpha_strips.is_empty() {
-                self.programs.upload_strips(self.gl, alpha_strips);
+            // Rebind attribute pointers with offset to start at the alpha portion.
+            if alpha_count > 0 {
+                let alpha_byte_offset = opaque_count * STRIP_STRIDE;
+                for i in 0..STRIP_ATTR_COUNT {
+                    self.gl.vertex_attrib_i_pointer_with_i32(
+                        i as u32,
+                        1,
+                        WebGl2RenderingContext::UNSIGNED_INT,
+                        STRIP_STRIDE,
+                        i as i32 * 4 + alpha_byte_offset,
+                    );
+                }
+
                 self.gl.depth_mask(false);
                 self.gl.enable(WebGl2RenderingContext::BLEND);
                 self.gl.draw_arrays_instanced(
                     WebGl2RenderingContext::TRIANGLE_STRIP,
                     0,
                     4,
-                    alpha_strips.len() as i32,
+                    alpha_count,
                 );
+
+                // Restore attribute offsets to base for subsequent passes.
+                for i in 0..STRIP_ATTR_COUNT {
+                    self.gl.vertex_attrib_i_pointer_with_i32(
+                        i as u32,
+                        1,
+                        WebGl2RenderingContext::UNSIGNED_INT,
+                        STRIP_STRIDE,
+                        i as i32 * 4,
+                    );
+                }
             }
 
             // Restore state.
@@ -2335,18 +2390,11 @@ impl WebGlRendererContext<'_> {
             self.gl.enable(WebGl2RenderingContext::BLEND);
         } else {
             // Slot texture / intermediate: single draw with blending, no depth.
-            // Combine both lists for upload.
-            let all_strips: Vec<GpuStrip> = opaque_strips
-                .iter()
-                .chain(alpha_strips.iter())
-                .copied()
-                .collect();
-            self.programs.upload_strips(self.gl, &all_strips);
             self.gl.draw_arrays_instanced(
                 WebGl2RenderingContext::TRIANGLE_STRIP,
                 0,
                 4,
-                all_strips.len() as i32,
+                opaque_count + alpha_count,
             );
         }
 

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -377,6 +377,7 @@ impl WebGlRenderer {
         if clear {
             self.programs.clear_view_framebuffer(&self.gl);
         }
+        self.programs.resources.depth_cleared_this_frame = false;
         let mut ctx = WebGlRendererContext {
             programs: &mut self.programs,
             gl: &self.gl,
@@ -793,6 +794,8 @@ struct WebGlResources {
     clear_config_buffer: WebGlBuffer,
 
     view_framebuffer_override: Option<WebGlFramebuffer>,
+    /// Whether the depth buffer has been cleared this frame.
+    depth_cleared_this_frame: bool,
 
     /// Slot textures.
     slot_textures: [WebGlTexture; 2],
@@ -1926,6 +1929,7 @@ fn create_webgl_resources(
         slot_textures,
         slot_framebuffers,
         view_framebuffer_override: None,
+        depth_cleared_this_frame: false,
         max_texture_dimension_2d,
         stub_atlas_texture_array,
         atlas_render_framebuffer: None,
@@ -2017,11 +2021,11 @@ fn initialize_strip_vao(gl: &WebGl2RenderingContext, resources: &WebGlResources)
     );
 
     const STRIDE: i32 = size_of::<GpuStrip>() as i32;
-    const { assert!(STRIDE == 20, "expected stride of 20") };
+    const { assert!(STRIDE == 24, "expected stride of 24") };
     let stride = STRIDE;
 
     // Configure attributes.
-    for i in 0..5 {
+    for i in 0..6 {
         let location = i as u32;
         let offset = i * 4;
 
@@ -2079,14 +2083,14 @@ impl WebGlRendererContext<'_> {
     /// Render strips to the specified render target.
     fn do_strip_render_pass(
         &mut self,
-        strips: &[GpuStrip],
+        opaque_strips: &[GpuStrip],
+        alpha_strips: &[GpuStrip],
         target: StripPassRenderTarget,
         load: LoadOp,
     ) {
-        if strips.is_empty() {
+        if opaque_strips.is_empty() && alpha_strips.is_empty() {
             return;
         }
-        self.programs.upload_strips(self.gl, strips);
 
         let scissor_rect = match &target {
             StripPassRenderTarget::FilterLayer(layer_id) => {
@@ -2284,13 +2288,67 @@ impl WebGlRendererContext<'_> {
         self.gl
             .uniform1i(Some(&self.programs.strip_uniforms.gradient_texture), 4);
 
-        // Draw.
-        self.gl.draw_arrays_instanced(
-            WebGl2RenderingContext::TRIANGLE_STRIP,
-            0,
-            4,
-            strips.len() as i32,
-        );
+        let is_final_view =
+            matches!(target, StripPassRenderTarget::Output(OutputTarget::FinalView));
+
+        if is_final_view {
+            // Clear depth buffer on first use per frame.
+            if !self.programs.resources.depth_cleared_this_frame {
+                self.programs.resources.depth_cleared_this_frame = true;
+                self.gl.clear_depth(1.0);
+                self.gl
+                    .clear(WebGl2RenderingContext::DEPTH_BUFFER_BIT);
+            }
+
+            self.gl.enable(WebGl2RenderingContext::DEPTH_TEST);
+            self.gl.depth_func(WebGl2RenderingContext::LEQUAL);
+
+            // Opaque pass: front-to-back, depth write ON, blend OFF.
+            if !opaque_strips.is_empty() {
+                self.programs.upload_strips(self.gl, opaque_strips);
+                self.gl.depth_mask(true);
+                self.gl.disable(WebGl2RenderingContext::BLEND);
+                self.gl.draw_arrays_instanced(
+                    WebGl2RenderingContext::TRIANGLE_STRIP,
+                    0,
+                    4,
+                    opaque_strips.len() as i32,
+                );
+            }
+
+            // Alpha pass: back-to-front, depth test ON, depth write OFF, blend ON.
+            if !alpha_strips.is_empty() {
+                self.programs.upload_strips(self.gl, alpha_strips);
+                self.gl.depth_mask(false);
+                self.gl.enable(WebGl2RenderingContext::BLEND);
+                self.gl.draw_arrays_instanced(
+                    WebGl2RenderingContext::TRIANGLE_STRIP,
+                    0,
+                    4,
+                    alpha_strips.len() as i32,
+                );
+            }
+
+            // Restore state.
+            self.gl.disable(WebGl2RenderingContext::DEPTH_TEST);
+            self.gl.depth_mask(true);
+            self.gl.enable(WebGl2RenderingContext::BLEND);
+        } else {
+            // Slot texture / intermediate: single draw with blending, no depth.
+            // Combine both lists for upload.
+            let all_strips: Vec<GpuStrip> = opaque_strips
+                .iter()
+                .chain(alpha_strips.iter())
+                .copied()
+                .collect();
+            self.programs.upload_strips(self.gl, &all_strips);
+            self.gl.draw_arrays_instanced(
+                WebGl2RenderingContext::TRIANGLE_STRIP,
+                0,
+                4,
+                all_strips.len() as i32,
+            );
+        }
 
         // Clean up.
         self.gl.bind_vertex_array(None);
@@ -2368,11 +2426,12 @@ impl RendererBackend for WebGlRendererContext<'_> {
     /// Execute a render pass for strips.
     fn render_strips(
         &mut self,
-        strips: &[GpuStrip],
+        opaque_strips: &[GpuStrip],
+        alpha_strips: &[GpuStrip],
         target: StripPassRenderTarget,
         load_op: LoadOp,
     ) {
-        self.do_strip_render_pass(strips, target, load_op);
+        self.do_strip_render_pass(opaque_strips, alpha_strips, target, load_op);
     }
 
     fn apply_filter(&mut self, layer_id: LayerId) {

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -177,7 +177,8 @@ impl WebGlRenderer {
                 .unwrap()
                 .as_f64()
                 .unwrap()
-                >= 24.0
+                >= 24.0,
+            "Depth buffer must be at least 24 bits"
         );
         let image_cache = ImageCache::new_with_config(settings.atlas_config);
         // Estimate the maximum number of gradient cache entries based on the max texture dimension
@@ -2081,8 +2082,10 @@ fn create_framebuffer_for_texture(
 
 const STRIP_STRIDE: i32 = size_of::<GpuStrip>() as i32;
 const STRIP_ATTR_COUNT: i32 = STRIP_STRIDE / 4;
-const _: () = assert!(STRIP_STRIDE == 24);
-const _: () = assert!(STRIP_ATTR_COUNT == 6);
+const _: () = assert!(
+    STRIP_STRIDE == 24,
+    "GpuStrip layout must match strip vertex stride"
+);
 
 /// Initialize strip VAO.
 fn initialize_strip_vao(gl: &WebGl2RenderingContext, resources: &WebGlResources) {

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -172,7 +172,13 @@ impl WebGlRenderer {
             1,
         );
         let total_slots: usize = (max_texture_dimension_2d / u32::from(Tile::HEIGHT)) as usize;
-        assert!(gl.get_parameter(WebGl2RenderingContext::DEPTH_BITS).unwrap().as_f64().unwrap() >= 24.0);
+        assert!(
+            gl.get_parameter(WebGl2RenderingContext::DEPTH_BITS)
+                .unwrap()
+                .as_f64()
+                .unwrap()
+                >= 24.0
+        );
         let image_cache = ImageCache::new_with_config(settings.atlas_config);
         // Estimate the maximum number of gradient cache entries based on the max texture dimension
         // and the maximum gradient LUT size - worst case scenario.
@@ -2352,8 +2358,10 @@ impl WebGlRendererContext<'_> {
         // TODO: Today, we only support early-z rejection on the final view. If we wanted to support
         // intermediate layers, we would require separate depth buffers for each target. We can explore
         // that possibility in the future.
-        let is_final_view =
-            matches!(target, StripPassRenderTarget::Root(RootRenderTarget::UserSurface));
+        let is_final_view = matches!(
+            target,
+            StripPassRenderTarget::Root(RootRenderTarget::UserSurface)
+        );
 
         self.programs
             .upload_strip_pair(self.gl, opaque_strips, alpha_strips);
@@ -2365,8 +2373,7 @@ impl WebGlRendererContext<'_> {
             if !self.programs.resources.depth_cleared_this_frame {
                 self.programs.resources.depth_cleared_this_frame = true;
                 self.gl.clear_depth(1.0);
-                self.gl
-                    .clear(WebGl2RenderingContext::DEPTH_BUFFER_BIT);
+                self.gl.clear(WebGl2RenderingContext::DEPTH_BUFFER_BIT);
             }
 
             self.gl.enable(WebGl2RenderingContext::DEPTH_TEST);

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -125,6 +125,7 @@ impl WebGlRenderer {
         // context.
         let context_options = js_sys::Object::new();
         js_sys::Reflect::set(&context_options, &"antialias".into(), &JsValue::FALSE).unwrap();
+        js_sys::Reflect::set(&context_options, &"depth".into(), &JsValue::TRUE).unwrap();
 
         let gl = canvas
             .get_context_with_context_options("webgl2", &context_options)
@@ -394,6 +395,22 @@ impl WebGlRenderer {
             &self.filter_context,
             &encoded_paints,
         )?;
+
+        // See: https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices#use_invalidateframebuffer
+        // We want to indicate to the GPU driver that we won't read the depth buffer again
+        // until the next clear. This enables the GPU to avoid storing depth tiles back to VRAM.
+        if self.programs.resources.depth_cleared_this_frame {
+            self.gl.bind_framebuffer(
+                WebGl2RenderingContext::FRAMEBUFFER,
+                self.programs.resources.view_framebuffer_override.as_ref(),
+            );
+            self.gl
+                .invalidate_framebuffer(
+                    WebGl2RenderingContext::FRAMEBUFFER,
+                    &self.programs.resources.depth_attachment_array,
+                )
+                .unwrap();
+        }
 
         encoded_paints.truncate(original_scene_paint_count);
         self.gradient_cache.maintain();
@@ -796,6 +813,8 @@ struct WebGlResources {
     view_framebuffer_override: Option<WebGlFramebuffer>,
     /// Whether the depth buffer has been cleared this frame.
     depth_cleared_this_frame: bool,
+    /// Pre-allocated JS array for `invalidateFramebuffer` calls.
+    depth_attachment_array: js_sys::Array,
 
     /// Slot textures.
     slot_textures: [WebGlTexture; 2],
@@ -1378,8 +1397,7 @@ impl WebGlPrograms {
         gl.clear(WebGl2RenderingContext::COLOR_BUFFER_BIT);
     }
 
-    /// Upload two strip slices (opaque then alpha) into a single GPU buffer,
-    /// avoiding multiple `bufferData` calls.
+    /// Uploads two strip slices (opaque then alpha) into a single GPU buffer.
     fn upload_strip_pair(
         &mut self,
         gl: &WebGl2RenderingContext,
@@ -1399,8 +1417,9 @@ impl WebGlPrograms {
         let second_bytes: &[u8] = bytemuck::cast_slice(second);
         let total_len = first_bytes.len() + second_bytes.len();
 
-        // Allocate buffer, then write both slices via bufferSubData to avoid
-        // a temporary concatenation Vec.
+        // Allocate buffer, then write both slices via bufferSubData.
+        // We don't want to pay for concatenating the two slices. It's better to
+        // simply write twice.
         gl.buffer_data_with_i32(
             WebGl2RenderingContext::ARRAY_BUFFER,
             total_len as i32,
@@ -1956,6 +1975,9 @@ fn create_webgl_resources(
         slot_framebuffers,
         view_framebuffer_override: None,
         depth_cleared_this_frame: false,
+        depth_attachment_array: js_sys::Array::of1(
+            &WebGl2RenderingContext::DEPTH_ATTACHMENT.into(),
+        ),
         max_texture_dimension_2d,
         stub_atlas_texture_array,
         atlas_render_framebuffer: None,
@@ -2040,7 +2062,7 @@ fn create_framebuffer_for_texture(
 
 const STRIP_STRIDE: i32 = size_of::<GpuStrip>() as i32;
 const STRIP_ATTR_COUNT: i32 = STRIP_STRIDE / 4;
-const _: () = assert!(STRIP_STRIDE == 24, "expected stride of 24");
+const _: () = assert!(STRIP_STRIDE == 24);
 const _: () = assert!(STRIP_ATTR_COUNT == 6);
 
 /// Initialize strip VAO.
@@ -2314,11 +2336,11 @@ impl WebGlRendererContext<'_> {
         self.gl
             .uniform1i(Some(&self.programs.strip_uniforms.gradient_texture), 4);
 
+        // TODO: Today, we only support early-z rejection on the final view. If we wanted to support
+        // intermediate layers, we would require separate depth buffers for each target.
         let is_final_view =
-            matches!(target, StripPassRenderTarget::Output(OutputTarget::FinalView));
+            matches!(target, StripPassRenderTarget::Root(RootRenderTarget::UserSurface));
 
-        // Single upload for all strip data (opaque then alpha) to avoid
-        // multiple bufferData calls which are more expensive than attribute rebinding.
         self.programs
             .upload_strip_pair(self.gl, opaque_strips, alpha_strips);
         let opaque_count = opaque_strips.len() as i32;
@@ -2337,7 +2359,6 @@ impl WebGlRendererContext<'_> {
             self.gl.depth_func(WebGl2RenderingContext::LEQUAL);
 
             // Opaque pass: front-to-back, depth write ON, blend OFF.
-            // Instances 0..opaque_count are already at offset 0 in the buffer.
             if opaque_count > 0 {
                 self.gl.depth_mask(true);
                 self.gl.disable(WebGl2RenderingContext::BLEND);
@@ -2350,7 +2371,8 @@ impl WebGlRendererContext<'_> {
             }
 
             // Alpha pass: back-to-front, depth test ON, depth write OFF, blend ON.
-            // Rebind attribute pointers with offset to start at the alpha portion.
+            // Rebind attribute pointers with offset to start at the alpha portion
+            // of the buffer.
             if alpha_count > 0 {
                 let alpha_byte_offset = opaque_count * STRIP_STRIDE;
                 for i in 0..STRIP_ATTR_COUNT {
@@ -2359,7 +2381,7 @@ impl WebGlRendererContext<'_> {
                         1,
                         WebGl2RenderingContext::UNSIGNED_INT,
                         STRIP_STRIDE,
-                        i as i32 * 4 + alpha_byte_offset,
+                        i * 4 + alpha_byte_offset,
                     );
                 }
 
@@ -2379,7 +2401,7 @@ impl WebGlRendererContext<'_> {
                         1,
                         WebGl2RenderingContext::UNSIGNED_INT,
                         STRIP_STRIDE,
-                        i as i32 * 4,
+                        i * 4,
                     );
                 }
             }

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -2373,15 +2373,15 @@ impl WebGlRendererContext<'_> {
         let alpha_count = alpha_strips.len() as i32;
 
         if is_final_view {
+            self.gl.enable(WebGl2RenderingContext::DEPTH_TEST);
+            self.gl.depth_func(WebGl2RenderingContext::LEQUAL);
+
             // Clear depth buffer on first use per frame.
             if !self.programs.resources.depth_cleared_this_frame {
                 self.programs.resources.depth_cleared_this_frame = true;
                 self.gl.clear_depth(1.0);
                 self.gl.clear(WebGl2RenderingContext::DEPTH_BUFFER_BIT);
             }
-
-            self.gl.enable(WebGl2RenderingContext::DEPTH_TEST);
-            self.gl.depth_func(WebGl2RenderingContext::LEQUAL);
 
             // Opaque pass: front-to-back, depth test ON, depth write ON, blend OFF.
             if opaque_count > 0 {

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -1995,6 +1995,9 @@ fn create_webgl_resources(
         slot_framebuffers,
         view_framebuffer_override: None,
         depth_cleared_this_frame: false,
+        // Note: we use DEPTH (not DEPTH_ATTACHMENT) because we render to the default
+        // framebuffer. If we ever support non-default framebuffers, this must change
+        // to DEPTH_ATTACHMENT.
         depth_attachment_array: js_sys::Array::of1(&WebGl2RenderingContext::DEPTH.into()),
         max_texture_dimension_2d,
         stub_atlas_texture_array,

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -125,6 +125,18 @@ impl WebGlRenderer {
         // context.
         let context_options = js_sys::Object::new();
         js_sys::Reflect::set(&context_options, &"antialias".into(), &JsValue::FALSE).unwrap();
+        // Vello only supports 24+ bit depth buffers. If the hardware falls back to a 16 bit depth buffer,
+        // correctness issues will arise. For all intents and purposes, a device manufactured in the past 10 years
+        // should support 24+ bit depth buffers (certainly those within the realm of what we consider "supported" devices)
+        // but:
+        //
+        // Relevant code for default depth buffer behaviour can be found here:
+        // - Chromium defaults to 24 bit with no fallback: https://github.com/chromium/chromium/blob/86bafb3aab8e999690d310b201d0b5489f512b08/third_party/blink/renderer/platform/graphics/gpu/drawing_buffer.cc#L1376-L1400
+        // - Firefox defaults to 24 bit with no fallback: https://github.com/mozilla/gecko-dev/blob/5836a062726f715fda621338a17b51aff30d0a8c/gfx/gl/MozFramebuffer.cpp#L155-L161
+        // - Safari defaults to 24 bit _with 16 bit_ fallback: https://github.com/WebKit/WebKit/blob/a6d6c154bbee0643f5ad1e55c071558c0df9aef7/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp#L393-L416
+        //
+        // TODO: The above understanding is encoded in a below assertion, but this should be encapsulated within a
+        // "this device can run Vello correctly" check function.
         js_sys::Reflect::set(&context_options, &"depth".into(), &JsValue::TRUE).unwrap();
 
         let gl = canvas
@@ -160,6 +172,7 @@ impl WebGlRenderer {
             1,
         );
         let total_slots: usize = (max_texture_dimension_2d / u32::from(Tile::HEIGHT)) as usize;
+        assert!(gl.get_parameter(WebGl2RenderingContext::DEPTH_BITS).unwrap().as_f64().unwrap() >= 24.0);
         let image_cache = ImageCache::new_with_config(settings.atlas_config);
         // Estimate the maximum number of gradient cache entries based on the max texture dimension
         // and the maximum gradient LUT size - worst case scenario.
@@ -2337,7 +2350,8 @@ impl WebGlRendererContext<'_> {
             .uniform1i(Some(&self.programs.strip_uniforms.gradient_texture), 4);
 
         // TODO: Today, we only support early-z rejection on the final view. If we wanted to support
-        // intermediate layers, we would require separate depth buffers for each target.
+        // intermediate layers, we would require separate depth buffers for each target. We can explore
+        // that possibility in the future.
         let is_final_view =
             matches!(target, StripPassRenderTarget::Root(RootRenderTarget::UserSurface));
 
@@ -2358,7 +2372,7 @@ impl WebGlRendererContext<'_> {
             self.gl.enable(WebGl2RenderingContext::DEPTH_TEST);
             self.gl.depth_func(WebGl2RenderingContext::LEQUAL);
 
-            // Opaque pass: front-to-back, depth write ON, blend OFF.
+            // Opaque pass: front-to-back, depth test ON, depth write ON, blend OFF.
             if opaque_count > 0 {
                 self.gl.depth_mask(true);
                 self.gl.disable(WebGl2RenderingContext::BLEND);
@@ -2371,9 +2385,9 @@ impl WebGlRendererContext<'_> {
             }
 
             // Alpha pass: back-to-front, depth test ON, depth write OFF, blend ON.
-            // Rebind attribute pointers with offset to start at the alpha portion
-            // of the buffer.
             if alpha_count > 0 {
+                // Rebind attribute pointers with offset to start at the alpha portion
+                // of the buffer.
                 let alpha_byte_offset = opaque_count * STRIP_STRIDE;
                 for i in 0..STRIP_ATTR_COUNT {
                     self.gl.vertex_attrib_i_pointer_with_i32(

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -2434,19 +2434,19 @@ impl Programs {
         &mut self,
         device: &Device,
         queue: &Queue,
-        first: &[GpuStrip],
-        second: &[GpuStrip],
+        opaque_strips: &[GpuStrip],
+        alpha_strips: &[GpuStrip],
     ) {
-        let first_bytes = size_of_val(first) as u64;
-        let second_bytes = size_of_val(second) as u64;
-        let total = first_bytes + second_bytes;
+        let opaque_bytes = size_of_val(opaque_strips) as u64;
+        let alpha_bytes = size_of_val(alpha_strips) as u64;
+        let total = opaque_bytes + alpha_bytes;
         self.resources.strips_buffer = Self::create_strips_buffer(device, total);
         // TODO: Consider using a staging belt to avoid an extra staging buffer allocation.
         let mut buffer = queue
             .write_buffer_with(&self.resources.strips_buffer, 0, total.try_into().unwrap())
             .expect("Capacity handled in creation");
-        buffer[..first_bytes as usize].copy_from_slice(bytemuck::cast_slice(first));
-        buffer[first_bytes as usize..].copy_from_slice(bytemuck::cast_slice(second));
+        buffer[..opaque_bytes as usize].copy_from_slice(bytemuck::cast_slice(opaque_strips));
+        buffer[opaque_bytes as usize..].copy_from_slice(bytemuck::cast_slice(alpha_strips));
     }
 }
 

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -2204,9 +2204,9 @@ impl Programs {
 
             self.depth_texture =
                 Self::create_depth_texture(device, new_render_size.width, new_render_size.height);
-            self.depth_texture_view =
-                self.depth_texture
-                    .create_view(&TextureViewDescriptor::default());
+            self.depth_texture_view = self
+                .depth_texture
+                .create_view(&TextureViewDescriptor::default());
 
             self.render_size = new_render_size.clone();
         }
@@ -2442,11 +2442,7 @@ impl Programs {
         let total = first_bytes + second_bytes;
         self.resources.strips_buffer = Self::create_strips_buffer(device, total);
         let mut buffer = queue
-            .write_buffer_with(
-                &self.resources.strips_buffer,
-                0,
-                total.try_into().unwrap(),
-            )
+            .write_buffer_with(&self.resources.strips_buffer, 0, total.try_into().unwrap())
             .expect("Capacity handled in creation");
         buffer[..first_bytes as usize].copy_from_slice(bytemuck::cast_slice(first));
         buffer[first_bytes as usize..].copy_from_slice(bytemuck::cast_slice(second));
@@ -2614,8 +2610,10 @@ impl RendererContext<'_> {
             0
         };
 
-        let is_final_view =
-            matches!(target, StripPassRenderTarget::Root(RootRenderTarget::UserSurface));
+        let is_final_view = matches!(
+            target,
+            StripPassRenderTarget::Root(RootRenderTarget::UserSurface)
+        );
 
         let depth_stencil_attachment = if is_final_view {
             let depth_load = if self.programs.depth_cleared_this_frame {

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -2422,6 +2422,8 @@ impl RendererContext<'_> {
         if opaque_strips.is_empty() && alpha_strips.is_empty() {
             return;
         }
+        // TODO: We currently allocate a new strips buffer for each render pass. A more efficient
+        // approach would be to re-use buffers or slices of a larger buffer.
         self.programs
             .upload_strip_pair(self.device, self.queue, opaque_strips, alpha_strips);
         let opaque_count = opaque_strips.len() as u32;

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -839,7 +839,7 @@ fn clear_atlas_region(queue: &Queue, renderer: &mut Renderer, rect: &PendingClea
 /// Defines the GPU resources and pipelines for rendering.
 #[derive(Debug)]
 struct Programs {
-    /// Pipelines for rendering strips to slot textures (no depth, blending ON).
+    /// Pipelines for rendering strips to slot textures (depth test OFF, depth write OFF, blending ON).
     /// The first pipeline should be used for color attachments in the native pixel format,
     /// the second for color attachments in RGBA8.
     slot_strip_pipelines: [RenderPipeline; 2],
@@ -1184,7 +1184,7 @@ impl Programs {
             attributes: &GpuStrip::vertex_attributes(),
         };
 
-        // Slot pipelines: no depth, blending ON (for slot textures without depth attachment).
+        // Slot pipelines: depth test OFF, depth write OFF, blending ON
         let slot_strip_pipelines: [RenderPipeline; 2] = core::array::from_fn(|i| {
             device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
                 label: Some("Strip Slot Pipeline"),
@@ -1216,7 +1216,7 @@ impl Programs {
             })
         });
 
-        // Alpha pipelines: blending ON, depth test ON (LessEqual), depth write OFF.
+        // Alpha pipelines: depth test ON (LessEqual), depth write OFF, blending ON.
         let alpha_strip_pipelines: [RenderPipeline; 2] = core::array::from_fn(|i| {
             device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
                 label: Some("Strip Alpha Pipeline"),
@@ -1254,7 +1254,7 @@ impl Programs {
             })
         });
 
-        // Opaque pipelines: blending OFF, depth test ON (LessEqual), depth write ON.
+        // Opaque pipelines: depth test ON (LessEqual), depth write ON, blending OFF.
         let opaque_strip_pipelines: [RenderPipeline; 2] = core::array::from_fn(|i| {
             device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
                 label: Some("Strip Opaque Pipeline"),
@@ -2428,8 +2428,7 @@ impl Programs {
         }
     }
 
-    /// Upload two strip slices (opaque then alpha) into a single GPU buffer,
-    /// avoiding an intermediate Vec allocation.
+    /// Uploads two strip slices (opaque then alpha) into a single GPU buffer.
     fn upload_strip_pair(
         &mut self,
         device: &Device,
@@ -2663,18 +2662,18 @@ impl RendererContext<'_> {
         render_pass.set_vertex_buffer(0, self.programs.resources.strips_buffer.slice(..));
 
         if is_final_view {
-            // Opaque pass: front-to-back, depth write ON, no blend.
+            // Opaque pass
             if opaque_count > 0 {
                 render_pass.set_pipeline(&self.programs.opaque_strip_pipelines[pipeline_idx]);
                 render_pass.draw(0..4, 0..opaque_count);
             }
-            // Alpha pass: back-to-front, depth test ON, depth write OFF, blend ON.
+            // Alpha pass
             if alpha_count > 0 {
                 render_pass.set_pipeline(&self.programs.alpha_strip_pipelines[pipeline_idx]);
                 render_pass.draw(0..4, opaque_count..opaque_count + alpha_count);
             }
         } else {
-            // Slot texture / intermediate: single draw, no depth pipeline.
+            // Slot texture / intermediate
             render_pass.set_pipeline(&self.programs.slot_strip_pipelines[pipeline_idx]);
             render_pass.draw(0..4, 0..opaque_count + alpha_count);
         }

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -2428,19 +2428,28 @@ impl Programs {
         }
     }
 
-    /// Upload the strip data by creating and assigning a new `self.resources.strips_buffer`.
-    fn upload_strips(&mut self, device: &Device, queue: &Queue, strips: &[GpuStrip]) {
-        let required_strips_size = size_of_val(strips) as u64;
-        self.resources.strips_buffer = Self::create_strips_buffer(device, required_strips_size);
-        // TODO: Consider using a staging belt to avoid an extra staging buffer allocation.
+    /// Upload two strip slices (opaque then alpha) into a single GPU buffer,
+    /// avoiding an intermediate Vec allocation.
+    fn upload_strip_pair(
+        &mut self,
+        device: &Device,
+        queue: &Queue,
+        first: &[GpuStrip],
+        second: &[GpuStrip],
+    ) {
+        let first_bytes = size_of_val(first) as u64;
+        let second_bytes = size_of_val(second) as u64;
+        let total = first_bytes + second_bytes;
+        self.resources.strips_buffer = Self::create_strips_buffer(device, total);
         let mut buffer = queue
             .write_buffer_with(
                 &self.resources.strips_buffer,
                 0,
-                required_strips_size.try_into().unwrap(),
+                total.try_into().unwrap(),
             )
             .expect("Capacity handled in creation");
-        buffer.copy_from_slice(bytemuck::cast_slice(strips));
+        buffer[..first_bytes as usize].copy_from_slice(bytemuck::cast_slice(first));
+        buffer[first_bytes as usize..].copy_from_slice(bytemuck::cast_slice(second));
     }
 }
 
@@ -2469,11 +2478,8 @@ impl RendererContext<'_> {
         if opaque_strips.is_empty() && alpha_strips.is_empty() {
             return;
         }
-        // Upload all strips (opaque first, then alpha) into a single buffer.
-        let total_strips: Vec<GpuStrip> =
-            opaque_strips.iter().chain(alpha_strips.iter()).copied().collect();
         self.programs
-            .upload_strips(self.device, self.queue, &total_strips);
+            .upload_strip_pair(self.device, self.queue, opaque_strips, alpha_strips);
         let opaque_count = u32::try_from(opaque_strips.len()).unwrap();
         let alpha_count = u32::try_from(alpha_strips.len()).unwrap();
 

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -1184,113 +1184,63 @@ impl Programs {
             attributes: &GpuStrip::vertex_attributes(),
         };
 
-        // Slot pipelines: depth test OFF, depth write OFF, blending ON
-        let slot_strip_pipelines: [RenderPipeline; 2] = core::array::from_fn(|i| {
-            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-                label: Some("Strip Slot Pipeline"),
-                layout: Some(&strip_pipeline_layout),
-                vertex: wgpu::VertexState {
-                    module: &strip_shader,
-                    entry_point: Some("vs_main"),
-                    buffers: core::slice::from_ref(&strip_vertex_state),
-                    compilation_options: PipelineCompilationOptions::default(),
-                },
-                fragment: Some(wgpu::FragmentState {
-                    module: &strip_shader,
-                    entry_point: Some("fs_main"),
-                    targets: &[Some(ColorTargetState {
-                        format: strip_formats[i],
-                        blend: Some(BlendState::PREMULTIPLIED_ALPHA_BLENDING),
-                        write_mask: ColorWrites::ALL,
-                    })],
-                    compilation_options: PipelineCompilationOptions::default(),
-                }),
-                primitive: wgpu::PrimitiveState {
-                    topology: wgpu::PrimitiveTopology::TriangleStrip,
-                    ..Default::default()
-                },
-                depth_stencil: None,
-                multisample: wgpu::MultisampleState::default(),
-                multiview_mask: None,
-                cache: None,
-            })
-        });
+        let create_strip_pipelines =
+            |label, blend, depth_stencil: Option<wgpu::DepthStencilState>| -> [RenderPipeline; 2] {
+                core::array::from_fn(|i| {
+                    device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                        label: Some(label),
+                        layout: Some(&strip_pipeline_layout),
+                        vertex: wgpu::VertexState {
+                            module: &strip_shader,
+                            entry_point: Some("vs_main"),
+                            buffers: core::slice::from_ref(&strip_vertex_state),
+                            compilation_options: PipelineCompilationOptions::default(),
+                        },
+                        fragment: Some(wgpu::FragmentState {
+                            module: &strip_shader,
+                            entry_point: Some("fs_main"),
+                            targets: &[Some(ColorTargetState {
+                                format: strip_formats[i],
+                                blend,
+                                write_mask: ColorWrites::ALL,
+                            })],
+                            compilation_options: PipelineCompilationOptions::default(),
+                        }),
+                        primitive: wgpu::PrimitiveState {
+                            topology: wgpu::PrimitiveTopology::TriangleStrip,
+                            ..Default::default()
+                        },
+                        depth_stencil: depth_stencil.clone(),
+                        multisample: wgpu::MultisampleState::default(),
+                        multiview_mask: None,
+                        cache: None,
+                    })
+                })
+            };
 
+        let depth_stencil = |depth_write_enabled| wgpu::DepthStencilState {
+            format: depth_format,
+            depth_write_enabled,
+            depth_compare: wgpu::CompareFunction::LessEqual,
+            stencil: wgpu::StencilState::default(),
+            bias: wgpu::DepthBiasState::default(),
+        };
+
+        // Slot pipelines: depth test OFF, depth write OFF, blending ON.
+        let slot_strip_pipelines = create_strip_pipelines(
+            "Strip Slot Pipeline",
+            Some(BlendState::PREMULTIPLIED_ALPHA_BLENDING),
+            None,
+        );
         // Alpha pipelines: depth test ON (LessEqual), depth write OFF, blending ON.
-        let alpha_strip_pipelines: [RenderPipeline; 2] = core::array::from_fn(|i| {
-            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-                label: Some("Strip Alpha Pipeline"),
-                layout: Some(&strip_pipeline_layout),
-                vertex: wgpu::VertexState {
-                    module: &strip_shader,
-                    entry_point: Some("vs_main"),
-                    buffers: core::slice::from_ref(&strip_vertex_state),
-                    compilation_options: PipelineCompilationOptions::default(),
-                },
-                fragment: Some(wgpu::FragmentState {
-                    module: &strip_shader,
-                    entry_point: Some("fs_main"),
-                    targets: &[Some(ColorTargetState {
-                        format: strip_formats[i],
-                        blend: Some(BlendState::PREMULTIPLIED_ALPHA_BLENDING),
-                        write_mask: ColorWrites::ALL,
-                    })],
-                    compilation_options: PipelineCompilationOptions::default(),
-                }),
-                primitive: wgpu::PrimitiveState {
-                    topology: wgpu::PrimitiveTopology::TriangleStrip,
-                    ..Default::default()
-                },
-                depth_stencil: Some(wgpu::DepthStencilState {
-                    format: depth_format,
-                    depth_write_enabled: false,
-                    depth_compare: wgpu::CompareFunction::LessEqual,
-                    stencil: wgpu::StencilState::default(),
-                    bias: wgpu::DepthBiasState::default(),
-                }),
-                multisample: wgpu::MultisampleState::default(),
-                multiview_mask: None,
-                cache: None,
-            })
-        });
-
+        let alpha_strip_pipelines = create_strip_pipelines(
+            "Strip Alpha Pipeline",
+            Some(BlendState::PREMULTIPLIED_ALPHA_BLENDING),
+            Some(depth_stencil(false)),
+        );
         // Opaque pipelines: depth test ON (LessEqual), depth write ON, blending OFF.
-        let opaque_strip_pipelines: [RenderPipeline; 2] = core::array::from_fn(|i| {
-            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-                label: Some("Strip Opaque Pipeline"),
-                layout: Some(&strip_pipeline_layout),
-                vertex: wgpu::VertexState {
-                    module: &strip_shader,
-                    entry_point: Some("vs_main"),
-                    buffers: core::slice::from_ref(&strip_vertex_state),
-                    compilation_options: PipelineCompilationOptions::default(),
-                },
-                fragment: Some(wgpu::FragmentState {
-                    module: &strip_shader,
-                    entry_point: Some("fs_main"),
-                    targets: &[Some(ColorTargetState {
-                        format: strip_formats[i],
-                        blend: None,
-                        write_mask: ColorWrites::ALL,
-                    })],
-                    compilation_options: PipelineCompilationOptions::default(),
-                }),
-                primitive: wgpu::PrimitiveState {
-                    topology: wgpu::PrimitiveTopology::TriangleStrip,
-                    ..Default::default()
-                },
-                depth_stencil: Some(wgpu::DepthStencilState {
-                    format: depth_format,
-                    depth_write_enabled: true,
-                    depth_compare: wgpu::CompareFunction::LessEqual,
-                    stencil: wgpu::StencilState::default(),
-                    bias: wgpu::DepthBiasState::default(),
-                }),
-                multisample: wgpu::MultisampleState::default(),
-                multiview_mask: None,
-                cache: None,
-            })
-        });
+        let opaque_strip_pipelines =
+            create_strip_pipelines("Strip Opaque Pipeline", None, Some(depth_stencil(true)));
 
         let clear_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
             label: Some("Clear Slots Pipeline"),

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -2441,6 +2441,7 @@ impl Programs {
         let second_bytes = size_of_val(second) as u64;
         let total = first_bytes + second_bytes;
         self.resources.strips_buffer = Self::create_strips_buffer(device, total);
+        // TODO: Consider using a staging belt to avoid an extra staging buffer allocation.
         let mut buffer = queue
             .write_buffer_with(&self.resources.strips_buffer, 0, total.try_into().unwrap())
             .expect("Capacity handled in creation");

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -1683,6 +1683,7 @@ impl Programs {
         }
     }
 
+    #[inline]
     fn create_depth_texture(device: &Device, width: u32, height: u32) -> Texture {
         device.create_texture(&wgpu::TextureDescriptor {
             label: Some("Depth Texture"),
@@ -2479,8 +2480,8 @@ impl RendererContext<'_> {
         }
         self.programs
             .upload_strip_pair(self.device, self.queue, opaque_strips, alpha_strips);
-        let opaque_count = u32::try_from(opaque_strips.len()).unwrap();
-        let alpha_count = u32::try_from(alpha_strips.len()).unwrap();
+        let opaque_count = opaque_strips.len() as u32;
+        let alpha_count = alpha_strips.len() as u32;
 
         enum MaybeOwned<'a, T> {
             Borrowed(&'a T),

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -418,6 +418,7 @@ impl Renderer {
         clear: bool,
         root_output_target: RootRenderTarget,
     ) -> Result<(), RenderError> {
+        self.programs.depth_cleared_this_frame = false;
         self.prepare_gpu_encoded_paints(encoded_paints, image_cache);
         // TODO: For the time being, we upload the entire alpha buffer as one big chunk. As a future
         // refinement, we could have a bounded alpha buffer, and break draws when the alpha
@@ -838,10 +839,20 @@ fn clear_atlas_region(queue: &Queue, renderer: &mut Renderer, rect: &PendingClea
 /// Defines the GPU resources and pipelines for rendering.
 #[derive(Debug)]
 struct Programs {
-    /// Pipelines for rendering strips.
+    /// Pipelines for rendering strips to slot textures (no depth, blending ON).
     /// The first pipeline should be used for color attachments in the native pixel format,
     /// the second for color attachments in RGBA8.
-    strip_pipelines: [RenderPipeline; 2],
+    slot_strip_pipelines: [RenderPipeline; 2],
+    /// Alpha pipelines for rendering strips to Output targets (depth test ON, depth write OFF, blending ON).
+    alpha_strip_pipelines: [RenderPipeline; 2],
+    /// Opaque pipelines for rendering strips to Output targets (depth test ON, depth write ON, blending OFF).
+    opaque_strip_pipelines: [RenderPipeline; 2],
+    /// Depth texture for early-z rejection on the Output target.
+    depth_texture: Texture,
+    /// View for the depth texture.
+    depth_texture_view: TextureView,
+    /// Whether the depth buffer has been cleared this frame.
+    depth_cleared_this_frame: bool,
     /// Bind group layout for strip draws
     strip_bind_group_layout: BindGroupLayout,
     /// Bind group layout for encoded paints
@@ -1017,13 +1028,14 @@ struct ClearSlotsConfig {
 
 impl GpuStrip {
     /// Vertex attributes for the strip
-    pub fn vertex_attributes() -> [wgpu::VertexAttribute; 5] {
+    pub fn vertex_attributes() -> [wgpu::VertexAttribute; 6] {
         wgpu::vertex_attr_array![
             0 => Uint32,
             1 => Uint32,
             2 => Uint32,
             3 => Uint32,
             4 => Uint32,
+            5 => Uint32,
         ]
     }
 }
@@ -1163,19 +1175,24 @@ impl Programs {
                 immediate_size: 0,
             });
 
+        let depth_format = wgpu::TextureFormat::Depth24Plus;
         let strip_formats = [render_target_config.format, wgpu::TextureFormat::Rgba8Unorm];
-        let strip_pipelines: [RenderPipeline; 2] = core::array::from_fn(|i| {
+
+        let strip_vertex_state = wgpu::VertexBufferLayout {
+            array_stride: size_of::<GpuStrip>() as u64,
+            step_mode: wgpu::VertexStepMode::Instance,
+            attributes: &GpuStrip::vertex_attributes(),
+        };
+
+        // Slot pipelines: no depth, blending ON (for slot textures without depth attachment).
+        let slot_strip_pipelines: [RenderPipeline; 2] = core::array::from_fn(|i| {
             device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-                label: Some("Strip Pipeline"),
+                label: Some("Strip Slot Pipeline"),
                 layout: Some(&strip_pipeline_layout),
                 vertex: wgpu::VertexState {
                     module: &strip_shader,
                     entry_point: Some("vs_main"),
-                    buffers: &[wgpu::VertexBufferLayout {
-                        array_stride: size_of::<GpuStrip>() as u64,
-                        step_mode: wgpu::VertexStepMode::Instance,
-                        attributes: &GpuStrip::vertex_attributes(),
-                    }],
+                    buffers: core::slice::from_ref(&strip_vertex_state),
                     compilation_options: PipelineCompilationOptions::default(),
                 },
                 fragment: Some(wgpu::FragmentState {
@@ -1193,6 +1210,82 @@ impl Programs {
                     ..Default::default()
                 },
                 depth_stencil: None,
+                multisample: wgpu::MultisampleState::default(),
+                multiview_mask: None,
+                cache: None,
+            })
+        });
+
+        // Alpha pipelines: blending ON, depth test ON (LessEqual), depth write OFF.
+        let alpha_strip_pipelines: [RenderPipeline; 2] = core::array::from_fn(|i| {
+            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("Strip Alpha Pipeline"),
+                layout: Some(&strip_pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &strip_shader,
+                    entry_point: Some("vs_main"),
+                    buffers: core::slice::from_ref(&strip_vertex_state),
+                    compilation_options: PipelineCompilationOptions::default(),
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &strip_shader,
+                    entry_point: Some("fs_main"),
+                    targets: &[Some(ColorTargetState {
+                        format: strip_formats[i],
+                        blend: Some(BlendState::PREMULTIPLIED_ALPHA_BLENDING),
+                        write_mask: ColorWrites::ALL,
+                    })],
+                    compilation_options: PipelineCompilationOptions::default(),
+                }),
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleStrip,
+                    ..Default::default()
+                },
+                depth_stencil: Some(wgpu::DepthStencilState {
+                    format: depth_format,
+                    depth_write_enabled: false,
+                    depth_compare: wgpu::CompareFunction::LessEqual,
+                    stencil: wgpu::StencilState::default(),
+                    bias: wgpu::DepthBiasState::default(),
+                }),
+                multisample: wgpu::MultisampleState::default(),
+                multiview_mask: None,
+                cache: None,
+            })
+        });
+
+        // Opaque pipelines: blending OFF, depth test ON (LessEqual), depth write ON.
+        let opaque_strip_pipelines: [RenderPipeline; 2] = core::array::from_fn(|i| {
+            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("Strip Opaque Pipeline"),
+                layout: Some(&strip_pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &strip_shader,
+                    entry_point: Some("vs_main"),
+                    buffers: core::slice::from_ref(&strip_vertex_state),
+                    compilation_options: PipelineCompilationOptions::default(),
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &strip_shader,
+                    entry_point: Some("fs_main"),
+                    targets: &[Some(ColorTargetState {
+                        format: strip_formats[i],
+                        blend: None,
+                        write_mask: ColorWrites::ALL,
+                    })],
+                    compilation_options: PipelineCompilationOptions::default(),
+                }),
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleStrip,
+                    ..Default::default()
+                },
+                depth_stencil: Some(wgpu::DepthStencilState {
+                    format: depth_format,
+                    depth_write_enabled: true,
+                    depth_compare: wgpu::CompareFunction::LessEqual,
+                    stencil: wgpu::StencilState::default(),
+                    bias: wgpu::DepthBiasState::default(),
+                }),
                 multisample: wgpu::MultisampleState::default(),
                 multiview_mask: None,
                 cache: None,
@@ -1557,8 +1650,20 @@ impl Programs {
             view_config_buffer,
         };
 
+        let depth_texture = Self::create_depth_texture(
+            device,
+            render_target_config.width,
+            render_target_config.height,
+        );
+        let depth_texture_view = depth_texture.create_view(&TextureViewDescriptor::default());
+
         Self {
-            strip_pipelines,
+            slot_strip_pipelines,
+            alpha_strip_pipelines,
+            opaque_strip_pipelines,
+            depth_texture,
+            depth_texture_view,
+            depth_cleared_this_frame: false,
             strip_bind_group_layout,
             encoded_paints_bind_group_layout,
             gradient_bind_group_layout,
@@ -1576,6 +1681,23 @@ impl Programs {
             clear_pipeline,
             atlas_clear_pipeline,
         }
+    }
+
+    fn create_depth_texture(device: &Device, width: u32, height: u32) -> Texture {
+        device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("Depth Texture"),
+            size: Extent3d {
+                width: width.max(1),
+                height: height.max(1),
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Depth24Plus,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        })
     }
 
     fn create_strips_buffer(device: &Device, required_strips_size: u64) -> Buffer {
@@ -1879,7 +2001,7 @@ impl Programs {
         self.maybe_resize_alphas_tex(device, max_texture_dimension_2d, alphas.len());
         self.maybe_resize_encoded_paints_tex(device, max_texture_dimension_2d, paint_idxs);
         self.maybe_resize_filter_tex(device, max_texture_dimension_2d, filter_context);
-        self.maybe_update_config_buffer(queue, max_texture_dimension_2d, new_render_size);
+        self.maybe_update_config_buffer(device, queue, max_texture_dimension_2d, new_render_size);
 
         self.upload_alpha_texture(queue, alphas);
         self.upload_encoded_paints_texture(queue, encoded_paints);
@@ -2058,6 +2180,7 @@ impl Programs {
     /// Update config buffer if dimensions changed.
     fn maybe_update_config_buffer(
         &mut self,
+        device: &Device,
         queue: &Queue,
         max_texture_dimension_2d: u32,
         new_render_size: &RenderSize,
@@ -2077,6 +2200,12 @@ impl Programs {
                 .write_buffer_with(&self.resources.view_config_buffer, 0, SIZE_OF_CONFIG)
                 .expect("Buffer only ever holds `Config`");
             buffer.copy_from_slice(bytemuck::bytes_of(&config));
+
+            self.depth_texture =
+                Self::create_depth_texture(device, new_render_size.width, new_render_size.height);
+            self.depth_texture_view =
+                self.depth_texture
+                    .create_view(&TextureViewDescriptor::default());
 
             self.render_size = new_render_size.clone();
         }
@@ -2332,16 +2461,21 @@ impl RendererContext<'_> {
     /// Render the strips to the specified render target.
     fn do_strip_render_pass(
         &mut self,
-        strips: &[GpuStrip],
+        opaque_strips: &[GpuStrip],
+        alpha_strips: &[GpuStrip],
         target: StripPassRenderTarget,
         load: wgpu::LoadOp<wgpu::Color>,
     ) {
-        if strips.is_empty() {
+        if opaque_strips.is_empty() && alpha_strips.is_empty() {
             return;
         }
-        // TODO: We currently allocate a new strips buffer for each render pass. A more efficient
-        // approach would be to re-use buffers or slices of a larger buffer.
-        self.programs.upload_strips(self.device, self.queue, strips);
+        // Upload all strips (opaque first, then alpha) into a single buffer.
+        let total_strips: Vec<GpuStrip> =
+            opaque_strips.iter().chain(alpha_strips.iter()).copied().collect();
+        self.programs
+            .upload_strips(self.device, self.queue, &total_strips);
+        let opaque_count = u32::try_from(opaque_strips.len()).unwrap();
+        let alpha_count = u32::try_from(alpha_strips.len()).unwrap();
 
         enum MaybeOwned<'a, T> {
             Borrowed(&'a T),
@@ -2474,6 +2608,28 @@ impl RendererContext<'_> {
             0
         };
 
+        let is_final_view =
+            matches!(target, StripPassRenderTarget::Output(OutputTarget::FinalView));
+
+        let depth_stencil_attachment = if is_final_view {
+            let depth_load = if self.programs.depth_cleared_this_frame {
+                wgpu::LoadOp::Load
+            } else {
+                self.programs.depth_cleared_this_frame = true;
+                wgpu::LoadOp::Clear(1.0)
+            };
+            Some(wgpu::RenderPassDepthStencilAttachment {
+                view: &self.programs.depth_texture_view,
+                depth_ops: Some(wgpu::Operations {
+                    load: depth_load,
+                    store: wgpu::StoreOp::Store,
+                }),
+                stencil_ops: None,
+            })
+        } else {
+            None
+        };
+
         let mut render_pass = self.encoder.begin_render_pass(&RenderPassDescriptor {
             label: Some("Render to Texture Pass"),
             color_attachments: &[Some(RenderPassColorAttachment {
@@ -2485,7 +2641,7 @@ impl RendererContext<'_> {
                     store: wgpu::StoreOp::Store,
                 },
             })],
-            depth_stencil_attachment: None,
+            depth_stencil_attachment,
             occlusion_query_set: None,
             timestamp_writes: None,
             multiview_mask: None,
@@ -2493,13 +2649,29 @@ impl RendererContext<'_> {
         if let Some([x, y, width, height]) = scissor_rect {
             render_pass.set_scissor_rect(x, y, width, height);
         }
-        render_pass.set_pipeline(&self.programs.strip_pipelines[pipeline_idx]);
+
         render_pass.set_bind_group(0, bind_group.as_ref(), &[]);
         render_pass.set_bind_group(1, &self.programs.resources.atlas_bind_group, &[]);
         render_pass.set_bind_group(2, &self.programs.resources.encoded_paints_bind_group, &[]);
         render_pass.set_bind_group(3, &self.programs.resources.gradient_bind_group, &[]);
         render_pass.set_vertex_buffer(0, self.programs.resources.strips_buffer.slice(..));
-        render_pass.draw(0..4, 0..u32::try_from(strips.len()).unwrap());
+
+        if is_final_view {
+            // Opaque pass: front-to-back, depth write ON, no blend.
+            if opaque_count > 0 {
+                render_pass.set_pipeline(&self.programs.opaque_strip_pipelines[pipeline_idx]);
+                render_pass.draw(0..4, 0..opaque_count);
+            }
+            // Alpha pass: back-to-front, depth test ON, depth write OFF, blend ON.
+            if alpha_count > 0 {
+                render_pass.set_pipeline(&self.programs.alpha_strip_pipelines[pipeline_idx]);
+                render_pass.draw(0..4, opaque_count..opaque_count + alpha_count);
+            }
+        } else {
+            // Slot texture / intermediate: single draw, no depth pipeline.
+            render_pass.set_pipeline(&self.programs.slot_strip_pipelines[pipeline_idx]);
+            render_pass.draw(0..4, 0..opaque_count + alpha_count);
+        }
     }
 
     /// Clear specific slots from a slot texture.
@@ -2561,7 +2733,8 @@ impl RendererBackend for RendererContext<'_> {
     /// Execute the render pass for rendering strips.
     fn render_strips(
         &mut self,
-        strips: &[GpuStrip],
+        opaque_strips: &[GpuStrip],
+        alpha_strips: &[GpuStrip],
         target: StripPassRenderTarget,
         load_op: LoadOp,
     ) {
@@ -2569,7 +2742,7 @@ impl RendererBackend for RendererContext<'_> {
             LoadOp::Load => wgpu::LoadOp::Load,
             LoadOp::Clear => wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
         };
-        self.do_strip_render_pass(strips, target, wgpu_load_op);
+        self.do_strip_render_pass(opaque_strips, alpha_strips, target, wgpu_load_op);
     }
 
     fn apply_filter(&mut self, layer_id: LayerId) {

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -2615,7 +2615,7 @@ impl RendererContext<'_> {
         };
 
         let is_final_view =
-            matches!(target, StripPassRenderTarget::Output(OutputTarget::FinalView));
+            matches!(target, StripPassRenderTarget::Root(RootRenderTarget::UserSurface));
 
         let depth_stencil_attachment = if is_final_view {
             let depth_load = if self.programs.depth_cleared_this_frame {

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -490,6 +490,10 @@ impl Scene {
         self.fill_path(&rect.to_path(DEFAULT_TOLERANCE));
     }
 
+    pub fn paint_transform(&self) -> &Affine {
+        &self.render_state.paint_transform
+    }
+
     #[expect(
         clippy::cast_possible_truncation,
         reason = "f64→f32 truncation is acceptable for pixel coordinates"

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -490,10 +490,6 @@ impl Scene {
         self.fill_path(&rect.to_path(DEFAULT_TOLERANCE));
     }
 
-    pub fn paint_transform(&self) -> &Affine {
-        &self.render_state.paint_transform
-    }
-
     #[expect(
         clippy::cast_possible_truncation,
         reason = "f64→f32 truncation is acceptable for pixel coordinates"

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -241,11 +241,20 @@ pub(crate) trait RendererBackend {
     /// Clear specific slots in a texture.
     fn clear_slots(&mut self, texture_index: usize, slots: &[u32]);
 
-    /// Execute a render pass for strips, split into opaque and alpha sub-passes.
-    ///
-    /// For Output targets: `opaque_strips` are rendered front-to-back with depth writes
-    /// and no blending; `alpha_strips` are rendered back-to-front with depth testing
-    /// and alpha blending. For `SlotTexture` targets: only `alpha_strips` are used.
+    /// Execute a render pass for strips, split into opaque and alpha passes.
+    /// 
+    /// For output targets, render the strips in opaque then alpha order with:
+    /// 
+    /// | Pass   | Depth Test     | Depth Write    | Blend | Strip Ordering |
+    /// | ------ | -------------- | -------------- | ----- | -------------- |
+    /// | Opaque | ON (LessEqual) | ON             | OFF   | Front-to-back  |
+    /// | Alpha  | OFF            | ON (LessEqual) | ON    | Back-to-front  |
+    /// 
+    /// For slot textures, there are no opaque strips, so we only render the alpha strips with:
+    /// 
+    /// | Pass   | Depth Test     | Depth Write    | Blend | Strip Ordering |
+    /// | ------ | -------------- | -------------- | ----- | -------------- |
+    /// | Alpha  | OFF            | OFF            | ON    | Back-to-front  |
     fn render_strips(
         &mut self,
         opaque_strips: &[GpuStrip],
@@ -286,7 +295,6 @@ pub(crate) struct Scheduler {
     /// The output target for the main rendering operations.
     output_target: StripPassRenderTarget,
     /// Monotonically increasing counter for assigning `layer_index` to strips.
-    /// Drives z-depth computation for TBDR early-z rejection. Reset per frame.
     layer_counter: u32,
 }
 
@@ -441,11 +449,9 @@ impl TileEl {
 
 #[derive(Debug, Default)]
 struct Draw {
-    /// Opaque strips: interior fills with fully opaque paint at surface level.
-    /// Rendered front-to-back with depth writes and no blending for TBDR early-z.
+    /// Opaque strips: See `RendererBackend::render_strips` documentation.
     opaque: Vec<GpuStrip>,
-    /// Alpha strips: boundary strips, transparent paints, blend/clip ops.
-    /// Rendered back-to-front with depth testing and alpha blending.
+    /// Alpha strips: See `RendererBackend::render_strips` documentation.
     alpha: Vec<GpuStrip>,
 }
 

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -799,10 +799,10 @@ impl Scheduler {
         let draw = self.draw_mut(round, 2);
 
         for cmd in &scene.fast_strips_buffer.commands[range] {
+            let layer_index = layer_counter;
+            layer_counter += 1;
             match cmd {
                 FastStripCommand::Path(path) => {
-                    let layer_index = layer_counter;
-                    layer_counter += 1;
                     generate_gpu_strips_for_fast_path(
                         path,
                         &strip_storage,
@@ -814,15 +814,12 @@ impl Scheduler {
                     );
                 }
                 FastStripCommand::Rect(r) => {
-                    let layer_index = layer_counter;
-                    layer_counter += 1;
-                    let is_opaque = Self::is_paint_opaque(&r.paint, encoded_paints);
                     pack_rectangle_into_gpu(
                         r,
                         encoded_paints,
                         paint_idxs,
                         layer_index,
-                        is_opaque,
+                        Self::is_paint_opaque(&r.paint, encoded_paints),
                         draw,
                     );
                 }

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -242,20 +242,20 @@ pub(crate) trait RendererBackend {
     fn clear_slots(&mut self, texture_index: usize, slots: &[u32]);
 
     /// Execute a render pass for strips, split into opaque and alpha passes.
-    /// 
+    ///
     /// For output targets, render the strips in opaque then alpha order with:
-    /// 
+    ///
     /// | Pass   | Depth Test     | Depth Write | Blend | Strip Ordering |
     /// | ------ | -------------- | ----------- | ----- | -------------- |
     /// | Opaque | ON (LessEqual) | ON          | OFF   | Front-to-back  |
     /// | Alpha  | ON (LessEqual) | OFF         | ON    | Back-to-front  |
-    /// 
+    ///
     /// For slot textures, there are no opaque strips, so we only render the alpha strips with:
-    /// 
+    ///
     /// | Pass   | Depth Test     | Depth Write | Blend | Strip Ordering |
     /// | ------ | -------------- | ----------- | ----- | -------------- |
     /// | Alpha  | OFF            | OFF         | ON    | Back-to-front  |
-    /// 
+    ///
     // TODO: Consider using opaque passes for non-output targets.
     fn render_strips(
         &mut self,
@@ -815,7 +815,14 @@ impl Scheduler {
                     let layer_index = layer_counter;
                     layer_counter += 1;
                     let is_opaque = Self::is_paint_opaque(&r.paint, encoded_paints);
-                    pack_rectangle_into_gpu(r, encoded_paints, paint_idxs, layer_index, is_opaque, draw);
+                    pack_rectangle_into_gpu(
+                        r,
+                        encoded_paints,
+                        paint_idxs,
+                        layer_index,
+                        is_opaque,
+                        draw,
+                    );
                 }
             }
         }
@@ -1015,12 +1022,8 @@ impl Scheduler {
 
             let layer_index = self.next_layer_index();
             let draw = self.draw_mut(self.round, 2);
-            let strip =
-                GpuStripBuilder::at_surface(wide_tile_x, wide_tile_y, WideTile::WIDTH).paint(
-                    payload,
-                    paint,
-                    layer_index,
-                );
+            let strip = GpuStripBuilder::at_surface(wide_tile_x, wide_tile_y, WideTile::WIDTH)
+                .paint(payload, paint, layer_index);
             if tile.bg.is_opaque() {
                 draw.push_opaque(strip);
             } else {
@@ -1478,8 +1481,7 @@ impl Scheduler {
             GpuStripBuilder::at_slot(slot_idx, cmd.x, cmd.width)
         };
 
-        draw.push_alpha(
-        gpu_strip_builder.with_sparse(cmd.width, col_idx).paint(
+        draw.push_alpha(gpu_strip_builder.with_sparse(cmd.width, col_idx).paint(
             payload,
             paint,
             layer_index,
@@ -2110,7 +2112,8 @@ fn pack_unorm4x8(v: [f32; 4]) -> u32 {
 #[cfg(test)]
 mod tests {
     use super::{
-        Draw, RECT_STRIP_FLAG, RectPart, SplitRect, pack_rectangle_into_gpu, pack_unorm4x8, split_rect,
+        Draw, RECT_STRIP_FLAG, RectPart, SplitRect, pack_rectangle_into_gpu, pack_unorm4x8,
+        split_rect,
     };
     use crate::scene::FastPathRect;
     use alloc::vec;

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -300,48 +300,28 @@ pub(crate) struct Scheduler {
     depth: DepthCounter,
 }
 
-/// Assigns depth indices to GPU strips for early z rejection.
+/// Assigns z depth indices to GPU strips for early z rejection.
+///
+/// Because only opaque strips write to the depth buffer, only opaque
+/// strips require unique z values (so z must be incremented for each opaque).
+/// Alpha strips, however, can re-use whatever was the last z index since the
+/// GPU does a LEQUAL test only.
 #[derive(Debug, Default)]
 struct DepthCounter {
-    counter: u32,
-    coarse_offset: u32,
+    count: u32,
 }
 
 impl DepthCounter {
+    #[inline(always)]
     fn reset(&mut self) {
-        self.counter = 0;
+        self.count = 0;
     }
 
+    /// Returns the next depth index for early z rejection.
     #[inline(always)]
-    fn next(&mut self) -> u32 {
-        let idx = self.counter;
-        self.counter += 1;
-        idx
-    }
-
-    fn begin_coarse_batch(&mut self) {
-        // +1 to reserve a background slot.
-        self.coarse_offset = self.counter + 1;
-        self.counter = self.coarse_offset;
-    }
-
-    fn begin_filter_batch(&mut self) {
-        self.coarse_offset = self.counter;
-    }
-
-    /// Depth index for the tile background in the current coarse batch.
-    #[inline(always)]
-    fn coarse_bg(&self) -> u32 {
-        self.coarse_offset - 1
-    }
-
-    /// Depth index for a coarse alpha or opaque fill command with the 
-    /// given `attrs_idx`.
-    #[inline(always)]
-    fn fill(&mut self, attrs_idx: u32) -> u32 {
-        let idx = self.coarse_offset + attrs_idx;
-        self.counter = self.counter.max(idx + 1);
-        idx
+    fn next(&mut self, opaque: bool) -> u32 {
+        self.count += opaque as u32;
+        self.count
     }
 }
 
@@ -778,7 +758,6 @@ impl Scheduler {
         // The maximum layer of other filter nodes should not leak into new filter nodes, hence
         // we need to reset it.
         state.max_round = self.round;
-        self.depth.begin_filter_batch();
 
         for y in wtile_bbox.y0()..wtile_bbox.y1() {
             for x in wtile_bbox.x0()..wtile_bbox.x1() {
@@ -841,31 +820,34 @@ impl Scheduler {
         let strip_storage = scene.strip_storage.borrow();
         // Always choose the draw of the final surface, since direct strips are only ever
         // rendered to the final surface.
-        // Take a local copy of the counter to avoid borrow conflicts with `draw`.
         let mut depth = core::mem::take(&mut self.depth);
         let draw = self.draw_mut(round, 2);
 
         for cmd in &scene.fast_strips_buffer.commands[range] {
-            let layer_index = depth.next();
             match cmd {
                 FastStripCommand::Path(path) => {
+                    let is_opaque = Self::is_paint_opaque(&path.paint, encoded_paints);
+                    let depth_index = depth.next(is_opaque);
                     generate_gpu_strips_for_fast_path(
                         path,
                         &strip_storage,
                         scene,
                         encoded_paints,
                         paint_idxs,
-                        layer_index,
+                        depth_index,
+                        is_opaque,
                         draw,
                     );
                 }
                 FastStripCommand::Rect(r) => {
+                    let is_opaque = Self::is_paint_opaque(&r.paint, encoded_paints);
+                    let depth_index = depth.next(is_opaque);
                     pack_rectangle_into_gpu(
                         r,
                         encoded_paints,
                         paint_idxs,
-                        layer_index,
-                        Self::is_paint_opaque(&r.paint, encoded_paints),
+                        depth_index,
+                        is_opaque,
                         draw,
                     );
                 }
@@ -891,7 +873,6 @@ impl Scheduler {
         filter_context: &FilterContext,
         encoded_paints: &[EncodedPaint],
     ) -> Result<(), RenderError> {
-        self.depth.begin_coarse_batch();
         for row in 0..rows {
             for col in 0..cols {
                 let idx = (row * cols + col) as usize;
@@ -1061,11 +1042,12 @@ impl Scheduler {
                 idxs,
             );
 
-            let bg_layer_index = self.depth.coarse_bg();
+            let is_opaque = tile.bg.is_opaque();
+            let bg_depth_index = self.depth.next(is_opaque);
             let draw = self.draw_mut(self.round, 2);
             let strip = GpuStripBuilder::at_surface(wide_tile_x, wide_tile_y, WideTile::WIDTH)
-                .paint(payload, paint, bg_layer_index);
-            if tile.bg.is_opaque() {
+                .paint(payload, paint, bg_depth_index);
+            if is_opaque {
                 draw.push_opaque(strip);
             } else {
                 draw.push_alpha(strip);
@@ -1212,7 +1194,7 @@ impl Scheduler {
                                 wide_tile_x,
                                 wide_tile_y,
                             );
-                            let layer_index = scheduler.depth.next();
+                            let depth_index = scheduler.depth.next(false);
                             scheduler.do_fill_with(
                                 state,
                                 &cmd,
@@ -1221,7 +1203,7 @@ impl Scheduler {
                                 payload,
                                 paint,
                                 false,
-                                layer_index,
+                                depth_index,
                             );
                         };
 
@@ -1322,11 +1304,11 @@ impl Scheduler {
             if let TemporarySlot::Invalid(temp_slot) = tos.temporary_slot {
                 let next_round = depth.is_multiple_of(2);
                 let el_round = tos.round + usize::from(next_round);
-                let layer_index = self.depth.next();
+                let depth_index = self.depth.next(false);
                 let draw = self.draw_mut(el_round, temp_slot.get_texture());
                 draw.push_alpha(
                     GpuStripBuilder::at_slot(temp_slot.get_idx(), 0, WideTile::WIDTH)
-                        .copy_from_slot(tos.dest_slot.get_idx(), 0xFF, layer_index),
+                        .copy_from_slot(tos.dest_slot.get_idx(), 0xFF, depth_index),
                 );
 
                 tos.temporary_slot = TemporarySlot::Valid(temp_slot);
@@ -1432,7 +1414,7 @@ impl Scheduler {
 
         let next_round: bool = depth.is_multiple_of(2) && depth > 2;
         let round = nos.round.max(tos.round + usize::from(next_round));
-        let layer_index = self.depth.next();
+        let depth_index = self.depth.next(false);
 
         let draw = self.draw_mut(
             round,
@@ -1459,7 +1441,7 @@ impl Scheduler {
                 opacity_u8,
                 mix_mode,
                 compose_mode,
-                layer_index,
+                depth_index,
             ));
             // Invalidate the temporary slot after use
             let nos_ptr = state.tile_state.stack.len() - 2;
@@ -1480,7 +1462,7 @@ impl Scheduler {
             draw.push_alpha(gpu_strip_builder.copy_from_slot(
                 tos.dest_slot.get_idx(),
                 (tos.opacity * 255.0) as u8,
-                layer_index,
+                depth_index,
             ));
         }
     }
@@ -1497,7 +1479,7 @@ impl Scheduler {
         attrs: &CommandAttrs,
     ) {
         let depth = state.tile_state.stack.len();
-        let layer_index = self.depth.fill(cmd.attrs_idx);
+        let depth_index = self.depth.next(false);
 
         let el = state.tile_state.stack.last_mut().unwrap();
         let draw = self.draw_mut(el.round, el.get_draw_texture(depth));
@@ -1527,7 +1509,7 @@ impl Scheduler {
         draw.push_alpha(gpu_strip_builder.with_sparse(cmd.width, col_idx).paint(
             payload,
             paint,
-            layer_index,
+            depth_index,
         ));
     }
 
@@ -1543,7 +1525,13 @@ impl Scheduler {
         attrs: &CommandAttrs,
     ) {
         let fill_attrs = &attrs.fill[cmd.attrs_idx as usize];
-        let layer_index = self.depth.fill(cmd.attrs_idx);
+        let is_opaque = Self::is_paint_opaque(&fill_attrs.paint, encoded_paints);
+        let stack_depth = state.tile_state.stack.len();
+        let depth_index = self.depth.next(
+            // We currently only support opaques that are drawn to the surface. See TODO in
+            // `RendererBackend::render_strips`.
+            stack_depth == 1 && is_opaque,
+        );
         let (scene_strip_x, scene_strip_y) = (wide_tile_x + cmd.x, wide_tile_y);
         let (payload, paint) = Self::process_paint(
             &fill_attrs.paint,
@@ -1559,8 +1547,8 @@ impl Scheduler {
             scene_strip_y,
             payload,
             paint,
-            Self::is_paint_opaque(&fill_attrs.paint, encoded_paints),
-            layer_index,
+            is_opaque,
+            depth_index,
         );
     }
 
@@ -1574,7 +1562,7 @@ impl Scheduler {
         payload: u32,
         paint: u32,
         is_opaque: bool,
-        layer_index: u32,
+        depth_index: u32,
     ) {
         let depth = state.tile_state.stack.len();
 
@@ -1592,7 +1580,7 @@ impl Scheduler {
             GpuStripBuilder::at_slot(slot_idx, cmd.x, cmd.width)
         };
 
-        let strip = gpu_strip_builder.paint(payload, paint, layer_index);
+        let strip = gpu_strip_builder.paint(payload, paint, depth_index);
         if depth == 1 && is_opaque {
             draw.push_opaque(strip);
         } else {
@@ -1655,16 +1643,16 @@ impl Scheduler {
         // enough "ping-ponging" to resolve all dependencies.
         let next_round = depth.is_multiple_of(2) && depth > 2;
         let round = nos.round.max(tos.round + usize::from(next_round));
-        let layer_index = self.depth.next();
+        let depth_index = self.depth.next(false);
         if let TemporarySlot::Valid(temp_slot) = nos.temporary_slot {
             let draw = self.draw_mut(round, nos.dest_slot.get_texture());
             draw.push_alpha(
                 GpuStripBuilder::at_slot(nos.dest_slot.get_idx(), 0, WideTile::WIDTH)
-                    .copy_from_slot(temp_slot.get_idx(), 0xFF, layer_index),
+                    .copy_from_slot(temp_slot.get_idx(), 0xFF, depth_index),
             );
         }
 
-        let layer_index = self.depth.next();
+        let depth_index = self.depth.next(false);
         let draw = self.draw_mut(
             round,
             if (depth - 1) <= 1 {
@@ -1681,7 +1669,7 @@ impl Scheduler {
         draw.push_alpha(gpu_strip_builder.copy_from_slot(
             tos.dest_slot.get_idx(),
             0xFF,
-            layer_index,
+            depth_index,
         ));
 
         let nos_ptr = state.tile_state.stack.len() - 2;
@@ -1703,17 +1691,17 @@ impl Scheduler {
         let next_round = depth.is_multiple_of(2) && depth > 2;
         let round = nos.round.max(tos.round + usize::from(next_round));
 
-        let layer_index = self.depth.next();
+        let depth_index = self.depth.next(false);
         // If nos has a temporary slot, copy it to `dest_slot` first
         if let TemporarySlot::Valid(temp_slot) = nos.temporary_slot {
             let draw = self.draw_mut(round, nos.dest_slot.get_texture());
             draw.push_alpha(
                 GpuStripBuilder::at_slot(nos.dest_slot.get_idx(), 0, WideTile::WIDTH)
-                    .copy_from_slot(temp_slot.get_idx(), 0xFF, layer_index),
+                    .copy_from_slot(temp_slot.get_idx(), 0xFF, depth_index),
             );
         }
 
-        let layer_index = self.depth.next();
+        let depth_index = self.depth.next(false);
         let draw = self.draw_mut(
             round,
             if (depth - 1) <= 1 {
@@ -1735,7 +1723,7 @@ impl Scheduler {
         draw.push_alpha(
             gpu_strip_builder
                 .with_sparse(cmd.width, col_idx)
-                .copy_from_slot(tos.dest_slot.get_idx(), 0xFF, layer_index),
+                .copy_from_slot(tos.dest_slot.get_idx(), 0xFF, depth_index),
         );
         let nos_ptr = state.tile_state.stack.len() - 2;
         state.tile_state.stack[nos_ptr].temporary_slot.invalidate();
@@ -1848,7 +1836,7 @@ impl GpuStripBuilder {
     }
 
     /// Paint into strip.
-    fn paint(self, payload: u32, paint: u32, layer_index: u32) -> GpuStrip {
+    fn paint(self, payload: u32, paint: u32, depth_index: u32) -> GpuStrip {
         GpuStrip {
             x: self.x,
             y: self.y,
@@ -1857,12 +1845,12 @@ impl GpuStripBuilder {
             col_idx_or_rect_frac: self.col_idx_or_rect_frac,
             payload,
             paint_and_rect_flag: paint,
-            layer_index,
+            depth_index,
         }
     }
 
     /// Copy from slot.
-    fn copy_from_slot(self, from_slot: usize, opacity: u8, layer_index: u32) -> GpuStrip {
+    fn copy_from_slot(self, from_slot: usize, opacity: u8, depth_index: u32) -> GpuStrip {
         GpuStrip {
             x: self.x,
             y: self.y,
@@ -1871,7 +1859,7 @@ impl GpuStripBuilder {
             col_idx_or_rect_frac: self.col_idx_or_rect_frac,
             payload: u32::try_from(from_slot).unwrap(),
             paint_and_rect_flag: (COLOR_SOURCE_SLOT << 29) | (opacity as u32),
-            layer_index,
+            depth_index,
         }
     }
 
@@ -1883,7 +1871,7 @@ impl GpuStripBuilder {
         opacity: u8,
         mix_mode: u8,
         compose_mode: u8,
-        layer_index: u32,
+        depth_index: u32,
     ) -> GpuStrip {
         GpuStrip {
             x: self.x,
@@ -1897,7 +1885,7 @@ impl GpuStripBuilder {
                 | ((opacity as u32) << 16)
                 | ((mix_mode as u32) << 8)
                 | (compose_mode as u32),
-            layer_index,
+            depth_index,
         }
     }
 }
@@ -1913,7 +1901,8 @@ fn generate_gpu_strips_for_fast_path(
     scene: &Scene,
     encoded_paints: &[EncodedPaint],
     paint_idxs: &[u32],
-    layer_index: u32,
+    depth_index: u32,
+    is_opaque: bool,
     draw: &mut Draw,
 ) {
     let strips = &strip_storage.strips[path.strips.clone()];
@@ -1921,8 +1910,6 @@ fn generate_gpu_strips_for_fast_path(
     if strips.is_empty() {
         return;
     }
-
-    let is_opaque = Scheduler::is_paint_opaque(&path.paint, encoded_paints);
 
     // Note: Some of this logic is similar to current coarse rasterization code, but
     // the coarse rasterization code is more complex due to clip paths and other factors.
@@ -1949,7 +1936,7 @@ fn generate_gpu_strips_for_fast_path(
             draw.push_alpha(
                 GpuStripBuilder::at_surface(x0, y, strip_width)
                     .with_sparse(strip_width, col)
-                    .paint(payload, paint, layer_index),
+                    .paint(payload, paint, depth_index),
             );
         }
 
@@ -1966,7 +1953,7 @@ fn generate_gpu_strips_for_fast_path(
                 let (payload, paint) =
                     Scheduler::process_paint(&path.paint, encoded_paints, (x1, y), paint_idxs);
                 let strip =
-                    GpuStripBuilder::at_surface(x1, y, x2 - x1).paint(payload, paint, layer_index);
+                    GpuStripBuilder::at_surface(x1, y, x2 - x1).paint(payload, paint, depth_index);
                 if is_opaque {
                     draw.push_opaque(strip);
                 } else {
@@ -1981,7 +1968,7 @@ fn pack_rectangle_into_gpu(
     rect: &FastPathRect,
     encoded_paints: &[EncodedPaint],
     paint_idxs: &[u32],
-    layer_index: u32,
+    depth_index: u32,
     is_opaque: bool,
     draw: &mut Draw,
 ) {
@@ -2000,7 +1987,7 @@ fn pack_rectangle_into_gpu(
     {
         let (payload, paint_packed) =
             Scheduler::process_paint(&rect.paint, encoded_paints, (part.x, part.y), paint_idxs);
-        let strip = make_gpu_rect(part, payload, paint_packed, layer_index);
+        let strip = make_gpu_rect(part, payload, paint_packed, depth_index);
         if is_first && is_opaque && part.frac == 0 {
             draw.push_opaque(strip);
         } else {
@@ -2127,7 +2114,7 @@ fn split_rect(rect: &FastPathRect) -> SplitRect {
     }
 }
 
-fn make_gpu_rect(part: RectPart, payload: u32, paint_packed: u32, layer_index: u32) -> GpuStrip {
+fn make_gpu_rect(part: RectPart, payload: u32, paint_packed: u32, depth_index: u32) -> GpuStrip {
     GpuStrip {
         x: part.x,
         y: part.y,
@@ -2136,7 +2123,7 @@ fn make_gpu_rect(part: RectPart, payload: u32, paint_packed: u32, layer_index: u
         col_idx_or_rect_frac: part.frac,
         payload,
         paint_and_rect_flag: paint_packed | RECT_STRIP_FLAG,
-        layer_index,
+        depth_index,
     }
 }
 

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -959,10 +959,9 @@ impl Scheduler {
             if i == 2 {
                 // Output target: reverse opaque for front-to-back rendering.
                 // Alpha strips stay in natural back-to-front order.
-                let mut opaque = core::mem::take(&mut draw.opaque);
+                let Draw {opaque, alpha} = draw;
                 opaque.reverse();
-                renderer.render_strips(&opaque, &draw.alpha, target, load);
-                draw.opaque = opaque; // Return allocation for later reuse.
+                renderer.render_strips(&opaque, &alpha, target, load);
             } else {
                 // Slot textures: no depth optimization, everything in alpha list.
                 assert!(

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -245,16 +245,18 @@ pub(crate) trait RendererBackend {
     /// 
     /// For output targets, render the strips in opaque then alpha order with:
     /// 
-    /// | Pass   | Depth Test     | Depth Write    | Blend | Strip Ordering |
-    /// | ------ | -------------- | -------------- | ----- | -------------- |
-    /// | Opaque | ON (LessEqual) | ON             | OFF   | Front-to-back  |
-    /// | Alpha  | OFF            | ON (LessEqual) | ON    | Back-to-front  |
+    /// | Pass   | Depth Test     | Depth Write | Blend | Strip Ordering |
+    /// | ------ | -------------- | ----------- | ----- | -------------- |
+    /// | Opaque | ON (LessEqual) | ON          | OFF   | Front-to-back  |
+    /// | Alpha  | ON (LessEqual) | OFF         | ON    | Back-to-front  |
     /// 
     /// For slot textures, there are no opaque strips, so we only render the alpha strips with:
     /// 
-    /// | Pass   | Depth Test     | Depth Write    | Blend | Strip Ordering |
-    /// | ------ | -------------- | -------------- | ----- | -------------- |
-    /// | Alpha  | OFF            | OFF            | ON    | Back-to-front  |
+    /// | Pass   | Depth Test     | Depth Write | Blend | Strip Ordering |
+    /// | ------ | -------------- | ----------- | ----- | -------------- |
+    /// | Alpha  | OFF            | OFF         | ON    | Back-to-front  |
+    /// 
+    // TODO: Consider using opaque passes for non-output targets.
     fn render_strips(
         &mut self,
         opaque_strips: &[GpuStrip],
@@ -813,7 +815,7 @@ impl Scheduler {
                     let layer_index = layer_counter;
                     layer_counter += 1;
                     let is_opaque = Self::is_paint_opaque(&r.paint, encoded_paints);
-                    emit_rect_strips(r, encoded_paints, paint_idxs, layer_index, is_opaque, draw);
+                    pack_rectangle_into_gpu(r, encoded_paints, paint_idxs, layer_index, is_opaque, draw);
                 }
             }
         }
@@ -951,12 +953,10 @@ impl Scheduler {
                 let mut opaque = core::mem::take(&mut draw.opaque);
                 opaque.reverse();
                 renderer.render_strips(&opaque, &draw.alpha, target, load);
+                draw.opaque = opaque; // Return allocation for later reuse.
             } else {
                 // Slot textures: no depth optimization, everything in alpha list.
-                debug_assert!(
-                    draw.opaque.is_empty(),
-                    "slot texture draws should not contain opaque strips"
-                );
+                assert!(draw.opaque.is_empty());
                 renderer.render_strips(&[], &draw.alpha, target, load);
             }
         }
@@ -994,7 +994,7 @@ impl Scheduler {
     }
 
     /// Render the tile's background color (set by overdraw elimination) to the
-    /// surface. Returns `true` if a strip was emitted.
+    /// surface.
     fn paint_tile_bg(
         &mut self,
         tile: &WideTile<MODE_HYBRID>,
@@ -1015,13 +1015,17 @@ impl Scheduler {
 
             let layer_index = self.next_layer_index();
             let draw = self.draw_mut(self.round, 2);
-            draw.push_opaque(
+            let strip =
                 GpuStripBuilder::at_surface(wide_tile_x, wide_tile_y, WideTile::WIDTH).paint(
                     payload,
                     paint,
                     layer_index,
-                ),
-            );
+                );
+            if tile.bg.is_opaque() {
+                draw.push_opaque(strip);
+            } else {
+                draw.push_alpha(strip);
+            }
         }
     }
 
@@ -1384,12 +1388,14 @@ impl Scheduler {
         let round = nos.round.max(tos.round + usize::from(next_round));
         let layer_index = self.next_layer_index();
 
-        let draw_texture = if depth <= 2 {
-            2
-        } else {
-            nos.dest_slot.get_texture()
-        };
-        let draw = self.draw_mut(round, draw_texture);
+        let draw = self.draw_mut(
+            round,
+            if depth <= 2 {
+                2
+            } else {
+                nos.dest_slot.get_texture()
+            },
+        );
 
         let gpu_strip_builder = if depth <= 2 {
             GpuStripBuilder::at_surface(wide_tile_x, wide_tile_y, WideTile::WIDTH)
@@ -1445,6 +1451,10 @@ impl Scheduler {
         attrs: &CommandAttrs,
     ) {
         let depth = state.tile_state.stack.len();
+        let layer_index = self.next_layer_index();
+
+        let el = state.tile_state.stack.last_mut().unwrap();
+        let draw = self.draw_mut(el.round, el.get_draw_texture(depth));
 
         let fill_attrs = &attrs.fill[cmd.attrs_idx as usize];
         let alpha_idx = fill_attrs.alpha_idx(cmd.alpha_offset);
@@ -1457,12 +1467,9 @@ impl Scheduler {
             paint_idxs,
         );
 
-        let layer_index = self.next_layer_index();
-
         let gpu_strip_builder = if depth == 1 {
             GpuStripBuilder::at_surface(scene_strip_x, scene_strip_y, cmd.width)
         } else {
-            let el = state.tile_state.stack.last().unwrap();
             let slot_idx = if let TemporarySlot::Valid(temp_slot) = el.temporary_slot {
                 temp_slot.get_idx()
             } else {
@@ -1471,11 +1478,8 @@ impl Scheduler {
             GpuStripBuilder::at_slot(slot_idx, cmd.x, cmd.width)
         };
 
-        let el = state.tile_state.stack.last().unwrap();
-        let el_round = el.round;
-        let draw_texture = el.get_draw_texture(depth);
-        let draw = self.draw_mut(el_round, draw_texture);
-        draw.push_alpha(gpu_strip_builder.with_sparse(cmd.width, col_idx).paint(
+        draw.push_alpha(
+        gpu_strip_builder.with_sparse(cmd.width, col_idx).paint(
             payload,
             paint,
             layer_index,
@@ -1502,7 +1506,6 @@ impl Scheduler {
             paint_idxs,
         );
 
-        let is_opaque = Self::is_paint_opaque(&fill_attrs.paint, encoded_paints);
         self.do_fill_with(
             state,
             cmd,
@@ -1510,7 +1513,7 @@ impl Scheduler {
             scene_strip_y,
             payload,
             paint,
-            is_opaque,
+            Self::is_paint_opaque(&fill_attrs.paint, encoded_paints),
         );
     }
 
@@ -1891,10 +1894,13 @@ fn generate_gpu_strips_for_fast_path(
         let x0 = strip.x;
         let y = strip.y;
 
-        // Alpha fill for the strip's coverage region (always alpha — has AA).
+        // Since the components of a single strip are not overlapping, we can re-use the same
+        // layer index for all the components (alpha + fill) for a single strip.
+        let layer_index = *layer_counter;
+        *layer_counter += 1;
+
+        // Alpha fill for the strip's coverage region.
         if strip_width > 0 {
-            let layer_index = *layer_counter;
-            *layer_counter += 1;
             let (payload, paint) =
                 Scheduler::process_paint(&path.paint, encoded_paints, (x0, y), paint_idxs);
             draw.push_alpha(
@@ -1914,8 +1920,6 @@ fn generate_gpu_strips_for_fast_path(
                     .unwrap_or(u16::MAX),
             );
             if x2 > x1 {
-                let layer_index = *layer_counter;
-                *layer_counter += 1;
                 let (payload, paint) =
                     Scheduler::process_paint(&path.paint, encoded_paints, (x1, y), paint_idxs);
                 let strip =
@@ -1930,16 +1934,7 @@ fn generate_gpu_strips_for_fast_path(
     }
 }
 
-/// Decompose a rectangle into a pixel-aligned opaque interior plus thin AA edge
-/// strips. The interior has `rect_frac=0` so the fragment shader skips the AA
-/// coverage math entirely; when the paint is opaque this quad goes to the opaque
-/// draw list for TBDR early-z. The 1px edge strips carry fractional coverage and
-/// always go to the alpha list.
-///
-/// For small rects (under `LARGE_RECT_SPLIT_THRESHOLD` in either dimension),
-/// we fall back to a single rect instance with full AA fracs — the overhead
-/// of 5 draw instances outweighs the per-fragment savings at small sizes.
-fn emit_rect_strips(
+fn pack_rectangle_into_gpu(
     rect: &FastPathRect,
     encoded_paints: &[EncodedPaint],
     paint_idxs: &[u32],
@@ -1963,9 +1958,11 @@ fn emit_rect_strips(
         let (payload, paint_packed) =
             Scheduler::process_paint(&rect.paint, encoded_paints, (part.x, part.y), paint_idxs);
         let strip = make_gpu_rect(part, payload, paint_packed, layer_index);
-        if is_first && is_opaque && part.frac == 0 {
+        if is_first && is_opaque {
+            assert!(part.frac == 0);
             draw.push_opaque(strip);
         } else {
+            assert!(part.frac != 0);
             draw.push_alpha(strip);
         }
         is_first = false;
@@ -2113,7 +2110,7 @@ fn pack_unorm4x8(v: [f32; 4]) -> u32 {
 #[cfg(test)]
 mod tests {
     use super::{
-        Draw, RECT_STRIP_FLAG, RectPart, SplitRect, emit_rect_strips, pack_unorm4x8, split_rect,
+        Draw, RECT_STRIP_FLAG, RectPart, SplitRect, pack_rectangle_into_gpu, pack_unorm4x8, split_rect,
     };
     use crate::scene::FastPathRect;
     use alloc::vec;
@@ -2318,7 +2315,7 @@ mod tests {
         let rect = solid_rect(10.0, 20.5, 42.0, 53.0);
         let mut draw = Draw::default();
 
-        emit_rect_strips(&rect, &[], &[], 0, true, &mut draw);
+        pack_rectangle_into_gpu(&rect, &[], &[], 0, true, &mut draw);
 
         let out: Vec<_> = draw.opaque.iter().chain(draw.alpha.iter()).collect();
         assert_eq!(out.len(), 2);
@@ -2371,7 +2368,7 @@ mod tests {
         })];
         let mut draw = Draw::default();
 
-        emit_rect_strips(&rect, &encoded_paints, &[7], 0, true, &mut draw);
+        pack_rectangle_into_gpu(&rect, &encoded_paints, &[7], 0, true, &mut draw);
 
         let out: Vec<_> = draw.opaque.iter().chain(draw.alpha.iter()).collect();
         assert_eq!(out.len(), 5);

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -1588,7 +1588,7 @@ impl Scheduler {
         }
     }
 
-    /// Determine if a paint is fully opaque (no transparency).
+    /// Determine if a paint is fully opaque.
     #[inline]
     fn is_paint_opaque(paint: &Paint, encoded_paints: &[EncodedPaint]) -> bool {
         match paint {

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -210,10 +210,6 @@ const PAINT_TYPE_SWEEP_GRADIENT: u32 = 4;
 /// Bit 31 of [`GpuStrip::paint_and_rect_flag`] signals that the strip
 /// represents a full rectangle.
 const RECT_STRIP_FLAG: u32 = 1 << 31;
-/// The threshold of the rectangle size after which a rectangle should be split up
-/// into multiple smaller ones.
-const LARGE_RECT_SPLIT_THRESHOLD: u16 = 32;
-
 // The sentinel tile index representing the surface.
 const SENTINEL_SLOT_IDX: usize = usize::MAX;
 
@@ -241,10 +237,15 @@ pub(crate) trait RendererBackend {
     /// Clear specific slots in a texture.
     fn clear_slots(&mut self, texture_index: usize, slots: &[u32]);
 
-    /// Execute a render pass for strips.
+    /// Execute a render pass for strips, split into opaque and alpha sub-passes.
+    ///
+    /// For Output targets: `opaque_strips` are rendered front-to-back with depth writes
+    /// and no blending; `alpha_strips` are rendered back-to-front with depth testing
+    /// and alpha blending. For `SlotTexture` targets: only `alpha_strips` are used.
     fn render_strips(
         &mut self,
-        strips: &[GpuStrip],
+        opaque_strips: &[GpuStrip],
+        alpha_strips: &[GpuStrip],
         target: StripPassRenderTarget,
         load_op: LoadOp,
     );
@@ -280,6 +281,9 @@ pub(crate) struct Scheduler {
     round_pool: RoundPool,
     /// The output target for the main rendering operations.
     output_target: StripPassRenderTarget,
+    /// Monotonically increasing counter for assigning `layer_index` to strips.
+    /// Drives z-depth computation for TBDR early-z rejection. Reset per frame.
+    layer_counter: u32,
 }
 
 #[derive(Debug, Default)]
@@ -432,16 +436,33 @@ impl TileEl {
 }
 
 #[derive(Debug, Default)]
-struct Draw(Vec<GpuStrip>);
+struct Draw {
+    /// Opaque strips: interior fills with fully opaque paint at surface level.
+    /// Rendered front-to-back with depth writes and no blending for TBDR early-z.
+    opaque: Vec<GpuStrip>,
+    /// Alpha strips: boundary strips, transparent paints, blend/clip ops.
+    /// Rendered back-to-front with depth testing and alpha blending.
+    alpha: Vec<GpuStrip>,
+}
 
 impl Draw {
     #[inline(always)]
-    fn push(&mut self, gpu_strip: GpuStrip) {
-        self.0.push(gpu_strip);
+    fn push_opaque(&mut self, gpu_strip: GpuStrip) {
+        self.opaque.push(gpu_strip);
+    }
+
+    #[inline(always)]
+    fn push_alpha(&mut self, gpu_strip: GpuStrip) {
+        self.alpha.push(gpu_strip);
+    }
+
+    fn is_empty(&self) -> bool {
+        self.opaque.is_empty() && self.alpha.is_empty()
     }
 
     fn clear(&mut self) {
-        self.0.clear();
+        self.opaque.clear();
+        self.alpha.clear();
     }
 }
 
@@ -458,6 +479,7 @@ impl Scheduler {
             rounds_queue: VecDeque::new(),
             round_pool: RoundPool::default(),
             output_target: StripPassRenderTarget::Root(RootRenderTarget::UserSurface),
+            layer_counter: 0,
         }
     }
 
@@ -502,6 +524,7 @@ impl Scheduler {
         filter_context: &FilterContext,
         encoded_paints: &[EncodedPaint],
     ) -> Result<(), RenderError> {
+        self.layer_counter = 0;
         for node_id in scene.render_graph.execution_order() {
             let node = &scene.render_graph.nodes[node_id];
 
@@ -760,6 +783,7 @@ impl Scheduler {
         let strip_storage = scene.strip_storage.borrow();
         // Always choose the draw of the final surface, since direct strips are only ever
         // rendered to the final surface.
+        let mut layer_counter = self.layer_counter;
         let draw = self.draw_mut(round, 2);
 
         for cmd in &scene.fast_strips_buffer.commands[range] {
@@ -771,14 +795,19 @@ impl Scheduler {
                         scene,
                         encoded_paints,
                         paint_idxs,
-                        &mut draw.0,
+                        &mut layer_counter,
+                        draw,
                     );
                 }
                 FastStripCommand::Rect(r) => {
-                    pack_rectangle_into_gpu(r, encoded_paints, paint_idxs, &mut draw.0);
+                    let layer_index = layer_counter;
+                    layer_counter += 1;
+                    let is_opaque = Self::is_paint_opaque(&r.paint, encoded_paints);
+                    emit_rect_strips(r, encoded_paints, paint_idxs, layer_index, is_opaque, draw);
                 }
             }
         }
+        self.layer_counter = layer_counter;
     }
 
     /// Process one batch of coarse-rasterized wide tile commands.
@@ -859,8 +888,8 @@ impl Scheduler {
     ///
     /// The rounds queue must not be empty.
     fn flush<R: RendererBackend>(&mut self, renderer: &mut R) {
-        let round = self.rounds_queue.pop_front().unwrap();
-        for (i, draw) in round.draws.iter().enumerate() {
+        let mut round = self.rounds_queue.pop_front().unwrap();
+        for (i, draw) in round.draws.iter_mut().enumerate() {
             #[cfg(debug_assertions)]
             {
                 // This is an expensive O(n²) debug only check that enforces that there are no
@@ -896,7 +925,7 @@ impl Scheduler {
                 }
             };
 
-            if draw.0.is_empty() {
+            if draw.is_empty() {
                 if load == LoadOp::Clear {
                     // There are no strips to render, so `render_strips` will not run and won't clear
                     // the texture. We still have slots to clear this round so explicitly clear
@@ -906,7 +935,20 @@ impl Scheduler {
                 continue;
             }
 
-            renderer.render_strips(&draw.0, target, load);
+            if i == 2 {
+                // Output target: reverse opaque for front-to-back rendering.
+                // Alpha strips stay in natural back-to-front order.
+                let mut opaque = core::mem::take(&mut draw.opaque);
+                opaque.reverse();
+                renderer.render_strips(&opaque, &draw.alpha, target, load);
+            } else {
+                // Slot textures: no depth optimization, everything in alpha list.
+                debug_assert!(
+                    draw.opaque.is_empty(),
+                    "slot texture draws should not contain opaque strips"
+                );
+                renderer.render_strips(&[], &draw.alpha, target, load);
+            }
         }
         for i in 0..2 {
             self.free[i].extend(&round.free[i]);
@@ -914,6 +956,14 @@ impl Scheduler {
         self.round += 1;
 
         self.round_pool.return_to_pool(round);
+    }
+
+    /// Allocate and return the next layer index for z-depth ordering.
+    #[inline(always)]
+    fn next_layer_index(&mut self) -> u32 {
+        let idx = self.layer_counter;
+        self.layer_counter += 1;
+        idx
     }
 
     // Find the appropriate draw call for rendering.
@@ -953,10 +1003,11 @@ impl Scheduler {
                 idxs,
             );
 
+            let layer_index = self.next_layer_index();
             let draw = self.draw_mut(self.round, 2);
-            draw.push(
+            draw.push_opaque(
                 GpuStripBuilder::at_surface(wide_tile_x, wide_tile_y, WideTile::WIDTH)
-                    .paint(payload, paint),
+                    .paint(payload, paint, layer_index),
             );
         }
     }
@@ -1107,6 +1158,7 @@ impl Scheduler {
                                 wide_tile_y,
                                 payload,
                                 paint,
+                                false,
                             );
                         };
 
@@ -1207,10 +1259,11 @@ impl Scheduler {
             if let TemporarySlot::Invalid(temp_slot) = tos.temporary_slot {
                 let next_round = depth.is_multiple_of(2);
                 let el_round = tos.round + usize::from(next_round);
+                let layer_index = self.next_layer_index();
                 let draw = self.draw_mut(el_round, temp_slot.get_texture());
-                draw.push(
+                draw.push_alpha(
                     GpuStripBuilder::at_slot(temp_slot.get_idx(), 0, WideTile::WIDTH)
-                        .copy_from_slot(tos.dest_slot.get_idx(), 0xFF),
+                        .copy_from_slot(tos.dest_slot.get_idx(), 0xFF, layer_index),
                 );
 
                 tos.temporary_slot = TemporarySlot::Valid(temp_slot);
@@ -1316,33 +1369,32 @@ impl Scheduler {
 
         let next_round: bool = depth.is_multiple_of(2) && depth > 2;
         let round = nos.round.max(tos.round + usize::from(next_round));
+        let layer_index = self.next_layer_index();
 
-        let draw = self.draw_mut(
-            round,
-            if depth <= 2 {
-                2
-            } else {
-                nos.dest_slot.get_texture()
-            },
-        );
+        let draw_texture = if depth <= 2 {
+            2
+        } else {
+            nos.dest_slot.get_texture()
+        };
+        let draw = self.draw_mut(round, draw_texture);
 
         let gpu_strip_builder = if depth <= 2 {
             GpuStripBuilder::at_surface(wide_tile_x, wide_tile_y, WideTile::WIDTH)
         } else {
             GpuStripBuilder::at_slot(nos.dest_slot.get_idx(), 0, WideTile::WIDTH)
         };
-
         if let TemporarySlot::Valid(temp_slot) = nos.temporary_slot {
             let opacity_u8 = (tos.opacity * 255.0) as u8;
             let mix_mode = mode.mix as u8;
             let compose_mode = mode.compose as u8;
 
-            draw.push(gpu_strip_builder.blend(
+            draw.push_alpha(gpu_strip_builder.blend(
                 tos.dest_slot.get_idx(),
                 temp_slot.get_idx(),
                 opacity_u8,
                 mix_mode,
                 compose_mode,
+                layer_index,
             ));
             // Invalidate the temporary slot after use
             let nos_ptr = state.tile_state.stack.len() - 2;
@@ -1360,9 +1412,12 @@ impl Scheduler {
             // `BlendState::PREMULTIPLIED_ALPHA_BLENDING`). This is the whole reason
             // why for default blend modes, we don't need to rely on temporary slots
             // to achieve blending.
-            draw.push(
-                gpu_strip_builder
-                    .copy_from_slot(tos.dest_slot.get_idx(), (tos.opacity * 255.0) as u8),
+            draw.push_alpha(
+                gpu_strip_builder.copy_from_slot(
+                    tos.dest_slot.get_idx(),
+                    (tos.opacity * 255.0) as u8,
+                    layer_index,
+                ),
             );
         }
     }
@@ -1379,9 +1434,9 @@ impl Scheduler {
         attrs: &CommandAttrs,
     ) {
         let depth = state.tile_state.stack.len();
-
         let el = state.tile_state.stack.last_mut().unwrap();
-        let draw = self.draw_mut(el.round, el.get_draw_texture(depth));
+        let el_round = el.round;
+        let draw_texture = el.get_draw_texture(depth);
 
         let fill_attrs = &attrs.fill[cmd.attrs_idx as usize];
         let alpha_idx = fill_attrs.alpha_idx(cmd.alpha_offset);
@@ -1394,9 +1449,12 @@ impl Scheduler {
             paint_idxs,
         );
 
+        let layer_index = self.next_layer_index();
+
         let gpu_strip_builder = if depth == 1 {
             GpuStripBuilder::at_surface(scene_strip_x, scene_strip_y, cmd.width)
         } else {
+            let el = state.tile_state.stack.last().unwrap();
             let slot_idx = if let TemporarySlot::Valid(temp_slot) = el.temporary_slot {
                 temp_slot.get_idx()
             } else {
@@ -1405,10 +1463,11 @@ impl Scheduler {
             GpuStripBuilder::at_slot(slot_idx, cmd.x, cmd.width)
         };
 
-        draw.push(
+        let draw = self.draw_mut(el_round, draw_texture);
+        draw.push_alpha(
             gpu_strip_builder
                 .with_sparse(cmd.width, col_idx)
-                .paint(payload, paint),
+                .paint(payload, paint, layer_index),
         );
     }
 
@@ -1432,7 +1491,16 @@ impl Scheduler {
             paint_idxs,
         );
 
-        self.do_fill_with(state, cmd, scene_strip_x, scene_strip_y, payload, paint);
+        let is_opaque = Self::is_paint_opaque(&fill_attrs.paint, encoded_paints);
+        self.do_fill_with(
+            state,
+            cmd,
+            scene_strip_x,
+            scene_strip_y,
+            payload,
+            paint,
+            is_opaque,
+        );
     }
 
     #[inline]
@@ -1444,9 +1512,11 @@ impl Scheduler {
         scene_strip_y: u16,
         payload: u32,
         paint: u32,
+        is_opaque: bool,
     ) {
         let depth = state.tile_state.stack.len();
 
+        let layer_index = self.next_layer_index();
         let el = state.tile_state.stack.last_mut().unwrap();
         let draw = self.draw_mut(el.round, el.get_draw_texture(depth));
 
@@ -1461,7 +1531,31 @@ impl Scheduler {
             GpuStripBuilder::at_slot(slot_idx, cmd.x, cmd.width)
         };
 
-        draw.push(gpu_strip_builder.paint(payload, paint));
+        let strip = gpu_strip_builder.paint(payload, paint, layer_index);
+        if depth == 1 && is_opaque {
+            draw.push_opaque(strip);
+        } else {
+            draw.push_alpha(strip);
+        }
+    }
+
+    /// Determine if a paint is fully opaque (no transparency).
+    #[inline]
+    fn is_paint_opaque(paint: &Paint, encoded_paints: &[EncodedPaint]) -> bool {
+        match paint {
+            Paint::Solid(color) => color.is_opaque(),
+            Paint::Indexed(indexed_paint) => {
+                let paint_id = indexed_paint.index();
+                match encoded_paints.get(paint_id) {
+                    Some(EncodedPaint::Image(img)) => {
+                        !img.may_have_opacities
+                            && img.sampler.alpha == 1.0
+                            && img.tint.is_none_or(|t| t.color.components[3] >= 1.0)
+                    }
+                    _ => false,
+                }
+            }
+        }
     }
 
     #[inline]
@@ -1498,14 +1592,16 @@ impl Scheduler {
         // enough "ping-ponging" to resolve all dependencies.
         let next_round = depth.is_multiple_of(2) && depth > 2;
         let round = nos.round.max(tos.round + usize::from(next_round));
+        let layer_index = self.next_layer_index();
         if let TemporarySlot::Valid(temp_slot) = nos.temporary_slot {
             let draw = self.draw_mut(round, nos.dest_slot.get_texture());
-            draw.push(
+            draw.push_alpha(
                 GpuStripBuilder::at_slot(nos.dest_slot.get_idx(), 0, WideTile::WIDTH)
-                    .copy_from_slot(temp_slot.get_idx(), 0xFF),
+                    .copy_from_slot(temp_slot.get_idx(), 0xFF, layer_index),
             );
         }
 
+        let layer_index = self.next_layer_index();
         let draw = self.draw_mut(
             round,
             if (depth - 1) <= 1 {
@@ -1519,7 +1615,9 @@ impl Scheduler {
         } else {
             GpuStripBuilder::at_slot(nos.dest_slot.get_idx(), cmd.x, cmd.width)
         };
-        draw.push(gpu_strip_builder.copy_from_slot(tos.dest_slot.get_idx(), 0xFF));
+        draw.push_alpha(
+            gpu_strip_builder.copy_from_slot(tos.dest_slot.get_idx(), 0xFF, layer_index),
+        );
 
         let nos_ptr = state.tile_state.stack.len() - 2;
         state.tile_state.stack[nos_ptr].temporary_slot.invalidate();
@@ -1540,15 +1638,17 @@ impl Scheduler {
         let next_round = depth.is_multiple_of(2) && depth > 2;
         let round = nos.round.max(tos.round + usize::from(next_round));
 
+        let layer_index = self.next_layer_index();
         // If nos has a temporary slot, copy it to `dest_slot` first
         if let TemporarySlot::Valid(temp_slot) = nos.temporary_slot {
             let draw = self.draw_mut(round, nos.dest_slot.get_texture());
-            draw.push(
+            draw.push_alpha(
                 GpuStripBuilder::at_slot(nos.dest_slot.get_idx(), 0, WideTile::WIDTH)
-                    .copy_from_slot(temp_slot.get_idx(), 0xFF),
+                    .copy_from_slot(temp_slot.get_idx(), 0xFF, layer_index),
             );
         }
 
+        let layer_index = self.next_layer_index();
         let draw = self.draw_mut(
             round,
             if (depth - 1) <= 1 {
@@ -1567,10 +1667,10 @@ impl Scheduler {
         let alpha_idx = clip_attrs.alpha_idx(cmd.alpha_offset);
         let col_idx = alpha_idx / u32::from(Tile::HEIGHT);
 
-        draw.push(
+        draw.push_alpha(
             gpu_strip_builder
                 .with_sparse(cmd.width, col_idx)
-                .copy_from_slot(tos.dest_slot.get_idx(), 0xFF),
+                .copy_from_slot(tos.dest_slot.get_idx(), 0xFF, layer_index),
         );
         let nos_ptr = state.tile_state.stack.len() - 2;
         state.tile_state.stack[nos_ptr].temporary_slot.invalidate();
@@ -1683,7 +1783,7 @@ impl GpuStripBuilder {
     }
 
     /// Paint into strip.
-    fn paint(self, payload: u32, paint: u32) -> GpuStrip {
+    fn paint(self, payload: u32, paint: u32, layer_index: u32) -> GpuStrip {
         GpuStrip {
             x: self.x,
             y: self.y,
@@ -1692,11 +1792,12 @@ impl GpuStripBuilder {
             col_idx_or_rect_frac: self.col_idx_or_rect_frac,
             payload,
             paint_and_rect_flag: paint,
+            layer_index,
         }
     }
 
     /// Copy from slot.
-    fn copy_from_slot(self, from_slot: usize, opacity: u8) -> GpuStrip {
+    fn copy_from_slot(self, from_slot: usize, opacity: u8, layer_index: u32) -> GpuStrip {
         GpuStrip {
             x: self.x,
             y: self.y,
@@ -1705,6 +1806,7 @@ impl GpuStripBuilder {
             col_idx_or_rect_frac: self.col_idx_or_rect_frac,
             payload: u32::try_from(from_slot).unwrap(),
             paint_and_rect_flag: (COLOR_SOURCE_SLOT << 29) | (opacity as u32),
+            layer_index,
         }
     }
 
@@ -1716,6 +1818,7 @@ impl GpuStripBuilder {
         opacity: u8,
         mix_mode: u8,
         compose_mode: u8,
+        layer_index: u32,
     ) -> GpuStrip {
         GpuStrip {
             x: self.x,
@@ -1729,6 +1832,7 @@ impl GpuStripBuilder {
                 | ((opacity as u32) << 16)
                 | ((mix_mode as u32) << 8)
                 | (compose_mode as u32),
+            layer_index,
         }
     }
 }
@@ -1744,13 +1848,16 @@ fn generate_gpu_strips_for_fast_path(
     scene: &Scene,
     encoded_paints: &[EncodedPaint],
     paint_idxs: &[u32],
-    gpu_strips: &mut Vec<GpuStrip>,
+    layer_counter: &mut u32,
+    draw: &mut Draw,
 ) {
     let strips = &strip_storage.strips[path.strips.clone()];
 
     if strips.is_empty() {
         return;
     }
+
+    let is_opaque = Scheduler::is_paint_opaque(&path.paint, encoded_paints);
 
     // Note: Some of this logic is similar to current coarse rasterization code, but
     // the coarse rasterization code is more complex due to clip paths and other factors.
@@ -1770,14 +1877,16 @@ fn generate_gpu_strips_for_fast_path(
         let x0 = strip.x;
         let y = strip.y;
 
-        // Alpha fill for the strip's coverage region.
+        // Alpha fill for the strip's coverage region (always alpha — has AA).
         if strip_width > 0 {
+            let layer_index = *layer_counter;
+            *layer_counter += 1;
             let (payload, paint) =
                 Scheduler::process_paint(&path.paint, encoded_paints, (x0, y), paint_idxs);
-            gpu_strips.push(
+            draw.push_alpha(
                 GpuStripBuilder::at_surface(x0, y, strip_width)
                     .with_sparse(strip_width, col)
-                    .paint(payload, paint),
+                    .paint(payload, paint, layer_index),
             );
         }
 
@@ -1791,163 +1900,198 @@ fn generate_gpu_strips_for_fast_path(
                     .unwrap_or(u16::MAX),
             );
             if x2 > x1 {
+                let layer_index = *layer_counter;
+                *layer_counter += 1;
                 let (payload, paint) =
                     Scheduler::process_paint(&path.paint, encoded_paints, (x1, y), paint_idxs);
-                gpu_strips.push(GpuStripBuilder::at_surface(x1, y, x2 - x1).paint(payload, paint));
+                let strip =
+                    GpuStripBuilder::at_surface(x1, y, x2 - x1).paint(payload, paint, layer_index);
+                if is_opaque {
+                    draw.push_opaque(strip);
+                } else {
+                    draw.push_alpha(strip);
+                }
             }
         }
     }
 }
 
-fn pack_rectangle_into_gpu(
+/// Decompose a rectangle into a pixel-aligned opaque interior plus thin AA edge
+/// strips. The interior has `rect_frac=0` so the fragment shader skips the AA
+/// coverage math entirely; when the paint is opaque this quad goes to the opaque
+/// draw list for TBDR early-z. The 1px edge strips carry fractional coverage and
+/// always go to the alpha list.
+///
+/// For small rects (under 20px in either dimension, or where the interior would be
+/// empty), we fall back to a single rect instance with full AA fracs — the overhead
+/// of 5 draw instances outweighs the per-fragment savings at small sizes.
+fn emit_rect_strips(
     rect: &FastPathRect,
     encoded_paints: &[EncodedPaint],
     paint_idxs: &[u32],
-    out: &mut Vec<GpuStrip>,
+    layer_index: u32,
+    is_opaque: bool,
+    draw: &mut Draw,
 ) {
-    let split = split_rect(rect);
-    for part in [
-        Some(split.main),
-        split.top,
-        split.bottom,
-        split.left,
-        split.right,
-    ]
-    .into_iter()
-    .flatten()
-    {
-        let (payload, paint_packed) =
-            Scheduler::process_paint(&rect.paint, encoded_paints, (part.x, part.y), paint_idxs);
-        out.push(make_gpu_rect(part, payload, paint_packed));
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct RectPart {
-    x: u16,
-    y: u16,
-    width: u16,
-    height: u16,
-    frac: u32,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct SplitRect {
-    main: RectPart,
-    top: Option<RectPart>,
-    bottom: Option<RectPart>,
-    left: Option<RectPart>,
-    right: Option<RectPart>,
-}
-
-fn split_rect(rect: &FastPathRect) -> SplitRect {
     let sx0 = rect.x0.floor();
     let sy0 = rect.y0.floor();
     let sx1 = rect.x1.ceil();
     let sy1 = rect.y1.ceil();
 
-    let x = sx0 as u16;
-    let y = sy0 as u16;
-    // Are guaranteed to be > 0 since we rejected negative rectangles.
-    let width = (sx1 - sx0) as u16;
-    let height = (sy1 - sy0) as u16;
+    let base_x = sx0 as u16;
+    let base_y = sy0 as u16;
+    let snapped_w = (sx1 - sx0) as u16;
+    let snapped_h = (sy1 - sy0) as u16;
 
-    // Note that `top_frac` and `left_fract` store the actual coverage, while
-    // `right_frac` and `bottom_fract` store one minus the coverage. This is on purpose
-    // and handled that way in the shader.
-    let left_frac = rect.x0 - sx0;
-    let top_frac = rect.y0 - sy0;
-    let right_frac = sx1 - rect.x1;
-    let bottom_frac = sy1 - rect.y1;
+    let q = |f: f32| -> u8 { (f * 255.0 + 0.5) as u8 };
+    let frac_l = q(rect.x0 - sx0);
+    let frac_t = q(rect.y0 - sy0);
+    let frac_r = q(sx1 - rect.x1);
+    let frac_b = q(sy1 - rect.y1);
 
-    // There's a balance to strike between reducing work in the fragment shader by splitting
-    // out the inner part of the rectangle without anti-aliasing, and additional overhead
-    // that arises from rendering 5 rectangles instead of just one. While the exact threshold
-    // will obviously depend on the device, some experiments on a low-tier tablet showed that
-    // `LARGE_RECT_SPLIT_THRESHOLD` seems to be a a reasonable value.
-    if rect.x1 - rect.x0 < f32::from(LARGE_RECT_SPLIT_THRESHOLD)
-        || rect.y1 - rect.y0 < f32::from(LARGE_RECT_SPLIT_THRESHOLD)
+    let has_left = frac_l > 0;
+    let has_top = frac_t > 0;
+    let has_right = frac_r > 0;
+    let has_bottom = frac_b > 0;
+
+    let left_inset: u16 = u16::from(has_left);
+    let top_inset: u16 = u16::from(has_top);
+    let right_inset: u16 = u16::from(has_right);
+    let bottom_inset: u16 = u16::from(has_bottom);
+
+    let interior_w = snapped_w.saturating_sub(left_inset + right_inset);
+    let interior_h = snapped_h.saturating_sub(top_inset + bottom_inset);
+
+    const MIN_SPLIT_SIZE: u16 = 20;
+    if snapped_w < MIN_SPLIT_SIZE || snapped_h < MIN_SPLIT_SIZE
+        || interior_w == 0 || interior_h == 0
     {
-        return SplitRect {
-            main: RectPart {
-                x,
-                y,
-                width,
-                height,
-                frac: pack_unorm4x8([left_frac, top_frac, right_frac, bottom_frac]),
-            },
-            top: None,
-            bottom: None,
-            left: None,
-            right: None,
-        };
+        let frac = pack_unorm4x8([rect.x0 - sx0, rect.y0 - sy0, sx1 - rect.x1, sy1 - rect.y1]);
+        let (payload, paint_packed) =
+            Scheduler::process_paint(&rect.paint, encoded_paints, (base_x, base_y), paint_idxs);
+        draw.push_alpha(GpuStrip {
+            x: base_x,
+            y: base_y,
+            width: snapped_w,
+            dense_width_or_rect_height: snapped_h,
+            col_idx_or_rect_frac: frac,
+            payload,
+            paint_and_rect_flag: paint_packed | RECT_STRIP_FLAG,
+            layer_index,
+        });
+        return;
     }
 
-    let has_left_aa = left_frac > 0.0;
-    let has_top_aa = top_frac > 0.0;
-    let has_right_aa = right_frac > 0.0;
-    let has_bottom_aa = bottom_frac > 0.0;
-    let has_top_strip = has_top_aa || has_left_aa || has_right_aa;
-    let has_bottom_strip = has_bottom_aa || has_left_aa || has_right_aa;
-    let left_inset = u16::from(has_left_aa);
-    let right_inset = u16::from(has_right_aa);
-    let top_inset = u16::from(has_top_strip);
-    let bottom_inset = u16::from(has_bottom_strip);
-    let inner_x = x + left_inset;
-    let inner_y = y + top_inset;
-    // Can't underflow because rectangles have at least `LARGE_RECT_SPLIT_THRESHOLD` in each
-    // direction, which is larger than 2.
-    let inner_width = width - left_inset - right_inset;
-    let inner_height = height - top_inset - bottom_inset;
-
-    SplitRect {
-        main: RectPart {
-            x: inner_x,
-            y: inner_y,
-            width: inner_width,
-            height: inner_height,
-            frac: 0,
-        },
-        top: has_top_strip.then_some(RectPart {
-            x,
-            y,
-            width,
-            height: 1,
-            frac: pack_unorm4x8([left_frac, top_frac, right_frac, 0.0]),
-        }),
-        bottom: has_bottom_strip.then_some(RectPart {
-            x,
-            y: y + height - 1,
-            width,
-            height: 1,
-            frac: pack_unorm4x8([left_frac, 0.0, right_frac, bottom_frac]),
-        }),
-        left: has_left_aa.then_some(RectPart {
-            x,
-            y: inner_y,
-            width: 1,
-            height: inner_height,
-            frac: pack_unorm4x8([left_frac, 0.0, 0.0, 0.0]),
-        }),
-        right: has_right_aa.then_some(RectPart {
-            x: x + width - 1,
-            y: inner_y,
-            width: 1,
-            height: inner_height,
-            frac: pack_unorm4x8([0.0, 0.0, right_frac, 0.0]),
-        }),
-    }
-}
-
-fn make_gpu_rect(part: RectPart, payload: u32, paint_packed: u32) -> GpuStrip {
-    GpuStrip {
-        x: part.x,
-        y: part.y,
-        width: part.width,
-        dense_width_or_rect_height: part.height,
-        col_idx_or_rect_frac: part.frac,
+    // Interior: pixel-aligned, rect_frac=0 → no AA in fragment shader.
+    let interior_x = base_x + left_inset;
+    let interior_y = base_y + top_inset;
+    let (payload, paint_packed) = Scheduler::process_paint(
+        &rect.paint,
+        encoded_paints,
+        (interior_x, interior_y),
+        paint_idxs,
+    );
+    let interior_strip = GpuStrip {
+        x: interior_x,
+        y: interior_y,
+        width: interior_w,
+        dense_width_or_rect_height: interior_h,
+        col_idx_or_rect_frac: 0,
         payload,
         paint_and_rect_flag: paint_packed | RECT_STRIP_FLAG,
+        layer_index,
+    };
+    if is_opaque {
+        draw.push_opaque(interior_strip);
+    } else {
+        draw.push_alpha(interior_strip);
+    }
+
+    // Edge strips: 1px wide/tall strips carrying fractional coverage.
+    // Top edge (full width, 1px tall).
+    if has_top {
+        let frac = u32::from(frac_l)
+            | (u32::from(frac_t) << 8)
+            | (u32::from(frac_r) << 16);
+        let (payload, paint_packed) =
+            Scheduler::process_paint(&rect.paint, encoded_paints, (base_x, base_y), paint_idxs);
+        draw.push_alpha(GpuStrip {
+            x: base_x,
+            y: base_y,
+            width: snapped_w,
+            dense_width_or_rect_height: 1,
+            col_idx_or_rect_frac: frac,
+            payload,
+            paint_and_rect_flag: paint_packed | RECT_STRIP_FLAG,
+            layer_index,
+        });
+    }
+
+    // Bottom edge (full width, 1px tall).
+    if has_bottom {
+        let bottom_y = base_y + snapped_h - 1;
+        let frac = u32::from(frac_l)
+            | (u32::from(frac_r) << 16)
+            | (u32::from(frac_b) << 24);
+        let (payload, paint_packed) = Scheduler::process_paint(
+            &rect.paint,
+            encoded_paints,
+            (base_x, bottom_y),
+            paint_idxs,
+        );
+        draw.push_alpha(GpuStrip {
+            x: base_x,
+            y: bottom_y,
+            width: snapped_w,
+            dense_width_or_rect_height: 1,
+            col_idx_or_rect_frac: frac,
+            payload,
+            paint_and_rect_flag: paint_packed | RECT_STRIP_FLAG,
+            layer_index,
+        });
+    }
+
+    // Left edge (1px wide, interior height only — corners handled by top/bottom).
+    if has_left {
+        let frac = u32::from(frac_l);
+        let (payload, paint_packed) = Scheduler::process_paint(
+            &rect.paint,
+            encoded_paints,
+            (base_x, interior_y),
+            paint_idxs,
+        );
+        draw.push_alpha(GpuStrip {
+            x: base_x,
+            y: interior_y,
+            width: 1,
+            dense_width_or_rect_height: interior_h,
+            col_idx_or_rect_frac: frac,
+            payload,
+            paint_and_rect_flag: paint_packed | RECT_STRIP_FLAG,
+            layer_index,
+        });
+    }
+
+    // Right edge (1px wide, interior height only).
+    if has_right {
+        let right_x = base_x + snapped_w - 1;
+        let frac = u32::from(frac_r) << 16;
+        let (payload, paint_packed) = Scheduler::process_paint(
+            &rect.paint,
+            encoded_paints,
+            (right_x, interior_y),
+            paint_idxs,
+        );
+        draw.push_alpha(GpuStrip {
+            x: right_x,
+            y: interior_y,
+            width: 1,
+            dense_width_or_rect_height: interior_h,
+            col_idx_or_rect_frac: frac,
+            payload,
+            paint_and_rect_flag: paint_packed | RECT_STRIP_FLAG,
+            layer_index,
+        });
     }
 }
 
@@ -1961,271 +2105,20 @@ fn pack_unorm4x8(v: [f32; 4]) -> u32 {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        RECT_STRIP_FLAG, RectPart, SplitRect, pack_rectangle_into_gpu, pack_unorm4x8, split_rect,
-    };
-    use crate::scene::FastPathRect;
-    use alloc::vec;
-    use alloc::vec::Vec;
-    use vello_common::encode::EncodedImage;
-    use vello_common::kurbo::{Affine, Vec2};
-    use vello_common::paint::{Color, ImageId, ImageSource, IndexedPaint, Paint};
-    use vello_common::peniko::ImageSampler;
+    use super::{pack_unorm4x8, RECT_STRIP_FLAG};
 
-    fn solid_rect(x0: f32, y0: f32, x1: f32, y1: f32) -> FastPathRect {
-        FastPathRect {
-            x0,
-            y0,
-            x1,
-            y1,
-            paint: Paint::from(Color::from_rgba8(255, 0, 0, 255)),
-        }
-    }
-
-    fn part(x: u16, y: u16, width: u16, height: u16, frac: [f32; 4]) -> RectPart {
-        RectPart {
-            x,
-            y,
-            width,
-            height,
-            frac: pack_unorm4x8(frac),
-        }
+    #[test]
+    fn pack_unorm4x8_basic() {
+        assert_eq!(pack_unorm4x8([0.0, 0.0, 0.0, 0.0]), 0);
+        let val = pack_unorm4x8([0.25, 0.5, 0.75, 1.0]);
+        assert_eq!(val & 0xFF, 64);
+        assert_eq!((val >> 8) & 0xFF, 128);
+        assert_eq!((val >> 16) & 0xFF, 191);
+        assert_eq!((val >> 24) & 0xFF, 255);
     }
 
     #[test]
-    fn splitter_keeps_small_rect_whole() {
-        let rect = solid_rect(10.25, 20.5, 25.75, 35.25);
-        let split = split_rect(&rect);
-
-        assert_eq!(
-            split,
-            SplitRect {
-                main: part(10, 20, 16, 16, [0.25, 0.5, 0.25, 0.75]),
-                top: None,
-                bottom: None,
-                left: None,
-                right: None,
-            }
-        );
-    }
-
-    #[test]
-    fn splitter_keeps_subpixel_rect_inside_one_pixel() {
-        let rect = solid_rect(10.125, 20.25, 10.875, 20.75);
-        let split = split_rect(&rect);
-
-        assert_eq!(
-            split,
-            SplitRect {
-                main: part(10, 20, 1, 1, [0.125, 0.25, 0.125, 0.25]),
-                top: None,
-                bottom: None,
-                left: None,
-                right: None,
-            }
-        );
-    }
-
-    #[test]
-    fn splitter_keeps_subpixel_rect_spanning_two_pixels_in_width() {
-        let rect = solid_rect(10.75, 20.125, 11.25, 20.875);
-        let split = split_rect(&rect);
-
-        assert_eq!(
-            split,
-            SplitRect {
-                main: part(10, 20, 2, 1, [0.75, 0.125, 0.75, 0.125]),
-                top: None,
-                bottom: None,
-                left: None,
-                right: None,
-            }
-        );
-    }
-
-    #[test]
-    fn splitter_keeps_subpixel_rect_spanning_two_pixels_in_height() {
-        let rect = solid_rect(10.125, 20.75, 10.875, 21.25);
-        let split = split_rect(&rect);
-
-        assert_eq!(
-            split,
-            SplitRect {
-                main: part(10, 20, 1, 2, [0.125, 0.75, 0.125, 0.75]),
-                top: None,
-                bottom: None,
-                left: None,
-                right: None,
-            }
-        );
-    }
-
-    #[test]
-    fn splitter_keeps_multi_pixel_width_rect_within_one_pixel_height() {
-        let rect = solid_rect(10.25, 20.125, 14.75, 20.875);
-        let split = split_rect(&rect);
-
-        assert_eq!(
-            split,
-            SplitRect {
-                main: part(10, 20, 5, 1, [0.25, 0.125, 0.25, 0.125]),
-                top: None,
-                bottom: None,
-                left: None,
-                right: None,
-            }
-        );
-    }
-
-    #[test]
-    fn splitter_keeps_multi_pixel_height_rect_within_one_pixel_width() {
-        let rect = solid_rect(10.125, 20.25, 10.875, 24.75);
-        let split = split_rect(&rect);
-
-        assert_eq!(
-            split,
-            SplitRect {
-                main: part(10, 20, 1, 5, [0.125, 0.25, 0.125, 0.25]),
-                top: None,
-                bottom: None,
-                left: None,
-                right: None,
-            }
-        );
-    }
-
-    #[test]
-    fn splitter_splits_large_rect_into_five_parts() {
-        let rect = solid_rect(10.25, 20.5, 42.75, 52.75);
-        let split = split_rect(&rect);
-
-        assert_eq!(
-            split,
-            SplitRect {
-                main: part(11, 21, 31, 31, [0.0, 0.0, 0.0, 0.0]),
-                top: Some(part(10, 20, 33, 1, [0.25, 0.5, 0.25, 0.0])),
-                bottom: Some(part(10, 52, 33, 1, [0.25, 0.0, 0.25, 0.25])),
-                left: Some(part(10, 21, 1, 31, [0.25, 0.0, 0.0, 0.0])),
-                right: Some(part(42, 21, 1, 31, [0.0, 0.0, 0.25, 0.0])),
-            }
-        );
-    }
-
-    #[test]
-    fn splitter_omits_unneeded_edge_parts() {
-        let rect = solid_rect(10.0, 20.5, 42.0, 53.0);
-        let split = split_rect(&rect);
-
-        assert_eq!(
-            split,
-            SplitRect {
-                main: part(10, 21, 32, 32, [0.0, 0.0, 0.0, 0.0]),
-                top: Some(part(10, 20, 32, 1, [0.0, 0.5, 0.0, 0.0])),
-                bottom: None,
-                left: None,
-                right: None,
-            }
-        );
-    }
-
-    #[test]
-    fn splitter_handles_large_rect_with_only_vertical_aa() {
-        let rect = solid_rect(5.0, 2.25, 37.0, 34.75);
-        let split = split_rect(&rect);
-
-        assert_eq!(
-            split,
-            SplitRect {
-                main: part(5, 3, 32, 31, [0.0, 0.0, 0.0, 0.0]),
-                top: Some(part(5, 2, 32, 1, [0.0, 0.25, 0.0, 0.0])),
-                bottom: Some(part(5, 34, 32, 1, [0.0, 0.0, 0.0, 0.25])),
-                left: None,
-                right: None,
-            }
-        );
-    }
-
-    #[test]
-    fn splitter_keeps_large_aligned_rect_as_single_main_rect() {
-        let rect = solid_rect(10.0, 20.0, 42.0, 60.0);
-        let split = split_rect(&rect);
-
-        assert_eq!(
-            split,
-            SplitRect {
-                main: part(10, 20, 32, 40, [0.0, 0.0, 0.0, 0.0]),
-                top: None,
-                bottom: None,
-                left: None,
-                right: None,
-            }
-        );
-    }
-
-    #[test]
-    fn gpu_upload_emits_main_and_present_optional_parts() {
-        let rect = solid_rect(10.0, 20.5, 42.0, 53.0);
-        let mut out = Vec::new();
-
-        pack_rectangle_into_gpu(&rect, &[], &[], &mut out);
-
-        assert_eq!(out.len(), 2);
-        assert_eq!(
-            (
-                out[0].x,
-                out[0].y,
-                out[0].width,
-                out[0].dense_width_or_rect_height
-            ),
-            (10, 21, 32, 32)
-        );
-        assert_eq!(out[0].col_idx_or_rect_frac, 0);
-        assert_eq!(
-            (
-                out[1].x,
-                out[1].y,
-                out[1].width,
-                out[1].dense_width_or_rect_height
-            ),
-            (10, 20, 32, 1)
-        );
-        assert_eq!(
-            out[1].col_idx_or_rect_frac,
-            pack_unorm4x8([0.0, 0.5, 0.0, 0.0])
-        );
-        assert!(
-            out.iter()
-                .all(|strip| strip.paint_and_rect_flag & RECT_STRIP_FLAG != 0)
-        );
-    }
-
-    #[test]
-    fn gpu_upload_updates_payload_for_each_split_part() {
-        let rect = FastPathRect {
-            x0: 10.25,
-            y0: 20.5,
-            x1: 42.75,
-            y1: 52.75,
-            paint: Paint::Indexed(IndexedPaint::new(0)),
-        };
-        let encoded_paints = vec![vello_common::encode::EncodedPaint::Image(EncodedImage {
-            source: ImageSource::opaque_id(ImageId::new(1)),
-            sampler: ImageSampler::new(),
-            may_have_opacities: false,
-            transform: Affine::IDENTITY,
-            x_advance: Vec2::new(1.0, 0.0),
-            y_advance: Vec2::new(0.0, 1.0),
-            tint: None,
-        })];
-        let mut out = Vec::new();
-
-        pack_rectangle_into_gpu(&rect, &encoded_paints, &[7], &mut out);
-
-        assert_eq!(out.len(), 5);
-        assert_eq!(out[0].payload, (21_u32 << 16) | 11_u32);
-        assert_eq!(out[1].payload, (20_u32 << 16) | 10_u32);
-        assert_eq!(out[2].payload, (52_u32 << 16) | 10_u32);
-        assert_eq!(out[3].payload, (21_u32 << 16) | 10_u32);
-        assert_eq!(out[4].payload, (21_u32 << 16) | 42_u32);
+    fn rect_strip_flag_is_set() {
+        assert_ne!(RECT_STRIP_FLAG, 0);
     }
 }

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -296,8 +296,53 @@ pub(crate) struct Scheduler {
     round_pool: RoundPool,
     /// The output target for the main rendering operations.
     output_target: StripPassRenderTarget,
-    /// Monotonically increasing counter for assigning `layer_index` to strips.
-    layer_counter: u32,
+    /// See [`DepthCounter`].
+    depth: DepthCounter,
+}
+
+/// Assigns depth indices to GPU strips for early z rejection.
+#[derive(Debug, Default)]
+struct DepthCounter {
+    counter: u32,
+    coarse_offset: u32,
+}
+
+impl DepthCounter {
+    fn reset(&mut self) {
+        self.counter = 0;
+    }
+
+    #[inline(always)]
+    fn next(&mut self) -> u32 {
+        let idx = self.counter;
+        self.counter += 1;
+        idx
+    }
+
+    fn begin_coarse_batch(&mut self) {
+        // +1 to reserve a background slot.
+        self.coarse_offset = self.counter + 1;
+        self.counter = self.coarse_offset;
+    }
+
+    fn begin_filter_batch(&mut self) {
+        self.coarse_offset = self.counter;
+    }
+
+    /// Depth index for the tile background in the current coarse batch.
+    #[inline(always)]
+    fn coarse_bg(&self) -> u32 {
+        self.coarse_offset - 1
+    }
+
+    /// Depth index for a coarse alpha or opaque fill command with the 
+    /// given `attrs_idx`.
+    #[inline(always)]
+    fn fill(&mut self, attrs_idx: u32) -> u32 {
+        let idx = self.coarse_offset + attrs_idx;
+        self.counter = self.counter.max(idx + 1);
+        idx
+    }
 }
 
 #[derive(Debug, Default)]
@@ -491,7 +536,7 @@ impl Scheduler {
             rounds_queue: VecDeque::new(),
             round_pool: RoundPool::default(),
             output_target: StripPassRenderTarget::Root(RootRenderTarget::UserSurface),
-            layer_counter: 0,
+            depth: DepthCounter::default(),
         }
     }
 
@@ -536,7 +581,7 @@ impl Scheduler {
         filter_context: &FilterContext,
         encoded_paints: &[EncodedPaint],
     ) -> Result<(), RenderError> {
-        self.layer_counter = 0;
+        self.depth.reset();
         for node_id in scene.render_graph.execution_order() {
             let node = &scene.render_graph.nodes[node_id];
 
@@ -733,6 +778,7 @@ impl Scheduler {
         // The maximum layer of other filter nodes should not leak into new filter nodes, hence
         // we need to reset it.
         state.max_round = self.round;
+        self.depth.begin_filter_batch();
 
         for y in wtile_bbox.y0()..wtile_bbox.y1() {
             for x in wtile_bbox.x0()..wtile_bbox.x1() {
@@ -795,12 +841,12 @@ impl Scheduler {
         let strip_storage = scene.strip_storage.borrow();
         // Always choose the draw of the final surface, since direct strips are only ever
         // rendered to the final surface.
-        let mut layer_counter = self.layer_counter;
+        // Take a local copy of the counter to avoid borrow conflicts with `draw`.
+        let mut depth = core::mem::take(&mut self.depth);
         let draw = self.draw_mut(round, 2);
 
         for cmd in &scene.fast_strips_buffer.commands[range] {
-            let layer_index = layer_counter;
-            layer_counter += 1;
+            let layer_index = depth.next();
             match cmd {
                 FastStripCommand::Path(path) => {
                     generate_gpu_strips_for_fast_path(
@@ -825,7 +871,7 @@ impl Scheduler {
                 }
             }
         }
-        self.layer_counter = layer_counter;
+        self.depth = depth;
     }
 
     /// Process one batch of coarse-rasterized wide tile commands.
@@ -845,6 +891,7 @@ impl Scheduler {
         filter_context: &FilterContext,
         encoded_paints: &[EncodedPaint],
     ) -> Result<(), RenderError> {
+        self.depth.begin_coarse_batch();
         for row in 0..rows {
             for col in 0..cols {
                 let idx = (row * cols + col) as usize;
@@ -956,7 +1003,7 @@ impl Scheduler {
             if i == 2 {
                 // Output target: reverse opaque for front-to-back rendering.
                 // Alpha strips stay in natural back-to-front order.
-                let Draw {opaque, alpha} = draw;
+                let Draw { opaque, alpha } = draw;
                 // This leaves `opaque` in a dirty state, but it doesn't matter because we never use it again.
                 opaque.reverse();
                 renderer.render_strips(opaque, alpha, target, load);
@@ -975,14 +1022,6 @@ impl Scheduler {
         self.round += 1;
 
         self.round_pool.return_to_pool(round);
-    }
-
-    /// Allocate and return the next layer index for z-depth ordering.
-    #[inline(always)]
-    fn next_layer_index(&mut self) -> u32 {
-        let idx = self.layer_counter;
-        self.layer_counter += 1;
-        idx
     }
 
     // Find the appropriate draw call for rendering.
@@ -1022,10 +1061,10 @@ impl Scheduler {
                 idxs,
             );
 
-            let layer_index = self.next_layer_index();
+            let bg_layer_index = self.depth.coarse_bg();
             let draw = self.draw_mut(self.round, 2);
             let strip = GpuStripBuilder::at_surface(wide_tile_x, wide_tile_y, WideTile::WIDTH)
-                .paint(payload, paint, layer_index);
+                .paint(payload, paint, bg_layer_index);
             if tile.bg.is_opaque() {
                 draw.push_opaque(strip);
             } else {
@@ -1173,6 +1212,7 @@ impl Scheduler {
                                 wide_tile_x,
                                 wide_tile_y,
                             );
+                            let layer_index = scheduler.depth.next();
                             scheduler.do_fill_with(
                                 state,
                                 &cmd,
@@ -1181,6 +1221,7 @@ impl Scheduler {
                                 payload,
                                 paint,
                                 false,
+                                layer_index,
                             );
                         };
 
@@ -1281,7 +1322,7 @@ impl Scheduler {
             if let TemporarySlot::Invalid(temp_slot) = tos.temporary_slot {
                 let next_round = depth.is_multiple_of(2);
                 let el_round = tos.round + usize::from(next_round);
-                let layer_index = self.next_layer_index();
+                let layer_index = self.depth.next();
                 let draw = self.draw_mut(el_round, temp_slot.get_texture());
                 draw.push_alpha(
                     GpuStripBuilder::at_slot(temp_slot.get_idx(), 0, WideTile::WIDTH)
@@ -1391,7 +1432,7 @@ impl Scheduler {
 
         let next_round: bool = depth.is_multiple_of(2) && depth > 2;
         let round = nos.round.max(tos.round + usize::from(next_round));
-        let layer_index = self.next_layer_index();
+        let layer_index = self.depth.next();
 
         let draw = self.draw_mut(
             round,
@@ -1456,7 +1497,7 @@ impl Scheduler {
         attrs: &CommandAttrs,
     ) {
         let depth = state.tile_state.stack.len();
-        let layer_index = self.next_layer_index();
+        let layer_index = self.depth.fill(cmd.attrs_idx);
 
         let el = state.tile_state.stack.last_mut().unwrap();
         let draw = self.draw_mut(el.round, el.get_draw_texture(depth));
@@ -1502,6 +1543,7 @@ impl Scheduler {
         attrs: &CommandAttrs,
     ) {
         let fill_attrs = &attrs.fill[cmd.attrs_idx as usize];
+        let layer_index = self.depth.fill(cmd.attrs_idx);
         let (scene_strip_x, scene_strip_y) = (wide_tile_x + cmd.x, wide_tile_y);
         let (payload, paint) = Self::process_paint(
             &fill_attrs.paint,
@@ -1518,6 +1560,7 @@ impl Scheduler {
             payload,
             paint,
             Self::is_paint_opaque(&fill_attrs.paint, encoded_paints),
+            layer_index,
         );
     }
 
@@ -1531,10 +1574,10 @@ impl Scheduler {
         payload: u32,
         paint: u32,
         is_opaque: bool,
+        layer_index: u32,
     ) {
         let depth = state.tile_state.stack.len();
 
-        let layer_index = self.next_layer_index();
         let el = state.tile_state.stack.last_mut().unwrap();
         let draw = self.draw_mut(el.round, el.get_draw_texture(depth));
 
@@ -1612,7 +1655,7 @@ impl Scheduler {
         // enough "ping-ponging" to resolve all dependencies.
         let next_round = depth.is_multiple_of(2) && depth > 2;
         let round = nos.round.max(tos.round + usize::from(next_round));
-        let layer_index = self.next_layer_index();
+        let layer_index = self.depth.next();
         if let TemporarySlot::Valid(temp_slot) = nos.temporary_slot {
             let draw = self.draw_mut(round, nos.dest_slot.get_texture());
             draw.push_alpha(
@@ -1621,7 +1664,7 @@ impl Scheduler {
             );
         }
 
-        let layer_index = self.next_layer_index();
+        let layer_index = self.depth.next();
         let draw = self.draw_mut(
             round,
             if (depth - 1) <= 1 {
@@ -1660,7 +1703,7 @@ impl Scheduler {
         let next_round = depth.is_multiple_of(2) && depth > 2;
         let round = nos.round.max(tos.round + usize::from(next_round));
 
-        let layer_index = self.next_layer_index();
+        let layer_index = self.depth.next();
         // If nos has a temporary slot, copy it to `dest_slot` first
         if let TemporarySlot::Valid(temp_slot) = nos.temporary_slot {
             let draw = self.draw_mut(round, nos.dest_slot.get_texture());
@@ -1670,7 +1713,7 @@ impl Scheduler {
             );
         }
 
-        let layer_index = self.next_layer_index();
+        let layer_index = self.depth.next();
         let draw = self.draw_mut(
             round,
             if (depth - 1) <= 1 {

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -1571,7 +1571,8 @@ impl Scheduler {
                             && img.tint.is_none_or(|t| t.color.components[3] >= 1.0)
                     }
                     Some(EncodedPaint::Gradient(g)) => !g.may_have_opacities,
-                    _ => false,
+                    Some(EncodedPaint::BlurredRoundedRect(_)) => false,
+                    None => unreachable!("Paint must be in encoded paints"),
                 }
             }
         }

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -1963,8 +1963,11 @@ fn emit_rect_strips(
     let interior_h = snapped_h.saturating_sub(top_inset + bottom_inset);
 
     const MIN_SPLIT_SIZE: u16 = 20;
-    if snapped_w < MIN_SPLIT_SIZE || snapped_h < MIN_SPLIT_SIZE
-        || interior_w == 0 || interior_h == 0
+    if snapped_w < MIN_SPLIT_SIZE
+        || snapped_h < MIN_SPLIT_SIZE
+        || interior_w == 0
+        || interior_h == 0
+        || !is_opaque
     {
         let frac = pack_unorm4x8([rect.x0 - sx0, rect.y0 - sy0, sx1 - rect.x1, sy1 - rect.y1]);
         let (payload, paint_packed) =

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -960,8 +960,9 @@ impl Scheduler {
                 // Output target: reverse opaque for front-to-back rendering.
                 // Alpha strips stay in natural back-to-front order.
                 let Draw {opaque, alpha} = draw;
+                // This leaves `opaque` in a dirty state, but it doesn't matter because we never use it again.
                 opaque.reverse();
-                renderer.render_strips(&opaque, &alpha, target, load);
+                renderer.render_strips(opaque, alpha, target, load);
             } else {
                 // Slot textures: no depth optimization, everything in alpha list.
                 assert!(

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -1006,8 +1006,11 @@ impl Scheduler {
             let layer_index = self.next_layer_index();
             let draw = self.draw_mut(self.round, 2);
             draw.push_opaque(
-                GpuStripBuilder::at_surface(wide_tile_x, wide_tile_y, WideTile::WIDTH)
-                    .paint(payload, paint, layer_index),
+                GpuStripBuilder::at_surface(wide_tile_x, wide_tile_y, WideTile::WIDTH).paint(
+                    payload,
+                    paint,
+                    layer_index,
+                ),
             );
         }
     }
@@ -1412,13 +1415,11 @@ impl Scheduler {
             // `BlendState::PREMULTIPLIED_ALPHA_BLENDING`). This is the whole reason
             // why for default blend modes, we don't need to rely on temporary slots
             // to achieve blending.
-            draw.push_alpha(
-                gpu_strip_builder.copy_from_slot(
-                    tos.dest_slot.get_idx(),
-                    (tos.opacity * 255.0) as u8,
-                    layer_index,
-                ),
-            );
+            draw.push_alpha(gpu_strip_builder.copy_from_slot(
+                tos.dest_slot.get_idx(),
+                (tos.opacity * 255.0) as u8,
+                layer_index,
+            ));
         }
     }
 
@@ -1464,11 +1465,11 @@ impl Scheduler {
         };
 
         let draw = self.draw_mut(el_round, draw_texture);
-        draw.push_alpha(
-            gpu_strip_builder
-                .with_sparse(cmd.width, col_idx)
-                .paint(payload, paint, layer_index),
-        );
+        draw.push_alpha(gpu_strip_builder.with_sparse(cmd.width, col_idx).paint(
+            payload,
+            paint,
+            layer_index,
+        ));
     }
 
     #[inline]
@@ -1552,6 +1553,7 @@ impl Scheduler {
                             && img.sampler.alpha == 1.0
                             && img.tint.is_none_or(|t| t.color.components[3] >= 1.0)
                     }
+                    Some(EncodedPaint::Gradient(g)) => !g.may_have_opacities,
                     _ => false,
                 }
             }
@@ -1615,9 +1617,11 @@ impl Scheduler {
         } else {
             GpuStripBuilder::at_slot(nos.dest_slot.get_idx(), cmd.x, cmd.width)
         };
-        draw.push_alpha(
-            gpu_strip_builder.copy_from_slot(tos.dest_slot.get_idx(), 0xFF, layer_index),
-        );
+        draw.push_alpha(gpu_strip_builder.copy_from_slot(
+            tos.dest_slot.get_idx(),
+            0xFF,
+            layer_index,
+        ));
 
         let nos_ptr = state.tile_state.stack.len() - 2;
         state.tile_state.stack[nos_ptr].temporary_slot.invalidate();
@@ -2013,9 +2017,7 @@ fn emit_rect_strips(
     // Edge strips: 1px wide/tall strips carrying fractional coverage.
     // Top edge (full width, 1px tall).
     if has_top {
-        let frac = u32::from(frac_l)
-            | (u32::from(frac_t) << 8)
-            | (u32::from(frac_r) << 16);
+        let frac = u32::from(frac_l) | (u32::from(frac_t) << 8) | (u32::from(frac_r) << 16);
         let (payload, paint_packed) =
             Scheduler::process_paint(&rect.paint, encoded_paints, (base_x, base_y), paint_idxs);
         draw.push_alpha(GpuStrip {
@@ -2033,15 +2035,9 @@ fn emit_rect_strips(
     // Bottom edge (full width, 1px tall).
     if has_bottom {
         let bottom_y = base_y + snapped_h - 1;
-        let frac = u32::from(frac_l)
-            | (u32::from(frac_r) << 16)
-            | (u32::from(frac_b) << 24);
-        let (payload, paint_packed) = Scheduler::process_paint(
-            &rect.paint,
-            encoded_paints,
-            (base_x, bottom_y),
-            paint_idxs,
-        );
+        let frac = u32::from(frac_l) | (u32::from(frac_r) << 16) | (u32::from(frac_b) << 24);
+        let (payload, paint_packed) =
+            Scheduler::process_paint(&rect.paint, encoded_paints, (base_x, bottom_y), paint_idxs);
         draw.push_alpha(GpuStrip {
             x: base_x,
             y: bottom_y,

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -801,13 +801,15 @@ impl Scheduler {
         for cmd in &scene.fast_strips_buffer.commands[range] {
             match cmd {
                 FastStripCommand::Path(path) => {
+                    let layer_index = layer_counter;
+                    layer_counter += 1;
                     generate_gpu_strips_for_fast_path(
                         path,
                         &strip_storage,
                         scene,
                         encoded_paints,
                         paint_idxs,
-                        &mut layer_counter,
+                        layer_index,
                         draw,
                     );
                 }
@@ -1870,7 +1872,7 @@ fn generate_gpu_strips_for_fast_path(
     scene: &Scene,
     encoded_paints: &[EncodedPaint],
     paint_idxs: &[u32],
-    layer_counter: &mut u32,
+    layer_index: u32,
     draw: &mut Draw,
 ) {
     let strips = &strip_storage.strips[path.strips.clone()];
@@ -1898,11 +1900,6 @@ fn generate_gpu_strips_for_fast_path(
         let strip_width = next_col.saturating_sub(col) as u16;
         let x0 = strip.x;
         let y = strip.y;
-
-        // Since the components of a single strip are not overlapping, we can re-use the same
-        // layer index for all the components (alpha + fill) for a single strip.
-        let layer_index = *layer_counter;
-        *layer_counter += 1;
 
         // Alpha fill for the strip's coverage region.
         if strip_width > 0 {

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -245,16 +245,16 @@ pub(crate) trait RendererBackend {
     ///
     /// For output targets, render the strips in opaque then alpha order with:
     ///
-    /// | Pass   | Depth Test     | Depth Write | Blend | Strip Ordering |
-    /// | ------ | -------------- | ----------- | ----- | -------------- |
-    /// | Opaque | ON (LessEqual) | ON          | OFF   | Front-to-back  |
-    /// | Alpha  | ON (LessEqual) | OFF         | ON    | Back-to-front  |
+    /// | Pass   | Depth Test       | Depth Write | Blend | Strip Ordering |
+    /// | ------ | ---------------- | ----------- | ----- | -------------- |
+    /// | Opaque | ON (`LessEqual`) | ON          | OFF   | Front-to-back  |
+    /// | Alpha  | ON (`LessEqual`) | OFF         | ON    | Back-to-front  |
     ///
     /// For slot textures, there are no opaque strips, so we only render the alpha strips with:
     ///
-    /// | Pass   | Depth Test     | Depth Write | Blend | Strip Ordering |
-    /// | ------ | -------------- | ----------- | ----- | -------------- |
-    /// | Alpha  | OFF            | OFF         | ON    | Back-to-front  |
+    /// | Pass   | Depth Test       | Depth Write | Blend | Strip Ordering |
+    /// | ------ | ---------------- | ----------- | ----- | -------------- |
+    /// | Alpha  | OFF              | OFF         | ON    | Back-to-front  |
     ///
     // TODO: Consider using opaque passes for non-output targets.
     fn render_strips(
@@ -963,7 +963,10 @@ impl Scheduler {
                 draw.opaque = opaque; // Return allocation for later reuse.
             } else {
                 // Slot textures: no depth optimization, everything in alpha list.
-                assert!(draw.opaque.is_empty());
+                assert!(
+                    draw.opaque.is_empty(),
+                    "opaque pass unsupported for slot textures"
+                );
                 renderer.render_strips(&[], &draw.alpha, target, load);
             }
         }
@@ -1960,11 +1963,9 @@ fn pack_rectangle_into_gpu(
         let (payload, paint_packed) =
             Scheduler::process_paint(&rect.paint, encoded_paints, (part.x, part.y), paint_idxs);
         let strip = make_gpu_rect(part, payload, paint_packed, layer_index);
-        if is_first && is_opaque {
-            assert!(part.frac == 0);
+        if is_first && is_opaque && part.frac == 0 {
             draw.push_opaque(strip);
         } else {
-            assert!(part.frac != 0);
             draw.push_alpha(strip);
         }
         is_first = false;

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -1005,6 +1005,16 @@ impl Scheduler {
         self.round_pool.return_to_pool(round);
     }
 
+    /// Whether the scheduler is currently rendering to the final user surface
+    /// (as opposed to a filter layer or slot texture).
+    #[inline(always)]
+    fn is_rendering_to_user_surface(&self) -> bool {
+        matches!(
+            self.output_target,
+            StripPassRenderTarget::Root(RootRenderTarget::UserSurface)
+        )
+    }
+
     // Find the appropriate draw call for rendering.
     #[inline(always)]
     fn draw_mut(&mut self, el_round: usize, texture_idx: usize) -> &mut Draw {
@@ -1043,11 +1053,12 @@ impl Scheduler {
             );
 
             let is_opaque = tile.bg.is_opaque();
-            let bg_depth_index = self.depth.next(is_opaque);
+            let is_user_surface = self.is_rendering_to_user_surface();
+            let bg_depth_index = self.depth.next(is_opaque && is_user_surface);
             let draw = self.draw_mut(self.round, 2);
             let strip = GpuStripBuilder::at_surface(wide_tile_x, wide_tile_y, WideTile::WIDTH)
                 .paint(payload, paint, bg_depth_index);
-            if is_opaque {
+            if is_opaque && is_user_surface {
                 draw.push_opaque(strip);
             } else {
                 draw.push_alpha(strip);
@@ -1527,10 +1538,12 @@ impl Scheduler {
         let fill_attrs = &attrs.fill[cmd.attrs_idx as usize];
         let is_opaque = Self::is_paint_opaque(&fill_attrs.paint, encoded_paints);
         let stack_depth = state.tile_state.stack.len();
+        let is_root_opaque =
+            stack_depth == 1 && is_opaque && self.is_rendering_to_user_surface();
         let depth_index = self.depth.next(
-            // We currently only support opaques that are drawn to the surface. See TODO in
-            // `RendererBackend::render_strips`.
-            stack_depth == 1 && is_opaque,
+            // We currently only support opaques that are drawn to the user surface.
+            // See TODO in `RendererBackend::render_strips`.
+            is_root_opaque,
         );
         let (scene_strip_x, scene_strip_y) = (wide_tile_x + cmd.x, wide_tile_y);
         let (payload, paint) = Self::process_paint(
@@ -1547,7 +1560,7 @@ impl Scheduler {
             scene_strip_y,
             payload,
             paint,
-            is_opaque,
+            is_root_opaque,
             depth_index,
         );
     }
@@ -1561,7 +1574,7 @@ impl Scheduler {
         scene_strip_y: u16,
         payload: u32,
         paint: u32,
-        is_opaque: bool,
+        is_root_opaque: bool,
         depth_index: u32,
     ) {
         let depth = state.tile_state.stack.len();
@@ -1581,7 +1594,7 @@ impl Scheduler {
         };
 
         let strip = gpu_strip_builder.paint(payload, paint, depth_index);
-        if depth == 1 && is_opaque {
+        if is_root_opaque {
             draw.push_opaque(strip);
         } else {
             draw.push_alpha(strip);

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -1538,8 +1538,7 @@ impl Scheduler {
         let fill_attrs = &attrs.fill[cmd.attrs_idx as usize];
         let is_opaque = Self::is_paint_opaque(&fill_attrs.paint, encoded_paints);
         let stack_depth = state.tile_state.stack.len();
-        let is_root_opaque =
-            stack_depth == 1 && is_opaque && self.is_rendering_to_user_surface();
+        let is_root_opaque = stack_depth == 1 && is_opaque && self.is_rendering_to_user_surface();
         let depth_index = self.depth.next(
             // We currently only support opaques that are drawn to the user surface.
             // See TODO in `RendererBackend::render_strips`.

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -210,6 +210,10 @@ const PAINT_TYPE_SWEEP_GRADIENT: u32 = 4;
 /// Bit 31 of [`GpuStrip::paint_and_rect_flag`] signals that the strip
 /// represents a full rectangle.
 const RECT_STRIP_FLAG: u32 = 1 << 31;
+/// The threshold of the rectangle size after which a rectangle should be split up
+/// into multiple smaller ones.
+const LARGE_RECT_SPLIT_THRESHOLD: u16 = 32;
+
 // The sentinel tile index representing the surface.
 const SENTINEL_SLOT_IDX: usize = usize::MAX;
 
@@ -1435,9 +1439,6 @@ impl Scheduler {
         attrs: &CommandAttrs,
     ) {
         let depth = state.tile_state.stack.len();
-        let el = state.tile_state.stack.last_mut().unwrap();
-        let el_round = el.round;
-        let draw_texture = el.get_draw_texture(depth);
 
         let fill_attrs = &attrs.fill[cmd.attrs_idx as usize];
         let alpha_idx = fill_attrs.alpha_idx(cmd.alpha_offset);
@@ -1464,6 +1465,9 @@ impl Scheduler {
             GpuStripBuilder::at_slot(slot_idx, cmd.x, cmd.width)
         };
 
+        let el = state.tile_state.stack.last().unwrap();
+        let el_round = el.round;
+        let draw_texture = el.get_draw_texture(depth);
         let draw = self.draw_mut(el_round, draw_texture);
         draw.push_alpha(gpu_strip_builder.with_sparse(cmd.width, col_idx).paint(
             payload,
@@ -1926,8 +1930,8 @@ fn generate_gpu_strips_for_fast_path(
 /// draw list for TBDR early-z. The 1px edge strips carry fractional coverage and
 /// always go to the alpha list.
 ///
-/// For small rects (under 20px in either dimension, or where the interior would be
-/// empty), we fall back to a single rect instance with full AA fracs — the overhead
+/// For small rects (under `LARGE_RECT_SPLIT_THRESHOLD` in either dimension),
+/// we fall back to a single rect instance with full AA fracs — the overhead
 /// of 5 draw instances outweighs the per-fragment savings at small sizes.
 fn emit_rect_strips(
     rect: &FastPathRect,
@@ -1937,160 +1941,158 @@ fn emit_rect_strips(
     is_opaque: bool,
     draw: &mut Draw,
 ) {
+    let split = split_rect(rect);
+
+    let mut is_first = true;
+    for part in [
+        Some(split.main),
+        split.top,
+        split.bottom,
+        split.left,
+        split.right,
+    ]
+    .into_iter()
+    .flatten()
+    {
+        let (payload, paint_packed) =
+            Scheduler::process_paint(&rect.paint, encoded_paints, (part.x, part.y), paint_idxs);
+        let strip = make_gpu_rect(part, payload, paint_packed, layer_index);
+        if is_first && is_opaque && part.frac == 0 {
+            draw.push_opaque(strip);
+        } else {
+            draw.push_alpha(strip);
+        }
+        is_first = false;
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RectPart {
+    x: u16,
+    y: u16,
+    width: u16,
+    height: u16,
+    frac: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SplitRect {
+    main: RectPart,
+    top: Option<RectPart>,
+    bottom: Option<RectPart>,
+    left: Option<RectPart>,
+    right: Option<RectPart>,
+}
+
+fn split_rect(rect: &FastPathRect) -> SplitRect {
     let sx0 = rect.x0.floor();
     let sy0 = rect.y0.floor();
     let sx1 = rect.x1.ceil();
     let sy1 = rect.y1.ceil();
 
-    let base_x = sx0 as u16;
-    let base_y = sy0 as u16;
-    let snapped_w = (sx1 - sx0) as u16;
-    let snapped_h = (sy1 - sy0) as u16;
+    let x = sx0 as u16;
+    let y = sy0 as u16;
+    // Are guaranteed to be > 0 since we rejected negative rectangles.
+    let width = (sx1 - sx0) as u16;
+    let height = (sy1 - sy0) as u16;
 
-    let q = |f: f32| -> u8 { (f * 255.0 + 0.5) as u8 };
-    let frac_l = q(rect.x0 - sx0);
-    let frac_t = q(rect.y0 - sy0);
-    let frac_r = q(sx1 - rect.x1);
-    let frac_b = q(sy1 - rect.y1);
+    // Note that `top_frac` and `left_fract` store the actual coverage, while
+    // `right_frac` and `bottom_fract` store one minus the coverage. This is on purpose
+    // and handled that way in the shader.
+    let left_frac = rect.x0 - sx0;
+    let top_frac = rect.y0 - sy0;
+    let right_frac = sx1 - rect.x1;
+    let bottom_frac = sy1 - rect.y1;
 
-    let has_left = frac_l > 0;
-    let has_top = frac_t > 0;
-    let has_right = frac_r > 0;
-    let has_bottom = frac_b > 0;
-
-    let left_inset: u16 = u16::from(has_left);
-    let top_inset: u16 = u16::from(has_top);
-    let right_inset: u16 = u16::from(has_right);
-    let bottom_inset: u16 = u16::from(has_bottom);
-
-    let interior_w = snapped_w.saturating_sub(left_inset + right_inset);
-    let interior_h = snapped_h.saturating_sub(top_inset + bottom_inset);
-
-    const MIN_SPLIT_SIZE: u16 = 20;
-    if snapped_w < MIN_SPLIT_SIZE
-        || snapped_h < MIN_SPLIT_SIZE
-        || interior_w == 0
-        || interior_h == 0
-        || !is_opaque
+    // There's a balance to strike between reducing work in the fragment shader by splitting
+    // out the inner part of the rectangle without anti-aliasing, and additional overhead
+    // that arises from rendering 5 rectangles instead of just one. While the exact threshold
+    // will obviously depend on the device, some experiments on a low-tier tablet showed that
+    // `LARGE_RECT_SPLIT_THRESHOLD` seems to be a a reasonable value.
+    if rect.x1 - rect.x0 < f32::from(LARGE_RECT_SPLIT_THRESHOLD)
+        || rect.y1 - rect.y0 < f32::from(LARGE_RECT_SPLIT_THRESHOLD)
     {
-        let frac = pack_unorm4x8([rect.x0 - sx0, rect.y0 - sy0, sx1 - rect.x1, sy1 - rect.y1]);
-        let (payload, paint_packed) =
-            Scheduler::process_paint(&rect.paint, encoded_paints, (base_x, base_y), paint_idxs);
-        draw.push_alpha(GpuStrip {
-            x: base_x,
-            y: base_y,
-            width: snapped_w,
-            dense_width_or_rect_height: snapped_h,
-            col_idx_or_rect_frac: frac,
-            payload,
-            paint_and_rect_flag: paint_packed | RECT_STRIP_FLAG,
-            layer_index,
-        });
-        return;
+        return SplitRect {
+            main: RectPart {
+                x,
+                y,
+                width,
+                height,
+                frac: pack_unorm4x8([left_frac, top_frac, right_frac, bottom_frac]),
+            },
+            top: None,
+            bottom: None,
+            left: None,
+            right: None,
+        };
     }
 
-    // Interior: pixel-aligned, rect_frac=0 → no AA in fragment shader.
-    let interior_x = base_x + left_inset;
-    let interior_y = base_y + top_inset;
-    let (payload, paint_packed) = Scheduler::process_paint(
-        &rect.paint,
-        encoded_paints,
-        (interior_x, interior_y),
-        paint_idxs,
-    );
-    let interior_strip = GpuStrip {
-        x: interior_x,
-        y: interior_y,
-        width: interior_w,
-        dense_width_or_rect_height: interior_h,
-        col_idx_or_rect_frac: 0,
+    let has_left_aa = left_frac > 0.0;
+    let has_top_aa = top_frac > 0.0;
+    let has_right_aa = right_frac > 0.0;
+    let has_bottom_aa = bottom_frac > 0.0;
+    let has_top_strip = has_top_aa || has_left_aa || has_right_aa;
+    let has_bottom_strip = has_bottom_aa || has_left_aa || has_right_aa;
+    let left_inset = u16::from(has_left_aa);
+    let right_inset = u16::from(has_right_aa);
+    let top_inset = u16::from(has_top_strip);
+    let bottom_inset = u16::from(has_bottom_strip);
+    let inner_x = x + left_inset;
+    let inner_y = y + top_inset;
+    // Can't underflow because rectangles have at least `LARGE_RECT_SPLIT_THRESHOLD` in each
+    // direction, which is larger than 2.
+    let inner_width = width - left_inset - right_inset;
+    let inner_height = height - top_inset - bottom_inset;
+
+    SplitRect {
+        main: RectPart {
+            x: inner_x,
+            y: inner_y,
+            width: inner_width,
+            height: inner_height,
+            frac: 0,
+        },
+        top: has_top_strip.then_some(RectPart {
+            x,
+            y,
+            width,
+            height: 1,
+            frac: pack_unorm4x8([left_frac, top_frac, right_frac, 0.0]),
+        }),
+        bottom: has_bottom_strip.then_some(RectPart {
+            x,
+            y: y + height - 1,
+            width,
+            height: 1,
+            frac: pack_unorm4x8([left_frac, 0.0, right_frac, bottom_frac]),
+        }),
+        left: has_left_aa.then_some(RectPart {
+            x,
+            y: inner_y,
+            width: 1,
+            height: inner_height,
+            frac: pack_unorm4x8([left_frac, 0.0, 0.0, 0.0]),
+        }),
+        right: has_right_aa.then_some(RectPart {
+            x: x + width - 1,
+            y: inner_y,
+            width: 1,
+            height: inner_height,
+            frac: pack_unorm4x8([0.0, 0.0, right_frac, 0.0]),
+        }),
+    }
+}
+
+fn make_gpu_rect(part: RectPart, payload: u32, paint_packed: u32, layer_index: u32) -> GpuStrip {
+    GpuStrip {
+        x: part.x,
+        y: part.y,
+        width: part.width,
+        dense_width_or_rect_height: part.height,
+        col_idx_or_rect_frac: part.frac,
         payload,
         paint_and_rect_flag: paint_packed | RECT_STRIP_FLAG,
         layer_index,
-    };
-    if is_opaque {
-        draw.push_opaque(interior_strip);
-    } else {
-        draw.push_alpha(interior_strip);
-    }
-
-    // Edge strips: 1px wide/tall strips carrying fractional coverage.
-    // Top edge (full width, 1px tall).
-    if has_top {
-        let frac = u32::from(frac_l) | (u32::from(frac_t) << 8) | (u32::from(frac_r) << 16);
-        let (payload, paint_packed) =
-            Scheduler::process_paint(&rect.paint, encoded_paints, (base_x, base_y), paint_idxs);
-        draw.push_alpha(GpuStrip {
-            x: base_x,
-            y: base_y,
-            width: snapped_w,
-            dense_width_or_rect_height: 1,
-            col_idx_or_rect_frac: frac,
-            payload,
-            paint_and_rect_flag: paint_packed | RECT_STRIP_FLAG,
-            layer_index,
-        });
-    }
-
-    // Bottom edge (full width, 1px tall).
-    if has_bottom {
-        let bottom_y = base_y + snapped_h - 1;
-        let frac = u32::from(frac_l) | (u32::from(frac_r) << 16) | (u32::from(frac_b) << 24);
-        let (payload, paint_packed) =
-            Scheduler::process_paint(&rect.paint, encoded_paints, (base_x, bottom_y), paint_idxs);
-        draw.push_alpha(GpuStrip {
-            x: base_x,
-            y: bottom_y,
-            width: snapped_w,
-            dense_width_or_rect_height: 1,
-            col_idx_or_rect_frac: frac,
-            payload,
-            paint_and_rect_flag: paint_packed | RECT_STRIP_FLAG,
-            layer_index,
-        });
-    }
-
-    // Left edge (1px wide, interior height only — corners handled by top/bottom).
-    if has_left {
-        let frac = u32::from(frac_l);
-        let (payload, paint_packed) = Scheduler::process_paint(
-            &rect.paint,
-            encoded_paints,
-            (base_x, interior_y),
-            paint_idxs,
-        );
-        draw.push_alpha(GpuStrip {
-            x: base_x,
-            y: interior_y,
-            width: 1,
-            dense_width_or_rect_height: interior_h,
-            col_idx_or_rect_frac: frac,
-            payload,
-            paint_and_rect_flag: paint_packed | RECT_STRIP_FLAG,
-            layer_index,
-        });
-    }
-
-    // Right edge (1px wide, interior height only).
-    if has_right {
-        let right_x = base_x + snapped_w - 1;
-        let frac = u32::from(frac_r) << 16;
-        let (payload, paint_packed) = Scheduler::process_paint(
-            &rect.paint,
-            encoded_paints,
-            (right_x, interior_y),
-            paint_idxs,
-        );
-        draw.push_alpha(GpuStrip {
-            x: right_x,
-            y: interior_y,
-            width: 1,
-            dense_width_or_rect_height: interior_h,
-            col_idx_or_rect_frac: frac,
-            payload,
-            paint_and_rect_flag: paint_packed | RECT_STRIP_FLAG,
-            layer_index,
-        });
     }
 }
 
@@ -2104,20 +2106,273 @@ fn pack_unorm4x8(v: [f32; 4]) -> u32 {
 
 #[cfg(test)]
 mod tests {
-    use super::{pack_unorm4x8, RECT_STRIP_FLAG};
+    use super::{
+        Draw, RECT_STRIP_FLAG, RectPart, SplitRect, emit_rect_strips, pack_unorm4x8, split_rect,
+    };
+    use crate::scene::FastPathRect;
+    use alloc::vec;
+    use alloc::vec::Vec;
+    use vello_common::encode::EncodedImage;
+    use vello_common::kurbo::{Affine, Vec2};
+    use vello_common::paint::{Color, ImageId, ImageSource, IndexedPaint, Paint};
+    use vello_common::peniko::ImageSampler;
 
-    #[test]
-    fn pack_unorm4x8_basic() {
-        assert_eq!(pack_unorm4x8([0.0, 0.0, 0.0, 0.0]), 0);
-        let val = pack_unorm4x8([0.25, 0.5, 0.75, 1.0]);
-        assert_eq!(val & 0xFF, 64);
-        assert_eq!((val >> 8) & 0xFF, 128);
-        assert_eq!((val >> 16) & 0xFF, 191);
-        assert_eq!((val >> 24) & 0xFF, 255);
+    fn solid_rect(x0: f32, y0: f32, x1: f32, y1: f32) -> FastPathRect {
+        FastPathRect {
+            x0,
+            y0,
+            x1,
+            y1,
+            paint: Paint::from(Color::from_rgba8(255, 0, 0, 255)),
+        }
+    }
+
+    fn part(x: u16, y: u16, width: u16, height: u16, frac: [f32; 4]) -> RectPart {
+        RectPart {
+            x,
+            y,
+            width,
+            height,
+            frac: pack_unorm4x8(frac),
+        }
     }
 
     #[test]
-    fn rect_strip_flag_is_set() {
-        assert_ne!(RECT_STRIP_FLAG, 0);
+    fn splitter_keeps_small_rect_whole() {
+        let rect = solid_rect(10.25, 20.5, 25.75, 35.25);
+        let split = split_rect(&rect);
+
+        assert_eq!(
+            split,
+            SplitRect {
+                main: part(10, 20, 16, 16, [0.25, 0.5, 0.25, 0.75]),
+                top: None,
+                bottom: None,
+                left: None,
+                right: None,
+            }
+        );
+    }
+
+    #[test]
+    fn splitter_keeps_subpixel_rect_inside_one_pixel() {
+        let rect = solid_rect(10.125, 20.25, 10.875, 20.75);
+        let split = split_rect(&rect);
+
+        assert_eq!(
+            split,
+            SplitRect {
+                main: part(10, 20, 1, 1, [0.125, 0.25, 0.125, 0.25]),
+                top: None,
+                bottom: None,
+                left: None,
+                right: None,
+            }
+        );
+    }
+
+    #[test]
+    fn splitter_keeps_subpixel_rect_spanning_two_pixels_in_width() {
+        let rect = solid_rect(10.75, 20.125, 11.25, 20.875);
+        let split = split_rect(&rect);
+
+        assert_eq!(
+            split,
+            SplitRect {
+                main: part(10, 20, 2, 1, [0.75, 0.125, 0.75, 0.125]),
+                top: None,
+                bottom: None,
+                left: None,
+                right: None,
+            }
+        );
+    }
+
+    #[test]
+    fn splitter_keeps_subpixel_rect_spanning_two_pixels_in_height() {
+        let rect = solid_rect(10.125, 20.75, 10.875, 21.25);
+        let split = split_rect(&rect);
+
+        assert_eq!(
+            split,
+            SplitRect {
+                main: part(10, 20, 1, 2, [0.125, 0.75, 0.125, 0.75]),
+                top: None,
+                bottom: None,
+                left: None,
+                right: None,
+            }
+        );
+    }
+
+    #[test]
+    fn splitter_keeps_multi_pixel_width_rect_within_one_pixel_height() {
+        let rect = solid_rect(10.25, 20.125, 14.75, 20.875);
+        let split = split_rect(&rect);
+
+        assert_eq!(
+            split,
+            SplitRect {
+                main: part(10, 20, 5, 1, [0.25, 0.125, 0.25, 0.125]),
+                top: None,
+                bottom: None,
+                left: None,
+                right: None,
+            }
+        );
+    }
+
+    #[test]
+    fn splitter_keeps_multi_pixel_height_rect_within_one_pixel_width() {
+        let rect = solid_rect(10.125, 20.25, 10.875, 24.75);
+        let split = split_rect(&rect);
+
+        assert_eq!(
+            split,
+            SplitRect {
+                main: part(10, 20, 1, 5, [0.125, 0.25, 0.125, 0.25]),
+                top: None,
+                bottom: None,
+                left: None,
+                right: None,
+            }
+        );
+    }
+
+    #[test]
+    fn splitter_splits_large_rect_into_five_parts() {
+        let rect = solid_rect(10.25, 20.5, 42.75, 52.75);
+        let split = split_rect(&rect);
+
+        assert_eq!(
+            split,
+            SplitRect {
+                main: part(11, 21, 31, 31, [0.0, 0.0, 0.0, 0.0]),
+                top: Some(part(10, 20, 33, 1, [0.25, 0.5, 0.25, 0.0])),
+                bottom: Some(part(10, 52, 33, 1, [0.25, 0.0, 0.25, 0.25])),
+                left: Some(part(10, 21, 1, 31, [0.25, 0.0, 0.0, 0.0])),
+                right: Some(part(42, 21, 1, 31, [0.0, 0.0, 0.25, 0.0])),
+            }
+        );
+    }
+
+    #[test]
+    fn splitter_omits_unneeded_edge_parts() {
+        let rect = solid_rect(10.0, 20.5, 42.0, 53.0);
+        let split = split_rect(&rect);
+
+        assert_eq!(
+            split,
+            SplitRect {
+                main: part(10, 21, 32, 32, [0.0, 0.0, 0.0, 0.0]),
+                top: Some(part(10, 20, 32, 1, [0.0, 0.5, 0.0, 0.0])),
+                bottom: None,
+                left: None,
+                right: None,
+            }
+        );
+    }
+
+    #[test]
+    fn splitter_handles_large_rect_with_only_vertical_aa() {
+        let rect = solid_rect(5.0, 2.25, 37.0, 34.75);
+        let split = split_rect(&rect);
+
+        assert_eq!(
+            split,
+            SplitRect {
+                main: part(5, 3, 32, 31, [0.0, 0.0, 0.0, 0.0]),
+                top: Some(part(5, 2, 32, 1, [0.0, 0.25, 0.0, 0.0])),
+                bottom: Some(part(5, 34, 32, 1, [0.0, 0.0, 0.0, 0.25])),
+                left: None,
+                right: None,
+            }
+        );
+    }
+
+    #[test]
+    fn splitter_keeps_large_aligned_rect_as_single_main_rect() {
+        let rect = solid_rect(10.0, 20.0, 42.0, 60.0);
+        let split = split_rect(&rect);
+
+        assert_eq!(
+            split,
+            SplitRect {
+                main: part(10, 20, 32, 40, [0.0, 0.0, 0.0, 0.0]),
+                top: None,
+                bottom: None,
+                left: None,
+                right: None,
+            }
+        );
+    }
+
+    #[test]
+    fn gpu_upload_emits_main_and_present_optional_parts() {
+        let rect = solid_rect(10.0, 20.5, 42.0, 53.0);
+        let mut draw = Draw::default();
+
+        emit_rect_strips(&rect, &[], &[], 0, true, &mut draw);
+
+        let out: Vec<_> = draw.opaque.iter().chain(draw.alpha.iter()).collect();
+        assert_eq!(out.len(), 2);
+        assert_eq!(
+            (
+                out[0].x,
+                out[0].y,
+                out[0].width,
+                out[0].dense_width_or_rect_height
+            ),
+            (10, 21, 32, 32)
+        );
+        assert_eq!(out[0].col_idx_or_rect_frac, 0);
+        assert_eq!(
+            (
+                out[1].x,
+                out[1].y,
+                out[1].width,
+                out[1].dense_width_or_rect_height
+            ),
+            (10, 20, 32, 1)
+        );
+        assert_eq!(
+            out[1].col_idx_or_rect_frac,
+            pack_unorm4x8([0.0, 0.5, 0.0, 0.0])
+        );
+        assert!(
+            out.iter()
+                .all(|strip| strip.paint_and_rect_flag & RECT_STRIP_FLAG != 0)
+        );
+    }
+
+    #[test]
+    fn gpu_upload_updates_payload_for_each_split_part() {
+        let rect = FastPathRect {
+            x0: 10.25,
+            y0: 20.5,
+            x1: 42.75,
+            y1: 52.75,
+            paint: Paint::Indexed(IndexedPaint::new(0)),
+        };
+        let encoded_paints = vec![vello_common::encode::EncodedPaint::Image(EncodedImage {
+            source: ImageSource::opaque_id(ImageId::new(1)),
+            sampler: ImageSampler::new(),
+            may_have_opacities: false,
+            transform: Affine::IDENTITY,
+            x_advance: Vec2::new(1.0, 0.0),
+            y_advance: Vec2::new(0.0, 1.0),
+            tint: None,
+        })];
+        let mut draw = Draw::default();
+
+        emit_rect_strips(&rect, &encoded_paints, &[7], 0, true, &mut draw);
+
+        let out: Vec<_> = draw.opaque.iter().chain(draw.alpha.iter()).collect();
+        assert_eq!(out.len(), 5);
+        assert_eq!(out[0].payload, (21_u32 << 16) | 11_u32);
+        assert_eq!(out[1].payload, (20_u32 << 16) | 10_u32);
+        assert_eq!(out[2].payload, (52_u32 << 16) | 10_u32);
+        assert_eq!(out[3].payload, (21_u32 << 16) | 10_u32);
+        assert_eq!(out[4].payload, (21_u32 << 16) | 42_u32);
     }
 }

--- a/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
@@ -308,6 +308,8 @@ fn vs_main(
     let col_offset = select(f32(instance.col_idx_or_rect_frac), 0.0, is_rect);
     out.tex_coord = vec2<f32>(col_offset + x * f32(width), y * f32(height));
 
+    // Divide by a power of 2 to ensure exact f32 arithmetic (and divide by the expected depth
+    // buffer precision of 24 bits).
     let z = 1.0 - f32(instance.layer_index) / f32(1u << 24u);
     // Flip it based on the flag.
     let final_ndc_y = select(ndc_y, -ndc_y, config.ndc_y_negate != 0u);

--- a/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
@@ -211,6 +211,9 @@ struct StripInstance {
     @location(3) payload: u32,
     // See StripInstance documentation above.
     @location(4) paint_and_rect_flag: u32,
+    // Painter's-order index for z-depth computation (TBDR early-z).
+    // Monotonically increasing in back-to-front order within a frame.
+    @location(5) layer_index: u32,
 }
 
 struct VertexOutput {
@@ -306,9 +309,10 @@ fn vs_main(
     let col_offset = select(f32(instance.col_idx_or_rect_frac), 0.0, is_rect);
     out.tex_coord = vec2<f32>(col_offset + x * f32(width), y * f32(height));
 
+    let z = 1.0 - f32(instance.layer_index) / f32(1u << 24u);
     // Flip it based on the flag.
     let final_ndc_y = select(ndc_y, -ndc_y, config.ndc_y_negate != 0u);
-    out.position = vec4<f32>(ndc_x, final_ndc_y, 0.0, 1.0);
+    out.position = vec4<f32>(ndc_x, final_ndc_y, z, 1.0);
     out.payload = instance.payload;
     out.paint_and_rect_flag = instance.paint_and_rect_flag;
 

--- a/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
@@ -212,7 +212,7 @@ struct StripInstance {
     // See StripInstance documentation above.
     @location(4) paint_and_rect_flag: u32,
     // Painter's-order index for z-depth computation.
-    @location(5) layer_index: u32,
+    @location(5) depth_index: u32,
 }
 
 struct VertexOutput {
@@ -310,7 +310,7 @@ fn vs_main(
 
     // Divide by a power of 2 to ensure exact f32 arithmetic (and divide by the expected depth
     // buffer precision of 24 bits).
-    let z = 1.0 - f32(instance.layer_index) / f32(1u << 24u);
+    let z = 1.0 - f32(instance.depth_index) / f32(1u << 24u);
     // Flip it based on the flag.
     let final_ndc_y = select(ndc_y, -ndc_y, config.ndc_y_negate != 0u);
     out.position = vec4<f32>(ndc_x, final_ndc_y, z, 1.0);

--- a/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
@@ -211,8 +211,7 @@ struct StripInstance {
     @location(3) payload: u32,
     // See StripInstance documentation above.
     @location(4) paint_and_rect_flag: u32,
-    // Painter's-order index for z-depth computation (TBDR early-z).
-    // Monotonically increasing in back-to-front order within a frame.
+    // Painter's-order index for z-depth computation.
     @location(5) layer_index: u32,
 }
 

--- a/sparse_strips/vello_sparse_tests/snapshots/issue_filter_preserves_painter_order_for_opaque_and_alpha.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/issue_filter_preserves_painter_order_for_opaque_and_alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81ec9fe16e54b69ddf97610d195c33bf237b0614bf214775526e39efa4648478
+size 121

--- a/sparse_strips/vello_sparse_tests/tests/issues.rs
+++ b/sparse_strips/vello_sparse_tests/tests/issues.rs
@@ -796,3 +796,15 @@ fn issue_bicubic_filtering_clamping(ctx: &mut impl Renderer) {
         .font_size(font_size)
         .fill_glyphs(glyphs.into_iter());
 }
+
+#[vello_test(skip_multithreaded)]
+fn issue_filter_preserves_painter_order_for_opaque_and_alpha(ctx: &mut impl Renderer) {
+    let filter = Filter::from_primitive(FilterPrimitive::Offset { dx: 0.0, dy: 0.0 });
+
+    ctx.push_filter_layer(filter);
+    ctx.set_paint(Color::from_rgba8(0, 0, 255, 128));
+    ctx.fill_rect(&Rect::new(20.0, 20.0, 80.0, 80.0));
+    ctx.set_paint(RED);
+    ctx.fill_rect(&Rect::new(30.0, 30.0, 70.0, 70.0));
+    ctx.pop_layer();
+}


### PR DESCRIPTION
Follows from [#vello > Early z culling in hybrid via front to back rendering @ 💬](https://xi.zulipchat.com/#narrow/channel/197075-vello/topic/Early.20z.20culling.20in.20hybrid.20via.20front.20to.20back.20rendering/near/582436173).

## Intent

Introduces a "front to back" render pass of opaque strips before a "back to front" pass of strips with alpha.

On low tier devices, overdraw (that is, running the fragment shader over a pixel unnecessarily (because it will be later overwritten with an opaque fragment) is particularly hurtful to performance.

Our current pipeline already splits out opaque strips from alpha strips. This PR merely schedules the opaque strips in a separate front-to-back render pass with depth test and write enabled (with blending disabled). Then, the alpha strips are rendered in a back-to-front render pass with depth test enabled (depth write disabled and blending enabled). Or...

1. Front to back opaque strip pass: Depth write ON, depth test ON, blending OFF
2. Back to front alpha strip pass: Depth write OFF, depth test ON, blending ON

## Results

The performance as measured on `vello_bench2` is found here: [#vello > Early z culling in hybrid via front to back rendering @ 💬](https://xi.zulipchat.com/#narrow/channel/197075-vello/topic/Early.20z.20culling.20in.20hybrid.20via.20front.20to.20back.20rendering/near/582436173).

When testing in a "real" application, I see roughly 30% improved performance for scenes with large opaque backgrounds (fairly common in the web and design world).
