### PR TITLE
Increase hybrid tolerance for two filter tests.

### DIFF
--- a/sparse_strips/vello_sparse_tests/tests/filter.rs
+++ b/sparse_strips/vello_sparse_tests/tests/filter.rs
@@ -1473,7 +1473,7 @@ fn filter_with_non_rect_clip(ctx: &mut impl Renderer) {
     ctx.pop_layer();
 }
 
-#[vello_test(skip_multithreaded)]
+#[vello_test(skip_multithreaded, hybrid_tolerance = 1)]
 fn filter_drop_shadow_inside_clip(ctx: &mut impl Renderer) {
     let filter = Filter::from_primitive(FilterPrimitive::DropShadow {
         dx: 20.0,
@@ -1529,7 +1529,7 @@ fn filter_with_out_of_bounds_clip(ctx: &mut impl Renderer) {
     ctx.pop_layer();
 }
 
-#[vello_test(skip_multithreaded, hybrid_tolerance = 1)]
+#[vello_test(skip_multithreaded, hybrid_tolerance = 2)]
 fn filter_with_inner_clip(ctx: &mut impl Renderer) {
     let filter = Filter::from_primitive(FilterPrimitive::GaussianBlur {
         std_deviation: 5.0,


### PR DESCRIPTION
Both `filter_with_inner_clip` and `filter_drop_shadow_inside_clip` needed a bump in tolerance in order to pass on my RTX 4090 Windows 11 setup.