### PR TITLE
vello_hybrid: Add support for CPU fast path rectangles

### DIFF
--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -486,8 +486,24 @@ impl Scene {
             return;
         }
 
-        // TODO: Use a temporary storage for rect paths, like in `vello_cpu`.
-        self.fill_path(&rect.to_path(DEFAULT_TOLERANCE));
+        if is_axis_aligned(&self.render_state.transform) && self.aliasing_threshold.is_none() {
+            self.with_optional_filter(|ctx| {
+                let paint = ctx.encode_current_paint();
+                let transformed_rect = ctx.render_state.transform.transform_rect_bbox(*rect);
+                let strip_storage = &mut ctx.strip_storage.borrow_mut();
+                let strip_start = strip_storage.strips.len();
+                ctx.strip_generator.generate_filled_rect_fast(
+                    &transformed_rect,
+                    strip_storage,
+                    ctx.clip_context.get(),
+                );
+
+                submit_strips!(ctx, strip_storage, strip_start, paint);
+            });
+        } else {
+            // TODO: Use a temporary storage for rect paths, like in `vello_cpu`.
+            self.fill_path(&rect.to_path(DEFAULT_TOLERANCE));
+        }
     }
 
     #[expect(

--- a/sparse_strips/vello_sparse_tests/snapshots/clip_non_isolated_with_aa_with_rect.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/clip_non_isolated_with_aa_with_rect.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ddc615dbfff2d5b22bed948d71fd324f411bba69740faba50a5e4de4c3ce3be4
+size 131

--- a/sparse_strips/vello_sparse_tests/snapshots/clip_non_isolated_with_aa_with_rect_aa.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/clip_non_isolated_with_aa_with_rect_aa.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4570d3dcd411493fd93c50ec531b38539495581bd4014c7f118b5d9c50e4bdd5
+size 131

--- a/sparse_strips/vello_sparse_tests/snapshots/clip_non_isolated_with_rect.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/clip_non_isolated_with_rect.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf32fbab19052970ff7cc8fd88e541cd12deb58a4606b0d5cef6f735d7880074
+size 104

--- a/sparse_strips/vello_sparse_tests/snapshots/clip_non_isolated_with_rotated_rect.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/clip_non_isolated_with_rotated_rect.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9978ff6d959a00909919db7758d58c0ba9757c4e636ab77453579fbd7ffa466c
+size 238

--- a/sparse_strips/vello_sparse_tests/snapshots/clip_non_isolated_with_scaled_rect.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/clip_non_isolated_with_scaled_rect.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf32fbab19052970ff7cc8fd88e541cd12deb58a4606b0d5cef6f735d7880074
+size 104

--- a/sparse_strips/vello_sparse_tests/tests/clip.rs
+++ b/sparse_strips/vello_sparse_tests/tests/clip.rs
@@ -389,6 +389,65 @@ fn clip_non_isolated_outside_canvas(ctx: &mut impl Renderer) {
 }
 
 #[vello_test]
+fn clip_non_isolated_with_rect(ctx: &mut impl Renderer) {
+    let clip_rect = Rect::new(10.0, 10.0, 90.0, 90.0);
+    ctx.push_clip_path(&clip_rect.to_path(0.1));
+
+    ctx.set_paint(BLUE);
+    ctx.fill_rect(&Rect::new(0.0, 0.0, 100.0, 100.0));
+    ctx.pop_clip_path();
+}
+
+#[vello_test]
+fn clip_non_isolated_with_rotated_rect(ctx: &mut impl Renderer) {
+    let clip_rect = Rect::new(10.0, 10.0, 90.0, 90.0);
+    ctx.push_clip_path(&clip_rect.to_path(0.1));
+
+    ctx.set_transform(Affine::rotate_about(
+        25.0 * PI / 180.0,
+        Point::new(50.0, 50.0),
+    ));
+    ctx.set_paint(BLUE);
+    ctx.fill_rect(&Rect::new(0.0, 0.0, 100.0, 100.0));
+    ctx.pop_clip_path();
+}
+
+#[vello_test]
+fn clip_non_isolated_with_scaled_rect(ctx: &mut impl Renderer) {
+    let clip_rect = Rect::new(10.0, 10.0, 90.0, 90.0);
+    ctx.push_clip_path(&clip_rect.to_path(0.1));
+
+    ctx.set_transform(
+        Affine::translate((50.0, 50.0)) * Affine::scale(4.0) * Affine::translate((-50.0, -50.0)),
+    );
+    ctx.set_paint(BLUE);
+    ctx.fill_rect(&Rect::new(40.0, 40.0, 60.0, 60.0));
+    ctx.pop_clip_path();
+}
+
+#[vello_test]
+fn clip_non_isolated_with_aa_with_rect(ctx: &mut impl Renderer) {
+    let clip_rect = Rect::new(10.5, 10.5, 89.5, 89.5);
+    ctx.push_clip_path(&clip_rect.to_path(0.1));
+
+    ctx.set_paint(BLUE);
+    ctx.fill_rect(&Rect::new(0.0, 0.0, 100.0, 100.0));
+    ctx.pop_clip_path();
+}
+
+#[vello_test]
+fn clip_non_isolated_with_aa_with_rect_aa(ctx: &mut impl Renderer) {
+    // In theory, anti-aliasing should be 50% here, but due to conflation artifacts it will be
+    // 25% instead.
+    let rect = Rect::new(10.5, 10.5, 89.5, 89.5);
+    ctx.push_clip_path(&rect.to_path(0.1));
+
+    ctx.set_paint(BLUE);
+    ctx.fill_rect(&rect);
+    ctx.pop_clip_path();
+}
+
+#[vello_test]
 fn clip_non_isolated_rectangle_with_star_evenodd(ctx: &mut impl Renderer) {
     let rect = Rect::new(0.0, 0.0, 100.0, 100.0);
     let star_path = crossed_line_star();


### PR DESCRIPTION
While Vello Hybrid already has a fast path for axis-aligned rectangle, that doesn't work when there is a clip path in place. However, in COLR the operation "draw this rectangle with this clip path" is used everywhere. Therefore, we also add the option to fall back to the CPU rectangle fast path for this specific case.

Also adds some more tests for this.