### PR TITLE
vello_cpu: Optimize alpha fills for solid colors

### DIFF
--- a/sparse_strips/vello_bench/src/fine/strip.rs
+++ b/sparse_strips/vello_bench/src/fine/strip.rs
@@ -16,14 +16,21 @@ use vello_cpu::fine::{Fine, FineKernel};
 use vello_dev_macros::vello_bench;
 
 pub fn strip(c: &mut Criterion) {
-    solid_single(c);
-    solid_short(c);
-    solid_medium(c);
-    solid_long(c);
+    solid_opaque_single(c);
+    solid_transparent_single(c);
+
+    solid_opaque_short(c);
+    solid_transparent_short(c);
+
+    solid_opaque_medium(c);
+    solid_transparent_medium(c);
+
+    solid_opaque_long(c);
+    solid_transparent_long(c);
 }
 
 #[vello_bench]
-pub fn solid_single<S: Simd, N: FineKernel<S>>(b: &mut Bencher<'_>, fine: &mut Fine<S, N>) {
+pub fn solid_opaque_single<S: Simd, N: FineKernel<S>>(b: &mut Bencher<'_>, fine: &mut Fine<S, N>) {
     let paint = Paint::Solid(PremulColor::from_alpha_color(ROYAL_BLUE));
     let width = Tile::WIDTH;
 
@@ -31,7 +38,7 @@ pub fn solid_single<S: Simd, N: FineKernel<S>>(b: &mut Bencher<'_>, fine: &mut F
 }
 
 #[vello_bench]
-pub fn solid_short<S: Simd, N: FineKernel<S>>(b: &mut Bencher<'_>, fine: &mut Fine<S, N>) {
+pub fn solid_opaque_short<S: Simd, N: FineKernel<S>>(b: &mut Bencher<'_>, fine: &mut Fine<S, N>) {
     let paint = Paint::Solid(PremulColor::from_alpha_color(ROYAL_BLUE));
     let width = 8;
 
@@ -39,7 +46,7 @@ pub fn solid_short<S: Simd, N: FineKernel<S>>(b: &mut Bencher<'_>, fine: &mut Fi
 }
 
 #[vello_bench]
-pub fn solid_medium<S: Simd, N: FineKernel<S>>(b: &mut Bencher<'_>, fine: &mut Fine<S, N>) {
+pub fn solid_opaque_medium<S: Simd, N: FineKernel<S>>(b: &mut Bencher<'_>, fine: &mut Fine<S, N>) {
     let paint = Paint::Solid(PremulColor::from_alpha_color(ROYAL_BLUE));
     let width = 16;
 
@@ -47,8 +54,52 @@ pub fn solid_medium<S: Simd, N: FineKernel<S>>(b: &mut Bencher<'_>, fine: &mut F
 }
 
 #[vello_bench]
-pub fn solid_long<S: Simd, N: FineKernel<S>>(b: &mut Bencher<'_>, fine: &mut Fine<S, N>) {
+pub fn solid_opaque_long<S: Simd, N: FineKernel<S>>(b: &mut Bencher<'_>, fine: &mut Fine<S, N>) {
     let paint = Paint::Solid(PremulColor::from_alpha_color(ROYAL_BLUE));
+    let width = 64;
+
+    strip_single(&paint, &[], width, b, fine);
+}
+
+#[vello_bench]
+pub fn solid_transparent_single<S: Simd, N: FineKernel<S>>(
+    b: &mut Bencher<'_>,
+    fine: &mut Fine<S, N>,
+) {
+    let paint = Paint::Solid(PremulColor::from_alpha_color(ROYAL_BLUE.with_alpha(0.3)));
+    let width = Tile::WIDTH;
+
+    strip_single(&paint, &[], width as usize, b, fine);
+}
+
+#[vello_bench]
+pub fn solid_transparent_short<S: Simd, N: FineKernel<S>>(
+    b: &mut Bencher<'_>,
+    fine: &mut Fine<S, N>,
+) {
+    let paint = Paint::Solid(PremulColor::from_alpha_color(ROYAL_BLUE.with_alpha(0.3)));
+    let width = 8;
+
+    strip_single(&paint, &[], width, b, fine);
+}
+
+#[vello_bench]
+pub fn solid_transparent_medium<S: Simd, N: FineKernel<S>>(
+    b: &mut Bencher<'_>,
+    fine: &mut Fine<S, N>,
+) {
+    let paint = Paint::Solid(PremulColor::from_alpha_color(ROYAL_BLUE.with_alpha(0.3)));
+    let width = 16;
+
+    strip_single(&paint, &[], width, b, fine);
+}
+
+#[vello_bench]
+pub fn solid_transparent_long<S: Simd, N: FineKernel<S>>(
+    b: &mut Bencher<'_>,
+    fine: &mut Fine<S, N>,
+) {
+    let paint = Paint::Solid(PremulColor::from_alpha_color(ROYAL_BLUE.with_alpha(0.3)));
     let width = 64;
 
     strip_single(&paint, &[], width, b, fine);

--- a/sparse_strips/vello_cpu/src/fine/highp/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/highp/mod.rs
@@ -213,6 +213,21 @@ impl<S: Simd> FineKernel<S> for F32Kernel {
         }
     }
 
+    #[inline(always)]
+    fn alpha_composite_opaque_solid(
+        simd: S,
+        dest: &mut [Self::Numeric],
+        src: [Self::Numeric; 4],
+        alphas: &[u8],
+    ) {
+        alpha_fill::alpha_composite_opaque_solid(
+            simd,
+            dest,
+            src,
+            bytemuck::cast_slice::<u8, [u8; 4]>(alphas).iter().copied(),
+        );
+    }
+
     /// Composites a source buffer onto a destination buffer using alpha blending.
     ///
     /// Dispatches to either the masked or unmasked implementation based on the
@@ -441,6 +456,32 @@ mod alpha_fill {
 
                 for (next_dest, next_mask) in dest.chunks_exact_mut(16).zip(alphas) {
                     alpha_composite_inner(s, next_dest, &next_mask, src_c, src_a, one);
+                }
+            },
+        );
+    }
+
+    /// Composites an opaque solid color with alpha masks.
+    #[inline(always)]
+    pub(super) fn alpha_composite_opaque_solid<S: Simd>(
+        s: S,
+        dest: &mut [f32],
+        src: [f32; 4],
+        alphas: impl Iterator<Item = [u8; 4]>,
+    ) {
+        s.vectorize(
+            #[inline(always)]
+            || {
+                let src_c = f32x16::block_splat(src.simd_into(s));
+                let one = f32x16::splat(s, 1.0);
+
+                for (next_dest, next_mask) in dest.chunks_exact_mut(16).zip(alphas) {
+                    let bg_c = f32x16::from_slice(s, next_dest);
+                    let mask_a = extract_masks(s, &next_mask);
+                    let inv_mask_a = one - mask_a;
+
+                    let res = bg_c.mul_add(inv_mask_a, src_c * mask_a);
+                    res.store_slice(next_dest);
                 }
             },
         );

--- a/sparse_strips/vello_cpu/src/fine/lowp/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/lowp/mod.rs
@@ -249,6 +249,21 @@ impl<S: Simd> FineKernel<S> for U8Kernel {
         }
     }
 
+    #[inline(always)]
+    fn alpha_composite_opaque_solid(
+        simd: S,
+        dest: &mut [Self::Numeric],
+        src: [Self::Numeric; 4],
+        alphas: &[u8],
+    ) {
+        alpha_fill::alpha_composite_opaque_solid(
+            simd,
+            dest,
+            src,
+            cast_slice::<u8, [u8; 8]>(alphas).iter().copied(),
+        );
+    }
+
     /// Composites a source buffer onto a destination buffer using alpha blending.
     ///
     /// Dispatches to either the masked or unmasked implementation based on the
@@ -504,6 +519,35 @@ mod alpha_fill {
 
                 for (next_bg, next_mask) in dest.chunks_exact_mut(32).zip(alphas) {
                     alpha_composite_inner(s, next_bg, &next_mask, src_c, src_a, one);
+                }
+            },
+        );
+    }
+
+    /// Composites an opaque solid color with alpha masks.
+    #[inline(always)]
+    pub(super) fn alpha_composite_opaque_solid<S: Simd>(
+        s: S,
+        dest: &mut [u8],
+        src: [u8; 4],
+        alphas: impl Iterator<Item = [u8; 8]>,
+    ) {
+        s.vectorize(
+            #[inline(always)]
+            || {
+                let src_c = u32x8::splat(s, u32::from_ne_bytes(src)).to_bytes();
+                let one = u8x32::splat(s, 255);
+
+                for (next_bg, next_mask) in dest.chunks_exact_mut(32).zip(alphas) {
+                    let bg_v = u8x32::from_slice(s, next_bg);
+                    let mask_v = extract_masks(s, &next_mask);
+                    let inv_mask = one - mask_v;
+
+                    let p1 = s.widen_u8x32(bg_v) * s.widen_u8x32(inv_mask);
+                    let p2 = s.widen_u8x32(src_c) * s.widen_u8x32(mask_v);
+                    let res = s.narrow_u16x32((p1 + p2).div_255());
+
+                    res.store_slice(next_bg);
                 }
             },
         );

--- a/sparse_strips/vello_cpu/src/fine/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/mod.rs
@@ -418,6 +418,17 @@ pub trait FineKernel<S: Simd>: Send + Sync + 'static {
         alphas: Option<&[u8]>,
     );
 
+    /// Perform alpha compositing with an opaque solid color and per-pixel alpha values.
+    ///
+    /// Blends an opaque RGBA color over the destination while modulating the source
+    /// contribution by the provided per-pixel alpha values.
+    fn alpha_composite_opaque_solid(
+        simd: S,
+        target: &mut [Self::Numeric],
+        src: [Self::Numeric; 4],
+        alphas: &[u8],
+    );
+
     /// Perform alpha compositing with a source buffer over the destination buffer.
     ///
     /// Blends the source buffer contents over the destination using standard alpha compositing.
@@ -687,14 +698,14 @@ impl<S: Simd, T: FineKernel<S>> Fine<S, T> {
             Paint::Solid(color) => {
                 let color = T::extract_color(*color);
 
-                // If color is completely opaque, we can just directly override
-                // the blend buffer.
-                if color[3] == T::Numeric::ONE
-                    && default_blend
-                    && alphas.is_none()
-                    && mask.is_none()
-                {
-                    T::copy_solid(self.simd, blend_buf, color);
+                // If color is completely opaque and we have the default blend
+                // mode, we can use the solid-color fast path.
+                if color[3] == T::Numeric::ONE && default_blend && mask.is_none() {
+                    if let Some(alphas) = alphas {
+                        T::alpha_composite_opaque_solid(self.simd, blend_buf, color, alphas);
+                    } else {
+                        T::copy_solid(self.simd, blend_buf, color);
+                    }
 
                     return;
                 }


### PR DESCRIPTION
Based on #1615.

Up until now, when rendering alpha fills we only had a single code path that takes into account the alpha of the source color to calculate the final alpha and then composite. However, in case the color is fully opaque, this can be simplified a lot since the only source of alpha is from the alpha mask (from anti-aliasing). Therefore, we can save ourselves the operation that multiplies it with the alpha of the source color.

As can be seen in the benchmarks, this makes a pretty huge difference for solid colors (compare each opaque version with its corresponding transparent version):

```
fine/strip/solid_opaque_single_u8_neon
                        time:   [10.403 ns 10.469 ns 10.529 ns]
                        change: [-2.1594% -0.8205% +0.2495%] (p = 0.17 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  4 (4.00%) low severe
  7 (7.00%) low mild

fine/strip/solid_transparent_single_u8_neon
                        time:   [12.117 ns 12.162 ns 12.206 ns]
                        change: [+0.7448% +1.6490% +2.6538%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low severe
  2 (2.00%) low mild
  3 (3.00%) high mild

fine/strip/solid_opaque_short_u8_neon
                        time:   [12.419 ns 12.503 ns 12.593 ns]
                        change: [-6.0021% -3.9354% -2.0884%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

fine/strip/solid_transparent_short_u8_neon
                        time:   [13.106 ns 13.379 ns 13.655 ns]
                        change: [-1.9953% +0.1353% +2.3733%] (p = 0.90 > 0.05)
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

fine/strip/solid_opaque_medium_u8_neon
                        time:   [14.023 ns 14.196 ns 14.416 ns]
                        change: [-1.5650% -0.5159% +0.5592%] (p = 0.36 > 0.05)
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) high mild
  7 (7.00%) high severe

fine/strip/solid_transparent_medium_u8_neon
                        time:   [21.052 ns 21.088 ns 21.129 ns]
                        change: [+0.2684% +0.6005% +0.9341%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

fine/strip/solid_opaque_long_u8_neon
                        time:   [45.880 ns 45.948 ns 46.022 ns]
                        change: [-3.2477% -2.4263% -1.8232%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

fine/strip/solid_transparent_long_u8_neon
                        time:   [73.942 ns 74.149 ns 74.375 ns]
                        change: [+1.1164% +1.5625% +1.9901%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
```