### PR TITLE
Add vectorisation to some suspicious blend related missing parts

### DIFF
--- a/sparse_strips/vello_cpu/src/fine/highp/blend.rs
+++ b/sparse_strips/vello_cpu/src/fine/highp/blend.rs
@@ -25,6 +25,7 @@ impl<S: Simd> Channels<S> {
 
 // TODO: blending is still extremely slow, investigate whether there is something obvious we are
 // missing that other renderers do.
+#[inline(always)]
 pub(crate) fn mix<S: Simd>(src_c: f32x16<S>, bg: f32x16<S>, blend_mode: BlendMode) -> f32x16<S> {
     if matches!(blend_mode.mix, Mix::Normal) {
         return src_c;
@@ -32,16 +33,19 @@ pub(crate) fn mix<S: Simd>(src_c: f32x16<S>, bg: f32x16<S>, blend_mode: BlendMod
     // See https://www.w3.org/TR/compositing-1/#blending
     let simd = src_c.simd;
 
-    let split = |input: f32x16<S>| {
-        let mut storage = [0.0; 16];
-        simd.store_interleaved_128_f32x16(input, &mut storage);
-        let input_v = f32x16::from_slice(simd, &storage);
+    let split = {
+        #[inline(always)]
+        |input: f32x16<S>| {
+            let mut storage = [0.0; 16];
+            simd.store_interleaved_128_f32x16(input, &mut storage);
+            let input_v = f32x16::from_slice(simd, &storage);
 
-        let p1 = simd.split_f32x16(input_v);
-        let (r, g) = simd.split_f32x8(p1.0);
-        let (b, a) = simd.split_f32x8(p1.1);
+            let p1 = simd.split_f32x16(input_v);
+            let (r, g) = simd.split_f32x8(p1.0);
+            let (b, a) = simd.split_f32x8(p1.1);
 
-        (Channels { r, g, b }, a)
+            (Channels { r, g, b }, a)
+        }
     };
 
     let (bg_channels, bg_a) = split(bg);
@@ -53,13 +57,16 @@ pub(crate) fn mix<S: Simd>(src_c: f32x16<S>, bg: f32x16<S>, blend_mode: BlendMod
     let mut res_bg = unpremultiplied_bg;
     let mix_src = blend_mode.mix(unpremultiplied_src, unpremultiplied_bg);
 
-    let apply_alpha = |unpremultiplied_src_channel: f32x4<S>,
-                       mix_src_channel: f32x4<S>,
-                       dest_channel: &mut f32x4<S>| {
-        let p1 = (1.0 - bg_a) * unpremultiplied_src_channel;
-        let p2 = bg_a * mix_src_channel;
+    let apply_alpha = {
+        #[inline(always)]
+        |unpremultiplied_src_channel: f32x4<S>,
+         mix_src_channel: f32x4<S>,
+         dest_channel: &mut f32x4<S>| {
+            let p1 = (1.0 - bg_a) * unpremultiplied_src_channel;
+            let p2 = bg_a * mix_src_channel;
 
-        *dest_channel = (p1 + p2).premultiply(src_a);
+            *dest_channel = (p1 + p2).premultiply(src_a);
+        }
     };
 
     apply_alpha(unpremultiplied_src.r, mix_src.r, &mut res_bg.r);

--- a/sparse_strips/vello_cpu/src/fine/highp/compose.rs
+++ b/sparse_strips/vello_cpu/src/fine/highp/compose.rs
@@ -16,6 +16,7 @@ pub(crate) trait ComposeExt {
 }
 
 impl ComposeExt for BlendMode {
+    #[inline(always)]
     fn compose<S: Simd>(
         &self,
         simd: S,
@@ -72,6 +73,7 @@ macro_rules! compose {
         struct $name;
 
         impl $name {
+            #[inline(always)]
             fn compose<S: Simd>(simd: S, src_c: f32x16<S>, bg_c: f32x16<S>) -> f32x16<S> {
                 let al_b = bg_c.splat_4th();
                 let al_s = src_c.splat_4th();

--- a/sparse_strips/vello_cpu/src/fine/highp/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/highp/mod.rs
@@ -379,18 +379,24 @@ mod fill {
     }
 
     /// Applies blend mode compositing to a buffer without per-pixel masks.
+    #[inline(always)]
     pub(super) fn blend<S: Simd, T: Iterator<Item = f32x16<S>>>(
         simd: S,
         dest: &mut [f32],
         src: T,
         blend_mode: BlendMode,
     ) {
-        for (next_dest, next_src) in dest.chunks_exact_mut(16).zip(src) {
-            let bg_v = f32x16::from_slice(simd, next_dest);
-            let src_c = blend::mix(next_src, bg_v, blend_mode);
-            let res = blend_mode.compose(simd, src_c, bg_v, None);
-            next_dest.copy_from_slice(res.as_slice());
-        }
+        simd.vectorize(
+            #[inline(always)]
+            || {
+                for (next_dest, next_src) in dest.chunks_exact_mut(16).zip(src) {
+                    let bg_v = f32x16::from_slice(simd, next_dest);
+                    let src_c = blend::mix(next_src, bg_v, blend_mode);
+                    let res = blend_mode.compose(simd, src_c, bg_v, None);
+                    next_dest.copy_from_slice(res.as_slice());
+                }
+            },
+        );
     }
 
     /// Performs the core alpha compositing calculation.


### PR DESCRIPTION
In writing #1578, I stumbled upon these missing instances.

I'm aware of the comment at https://github.com/linebender/vello/blob/6d23bf54894f52ccc72dce1d77c500d8346f53d7/sparse_strips/vello_cpu/src/fine/highp/mod.rs#L339-L342, and so haven't been aggressive as I might otherwise have expected to be.

I probably won't have time to drive this further (i.e. do the benchmarking myself), so feel free to push to this as appropriate.