### PR TITLE
Add two more benchmarks for alpha fill rendering

### DIFF
--- a/sparse_strips/vello_bench/src/fine/strip.rs
+++ b/sparse_strips/vello_bench/src/fine/strip.rs
@@ -16,14 +16,32 @@ use vello_cpu::fine::{Fine, FineKernel};
 use vello_dev_macros::vello_bench;
 
 pub fn strip(c: &mut Criterion) {
+    solid_single(c);
     solid_short(c);
+    solid_medium(c);
     solid_long(c);
+}
+
+#[vello_bench]
+pub fn solid_single<S: Simd, N: FineKernel<S>>(b: &mut Bencher<'_>, fine: &mut Fine<S, N>) {
+    let paint = Paint::Solid(PremulColor::from_alpha_color(ROYAL_BLUE));
+    let width = Tile::WIDTH;
+
+    strip_single(&paint, &[], width as usize, b, fine);
 }
 
 #[vello_bench]
 pub fn solid_short<S: Simd, N: FineKernel<S>>(b: &mut Bencher<'_>, fine: &mut Fine<S, N>) {
     let paint = Paint::Solid(PremulColor::from_alpha_color(ROYAL_BLUE));
     let width = 8;
+
+    strip_single(&paint, &[], width, b, fine);
+}
+
+#[vello_bench]
+pub fn solid_medium<S: Simd, N: FineKernel<S>>(b: &mut Bencher<'_>, fine: &mut Fine<S, N>) {
+    let paint = Paint::Solid(PremulColor::from_alpha_color(ROYAL_BLUE));
+    let width = 16;
 
     strip_single(&paint, &[], width, b, fine);
 }


### PR DESCRIPTION
This PR adds two more benchmarks for strip painting in Vello CPU. One for a single strip (since this is probably actually the most common one), and one for strips of medium lengths.