### PR TITLE
glifo: Optimize COLR glyph rendering

### DIFF
--- a/glifo/src/colr.rs
+++ b/glifo/src/colr.rs
@@ -17,7 +17,7 @@ use core::fmt::Debug;
 use peniko::{LinearGradientPosition, RadialGradientPosition, SweepGradientPosition};
 use skrifa::color::{Brush, ColorPainter, ColorStop, CompositeMode, Transform};
 use skrifa::instance::LocationRef;
-use skrifa::outline::{DrawSettings, pen::ControlBoundsPen};
+use skrifa::outline::{DrawSettings, OutlineGlyphCollection, pen::ControlBoundsPen};
 use skrifa::raw::TableProvider;
 use skrifa::raw::types::BoundingBox;
 use skrifa::{FontRef, GlyphId, MetadataProvider};
@@ -44,6 +44,8 @@ impl<T: DrawSink + ?Sized> ColrDrawSinkExt for T {}
 pub(crate) struct ColrPainter<'a> {
     transforms: Vec<Affine>,
     colr_glyph: &'a GlyphColr<'a>,
+    outline_glyphs: OutlineGlyphCollection<'a>,
+    clip_outline: OutlinePath,
     context_color: AlphaColor<Srgb>,
     painter: &'a mut dyn DrawSink,
     stack: Vec<ColrStackEntry>,
@@ -72,6 +74,8 @@ impl<'a> ColrPainter<'a> {
         Self {
             transforms: vec![colr_glyph.draw_transform],
             colr_glyph,
+            outline_glyphs: colr_glyph.font_ref.outline_glyphs(),
+            clip_outline: OutlinePath::new(),
             context_color,
             painter,
             stack: Vec::new(),
@@ -216,7 +220,7 @@ struct GlyphInfoExtractor<'a> {
     clip_stack: Vec<Rect>,
     coarse_bbox: Option<Rect>,
     has_non_default_blend: bool,
-    font_ref: &'a FontRef<'a>,
+    outline_glyphs: OutlineGlyphCollection<'a>,
     location: LocationRef<'a>,
 }
 
@@ -227,7 +231,7 @@ impl<'a> GlyphInfoExtractor<'a> {
             clip_stack: Vec::new(),
             coarse_bbox: None,
             has_non_default_blend: false,
-            font_ref,
+            outline_glyphs: font_ref.outline_glyphs(),
             location,
         }
     }
@@ -273,22 +277,19 @@ impl ColorPainter for ColrPainter<'_> {
 
     fn push_clip_glyph(&mut self, glyph_id: GlyphId) {
         // TODO: Make it possible to use the outline cache for this.
-        let mut outline_builder = OutlinePath::new();
-
-        let outline_glyphs = self.colr_glyph.font_ref.outline_glyphs();
-        let Some(outline_glyph) = outline_glyphs.get(glyph_id) else {
+        let Some(outline_glyph) = self.outline_glyphs.get(glyph_id) else {
             return;
         };
 
+        self.clip_outline.reuse();
         let _ = outline_glyph.draw(
             DrawSettings::unhinted(skrifa::instance::Size::unscaled(), self.colr_glyph.location),
-            &mut outline_builder,
+            &mut self.clip_outline,
         );
 
-        let finished = outline_builder.path;
-        let transformed = self.cur_transform() * finished;
-
-        self.push_clip(&transformed);
+        self.clip_outline.path.apply_affine(self.cur_transform());
+        self.painter.push_clip_path(&self.clip_outline.path);
+        self.stack.push(ColrStackEntry::ClipPath);
     }
 
     fn push_clip_box(&mut self, clip_box: BoundingBox<f32>) {
@@ -473,8 +474,7 @@ impl ColorPainter for GlyphInfoExtractor<'_> {
         let mut outline_bbox = ControlBoundsPen::default();
 
         // TODO: Make it possible to use the outline cache for this.
-        let outline_glyphs = self.font_ref.outline_glyphs();
-        let Some(outline_glyph) = outline_glyphs.get(glyph_id) else {
+        let Some(outline_glyph) = self.outline_glyphs.get(glyph_id) else {
             return;
         };
 

--- a/glifo/src/colr.rs
+++ b/glifo/src/colr.rs
@@ -302,7 +302,9 @@ impl ColorPainter for ColrPainter<'_> {
         let transformed = self.cur_transform().transform_rect_bbox(rect);
         self.clip_outline.reuse();
         // Note that the bbox will become stale, but we don't need it anyway here.
-        self.clip_outline.path.extend(transformed.path_elements(0.1));
+        self.clip_outline
+            .path
+            .extend(transformed.path_elements(0.1));
         self.push_clip();
     }
 

--- a/glifo/src/colr.rs
+++ b/glifo/src/colr.rs
@@ -171,8 +171,8 @@ impl<'a> ColrPainter<'a> {
         ColorStops(stops)
     }
 
-    fn push_clip(&mut self, clip: &crate::kurbo::BezPath) {
-        self.painter.push_clip_path(clip);
+    fn push_clip(&mut self) {
+        self.painter.push_clip_path(&self.clip_outline.path);
         self.stack.push(ColrStackEntry::ClipPath);
     }
 
@@ -287,9 +287,9 @@ impl ColorPainter for ColrPainter<'_> {
             &mut self.clip_outline,
         );
 
+        // Note that the bbox will become stale, but we don't need it anyway here.
         self.clip_outline.path.apply_affine(self.cur_transform());
-        self.painter.push_clip_path(&self.clip_outline.path);
-        self.stack.push(ColrStackEntry::ClipPath);
+        self.push_clip();
     }
 
     fn push_clip_box(&mut self, clip_box: BoundingBox<f32>) {
@@ -299,9 +299,11 @@ impl ColorPainter for ColrPainter<'_> {
             f64::from(clip_box.x_max),
             f64::from(clip_box.y_max),
         );
-        let transformed = self.cur_transform() * rect.to_path(0.1);
-
-        self.push_clip(&transformed);
+        let transformed = self.cur_transform().transform_rect_bbox(rect);
+        self.clip_outline.reuse();
+        // Note that the bbox will become stale, but we don't need it anyway here.
+        self.clip_outline.path.extend(transformed.path_elements(0.1));
+        self.push_clip();
     }
 
     fn pop_clip(&mut self) {

--- a/glifo/src/glyph.rs
+++ b/glifo/src/glyph.rs
@@ -1453,7 +1453,7 @@ impl OutlinePath {
         }
     }
 
-    fn reuse(&mut self) {
+    pub(crate) fn reuse(&mut self) {
         self.path.truncate(0);
         self.bbox = Rect {
             x0: f64::INFINITY,


### PR DESCRIPTION
This PR reaps two missed low-hanging fruits for rendering COLR glyphs:
1) Instead of creating a new outline path for each clip glyph, we reuse the same one across multiple invocations. (This could probably be optimized to reuse one outline path across _multiple_ COLR glyphs, but for now this should already give good improvements).
2) Instead of storing the `FontRef`, store `OutlineGlyphCollection` such that we don't need to reparse it every time.

Before: Lots of allocations + repeated construction of `OutlineGlyphCollection` visible in profile:
<img width="1146" height="700" alt="image" src="https://github.com/user-attachments/assets/b49157e7-8244-4eba-aef2-7b44922b52ea" />


After: Much fewer allocations visible, and no more constructions:
<img width="1152" height="687" alt="image" src="https://github.com/user-attachments/assets/a2426219-87cb-4be3-a546-995b4b01fec2" />
