### PR TITLE
`vello_hybrid`: support blurred rounded rects fast path

### DIFF
--- a/sparse_strips/vello_dev_macros/src/test.rs
+++ b/sparse_strips/vello_dev_macros/src/test.rs
@@ -220,7 +220,6 @@ pub(crate) fn vello_test_inner(attr: TokenStream, item: TokenStream) -> TokenStr
     skip_hybrid |= {
         input_fn_name_str.contains("layer_multiple_properties")
             || input_fn_name_str.contains("mask")
-            || input_fn_name_str.contains("blurred_rounded_rect")
             || input_fn_name_str.contains("clip_clear")
             || input_fn_name_str.contains("mix_non_isolated")
             || input_fn_name_str.contains("compose_non_isolated")

--- a/sparse_strips/vello_example_scenes/src/blurred_rounded_rect.rs
+++ b/sparse_strips/vello_example_scenes/src/blurred_rounded_rect.rs
@@ -1,0 +1,110 @@
+// Copyright 2025 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Scene demonstrating blurred rounded rectangle rendering.
+
+use vello_common::kurbo::{Affine, Rect};
+use vello_common::peniko::color::palette;
+use vello_common::peniko::color::{AlphaColor, Srgb};
+
+use crate::{ExampleScene, RenderingContext};
+
+/// Scene state for blurred rounded rectangle examples.
+#[derive(Debug)]
+pub struct BlurredRoundedRectScene;
+
+impl BlurredRoundedRectScene {
+    /// Create a new `BlurredRoundedRectScene`.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for BlurredRoundedRectScene {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ExampleScene for BlurredRoundedRectScene {
+    fn render<T: RenderingContext>(
+        &mut self,
+        target: &mut T,
+        _resources: &mut T::Resources,
+        root_transform: Affine,
+    ) {
+        render(target, root_transform);
+    }
+}
+
+/// Draw blurred rounded rectangles adapted from Vello Classic's test scene.
+pub fn render(ctx: &mut impl RenderingContext, root_transform: Affine) {
+    let bounds = Rect::new(0.0, 0.0, f64::from(ctx.width()), f64::from(ctx.height()));
+    ctx.set_transform(Affine::IDENTITY);
+    ctx.set_paint(palette::css::WHITE);
+    ctx.fill_rect(&bounds);
+
+    let scene_transform = root_transform
+        * Affine::scale_non_uniform(ctx.width() as f64 / 1200.0, ctx.height() as f64 / 1200.0);
+    let rect = Rect::from_center_size((0.0, 0.0), (300.0, 240.0));
+
+    draw_blurred_rect(
+        ctx,
+        scene_transform * Affine::translate((300.0, 300.0)),
+        rect,
+        palette::css::BLUE,
+        50.0,
+        45.0,
+    );
+
+    draw_blurred_rect(
+        ctx,
+        scene_transform
+            * Affine::translate((900.0, 300.0))
+            * Affine::skew(20_f64.to_radians().tan(), 0.0),
+        rect,
+        palette::css::BLACK,
+        50.0,
+        45.0,
+    );
+
+    draw_blurred_rect(
+        ctx,
+        scene_transform,
+        Rect::new(100.0, 800.0, 400.0, 1100.0),
+        palette::css::BLACK,
+        150.0,
+        45.0,
+    );
+
+    draw_blurred_rect(
+        ctx,
+        scene_transform,
+        Rect::new(600.0, 800.0, 900.0, 900.0),
+        palette::css::BLACK,
+        150.0,
+        45.0,
+    );
+
+    draw_blurred_rect(
+        ctx,
+        scene_transform * Affine::translate((600.0, 600.0)) * Affine::scale_non_uniform(2.2, 0.9),
+        rect,
+        palette::css::BLACK,
+        50.0,
+        30.0,
+    );
+}
+
+fn draw_blurred_rect(
+    ctx: &mut impl RenderingContext,
+    transform: Affine,
+    rect: Rect,
+    color: AlphaColor<Srgb>,
+    radius: f32,
+    std_dev: f32,
+) {
+    ctx.set_transform(transform);
+    ctx.set_paint(color);
+    ctx.fill_blurred_rounded_rect(&rect, radius, std_dev);
+}

--- a/sparse_strips/vello_example_scenes/src/lib.rs
+++ b/sparse_strips/vello_example_scenes/src/lib.rs
@@ -4,6 +4,7 @@
 //! Example scenes for Vello Sparse Strips.
 
 pub mod blend;
+pub mod blurred_rounded_rect;
 pub mod clip;
 pub mod filter;
 pub mod filter_elements;
@@ -66,6 +67,8 @@ pub trait RenderingContext: Sized {
     fn stroke_path(&mut self, path: &BezPath);
     /// Fill a rectangle with the current paint.
     fn fill_rect(&mut self, rect: &Rect);
+    /// Fill a blurred rounded rectangle with the current solid paint.
+    fn fill_blurred_rounded_rect(&mut self, rect: &Rect, radius: f32, std_dev: f32);
     /// Create a glyph run builder for text rendering.
     fn glyph_run<'a>(
         &'a mut self,
@@ -146,6 +149,10 @@ impl RenderingContext for RenderContext {
 
     fn fill_rect(&mut self, rect: &Rect) {
         self.fill_rect(rect);
+    }
+
+    fn fill_blurred_rounded_rect(&mut self, rect: &Rect, radius: f32, std_dev: f32) {
+        self.fill_blurred_rounded_rect(rect, radius, std_dev);
     }
 
     fn glyph_run<'a>(
@@ -238,6 +245,10 @@ impl RenderingContext for Scene {
 
     fn fill_rect(&mut self, rect: &Rect) {
         self.fill_rect(rect);
+    }
+
+    fn fill_blurred_rounded_rect(&mut self, rect: &Rect, radius: f32, std_dev: f32) {
+        self.fill_blurred_rounded_rect(rect, radius, std_dev);
     }
 
     fn glyph_run<'a>(
@@ -437,6 +448,9 @@ where
     scenes.push(AnyScene::new(text::TextScene::new("Hello, Vello!")));
     scenes.push(AnyScene::new(random_text::RandomTextScene::new()));
     scenes.push(AnyScene::new(simple::SimpleScene::new()));
+    scenes.push(AnyScene::new(
+        blurred_rounded_rect::BlurredRoundedRectScene::new(),
+    ));
     scenes.push(AnyScene::new(clip::ClipScene::new()));
     scenes.push(AnyScene::new(filter::FilterScene::new()));
     scenes.push(AnyScene::new(blend::BlendScene::new()));
@@ -472,6 +486,7 @@ where
         AnyScene::new(text::TextScene::new("Hello, Vello!")),
         AnyScene::new(random_text::RandomTextScene::new()),
         AnyScene::new(simple::SimpleScene::new()),
+        AnyScene::new(blurred_rounded_rect::BlurredRoundedRectScene::new()),
         AnyScene::new(filter::FilterScene::new()),
         AnyScene::new(clip::ClipScene::new()),
         AnyScene::new(blend::BlendScene::new()),

--- a/sparse_strips/vello_hybrid/src/render/common.rs
+++ b/sparse_strips/vello_hybrid/src/render/common.rs
@@ -18,6 +18,8 @@ pub(crate) const GPU_LINEAR_GRADIENT_SIZE_TEXELS: u32 =
 pub(crate) const GPU_RADIAL_GRADIENT_SIZE_TEXELS: u32 =
     (size_of::<GpuRadialGradient>() / 16) as u32;
 pub(crate) const GPU_SWEEP_GRADIENT_SIZE_TEXELS: u32 = (size_of::<GpuSweepGradient>() / 16) as u32;
+pub(crate) const GPU_BLURRED_ROUNDED_RECT_SIZE_TEXELS: u32 =
+    (size_of::<GpuBlurredRoundedRect>() / 16) as u32;
 
 // TODO: If we want to use native bilinear sampling for uploaded images,
 // we can pass 1 instead of 0 here.
@@ -167,6 +169,8 @@ pub(crate) enum GpuEncodedPaint {
     RadialGradient(GpuRadialGradient),
     /// An encoded sweep gradient.
     SweepGradient(GpuSweepGradient),
+    /// An encoded blurred rounded rectangle.
+    BlurredRoundedRect(GpuBlurredRoundedRect),
 }
 
 impl GpuEncodedPaint {
@@ -178,6 +182,7 @@ impl GpuEncodedPaint {
             Self::LinearGradient(paint) => bytemuck::bytes_of(paint),
             Self::RadialGradient(paint) => bytemuck::bytes_of(paint),
             Self::SweepGradient(paint) => bytemuck::bytes_of(paint),
+            Self::BlurredRoundedRect(paint) => bytemuck::bytes_of(paint),
         }
     }
 
@@ -218,6 +223,28 @@ pub(crate) struct GpuEncodedImage {
     pub tint_mode: u32,
     /// Number of transparent padding pixels around the image in the atlas.
     pub image_padding: u32,
+}
+
+/// GPU encoded blurred rounded rectangle data.
+/// Align to 16 bytes for `RGBA32Uint` alignment.
+#[repr(C, align(16))]
+#[derive(Debug, Clone, Copy, Zeroable, Pod)]
+#[allow(dead_code, reason = "Clippy fails when --no-default-features")]
+pub(crate) struct GpuBlurredRoundedRect {
+    /// Transform matrix [a, b, c, d, tx, ty].
+    pub transform: [f32; 6],
+    /// Premultiplied color packed as RGBA8 unorm (`pack4x8unorm` layout).
+    pub color: u32,
+    /// Padding for 16-byte alignment.
+    pub _padding0: u32,
+    /// Blur parameters: exponent, reciprocal exponent, scale, and inverse standard deviation.
+    pub params0: [f32; 4],
+    /// Blur parameters: minimum edge length, adjusted width, adjusted height, and outer radius.
+    pub params1: [f32; 4],
+    /// Blur parameters [width, height].
+    pub size: [f32; 2],
+    /// Padding for 16-byte alignment.
+    pub _padding1: [u32; 2],
 }
 
 /// GPU encoded linear gradient data.

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -28,8 +28,9 @@ use crate::{
     render::{
         Config,
         common::{
-            GPU_ENCODED_IMAGE_SIZE_TEXELS, GPU_LINEAR_GRADIENT_SIZE_TEXELS,
-            GPU_RADIAL_GRADIENT_SIZE_TEXELS, GPU_SWEEP_GRADIENT_SIZE_TEXELS, GpuEncodedImage,
+            GPU_BLURRED_ROUNDED_RECT_SIZE_TEXELS, GPU_ENCODED_IMAGE_SIZE_TEXELS,
+            GPU_LINEAR_GRADIENT_SIZE_TEXELS, GPU_RADIAL_GRADIENT_SIZE_TEXELS,
+            GPU_SWEEP_GRADIENT_SIZE_TEXELS, GpuBlurredRoundedRect, GpuEncodedImage,
             GpuEncodedPaint, GpuLinearGradient, GpuRadialGradient, GpuSweepGradient,
             normalize_atlas_config, pack_image_offset, pack_image_params, pack_image_size,
             pack_radial_kind_and_swapped, pack_texture_width_and_extend_mode, pack_tint,
@@ -56,7 +57,10 @@ use vello_common::probe::Probe;
 use vello_common::render_graph::LayerId;
 use vello_common::{
     coarse::WideTile,
-    encode::{EncodedGradient, EncodedKind, EncodedPaint, MAX_GRADIENT_LUT_SIZE, RadialKind},
+    encode::{
+        EncodedBlurredRoundedRectangle, EncodedGradient, EncodedKind, EncodedPaint,
+        MAX_GRADIENT_LUT_SIZE, RadialKind,
+    },
     paint::{ImageId, ImageSource},
     peniko::{self},
     pixmap::Pixmap,
@@ -748,11 +752,10 @@ impl WebGlRenderer {
                     self.encoded_paints[encoded_paint_idx] = gpu_gradient;
                     current_idx += gradient_size_texels;
                 }
-                EncodedPaint::BlurredRoundedRect(_blurred_rect) => {
-                    // TODO: Blurred rounded rectangles are not yet supported
-                    log::warn!(
-                        "Blurred rounded rectangles are not yet supported in sparse strips hybrid renderer"
-                    );
+                EncodedPaint::BlurredRoundedRect(blurred_rect) => {
+                    self.encoded_paints[encoded_paint_idx] =
+                        Self::encode_blurred_rounded_rect_paint(blurred_rect);
+                    current_idx += GPU_BLURRED_ROUNDED_RECT_SIZE_TEXELS;
                 }
             }
         }
@@ -855,6 +858,23 @@ impl WebGlRenderer {
                 _padding: [0, 0],
             }),
         }
+    }
+
+    fn encode_blurred_rounded_rect_paint(rect: &EncodedBlurredRoundedRectangle) -> GpuEncodedPaint {
+        GpuEncodedPaint::BlurredRoundedRect(GpuBlurredRoundedRect {
+            transform: rect.transform.as_coeffs().map(|x| x as f32),
+            color: rect.color.as_premul_rgba8().to_u32(),
+            _padding0: 0,
+            params0: [
+                rect.exponent,
+                rect.recip_exponent,
+                rect.scale,
+                rect.std_dev_inv,
+            ],
+            params1: [rect.min_edge, rect.w, rect.h, rect.r1],
+            size: [rect.width, rect.height],
+            _padding1: [0, 0],
+        })
     }
 }
 

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -26,8 +26,9 @@ use crate::{
     render::{
         Config,
         common::{
-            GPU_ENCODED_IMAGE_SIZE_TEXELS, GPU_LINEAR_GRADIENT_SIZE_TEXELS,
-            GPU_RADIAL_GRADIENT_SIZE_TEXELS, GPU_SWEEP_GRADIENT_SIZE_TEXELS, GpuEncodedImage,
+            GPU_BLURRED_ROUNDED_RECT_SIZE_TEXELS, GPU_ENCODED_IMAGE_SIZE_TEXELS,
+            GPU_LINEAR_GRADIENT_SIZE_TEXELS, GPU_RADIAL_GRADIENT_SIZE_TEXELS,
+            GPU_SWEEP_GRADIENT_SIZE_TEXELS, GpuBlurredRoundedRect, GpuEncodedImage,
             GpuEncodedPaint, GpuLinearGradient, GpuRadialGradient, GpuSweepGradient,
             normalize_atlas_config, pack_image_offset, pack_image_params, pack_image_size,
             pack_radial_kind_and_swapped, pack_texture_width_and_extend_mode, pack_tint,
@@ -49,7 +50,10 @@ use vello_common::multi_atlas::{AtlasConfig, AtlasError, AtlasId};
 use vello_common::render_graph::LayerId;
 use vello_common::{
     coarse::WideTile,
-    encode::{EncodedGradient, EncodedKind, EncodedPaint, MAX_GRADIENT_LUT_SIZE, RadialKind},
+    encode::{
+        EncodedBlurredRoundedRectangle, EncodedGradient, EncodedKind, EncodedPaint,
+        MAX_GRADIENT_LUT_SIZE, RadialKind,
+    },
     paint::ImageSource,
     peniko,
     pixmap::Pixmap,
@@ -693,11 +697,10 @@ impl Renderer {
                     self.encoded_paints[encoded_paint_idx] = gradient_paint;
                     current_idx += gradient_size_texels;
                 }
-                EncodedPaint::BlurredRoundedRect(_blurred_rect) => {
-                    // TODO: Blurred rounded rectangles are not yet supported
-                    log::warn!(
-                        "Blurred rounded rectangles are not yet supported in sparse strips hybrid renderer"
-                    );
+                EncodedPaint::BlurredRoundedRect(blurred_rect) => {
+                    self.encoded_paints[encoded_paint_idx] =
+                        Self::encode_blurred_rounded_rect_paint(blurred_rect);
+                    current_idx += GPU_BLURRED_ROUNDED_RECT_SIZE_TEXELS;
                 }
             }
         }
@@ -800,6 +803,23 @@ impl Renderer {
                 _padding: [0, 0],
             }),
         }
+    }
+
+    fn encode_blurred_rounded_rect_paint(rect: &EncodedBlurredRoundedRectangle) -> GpuEncodedPaint {
+        GpuEncodedPaint::BlurredRoundedRect(GpuBlurredRoundedRect {
+            transform: rect.transform.as_coeffs().map(|x| x as f32),
+            color: rect.color.as_premul_rgba8().to_u32(),
+            _padding0: 0,
+            params0: [
+                rect.exponent,
+                rect.recip_exponent,
+                rect.scale,
+                rect.std_dev_inv,
+            ],
+            params1: [rect.min_edge, rect.w, rect.h, rect.r1],
+            size: [rect.width, rect.height],
+            _padding1: [0, 0],
+        })
     }
 }
 

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -11,6 +11,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::cell::RefCell;
 use core::ops::Range;
+use vello_common::blurred_rounded_rect::BlurredRoundedRectangle;
 use vello_common::clip::ClipContext;
 use vello_common::coarse::{MODE_HYBRID, Wide, WideTilesBbox};
 use vello_common::encode::{EncodeExt, EncodedPaint};
@@ -22,6 +23,7 @@ use vello_common::multi_atlas::AtlasConfig;
 use vello_common::paint::{Paint, PaintType, Tint};
 #[cfg(feature = "text")]
 use vello_common::peniko::FontData;
+use vello_common::peniko::color::palette::css::BLACK;
 use vello_common::peniko::{BlendMode, Compose, Fill, Mix};
 use vello_common::render_graph::{RenderGraph, RenderNodeKind};
 use vello_common::render_state::RenderState;
@@ -209,7 +211,7 @@ pub struct Scene {
     // The reason we use `RefCell` here is that during `render`, we need
     // mutable access so we can store additional encoded paints for filtered layers,
     // if applicable.
-    /// Storage for encoded gradient and image paint data.
+    /// Storage for encoded non-solid paint data.
     pub(crate) encoded_paints: RefCell<Vec<EncodedPaint>>,
     /// Whether the current paint is visible (e.g., alpha > 0).
     paint_visible: bool,
@@ -503,20 +505,47 @@ impl Scene {
         }
     }
 
+    fn try_fast_rect(&mut self, rect: &Rect) -> bool {
+        if self.fast_rect_bounds(rect).is_none() {
+            return false;
+        }
+
+        let paint = self.encode_current_paint();
+        self.try_fast_rect_with_paint(rect, paint)
+    }
+
+    fn try_fast_rect_with_paint(&mut self, rect: &Rect, paint: Paint) -> bool {
+        let Some((x0, y0, x1, y1)) = self.fast_rect_bounds(rect) else {
+            return false;
+        };
+
+        self.fast_strips_buffer
+            .commands
+            .push(FastStripCommand::Rect(FastPathRect {
+                x0,
+                y0,
+                x1,
+                y1,
+                paint,
+            }));
+
+        true
+    }
+
     #[expect(
         clippy::cast_possible_truncation,
         reason = "f64→f32 truncation is acceptable for pixel coordinates"
     )]
