### PR TITLE
Use state guard in WebGL constructor

### DIFF
--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -150,6 +150,15 @@ impl WebGlRenderer {
             .dyn_into::<WebGl2RenderingContext>()
             .expect("Context to be a WebGL2 context");
 
+        let cloned_gl = gl.clone();
+        let _state_guard = WebGlStateGuard::with_config(
+            &cloned_gl,
+            WebGlStateConfig {
+                framebuffer: true,
+                ..Default::default()
+            },
+        );
+
         // Note: It is not entirely clear whether we really _have_ to ensure anti-aliasing is disabled.
         // This code is inherited from a similar snippet in wgpu
         // (https://github.com/gfx-rs/wgpu/blob/56e4a389ddd02403e232beef3d3ff305625e6485/wgpu-hal/src/gles/web.rs#L101-L106),

--- a/sparse_strips/vello_sparse_tests/tests/wasm_binary_invariants.rs
+++ b/sparse_strips/vello_sparse_tests/tests/wasm_binary_invariants.rs
@@ -72,10 +72,10 @@ fn webgl_probe_succeeds() {
 #[cfg(feature = "webgl")]
 #[wasm_bindgen_test]
 fn webgl_create_renderer_twice() {
+    use vello_hybrid::WebGlRenderer;
     use wasm_bindgen::JsCast;
     use web_sys::HtmlCanvasElement;
-    use vello_hybrid::WebGlRenderer;
-    
+
     let document = web_sys::window().unwrap().document().unwrap();
     let canvas = document
         .create_element("canvas")

--- a/sparse_strips/vello_sparse_tests/tests/wasm_binary_invariants.rs
+++ b/sparse_strips/vello_sparse_tests/tests/wasm_binary_invariants.rs
@@ -65,3 +65,26 @@ fn webgl_probe_succeeds() {
         }
     }
 }
+
+// This test reproduces a bug where creating a renderer would leave a non-default framebuffer without
+// depth attachment bound, as a result of which `DEPTH_BITS` would return 0 when creating a second
+// renderer.
+#[cfg(feature = "webgl")]
+#[wasm_bindgen_test]
+fn webgl_create_renderer_twice() {
+    use wasm_bindgen::JsCast;
+    use web_sys::HtmlCanvasElement;
+    use vello_hybrid::WebGlRenderer;
+    
+    let document = web_sys::window().unwrap().document().unwrap();
+    let canvas = document
+        .create_element("canvas")
+        .unwrap()
+        .dyn_into::<HtmlCanvasElement>()
+        .unwrap();
+    canvas.set_width(16);
+    canvas.set_height(16);
+
+    let _ = WebGlRenderer::new(&canvas);
+    let _ = WebGlRenderer::new(&canvas);
+}


### PR DESCRIPTION
Another bug that makes it evident that we should work on a better abstraction for our WebGL backend soon to avoid subtle state bugs! Note that this is only a bandaid fix until we have a better abstraction in place.

Currently, when constructing a new `WebGlRenderer`, we end up leaving a different framebuffer bound tot he WebGL2 context. As a result. when trying to create a second renderer, we hit a panic because `DEPTH_BITS` ends up being 0. For now, the solution is to simply use a state guard in the constructor so that the default framebuffer is bound again in the end.

It's possible that we currently have other functions that result in leaked framebuffers, I haven't checked that yet. As mentioned, this is just a bandaid fix for this specific bug.