### PR TITLE
sparse_strips: Improve handling of negative rectangles and add tests

### DIFF
--- a/sparse_strips/vello_common/src/strip_generator.rs
+++ b/sparse_strips/vello_common/src/strip_generator.rs
@@ -223,7 +223,7 @@ impl StripGenerator {
                 )
             })
             .unwrap_or(viewport);
-        let clamped = rect.intersect(clip_bbox);
+        let clamped = rect.abs().intersect(clip_bbox);
 
         let level = self.level;
         render_with_clip(
@@ -430,5 +430,10 @@ mod tests {
                 assert_rect_fast_eq_path(rect, &format!("exhaustive_{dx}_{dy}"));
             }
         }
+    }
+
+    #[test]
+    fn rect_inverted_both_axes() {
+        assert_rect_fast_eq_path(Rect::new(18.0, 18.0, 2.0, 2.0), "inverted_both_axes");
     }
 }

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -317,6 +317,7 @@ impl RenderContext {
     /// Note that this only works properly if the current paint is set to a solid color.
     /// If not, it will fall back to using black as the fill color.
     pub fn fill_blurred_rounded_rect(&mut self, rect: &Rect, radius: f32, std_dev: f32) {
+        let rect = rect.abs();
         let color = match self.state.paint {
             PaintType::Solid(s) => s,
             // Fallback to black when attempting to blur a rectangle with an image/gradient paint
@@ -324,7 +325,7 @@ impl RenderContext {
         };
 
         let blurred_rect = BlurredRoundedRectangle {
-            rect: *rect,
+            rect,
             color,
             radius,
             std_dev,

--- a/sparse_strips/vello_sparse_tests/snapshots/blurred_rounded_rect_inverted.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/blurred_rounded_rect_inverted.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d9c464184e159797dc0bc98014624c435218aad83f4bac8c75f0c9493dc7780
+size 626

--- a/sparse_strips/vello_sparse_tests/snapshots/filled_inverted_rect.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/filled_inverted_rect.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:645af102d301dc098f4447514bed87a9cde8a9a921f381c9068b78e8b82af614
+size 103

--- a/sparse_strips/vello_sparse_tests/snapshots/filled_inverted_rect_gradient.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/filled_inverted_rect_gradient.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:664ddaf4cc56846fd61d81d01ce4a703ba7c0017e253bd48aa77661eab263cca
+size 236

--- a/sparse_strips/vello_sparse_tests/snapshots/filled_inverted_rect_rotated.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/filled_inverted_rect_rotated.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a826265b0169dc231b928802c53d1edae15b2bfa9f0eae667dc789338123d7c3
+size 322

--- a/sparse_strips/vello_sparse_tests/tests/basic.rs
+++ b/sparse_strips/vello_sparse_tests/tests/basic.rs
@@ -4,15 +4,18 @@
 //! Tests for basic functionality.
 
 use crate::renderer::Renderer;
-use crate::util::{circular_star, crossed_line_star, layout_glyphs_roboto, miter_stroke_2};
+use crate::util::{
+    circular_star, crossed_line_star, layout_glyphs_roboto, miter_stroke_2, stops_green_blue,
+};
 use std::f64::consts::PI;
 use vello_common::coarse::Cmd;
 use vello_common::color::palette::css::{
     BEIGE, BLUE, DARK_BLUE, GREEN, LIME, MAROON, REBECCA_PURPLE, RED, TRANSPARENT,
 };
 use vello_common::kurbo::{Affine, BezPath, Circle, Join, Point, Rect, Shape, Stroke};
-use vello_common::peniko::Fill;
+use vello_common::peniko::{Fill, Gradient};
 use vello_cpu::color::palette::css::BLACK;
+use vello_cpu::peniko::LinearGradientPosition;
 use vello_cpu::{Glyph, Level, Pixmap, RenderContext, RenderMode, RenderSettings};
 use vello_dev_macros::vello_test;
 
@@ -183,6 +186,44 @@ fn filled_aligned_rect(ctx: &mut impl Renderer) {
     ctx.fill_rect(&rect);
 }
 
+#[vello_test(width = 100, height = 100)]
+fn filled_inverted_rect(ctx: &mut impl Renderer) {
+    let rect = Rect::new(80.0, 80.0, 20.0, 20.0);
+
+    ctx.set_paint(REBECCA_PURPLE);
+    ctx.fill_rect(&rect);
+}
+
+#[vello_test(width = 100, height = 100)]
+fn filled_inverted_rect_gradient(ctx: &mut impl Renderer) {
+    // Gradient paint should not be affected by the rect inversion.
+    let rect = Rect::new(80.0, 80.0, 20.0, 20.0);
+    let gradient = Gradient {
+        kind: LinearGradientPosition {
+            start: Point::new(20.0, 20.0),
+            end: Point::new(80.0, 20.0),
+        }
+        .into(),
+        stops: stops_green_blue(),
+        ..Default::default()
+    };
+
+    ctx.set_paint(gradient);
+    ctx.fill_rect(&rect);
+}
+
+#[vello_test(width = 100, height = 100)]
+fn filled_inverted_rect_rotated(ctx: &mut impl Renderer) {
+    let rect = Rect::new(80.0, 80.0, 20.0, 20.0);
+
+    ctx.set_transform(Affine::rotate_about(
+        45.0 * PI / 180.0,
+        Point::new(50.0, 50.0),
+    ));
+    ctx.set_paint(REBECCA_PURPLE);
+    ctx.fill_rect(&rect);
+}
+
 #[vello_test(width = 30, height = 30)]
 fn stroked_unaligned_rect(ctx: &mut impl Renderer) {
     let rect = Rect::new(5.0, 5.0, 25.0, 25.0);
@@ -304,6 +345,14 @@ fn filled_transformed_rect_4(ctx: &mut impl Renderer) {
     ));
     ctx.set_paint(REBECCA_PURPLE.with_alpha(0.5));
     ctx.fill_rect(&rect);
+}
+
+#[vello_test(width = 100, height = 100)]
+fn blurred_rounded_rect_inverted(ctx: &mut impl Renderer) {
+    let rect = Rect::new(80.0, 80.0, 20.0, 20.0);
+
+    ctx.set_paint(REBECCA_PURPLE);
+    ctx.fill_blurred_rounded_rect(&rect, 10.0, 2.0);
 }
 
 #[vello_test(width = 30, height = 30)]

--- a/sparse_strips/vello_sparse_tests/tests/issues.rs
+++ b/sparse_strips/vello_sparse_tests/tests/issues.rs
@@ -4,21 +4,21 @@
 //! Tests for GitHub issues.
 
 use crate::renderer::Renderer;
-use crate::util::layout_glyphs_noto_cbtf;
-use crate::util::render_pixmap;
 use crate::util::stops_blue_green_red_yellow;
+use crate::util::{layout_glyphs_noto_cbtf, render_pixmap};
 use std::sync::Arc;
-use vello_common::color::PremulRgba8;
-use vello_common::color::palette::css::{
-    BLUE, DARK_BLUE, LIME, PURPLE, REBECCA_PURPLE, ROYAL_BLUE, TOMATO,
-};
-use vello_common::filter_effects::{EdgeMode, Filter, FilterPrimitive};
-use vello_common::kurbo::{Affine, BezPath, Point, Rect, Shape, Stroke};
-use vello_common::paint::Image;
 use vello_common::peniko::GradientKind::Radial;
+use vello_common::peniko::color::palette::css::{PURPLE, ROYAL_BLUE, TOMATO};
+use vello_common::peniko::kurbo::Point;
+use vello_common::peniko::{ColorStops, RadialGradientPosition};
+use vello_common::color::PremulRgba8;
+use vello_common::color::palette::css::{BLUE, DARK_BLUE, LIME, REBECCA_PURPLE};
+use vello_common::filter_effects::{EdgeMode, Filter, FilterPrimitive};
+use vello_common::kurbo::{Affine, BezPath, Rect, Shape, Stroke};
+use vello_common::paint::Image;
 use vello_common::peniko::{
-    BlendMode, Color, ColorStop, ColorStops, Fill, Gradient, ImageQuality, ImageSampler,
-    InterpolationAlphaSpace, Mix, RadialGradientPosition,
+    BlendMode, Color, ColorStop, Fill, Gradient, ImageQuality, ImageSampler,
+    InterpolationAlphaSpace, Mix,
 };
 use vello_common::pixmap::Pixmap;
 use vello_cpu::color::palette::css::{BLACK, RED};

--- a/sparse_strips/vello_sparse_tests/tests/issues.rs
+++ b/sparse_strips/vello_sparse_tests/tests/issues.rs
@@ -7,19 +7,19 @@ use crate::renderer::Renderer;
 use crate::util::stops_blue_green_red_yellow;
 use crate::util::{layout_glyphs_noto_cbtf, render_pixmap};
 use std::sync::Arc;
-use vello_common::peniko::GradientKind::Radial;
-use vello_common::peniko::color::palette::css::{PURPLE, ROYAL_BLUE, TOMATO};
-use vello_common::peniko::kurbo::Point;
-use vello_common::peniko::{ColorStops, RadialGradientPosition};
 use vello_common::color::PremulRgba8;
 use vello_common::color::palette::css::{BLUE, DARK_BLUE, LIME, REBECCA_PURPLE};
 use vello_common::filter_effects::{EdgeMode, Filter, FilterPrimitive};
 use vello_common::kurbo::{Affine, BezPath, Rect, Shape, Stroke};
 use vello_common::paint::Image;
+use vello_common::peniko::GradientKind::Radial;
+use vello_common::peniko::color::palette::css::{PURPLE, ROYAL_BLUE, TOMATO};
+use vello_common::peniko::kurbo::Point;
 use vello_common::peniko::{
     BlendMode, Color, ColorStop, Fill, Gradient, ImageQuality, ImageSampler,
     InterpolationAlphaSpace, Mix,
 };
+use vello_common::peniko::{ColorStops, RadialGradientPosition};
 use vello_common::pixmap::Pixmap;
 use vello_cpu::color::palette::css::{BLACK, RED};
 use vello_cpu::peniko::{Compose, Extend};


### PR DESCRIPTION
This PR improves handling of negative-sized rectangles in two places and also adds some tests to ensure they work as expected.

I'm not entirely sure whether negative-sized rectangles are supposed to have special treatment. I think in PDF for example, they influence the direction of paints as well. However, in our case paint transforms have always been considered independent from the actual shape. Therefore, I think we don't need any special treatment for this. Just making sure that we always calls `.abs()` seems like the best thing to do from my perspective.