### PR TITLE
Slightly rewrite the `convolve` method

### DIFF
--- a/sparse_strips/vello_sparse_shaders/shaders/filters.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/filters.wgsl
@@ -287,9 +287,18 @@ fn convolve(
     var color = textureSampleLevel(in_tex, linear_sampler, (src_texel + 0.5) / tex_size, 0.0) * center_weight;
 
     // See https://github.com/linebender/vello/pull/1601#issuecomment-4323170395 for why we convert
-    // into array first.
-    let weights_arr = array<f32, 3>(weights.x, weights.y, weights.z);
-    let offsets_arr = array<f32, 3>(offsets.x, offsets.y, offsets.z);
+    // into array first. Also see https://github.com/linebender/vello/pull/1605 for why we
+    // assign each field separately.
+
+    var weights_arr: array<f32, 3>;
+    weights_arr[0] = weights.x;
+    weights_arr[1] = weights.y;
+    weights_arr[2] = weights.z;
+
+    var offsets_arr: array<f32, 3>;
+    offsets_arr[0] = offsets.x;
+    offsets_arr[1] = offsets.y;
+    offsets_arr[2] = offsets.z;
 
     // Then, compute and sum the contributions of the adjacent pixels.
     for (var i = 0u; i < n_linear_taps; i++) {


### PR DESCRIPTION
This is a follow-up to #1601.

As was mentioned there, we seemingly cannot use indices to index the vector, otherwise it fails on Windows. Therefore, we changed it so the vector is first converted into an array. However, this now leads to issues on certain Mali GPUs (in this case tested on a Realme 8, but I saw other phones affected by this as well). A shader as the following:

```
#version 300 es
precision highp float;
precision highp int;

out vec4 outColor;

void main() {
  float weight = 0.25;
  float weights_arr[1] = float[1](weight);
  outColor = vec4(weights_arr[0], 0.0, 0.0, 1.0);
}
```

unfortunately fails to compile for many phones:
<img width="330" height="85" alt="image" src="https://github.com/user-attachments/assets/b14e134b-cef4-490e-a966-fb160f8106f1" />

First zero-initializing and then assigning each field seems to work fine:
```
float weights_arr[1] = float[1](0.0);
weights_arr[0] = weight;
```

Therefore, we need to use this approach as well to make it work on those phones.