### PR TITLE
vello_sparse_tests: Remove usage of vello_api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4148,7 +4148,6 @@ dependencies = [
  "serde_json",
  "skrifa 0.40.0",
  "smallvec",
- "vello_api",
  "vello_common",
  "vello_cpu",
  "vello_dev_macros",

--- a/sparse_strips/vello_sparse_tests/Cargo.toml
+++ b/sparse_strips/vello_sparse_tests/Cargo.toml
@@ -16,7 +16,6 @@ path = "tests/mod.rs"
 
 [dependencies]
 glifo = { workspace = true }
-vello_api = { workspace = true }
 vello_common = { workspace = true, features = ["std"] }
 vello_cpu = { workspace = true, features = ["multithreading", "std", "f32_pipeline"] }
 vello_hybrid = { workspace = true }

--- a/sparse_strips/vello_sparse_tests/tests/filter.rs
+++ b/sparse_strips/vello_sparse_tests/tests/filter.rs
@@ -6,10 +6,9 @@
 use crate::load_image;
 use crate::util::{circular_star, stops_blue_green_red_yellow};
 use crate::{renderer::Renderer, util::layout_glyphs_roboto};
-use vello_api::peniko::color::palette::css::LIME;
 use vello_common::color::AlphaColor;
 use vello_common::color::palette::css::{
-    BLACK, PURPLE, REBECCA_PURPLE, ROYAL_BLUE, SEA_GREEN, TOMATO, VIOLET,
+    BLACK, LIME, PURPLE, REBECCA_PURPLE, ROYAL_BLUE, SEA_GREEN, TOMATO, VIOLET,
 };
 use vello_common::filter_effects::{EdgeMode, Filter, FilterPrimitive};
 use vello_common::kurbo::{Affine, BezPath, Circle, Point, Rect, Shape, Stroke};

--- a/sparse_strips/vello_sparse_tests/tests/issues.rs
+++ b/sparse_strips/vello_sparse_tests/tests/issues.rs
@@ -8,18 +8,17 @@ use crate::util::layout_glyphs_noto_cbtf;
 use crate::util::render_pixmap;
 use crate::util::stops_blue_green_red_yellow;
 use std::sync::Arc;
-use vello_api::peniko::GradientKind::Radial;
-use vello_api::peniko::color::palette::css::{PURPLE, ROYAL_BLUE, TOMATO};
-use vello_api::peniko::kurbo::Point;
-use vello_api::peniko::{ColorStops, RadialGradientPosition};
 use vello_common::color::PremulRgba8;
-use vello_common::color::palette::css::{BLUE, DARK_BLUE, LIME, REBECCA_PURPLE};
+use vello_common::color::palette::css::{
+    BLUE, DARK_BLUE, LIME, PURPLE, REBECCA_PURPLE, ROYAL_BLUE, TOMATO,
+};
 use vello_common::filter_effects::{EdgeMode, Filter, FilterPrimitive};
-use vello_common::kurbo::{Affine, BezPath, Rect, Shape, Stroke};
+use vello_common::kurbo::{Affine, BezPath, Point, Rect, Shape, Stroke};
 use vello_common::paint::Image;
+use vello_common::peniko::GradientKind::Radial;
 use vello_common::peniko::{
-    BlendMode, Color, ColorStop, Fill, Gradient, ImageQuality, ImageSampler,
-    InterpolationAlphaSpace, Mix,
+    BlendMode, Color, ColorStop, ColorStops, Fill, Gradient, ImageQuality, ImageSampler,
+    InterpolationAlphaSpace, Mix, RadialGradientPosition,
 };
 use vello_common::pixmap::Pixmap;
 use vello_cpu::color::palette::css::{BLACK, RED};


### PR DESCRIPTION
This was only used for imports which were only available via `vello_common`.