### PR TITLE
vello_hybrid: Let `destroy_image` methods take `Resources` directly instead of `ImageCache`

### DIFF
--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -469,10 +469,10 @@ impl WebGlRenderer {
     /// Destroy an image from the cache and clear the allocated slot in the atlas.
     pub fn destroy_image(
         &mut self,
-        image_cache: &mut ImageCache,
+        resources: &mut Resources,
         image_id: vello_common::paint::ImageId,
     ) {
-        if let Some(image_resource) = image_cache.deallocate(image_id) {
+        if let Some(image_resource) = resources.image_cache.deallocate(image_id) {
             let padding = image_resource.padding as u32;
             self.clear_atlas_region(
                 image_resource.atlas_id,

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -570,13 +570,13 @@ impl Renderer {
     /// Destroy an image from the cache and clear the allocated slot in the atlas.
     pub fn destroy_image(
         &mut self,
-        image_cache: &mut ImageCache,
+        resources: &mut Resources,
         device: &Device,
         queue: &Queue,
         encoder: &mut CommandEncoder,
         image_id: vello_common::paint::ImageId,
     ) {
-        if let Some(image_resource) = image_cache.deallocate(image_id) {
+        if let Some(image_resource) = resources.image_cache.deallocate(image_id) {
             let padding = image_resource.padding as u32;
 
             self.clear_atlas_region(


### PR DESCRIPTION
Since `ImageCache` is a private field in `Resources`, clients otherwise have no way of destroying their images!