### PR TITLE
Avoid using `map` iterator during flattening

### DIFF
--- a/sparse_strips/vello_common/src/flatten.rs
+++ b/sparse_strips/vello_common/src/flatten.rs
@@ -199,11 +199,6 @@ pub fn fill_impl<S: Simd>(
     cull_bbox: RectU16,
 ) {
     line_buf.clear();
-    let iter = path.into_iter().map(
-        #[inline(always)]
-        |el| affine * el,
-    );
-
     let mut lb = FlattenerCallback {
         line_buf,
         start: Point::ZERO,
@@ -211,7 +206,7 @@ pub fn fill_impl<S: Simd>(
         is_nan: false,
     };
 
-    crate::flatten_simd::flatten(simd, iter, &mut lb, flatten_ctx, cull_bbox);
+    crate::flatten_simd::flatten(simd, path, affine, &mut lb, flatten_ctx, cull_bbox);
 
     // A path that contains NaN is ill-defined, so ignore it.
     if lb.is_nan {

--- a/sparse_strips/vello_common/src/flatten_simd.rs
+++ b/sparse_strips/vello_common/src/flatten_simd.rs
@@ -49,6 +49,10 @@ pub(crate) trait Callback {
 pub(crate) fn flatten<S: Simd>(
     simd: S,
     path: impl IntoIterator<Item = PathEl>,
+    // Note: we explicitly pass the `Affine` here instead of using `map` on
+    // the iterator because it seems like the `map` function isn't always inlined
+    // properly, even when annotating the closure with `#[inline(always)]`.
+    // See https://github.com/linebender/vello/pull/1600.
     affine: Affine,
     callback: &mut impl Callback,
     flatten_ctx: &mut FlattenCtx,

--- a/sparse_strips/vello_common/src/flatten_simd.rs
+++ b/sparse_strips/vello_common/src/flatten_simd.rs
@@ -11,6 +11,7 @@ use crate::kurbo::{CubicBez, Line, ParamCurve, ParamCurveNearest, PathEl, Point,
 use crate::{
     flatten::{SQRT_TOL, TOL, TOL_2},
     geometry::RectU16,
+    kurbo::Affine,
     tile::Tile,
 };
 use alloc::vec::Vec;
@@ -48,6 +49,7 @@ pub(crate) trait Callback {
 pub(crate) fn flatten<S: Simd>(
     simd: S,
     path: impl IntoIterator<Item = PathEl>,
+    affine: Affine,
     callback: &mut impl Callback,
     flatten_ctx: &mut FlattenCtx,
     cull_bbox: RectU16,
@@ -83,6 +85,7 @@ pub(crate) fn flatten<S: Simd>(
     let Some(first_el) = path.next() else {
         return;
     };
+    let first_el = affine * first_el;
     let PathEl::MoveTo(start_pt) = first_el else {
         debug_assert!(
             matches!(first_el, PathEl::MoveTo(_)),
@@ -96,7 +99,7 @@ pub(crate) fn flatten<S: Simd>(
     callback.callback(LinePathEl::MoveTo(start_pt));
 
     for el in path {
-        match el {
+        match affine * el {
             PathEl::MoveTo(p) => {
                 if last_pt != start_pt {
                     callback.callback(LinePathEl::LineTo(start_pt));


### PR DESCRIPTION
I don't know why, but while looking at performance profiles I noticed that the map iterator didn't seem to properly be inlined, even though we have the annotation on top of the closure. When I change the code as in this PR, I get very nice improvements on both, my M4 Max and M1 Pro. I would be curious to know if this can also be reproduced on x86 machines.

```
flatten/Ghostscript_Tiger
                        time:   [192.49 µs 192.93 µs 193.40 µs]
                        change: [-2.4309% -2.0049% -1.6035%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
flatten/paris_30k       time:   [8.1785 ms 8.1923 ms 8.2071 ms]
                        change: [-28.216% -28.031% -27.859%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe
flatten/coat_of_arms    time:   [716.45 µs 717.42 µs 718.45 µs]
                        change: [-7.0934% -6.6994% -6.2106%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) high mild
  8 (8.00%) high severe
flatten/heraldry        time:   [358.84 µs 360.30 µs 362.42 µs]
                        change: [-11.778% -11.224% -10.712%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  6 (6.00%) high mild
  5 (5.00%) high severe
```