### PR TITLE
vello_common: Optimize fast rectangle path with active clip path

### DIFF
--- a/sparse_strips/vello_common/src/strip_generator.rs
+++ b/sparse_strips/vello_common/src/strip_generator.rs
@@ -211,16 +211,18 @@ impl StripGenerator {
         clip_path: Option<PathDataRef<'_>>,
     ) {
         let viewport = Rect::new(0.0, 0.0, self.width as f64, self.height as f64);
-        let clip_bbox = clip_path.map(|clip| {
-            // Clip bbox is always guaranteed to be within viewport bounds, so no need to
-            // intersect again.
-            Rect::new(
-                f64::from(clip.bbox.x0),
-                f64::from(clip.bbox.y0),
-                f64::from(clip.bbox.x1),
-                f64::from(clip.bbox.y1),
-            )
-        }).unwrap_or(viewport);
+        let clip_bbox = clip_path
+            .map(|clip| {
+                // Clip bbox is always guaranteed to be within viewport bounds, so no need to
+                // intersect again.
+                Rect::new(
+                    f64::from(clip.bbox.x0),
+                    f64::from(clip.bbox.y0),
+                    f64::from(clip.bbox.x1),
+                    f64::from(clip.bbox.y1),
+                )
+            })
+            .unwrap_or(viewport);
         let clamped = rect.intersect(clip_bbox);
 
         let level = self.level;

--- a/sparse_strips/vello_common/src/strip_generator.rs
+++ b/sparse_strips/vello_common/src/strip_generator.rs
@@ -211,8 +211,17 @@ impl StripGenerator {
         clip_path: Option<PathDataRef<'_>>,
     ) {
         let viewport = Rect::new(0.0, 0.0, self.width as f64, self.height as f64);
-
-        let clamped = rect.intersect(viewport);
+        let clip_bbox = clip_path.map(|clip| {
+            // Clip bbox is always guaranteed to be within viewport bounds, so no need to
+            // intersect again.
+            Rect::new(
+                f64::from(clip.bbox.x0),
+                f64::from(clip.bbox.y0),
+                f64::from(clip.bbox.x1),
+                f64::from(clip.bbox.y1),
+            )
+        }).unwrap_or(viewport);
+        let clamped = rect.intersect(clip_bbox);
 
         let level = self.level;
         render_with_clip(


### PR DESCRIPTION
Spun off from #1584. For axis aligned rectangles, we can make the rectangle even smaller by intersecting it with the (ceiled) bounding box of the currently active clip path.

This is important for COLR: Conceptually, in COLR we always draw rectangles with the full viewport size, but then clip it to the actual area of the glyph, which is usually very small. By doing so, we save a lot of unnecessary computations.