### PR TITLE
vello_hybrid: Use vec3 instead of arrays for `BlurParams`

### DIFF
--- a/sparse_strips/vello_sparse_shaders/shaders/filters.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/filters.wgsl
@@ -50,8 +50,9 @@ struct FloodFilter {
 struct BlurParams {
     n_linear_taps: u32,
     center_weight: f32,
-    linear_weights: array<f32, MAX_TAPS_PER_SIDE>,
-    linear_offsets: array<f32, MAX_TAPS_PER_SIDE>,
+    // Note: This assumes that `MAX_TAPS_PER_SIDE` = 3.
+    linear_weights: vec3<f32>,
+    linear_offsets: vec3<f32>,
 }
 
 struct DropShadowFilter {
@@ -86,8 +87,8 @@ fn unpack_flood_filter(data: GpuFilterData) -> FloodFilter {
 fn unpack_blur_params(data: GpuFilterData) -> BlurParams {
     let n_linear_taps = unpack_header_n_linear_taps(data.data[0]);
     let center_weight = bitcast<f32>(data.data[1]);
-    var weights: array<f32, MAX_TAPS_PER_SIDE>;
-    var offsets: array<f32, MAX_TAPS_PER_SIDE>;
+    var weights = vec3<f32>(0.0);
+    var offsets = vec3<f32>(0.0);
 
     for (var i = 0u; i < MAX_TAPS_PER_SIDE; i++) {
         weights[i] = bitcast<f32>(data.data[2u + i]);
@@ -264,8 +265,8 @@ fn convolve(
     dir: vec2<f32>,
     n_linear_taps: u32,
     center_weight: f32,
-    weights: array<f32, 3>,
-    offsets: array<f32, 3>,
+    weights: vec3<f32>,
+    offsets: vec3<f32>,
 ) -> vec4<f32> {
     // See the description in `filter.rs` for a bit more information on how this works. For vello_cpu, we
     // precompute a kernel and then apply separate horizontal/vertical passes to achieve the blurring.

--- a/sparse_strips/vello_sparse_shaders/shaders/filters.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/filters.wgsl
@@ -87,13 +87,16 @@ fn unpack_flood_filter(data: GpuFilterData) -> FloodFilter {
 fn unpack_blur_params(data: GpuFilterData) -> BlurParams {
     let n_linear_taps = unpack_header_n_linear_taps(data.data[0]);
     let center_weight = bitcast<f32>(data.data[1]);
-    var weights = vec3<f32>(0.0);
-    var offsets = vec3<f32>(0.0);
-
-    for (var i = 0u; i < MAX_TAPS_PER_SIDE; i++) {
-        weights[i] = bitcast<f32>(data.data[2u + i]);
-        offsets[i] = bitcast<f32>(data.data[2u + MAX_TAPS_PER_SIDE + i]);
-    }
+    let weights = vec3<f32>(
+        bitcast<f32>(data.data[2u]),
+        bitcast<f32>(data.data[3u]),
+        bitcast<f32>(data.data[4u]),
+    );
+    let offsets = vec3<f32>(
+        bitcast<f32>(data.data[2u + MAX_TAPS_PER_SIDE]),
+        bitcast<f32>(data.data[3u + MAX_TAPS_PER_SIDE]),
+        bitcast<f32>(data.data[4u + MAX_TAPS_PER_SIDE]),
+    );
 
     return BlurParams(n_linear_taps, center_weight, weights, offsets);
 }
@@ -283,10 +286,15 @@ fn convolve(
     // First compute the color contribution of the center pixel.
     var color = textureSampleLevel(in_tex, linear_sampler, (src_texel + 0.5) / tex_size, 0.0) * center_weight;
 
+    // See https://github.com/linebender/vello/pull/1601#issuecomment-4323170395 for why we convert
+    // into array first.
+    let weights_arr = array<f32, 3>(weights.x, weights.y, weights.z);
+    let offsets_arr = array<f32, 3>(offsets.x, offsets.y, offsets.z);
+
     // Then, compute and sum the contributions of the adjacent pixels.
     for (var i = 0u; i < n_linear_taps; i++) {
-        let w = weights[i];
-        let d = dir * offsets[i];
+        let w = weights_arr[i];
+        let d = dir * offsets_arr[i];
         color += textureSampleLevel(in_tex, linear_sampler, (src_texel + d + 0.5) / tex_size, 0.0) * w;
         color += textureSampleLevel(in_tex, linear_sampler, (src_texel - d + 0.5) / tex_size, 0.0) * w;
     }


### PR DESCRIPTION
This was tested on a Vivo y21. For some reason, this phone seems to have problems accepting structs that contain more than one array. Something like this:

```
#version 300 es
precision highp float;
precision highp int;
out vec4 outColor;
struct Params {
  float ar1[2];
  float ar2[2];
};
Params make_params() {
  float[2] a = float[2](0.0, 0.0);
  float[2] b = float[2](0.0, 0.0);
  return Params(a, b);
}
void main() {
  Params params = make_params();
  outColor = vec4(0.0, params.ar1[0], params.ar1[0], 1.0);
}
```

<img width="287" height="241" alt="image" src="https://github.com/user-attachments/assets/054eff9d-68a8-4109-b05f-a264e628e6a6" />


If I replace this with a single float array of larger size or try other stuff, it seems to work fine, it really seems to just stop working if there are at least two array fields. I don't think this is something actionable to report to naga.

However, luckily we can work around this from our side easily by instead using `vec3`, which the phone does support fine. While Vello Hybrid still doesn't work on that device, at least it fails with a different error now. 😆 