### PR TITLE
Update skrifa to 0.42 (and add support for Varc glyphs)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1087,9 +1087,9 @@ dependencies = [
 
 [[package]]
 name = "font-types"
-version = "0.11.0"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4d2d0cf79d38430cc9dc9aadec84774bff2e1ba30ae2bf6c16cfce9385a23"
+checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
 dependencies = [
  "bytemuck",
 ]
@@ -1302,7 +1302,7 @@ dependencies = [
  "log",
  "peniko 0.6.0",
  "png",
- "skrifa 0.40.0",
+ "skrifa 0.41.0",
  "smallvec",
  "vello_common",
 ]
@@ -3001,13 +3001,13 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
+checksum = "70eac20eeee8bd51247a0c2f349f657563fffd19d041cd12988cc2801ec2ebef"
 dependencies = [
  "bytemuck",
  "core_maths",
- "font-types 0.11.0",
+ "font-types 0.11.3",
 ]
 
 [[package]]
@@ -3188,7 +3188,7 @@ dependencies = [
  "image",
  "rand",
  "roxmltree",
- "skrifa 0.40.0",
+ "skrifa 0.41.0",
  "vello",
  "web-time",
 ]
@@ -3394,13 +3394,13 @@ dependencies = [
 
 [[package]]
 name = "skrifa"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
+checksum = "77c3bef975c2f5f07c0a780f95e1f5002deafb716f8e0484816cc08b1a823d2f"
 dependencies = [
  "bytemuck",
  "core_maths",
- "read-fonts 0.37.0",
+ "read-fonts 0.38.0",
 ]
 
 [[package]]
@@ -3975,7 +3975,7 @@ dependencies = [
  "log",
  "peniko 0.6.0",
  "png",
- "skrifa 0.40.0",
+ "skrifa 0.41.0",
  "static_assertions",
  "thiserror 2.0.18",
  "vello_encoding",
@@ -4068,7 +4068,7 @@ dependencies = [
  "bytemuck",
  "guillotiere",
  "peniko 0.6.0",
- "skrifa 0.40.0",
+ "skrifa 0.41.0",
  "smallvec",
 ]
 
@@ -4155,7 +4155,7 @@ dependencies = [
  "pollster",
  "serde",
  "serde_json",
- "skrifa 0.40.0",
+ "skrifa 0.41.0",
  "smallvec",
  "vello_api",
  "vello_common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,7 +1302,7 @@ dependencies = [
  "log",
  "peniko 0.6.0",
  "png",
- "skrifa 0.41.0",
+ "skrifa 0.42.0",
  "smallvec",
  "vello_common",
 ]
@@ -3001,9 +3001,9 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.38.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70eac20eeee8bd51247a0c2f349f657563fffd19d041cd12988cc2801ec2ebef"
+checksum = "32d7821ebf634094f5e5ae9d43c3109407f420f03a7a2e021d3a5d955a4f09fc"
 dependencies = [
  "bytemuck",
  "core_maths",
@@ -3188,7 +3188,7 @@ dependencies = [
  "image",
  "rand",
  "roxmltree",
- "skrifa 0.41.0",
+ "skrifa 0.42.0",
  "vello",
  "web-time",
 ]
@@ -3394,13 +3394,13 @@ dependencies = [
 
 [[package]]
 name = "skrifa"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3bef975c2f5f07c0a780f95e1f5002deafb716f8e0484816cc08b1a823d2f"
+checksum = "c844316c7318cf6ae9034ee45edd2c432076ef910fdc4bc598183b31f88d03c3"
 dependencies = [
  "bytemuck",
  "core_maths",
- "read-fonts 0.38.0",
+ "read-fonts 0.39.1",
 ]
 
 [[package]]
@@ -3975,7 +3975,7 @@ dependencies = [
  "log",
  "peniko 0.6.0",
  "png",
- "skrifa 0.41.0",
+ "skrifa 0.42.0",
  "static_assertions",
  "thiserror 2.0.18",
  "vello_encoding",
@@ -4068,7 +4068,7 @@ dependencies = [
  "bytemuck",
  "guillotiere",
  "peniko 0.6.0",
- "skrifa 0.41.0",
+ "skrifa 0.42.0",
  "smallvec",
 ]
 
@@ -4155,7 +4155,7 @@ dependencies = [
  "pollster",
  "serde",
  "serde_json",
- "skrifa 0.41.0",
+ "skrifa 0.42.0",
  "smallvec",
  "vello_api",
  "vello_common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ vello = { version = "0.8.0", path = "vello" }
 vello_encoding = { version = "0.8.0", path = "vello_encoding" }
 vello_shaders = { version = "0.8.0", path = "vello_shaders" }
 bytemuck = { version = "1.25.0", features = ["derive"] }
-skrifa = { version = "0.40.0", default-features = false, features = ["autohint_shaping"] }
+skrifa = { version = "0.41.0", default-features = false, features = ["autohint_shaping"] }
 # The version of kurbo used below should be kept in sync
 # with the version of kurbo used by peniko.
 peniko = { version = "0.6.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ vello = { version = "0.8.0", path = "vello" }
 vello_encoding = { version = "0.8.0", path = "vello_encoding" }
 vello_shaders = { version = "0.8.0", path = "vello_shaders" }
 bytemuck = { version = "1.25.0", features = ["derive"] }
-skrifa = { version = "0.41.0", default-features = false, features = ["autohint_shaping"] }
+skrifa = { version = "0.42.0", default-features = false, features = ["autohint_shaping"] }
 # The version of kurbo used below should be kept in sync
 # with the version of kurbo used by peniko.
 peniko = { version = "0.6.0", default-features = false }

--- a/glifo/src/glyph.rs
+++ b/glifo/src/glyph.rs
@@ -1774,6 +1774,7 @@ pub struct HintCache {
     // internal memory when reconfigured for the same format.
     glyf_entries: Vec<HintEntry>,
     cff_entries: Vec<HintEntry>,
+    varc_entries: Vec<HintEntry>,
     serial: u64,
 }
 
@@ -1782,6 +1783,7 @@ impl Debug for HintCache {
         f.debug_struct("HintCache")
             .field("glyf_entries", &self.glyf_entries.len())
             .field("cff_entries", &self.cff_entries.len())
+            .field("varc_entries", &self.varc_entries.len())
             .field("serial", &self.serial)
             .finish()
     }
@@ -1793,6 +1795,7 @@ impl HintCache {
         let entries = match key.outlines.format()? {
             OutlineGlyphFormat::Glyf => &mut self.glyf_entries,
             OutlineGlyphFormat::Cff | OutlineGlyphFormat::Cff2 => &mut self.cff_entries,
+            OutlineGlyphFormat::Varc => &mut self.varc_entries,
         };
         let (entry_ix, is_current) = find_hint_entry(entries, key)?;
         let entry = entries.get_mut(entry_ix)?;
@@ -1818,6 +1821,7 @@ impl HintCache {
     pub fn clear(&mut self) {
         self.glyf_entries.clear();
         self.cff_entries.clear();
+        self.varc_entries.clear();
         self.serial = 0;
     }
 }

--- a/vello_encoding/src/glyph_cache.rs
+++ b/vello_encoding/src/glyph_cache.rs
@@ -270,6 +270,7 @@ struct HintCache {
     // internal memory when reconfigured for the same format.
     glyf_entries: Vec<HintEntry>,
     cff_entries: Vec<HintEntry>,
+    varc_entries: Vec<HintEntry>,
     serial: u64,
 }
 
@@ -278,6 +279,7 @@ impl HintCache {
         let entries = match key.outlines.format()? {
             OutlineGlyphFormat::Glyf => &mut self.glyf_entries,
             OutlineGlyphFormat::Cff | OutlineGlyphFormat::Cff2 => &mut self.cff_entries,
+            OutlineGlyphFormat::Varc => &mut self.varc_entries,
         };
         let (entry_ix, is_current) = find_hint_entry(entries, key)?;
         let entry = entries.get_mut(entry_ix)?;


### PR DESCRIPTION
This is a rebase of https://github.com/linebender/vello/pull/1520 on top of the `glifo` work. Plus it bumps `skrifa` to 0.42 (matching Parley v0.9.0) instead of 0.41.

---

PR description from #1520:

> Main point was to update skrifa, but it turns out that Varc glyphs are now supported.
> Made an attempt, assuming that it works similar to the rest, but not sure how to test it (nor if it actually works).