-    fn try_fast_rect(&mut self, rect: &Rect) -> bool {
+    fn fast_rect_bounds(&self, rect: &Rect) -> Option<(f32, f32, f32, f32)> {
         if self.strip_path_mode == StripPathMode::CoarseOnly
             || self.wide.has_layers()
             || self.filter.is_some()
         {
-            return false;
+            return None;
         }
 
         if self.clip_context.get().is_some() {
-            return false;
+            return None;
         }
 
         // TODO: Either bail out or properly implement the case where `aliasing_threshold` is set.
@@ -525,7 +554,7 @@ impl Scene {
         // We can't handle skewed rectangles.
         // TODO: Maybe support rotated rectangles (https://github.com/linebender/vello/pull/1482#discussion_r2881223621)
         if !is_axis_aligned(&self.render_state.transform) {
-            return false;
+            return None;
         }
 
         let transformed_rect = self.render_state.transform.transform_rect_bbox(*rect);
@@ -537,27 +566,73 @@ impl Scene {
 
         // Can't handle mirrored or zero-sized rectangles.
         if x1 <= x0 || y1 <= y0 {
-            return false;
+            return None;
         }
 
-        let paint = self.encode_current_paint();
-
-        self.fast_strips_buffer
-            .commands
-            .push(FastStripCommand::Rect(FastPathRect {
-                x0: x0 as f32,
-                y0: y0 as f32,
-                x1: x1 as f32,
-                y1: y1 as f32,
-                paint,
-            }));
-
-        true
+        Some((x0 as f32, y0 as f32, x1 as f32, y1 as f32))
     }
 
     /// Stroke a rectangle with the current paint and stroke settings.
     pub fn stroke_rect(&mut self, rect: &Rect) {
         self.stroke_path(&rect.to_path(DEFAULT_TOLERANCE));
+    }
+
+    /// Fill a blurred rectangle with the given corner radius and standard deviation.
+    ///
+    /// This operation uses the current transform and paint transform. Like Vello CPU, it only
+    /// uses solid paints; non-solid paints fall back to black.
+    pub fn fill_blurred_rounded_rect(&mut self, rect: &Rect, radius: f32, std_dev: f32) {
+        if !self.paint_visible {
+            return;
+        }
+
+        self.with_optional_filter(|ctx| {
+            let rect = rect.abs();
+            let color = match ctx.render_state.paint {
+                PaintType::Solid(s) => s,
+                _ => BLACK,
+            };
+            let blurred_rect = BlurredRoundedRectangle {
+                rect,
+                color,
+                radius,
+                std_dev,
+            };
+
+            let kernel_size = 2.5 * std_dev;
+            let inflated_rect = rect.inflate(f64::from(kernel_size), f64::from(kernel_size));
+            let transform = ctx.render_state.transform * ctx.render_state.paint_transform;
+            let paint =
+                blurred_rect.encode_into(&mut ctx.encoded_paints.borrow_mut(), transform, None);
+
+            if ctx.try_fast_rect_with_paint(&inflated_rect, paint.clone()) {
+                return;
+            }
+
+            if is_axis_aligned(&ctx.render_state.transform) && ctx.aliasing_threshold.is_none() {
+                let transformed_rect = ctx
+                    .render_state
+                    .transform
+                    .transform_rect_bbox(inflated_rect);
+                let strip_storage = &mut ctx.strip_storage.borrow_mut();
+                let strip_start = strip_storage.strips.len();
+                ctx.strip_generator.generate_filled_rect_fast(
+                    &transformed_rect,
+                    strip_storage,
+                    ctx.clip_context.get(),
+                );
+
+                submit_strips!(ctx, strip_storage, strip_start, paint);
+            } else {
+                ctx.fill_path_with(
+                    &inflated_rect.to_path(DEFAULT_TOLERANCE),
+                    ctx.render_state.transform,
+                    Fill::NonZero,
+                    paint,
+                    ctx.aliasing_threshold,
+                );
+            }
+        });
     }
 
     /// Creates a builder for drawing a run of glyphs that have the same attributes.

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -506,29 +506,12 @@ impl Scene {
     }
 
     fn try_fast_rect(&mut self, rect: &Rect) -> bool {
-        if self.fast_rect_bounds(rect).is_none() {
-            return false;
-        }
-
-        let paint = self.encode_current_paint();
-        self.try_fast_rect_with_paint(rect, paint)
-    }
-
-    fn try_fast_rect_with_paint(&mut self, rect: &Rect, paint: Paint) -> bool {
-        let Some((x0, y0, x1, y1)) = self.fast_rect_bounds(rect) else {
+        let Some(bounds) = self.fast_rect_bounds(rect) else {
             return false;
         };
 
-        self.fast_strips_buffer
-            .commands
-            .push(FastStripCommand::Rect(FastPathRect {
-                x0,
-                y0,
-                x1,
-                y1,
-                paint,
-            }));
-
+        let paint = self.encode_current_paint();
+        self.push_fast_rect(bounds, paint);
         true
     }
 
@@ -536,7 +519,19 @@ impl Scene {
         clippy::cast_possible_truncation,
         reason = "f64→f32 truncation is acceptable for pixel coordinates"
     )]
-    fn fast_rect_bounds(&self, rect: &Rect) -> Option<(f32, f32, f32, f32)> {
+    fn push_fast_rect(&mut self, bounds: Rect, paint: Paint) {
+        self.fast_strips_buffer
+            .commands
+            .push(FastStripCommand::Rect(FastPathRect {
+                x0: bounds.x0 as f32,
+                y0: bounds.y0 as f32,
+                x1: bounds.x1 as f32,
+                y1: bounds.y1 as f32,
+                paint,
+            }));
+    }
+
+    fn fast_rect_bounds(&self, rect: &Rect) -> Option<Rect> {
         if self.strip_path_mode == StripPathMode::CoarseOnly
             || self.wide.has_layers()
             || self.filter.is_some()
@@ -569,7 +564,7 @@ impl Scene {
             return None;
         }
 
-        Some((x0 as f32, y0 as f32, x1 as f32, y1 as f32))
+        Some(Rect::new(x0, y0, x1, y1))
     }
 
     /// Stroke a rectangle with the current paint and stroke settings.
@@ -605,7 +600,8 @@ impl Scene {
             let paint =
                 blurred_rect.encode_into(&mut ctx.encoded_paints.borrow_mut(), transform, None);
 
-            if ctx.try_fast_rect_with_paint(&inflated_rect, paint.clone()) {
+            if let Some(bounds) = ctx.fast_rect_bounds(&inflated_rect) {
+                ctx.push_fast_rect(bounds, paint);
                 return;
             }
 

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -206,6 +206,7 @@ const PAINT_TYPE_IMAGE: u32 = 1;
 const PAINT_TYPE_LINEAR_GRADIENT: u32 = 2;
 const PAINT_TYPE_RADIAL_GRADIENT: u32 = 3;
 const PAINT_TYPE_SWEEP_GRADIENT: u32 = 4;
+const PAINT_TYPE_BLURRED_ROUNDED_RECT: u32 = 5;
 
 /// Bit 31 of [`GpuStrip::paint_and_rect_flag`] signals that the strip
 /// represents a full rectangle.
@@ -1805,7 +1806,13 @@ impl Scheduler {
                 let scene_strip_xy = ((scene_strip_y as u32) << 16) | (scene_strip_x as u32);
                 (scene_strip_xy, paint_packed)
             }
-            _ => unimplemented!("Unsupported paint type"),
+            EncodedPaint::BlurredRoundedRect(_) => {
+                let paint_packed = (COLOR_SOURCE_PAYLOAD << 29)
+                    | (PAINT_TYPE_BLURRED_ROUNDED_RECT << 26)
+                    | (paint_idx & 0x03FF_FFFF);
+                let scene_strip_xy = ((scene_strip_y as u32) << 16) | (scene_strip_x as u32);
+                (scene_strip_xy, paint_packed)
+            }
         }
     }
 }

--- a/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
@@ -37,6 +37,7 @@ const PAINT_TYPE_IMAGE: u32 = 1u;
 const PAINT_TYPE_LINEAR_GRADIENT: u32 = 2u;
 const PAINT_TYPE_RADIAL_GRADIENT: u32 = 3u;
 const PAINT_TYPE_SWEEP_GRADIENT: u32 = 4u;
+const PAINT_TYPE_BLURRED_ROUNDED_RECT: u32 = 5u;
 
 // Paint texture index mask (extracts lower 26 bits from paint field).
 const PAINT_TEXTURE_INDEX_MASK: u32 = 0x03FFFFFFu;
@@ -173,7 +174,10 @@ struct Config {
 // │
 // ├── paint_type = 2 (PAINT_TYPE_LINEAR_GRADIENT) - Linear gradient rendering
 // ├── paint_type = 3 (PAINT_TYPE_RADIAL_GRADIENT) - Radial gradient (with kind discriminator)
-// └── paint_type = 4 (PAINT_TYPE_SWEEP_GRADIENT) - Sweep gradient rendering
+// ├── paint_type = 4 (PAINT_TYPE_SWEEP_GRADIENT) - Sweep gradient rendering
+//     ├── payload = [x, y] scene coordinates (packed as u16s)
+//     └── bits 0-25 = paint_texture_idx
+// └── paint_type = 5 (PAINT_TYPE_BLURRED_ROUNDED_RECT) - Analytic blurred rounded rectangle
 //     ├── payload = [x, y] scene coordinates (packed as u16s)
 //     └── bits 0-25 = paint_texture_idx
 //
@@ -296,7 +300,7 @@ fn vs_main(
             // Use view coordinates for image sampling (always in global view space)
             let pos = vec2<f32>(f32(scene_strip_x) + x * f32(width), f32(scene_strip_y) + y * f32(height));
             out.sample_xy = encoded_image.translate + encoded_image.image_offset + encoded_image.transform * pos;
-        } else if paint_type == PAINT_TYPE_LINEAR_GRADIENT || paint_type == PAINT_TYPE_RADIAL_GRADIENT || paint_type == PAINT_TYPE_SWEEP_GRADIENT {
+        } else if paint_type == PAINT_TYPE_LINEAR_GRADIENT || paint_type == PAINT_TYPE_RADIAL_GRADIENT || paint_type == PAINT_TYPE_SWEEP_GRADIENT || paint_type == PAINT_TYPE_BLURRED_ROUNDED_RECT {
             // Use view coordinates for gradient transform (always in global view space)
             out.sample_xy = vec2<f32>(
                 f32(scene_strip_x) + x * f32(width),
@@ -509,6 +513,10 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
                 sweep_gradient.texture_width
             );
             final_color = alpha * gradient_color;
+        } else if paint_type == PAINT_TYPE_BLURRED_ROUNDED_RECT {
+            let paint_tex_idx = in.paint_and_rect_flag & PAINT_TEXTURE_INDEX_MASK;
+            let blurred_rect = unpack_blurred_rounded_rect(paint_tex_idx);
+            final_color = alpha * calculate_blurred_rounded_rect(in.sample_xy, blurred_rect);
         }
     } else if color_source == COLOR_SOURCE_SLOT {
         // Depending on the value of `ndc_y_negate`, the y position will have a value that either
@@ -1175,6 +1183,25 @@ struct SweepGradient {
     inv_angle_delta: f32,
 }
 
+struct BlurredRoundedRect {
+    /// 2×2 linear part of the affine transform (columns [a,b] and [c,d]).
+    transform: mat2x2<f32>,
+    /// Translation part of the affine transform [tx, ty].
+    translate: vec2<f32>,
+    /// Premultiplied rectangle color.
+    color: vec4<f32>,
+    exponent: f32,
+    recip_exponent: f32,
+    scale: f32,
+    std_dev_inv: f32,
+    min_edge: f32,
+    w: f32,
+    h: f32,
+    r1: f32,
+    width: f32,
+    height: f32,
+}
+
 // Unpack linear gradient from the encoded paints texture.
 fn unpack_linear_gradient(paint_tex_idx: u32) -> LinearGradient {
     let texel0 = textureLoad(encoded_paints_texture, encoded_paint_coord(paint_tex_idx), 0);
@@ -1348,6 +1375,67 @@ fn unpack_sweep_gradient(paint_tex_idx: u32) -> SweepGradient {
     return SweepGradient(
         extend_mode, gradient_start, texture_width, transform, translate, start_angle, inv_angle_delta
     );
+}
+
+// Unpack blurred rounded rectangle from the encoded paints texture.
+fn unpack_blurred_rounded_rect(paint_tex_idx: u32) -> BlurredRoundedRect {
+    let texel0 = textureLoad(encoded_paints_texture, encoded_paint_coord(paint_tex_idx), 0);
+    let texel1 = textureLoad(encoded_paints_texture, encoded_paint_coord(paint_tex_idx + 1u), 0);
+    let texel2 = textureLoad(encoded_paints_texture, encoded_paint_coord(paint_tex_idx + 2u), 0);
+    let texel3 = textureLoad(encoded_paints_texture, encoded_paint_coord(paint_tex_idx + 3u), 0);
+    let texel4 = textureLoad(encoded_paints_texture, encoded_paint_coord(paint_tex_idx + 4u), 0);
+
+    let transform = mat2x2<f32>(
+        vec2<f32>(bitcast<f32>(texel0.x), bitcast<f32>(texel0.y)),
+        vec2<f32>(bitcast<f32>(texel0.z), bitcast<f32>(texel0.w))
+    );
+    let translate = vec2<f32>(bitcast<f32>(texel1.x), bitcast<f32>(texel1.y));
+    let color = unpack4x8unorm(texel1.z);
+
+    return BlurredRoundedRect(
+        transform,
+        translate,
+        color,
+        bitcast<f32>(texel2.x),
+        bitcast<f32>(texel2.y),
+        bitcast<f32>(texel2.z),
+        bitcast<f32>(texel2.w),
+        bitcast<f32>(texel3.x),
+        bitcast<f32>(texel3.y),
+        bitcast<f32>(texel3.z),
+        bitcast<f32>(texel3.w),
+        bitcast<f32>(texel4.x),
+        bitcast<f32>(texel4.y)
+    );
+}
+
+// Approximation to erf used by Vello Classic and vello_cpu.
+fn erf7(x: f32) -> f32 {
+    let y = clamp(x * 1.1283791671, -100.0, 100.0);
+    let yy = y * y;
+    let z = y + (0.24295 + (0.03395 + 0.0104 * yy) * yy) * (y * yy);
+    return z / sqrt(1.0 + z * z);
+}
+
+// Approximation for the convolution of a gaussian filter with a rounded rectangle.
+fn calculate_blurred_rounded_rect(fragment_pos: vec2<f32>, rect: BlurredRoundedRect) -> vec4<f32> {
+    let local_xy = rect.transform * fragment_pos + rect.translate;
+    let y = local_xy.y - 0.5 * rect.height;
+    let y0 = rect.r1 + abs(y) - 0.5 * rect.h;
+    let y1 = max(y0, 0.0);
+
+    let x = local_xy.x - 0.5 * rect.width;
+    let x0 = rect.r1 + abs(x) - 0.5 * rect.w;
+    let x1 = max(x0, 0.0);
+
+    let d_pos = pow(pow(x1, rect.exponent) + pow(y1, rect.exponent), rect.recip_exponent);
+    let d_neg = min(max(x0, y0), 0.0);
+    let d = d_pos + d_neg - rect.r1;
+    let blur_alpha = rect.scale * (
+        erf7(rect.std_dev_inv * (rect.min_edge + d)) - erf7(rect.std_dev_inv * d)
+    );
+
+    return rect.color * blur_alpha;
 }
 
 // Unpack texture_width and extend_mode from packed field.

--- a/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
@@ -1417,9 +1417,11 @@ fn erf7(x: f32) -> f32 {
     return z / sqrt(1.0 + z * z);
 }
 
-// Approximation for the convolution of a gaussian filter with a rounded rectangle.
+// Approximation for the convolution of a gaussian filter with a rounded rectangle, modelled
+// after vello_cpu's blurred rounded rectangle painter rather than the Vello Classic shader.
 fn calculate_blurred_rounded_rect(fragment_pos: vec2<f32>, rect: BlurredRoundedRect) -> vec4<f32> {
     let local_xy = rect.transform * fragment_pos + rect.translate;
+    // The 0.5 and 0.0 constants correspond to vello_cpu's v1 and v0 respectively.
     let y = local_xy.y - 0.5 * rect.height;
     let y0 = rect.r1 + abs(y) - 0.5 * rect.h;
     let y1 = max(y0, 0.0);

--- a/sparse_strips/vello_sparse_tests/tests/renderer.rs
+++ b/sparse_strips/vello_sparse_tests/tests/renderer.rs
@@ -373,8 +373,8 @@ impl Renderer for HybridRenderer {
         self.scene.fill_rect(rect);
     }
 
-    fn fill_blurred_rounded_rect(&mut self, _: &Rect, _: f32, _: f32) {
-        unimplemented!()
+    fn fill_blurred_rounded_rect(&mut self, rect: &Rect, radius: f32, std_dev: f32) {
+        self.scene.fill_blurred_rounded_rect(rect, radius, std_dev);
     }
 
     fn stroke_rect(&mut self, rect: &Rect) {
@@ -691,8 +691,8 @@ impl Renderer for HybridRenderer {
         self.scene.fill_rect(rect);
     }
 
-    fn fill_blurred_rounded_rect(&mut self, _: &Rect, _: f32, _: f32) {
-        unimplemented!()
+    fn fill_blurred_rounded_rect(&mut self, rect: &Rect, radius: f32, std_dev: f32) {
+        self.scene.fill_blurred_rounded_rect(rect, radius, std_dev);
     }
 
     fn stroke_rect(&mut self, rect: &Rect) {


### PR DESCRIPTION
This wires Hybrid through the existing shared `vello_common` blurred rounded rect encoding, adds GPU/WebGL encoded paint upload support, and teaches the sparse strip shader to evaluate the analytic blurred rounded rect paint. Root-level unclipped cases use the existing direct rectangle fast path; other supported cases fall back through the normal strip/coarse path.

Also adds a small Hybrid `winit` demo scene, adapted from the Classic test scene, so the feature can be inspected interactively.