### PR TITLE
vello_sparse_shaders: Flatten fragment shader arguments

### DIFF
--- a/sparse_strips/vello_sparse_shaders/shaders/filters.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/filters.wgsl
@@ -166,27 +166,31 @@ fn vs_main(
 // Sample a pixel from the original texture.
 // Note: `rel_cord` needs to be positive and must not exceed the width/height of the image
 // that is to be sampled.
-fn sample_original(in: FilterVertexOutput, rel_coord: vec2<f32>) -> vec4<f32> {
-    let src_coord = vec2<u32>(vec2<i32>(in.original_offset) + vec2<i32>(rel_coord));
+fn sample_original(original_offset: vec2<u32>, rel_coord: vec2<f32>) -> vec4<f32> {
+    let src_coord = vec2<u32>(vec2<i32>(original_offset) + vec2<i32>(rel_coord));
     return textureLoad(original_tex, src_coord, 0);
 }
 
 // Sample a pixel from the input texture.
 // Note: `rel_cord` needs to be positive and must not exceed the width/height of the image
 // that is to be sampled.
-fn sample_input(in: FilterVertexOutput, rel_coord: vec2<f32>) -> vec4<f32> {
-    let src_coord = vec2<u32>(vec2<i32>(in.src_offset) + vec2<i32>(rel_coord));
+fn sample_input(src_offset: vec2<u32>, rel_coord: vec2<f32>) -> vec4<f32> {
+    let src_coord = vec2<u32>(vec2<i32>(src_offset) + vec2<i32>(rel_coord));
     return textureLoad(in_tex, src_coord, 0);
 }
 
 // Same as `sample_input`, but with bounds checking.
-fn sample_input_checked(in: FilterVertexOutput, rel_coord: vec2<f32>) -> vec4<f32> {
-    if rel_coord.x < 0.0 || rel_coord.x >= f32(in.src_size.x) ||
-       rel_coord.y < 0.0 || rel_coord.y >= f32(in.src_size.y) {
+fn sample_input_checked(
+    src_offset: vec2<u32>,
+    src_size: vec2<u32>,
+    rel_coord: vec2<f32>,
+) -> vec4<f32> {
+    if rel_coord.x < 0.0 || rel_coord.x >= f32(src_size.x) ||
+       rel_coord.y < 0.0 || rel_coord.y >= f32(src_size.y) {
         return vec4<f32>(0.0);
     }
 
-    return sample_input(in, rel_coord);
+    return sample_input(src_offset, rel_coord);
 }
 
 // TODO: Add support for edge modes when blurring. This unfortunately will make it harder/impossible to perform
@@ -199,11 +203,15 @@ fn sample_input_checked(in: FilterVertexOutput, rel_coord: vec2<f32>) -> vec4<f3
 // We need to use `textureSampleLevel` instead of `textureSample` for loops with dynamic
 // iteration count so that it works properly in the Direct3D backend.
 
-fn downscale(in: FilterVertexOutput) -> vec4<f32> {
-    let frag_coord = vec2<u32>(in.position.xy);
-    let rel = vec2<i32>(frag_coord - in.dest_offset);
+fn downscale(
+    position: vec4<f32>,
+    src_offset: vec2<u32>,
+    dest_offset: vec2<u32>,
+) -> vec4<f32> {
+    let frag_coord = vec2<u32>(position.xy);
+    let rel = vec2<i32>(frag_coord - dest_offset);
     let src_rel = vec2<f32>(rel * 2);
-    let src_texel = vec2<f32>(in.src_offset) + src_rel;
+    let src_texel = vec2<f32>(src_offset) + src_rel;
     let tex_size = vec2<f32>(textureDimensions(in_tex));
 
     // Overall, this follows the same approach that is used by the CPU, where a [1,3,3,1]/8 filter
@@ -227,11 +235,15 @@ fn downscale(in: FilterVertexOutput) -> vec4<f32> {
     return (s00 + s01 + s10 + s11) * 0.25;
 }
 
-fn upscale(in: FilterVertexOutput) -> vec4<f32> {
+fn upscale(
+    position: vec4<f32>,
+    src_offset: vec2<u32>,
+    dest_offset: vec2<u32>,
+) -> vec4<f32> {
     // Same story as for downscaling, but this time even simpler and we can get away with a single texture sample.
 
-    let frag_coord = vec2<u32>(in.position.xy);
-    let rel = vec2<i32>(frag_coord - in.dest_offset);
+    let frag_coord = vec2<u32>(position.xy);
+    let rel = vec2<i32>(frag_coord - dest_offset);
     let src_base = vec2<f32>(rel / 2);
     let phase = vec2<f32>(rel % 2);
     let tex_size = vec2<f32>(textureDimensions(in_tex));
@@ -239,14 +251,14 @@ fn upscale(in: FilterVertexOutput) -> vec4<f32> {
     // For even phases: 75% of current, 25% of top/left.
     // For odd phases: 75% of current, 25% of bottom/right.
     let sample_offset = select(vec2(-0.25), vec2(0.25), phase == vec2(1.0));
-    let src_texel = vec2<f32>(in.src_offset) + src_base + sample_offset;
+    let src_texel = vec2<f32>(src_offset) + src_base + sample_offset;
 
     // Yay, just a single sample!
     return textureSampleLevel(in_tex, linear_sampler, (src_texel + 0.5) / tex_size, 0.0);
 }
 
 fn convolve(
-    in: FilterVertexOutput,
+    src_offset: vec2<u32>,
     src_rel: vec2<f32>,
     dir: vec2<f32>,
     n_linear_taps: u32,
@@ -263,7 +275,7 @@ fn convolve(
     // TODO: Explore whether combining horizontal and vertical filtering is worth it. Likely not worth doing
     // since downscaling/upscaling forms the bottleneck for now.
 
-    let src_texel = vec2<f32>(in.src_offset) + src_rel;
+    let src_texel = vec2<f32>(src_offset) + src_rel;
     let tex_size = vec2<f32>(textureDimensions(in_tex));
 
     // First compute the color contribution of the center pixel.
@@ -298,45 +310,56 @@ const HORIZONTAL: vec2<f32> = vec2<f32>(1.0, 0.0);
 const VERTICAL: vec2<f32> = vec2<f32>(0.0, 1.0);
 
 @fragment
-fn fs_main(in: FilterVertexOutput) -> @location(0) vec4<f32> {
-    let frag_coord = vec2<u32>(in.position.xy);
-    let rel_coord = vec2<f32>(frag_coord - in.dest_offset);
+fn fs_main(
+    @location(0) @interpolate(flat) filter_offset: u32,
+    @location(1) @interpolate(flat) src_offset: vec2<u32>,
+    @location(2) @interpolate(flat) src_size: vec2<u32>,
+    @location(3) @interpolate(flat) dest_offset: vec2<u32>,
+    @location(4) @interpolate(flat) dest_size: vec2<u32>,
+    @location(5) @interpolate(flat) dest_atlas_size: vec2<u32>,
+    @location(6) @interpolate(flat) original_offset: vec2<u32>,
+    @location(7) @interpolate(flat) original_size: vec2<u32>,
+    @location(8) @interpolate(flat) pass_kind: u32,
+    @builtin(position) position: vec4<f32>,
+) -> @location(0) vec4<f32> {
+    let frag_coord = vec2<u32>(position.xy);
+    let rel_coord = vec2<f32>(frag_coord - dest_offset);
 
     // See the comment in `vs_main`.
-    if rel_coord.x >= f32(in.dest_size.x) || rel_coord.y >= f32(in.dest_size.y) {
+    if rel_coord.x >= f32(dest_size.x) || rel_coord.y >= f32(dest_size.y) {
         return vec4<f32>(0.0);
     }
 
-    switch in.pass_kind {
+    switch pass_kind {
         case PASS_COPY: {
-            return sample_input(in, rel_coord);
+            return sample_input(src_offset, rel_coord);
         }
         case PASS_FLOOD: {
-            let filter_texel0 = load_filter_texel(in.filter_offset, 0u);
+            let filter_texel0 = load_filter_texel(filter_offset, 0u);
             return unpack4x8unorm(get_flood_color(filter_texel0));
         }
         case PASS_OFFSET: {
-            let filter_texel0 = load_filter_texel(in.filter_offset, 0u);
+            let filter_texel0 = load_filter_texel(filter_offset, 0u);
             var dxdy: vec2<f32>;
 
             if get_filter_type(filter_texel0) == FILTER_TYPE_DROP_SHADOW {
-                let filter_texel2 = load_filter_texel(in.filter_offset, 2u);
+                let filter_texel2 = load_filter_texel(filter_offset, 2u);
                 dxdy = vec2<f32>(get_drop_shadow_dx(filter_texel2), get_drop_shadow_dy(filter_texel2));
             } else {
                 dxdy = vec2<f32>(get_offset_dx(filter_texel0), get_offset_dy(filter_texel0));
             }
 
             // CPU version uses normal round but WGSL round with ties even, so we use floor + 0.5 instead.
-            return sample_input_checked(in, rel_coord - floor(dxdy + 0.5));
+            return sample_input_checked(src_offset, src_size, rel_coord - floor(dxdy + 0.5));
         }
         case PASS_DOWNSCALE: {
-            return downscale(in);
+            return downscale(position, src_offset, dest_offset);
         }
         case PASS_BLUR_H: {
-            let filter_texel0 = load_filter_texel(in.filter_offset, 0u);
-            let filter_texel1 = load_filter_texel(in.filter_offset, 1u);
+            let filter_texel0 = load_filter_texel(filter_offset, 0u);
+            let filter_texel1 = load_filter_texel(filter_offset, 1u);
             return convolve(
-                in,
+                src_offset,
                 rel_coord,
                 HORIZONTAL,
                 get_filter_header_n_linear_taps(filter_texel0),
@@ -346,10 +369,10 @@ fn fs_main(in: FilterVertexOutput) -> @location(0) vec4<f32> {
             );
         }
         case PASS_BLUR_V: {
-            let filter_texel0 = load_filter_texel(in.filter_offset, 0u);
-            let filter_texel1 = load_filter_texel(in.filter_offset, 1u);
+            let filter_texel0 = load_filter_texel(filter_offset, 0u);
+            let filter_texel1 = load_filter_texel(filter_offset, 1u);
             return convolve(
-                in,
+                src_offset,
                 rel_coord,
                 VERTICAL,
                 get_filter_header_n_linear_taps(filter_texel0),
@@ -359,15 +382,15 @@ fn fs_main(in: FilterVertexOutput) -> @location(0) vec4<f32> {
             );
         }
         case PASS_UPSCALE: {
-            return upscale(in);
+            return upscale(position, src_offset, dest_offset);
         }
         case PASS_COMPOSITE_DROP_SHADOW: {
-            let filter_texel2 = load_filter_texel(in.filter_offset, 2u);
+            let filter_texel2 = load_filter_texel(filter_offset, 2u);
             // Drop shadow composite: colorize blurred result, composite original on top.
-            let blurred = sample_input(in, rel_coord);
+            let blurred = sample_input(src_offset, rel_coord);
             let shadow_color = unpack4x8unorm(get_drop_shadow_color(filter_texel2));
             let shadow_result = shadow_color * blurred.a;
-            let original = sample_original(in, rel_coord);
+            let original = sample_original(original_offset, rel_coord);
 
             // Simple source-over compositing.
             return original + shadow_result * (1.0 - original.a);

--- a/sparse_strips/vello_sparse_shaders/shaders/filters.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/filters.wgsl
@@ -7,6 +7,9 @@
 // for this. For now, fragment shader code should pass raw values and use accessor functions instead.
 // Contributions or cleaner solutions are welcome if someone finds a better approach.
 // See also https://github.com/linebender/vello/pull/1604 for more information.
+//
+// Also do not pass structs as an input to the fragment shader, instead passing the flattened
+// arguments individually. See https://github.com/linebender/vello/pull/1620.
 
 // The texture that holds the encoded parameters for all filter effects used in the scene.
 @group(0) @binding(0) var filter_data: texture_2d<u32>;

--- a/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
@@ -7,6 +7,9 @@
 // for this. For now, fragment shader code should pass raw values and use accessor functions instead.
 // Contributions or cleaner solutions are welcome if someone finds a better approach.
 // See also https://github.com/linebender/vello/pull/1604 for more information.
+//
+// Also do not pass structs as an input to the fragment shader, instead passing the flattened
+// arguments individually. See https://github.com/linebender/vello/pull/1620.
 
 // A WGSL shader for rendering sparse strips with alpha blending.
 //

--- a/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
@@ -349,28 +349,36 @@ var alphas_texture: texture_2d<u32>;
 var clip_input_texture: texture_2d<f32>;
 
 @fragment
-fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+fn fs_main(
+    @location(0) @interpolate(flat) paint_and_rect_flag: u32,
+    @location(1) tex_coord: vec2<f32>,
+    @location(2) sample_xy: vec2<f32>,
+    @location(3) @interpolate(flat) dense_end_or_rect_size: u32,
+    @location(4) @interpolate(flat) payload: u32,
+    @location(5) @interpolate(flat) rect_frac: u32,
+    @builtin(position) position: vec4<f32>,
+) -> @location(0) vec4<f32> {
     var alpha = 1.0;
-    let is_rect = (in.paint_and_rect_flag & RECT_STRIP_FLAG) != 0u;
+    let is_rect = (paint_and_rect_flag & RECT_STRIP_FLAG) != 0u;
     // TODO: Explore doing these calculations only for rectangle parts that actually need anti-aliasing. See
     // https://github.com/linebender/vello/pull/1482#discussion_r2861311034
-    if is_rect && in.rect_frac != 0u {
-        let frac = unpack4x8unorm(in.rect_frac);
+    if is_rect && rect_frac != 0u {
+        let frac = unpack4x8unorm(rect_frac);
         // Calculate how much of the pixel is actually covered by the rect.
         // We do this by simply calculating the fractions in the x and y direction, and
         // then multiplying them.
         // For (maybe?) better performance, we calculate the x and y dimension in a single
         // pass by packing everything into a vec2.
-        let rect_size = vec2<f32>(f32(in.dense_end_or_rect_size & 0xFFFFu), f32(in.dense_end_or_rect_size >> 16u));
-        let tc = in.tex_coord;
+        let rect_size = vec2<f32>(f32(dense_end_or_rect_size & 0xFFFFu), f32(dense_end_or_rect_size >> 16u));
+        let tc = tex_coord;
         // + 0.5 and -0.5 since the fragment shader positions the coordinates in the center of the pixel.
         let bottom_and_right = min(tc + 0.5, rect_size - frac.zw);
         let top_and_left = max(tc - 0.5, frac.xy);
         let a = clamp(bottom_and_right - top_and_left, vec2(0.0), vec2(1.0));
         alpha = a.x * a.y;
-    } else if !is_rect && in.dense_end_or_rect_size != 0u {
-        let x = u32(floor(in.tex_coord.x));
-        let y = u32(floor(in.tex_coord.y));
+    } else if !is_rect && dense_end_or_rect_size != 0u {
+        let x = u32(floor(tex_coord.x));
+        let y = u32(floor(tex_coord.y));
         // Retrieve alpha value from the texture. We store 16 1-byte alpha
         // values per texel, with each color channel packing 4 alpha values.
         // The code here assumes the strip height is 4, i.e., each color
@@ -396,17 +404,17 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
         alpha = f32((alphas_u32 >> (y * 8u)) & 0xffu) * (1.0 / 255.0);
     }
     // Apply the alpha value to the unpacked RGBA color or slot index
-    let color_source = (in.paint_and_rect_flag >> 29u) & 0x3u;
+    let color_source = (paint_and_rect_flag >> 29u) & 0x3u;
     var final_color: vec4<f32>;
 
     if color_source == COLOR_SOURCE_PAYLOAD {
-        let paint_type = (in.paint_and_rect_flag >> 26u) & 0x7u;
+        let paint_type = (paint_and_rect_flag >> 26u) & 0x7u;
 
         // in.payload encodes a color for PAINT_TYPE_SOLID or sample_xy for PAINT_TYPE_IMAGE
         if paint_type == PAINT_TYPE_SOLID {
-            final_color = alpha * unpack4x8unorm(in.payload);
+            final_color = alpha * unpack4x8unorm(payload);
         } else if paint_type == PAINT_TYPE_IMAGE {
-            let paint_tex_idx = in.paint_and_rect_flag & PAINT_TEXTURE_INDEX_MASK;
+            let paint_tex_idx = paint_and_rect_flag & PAINT_TEXTURE_INDEX_MASK;
             let image_texel0 = load_encoded_paint_texel(paint_tex_idx, 0u);
             let image_texel1 = load_encoded_paint_texel(paint_tex_idx, 1u);
             let image_texel2 = load_encoded_paint_texel(paint_tex_idx, 2u);
@@ -423,7 +431,7 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
             // Multiply mode so the math reduces to sample_color * 1.0 = sample_color.
             let image_tint = select(vec4<f32>(1.0), unpack4x8unorm(packed_tint), has_tint);
             let is_multiply = !has_tint || image_texel2.z != TINT_MODE_ALPHA_MASK;
-            let local_xy = in.sample_xy - image_offset;
+            let local_xy = sample_xy - image_offset;
             // This offset doesn't exist in vello_cpu, and we use it because 45 degree skewing seems to cause
             // artifacts on the GPU. We have something similar in place for gradients. It might be worth revisiting
             // this to see whether a better approach is possible.
@@ -483,12 +491,12 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
                 is_multiply
             );
         } else if paint_type == PAINT_TYPE_LINEAR_GRADIENT {
-            let paint_tex_idx = in.paint_and_rect_flag & PAINT_TEXTURE_INDEX_MASK;
+            let paint_tex_idx = paint_and_rect_flag & PAINT_TEXTURE_INDEX_MASK;
             let gradient_texel0 = load_encoded_paint_texel(paint_tex_idx, 0u);
             let gradient_texel1 = load_encoded_paint_texel(paint_tex_idx, 1u);
             
             // Calculate fragment position and apply affine transform
-            let fragment_pos = in.sample_xy;
+            let fragment_pos = sample_xy;
             let grad_pos = apply_gradient_transform(gradient_texel0, gradient_texel1, fragment_pos);
             
             // For linear gradient, t-value is just the x coordinate in gradient space
@@ -501,14 +509,14 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
             );
             final_color = alpha * gradient_color;
         } else if paint_type == PAINT_TYPE_RADIAL_GRADIENT {
-            let paint_tex_idx = in.paint_and_rect_flag & PAINT_TEXTURE_INDEX_MASK;
+            let paint_tex_idx = paint_and_rect_flag & PAINT_TEXTURE_INDEX_MASK;
             let gradient_texel0 = load_encoded_paint_texel(paint_tex_idx, 0u);
             let gradient_texel1 = load_encoded_paint_texel(paint_tex_idx, 1u);
             let gradient_texel2 = load_encoded_paint_texel(paint_tex_idx, 2u);
             let gradient_texel3 = load_encoded_paint_texel(paint_tex_idx, 3u);
             
             // Calculate fragment position and apply affine transform
-            let fragment_pos = in.sample_xy;
+            let fragment_pos = sample_xy;
             let grad_pos = apply_gradient_transform(gradient_texel0, gradient_texel1, fragment_pos);
             
             // For radial gradient, calculate distance from center
@@ -525,13 +533,13 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
                 gradient_result.y != 0.0
             );
         } else if paint_type == PAINT_TYPE_SWEEP_GRADIENT {
-            let paint_tex_idx = in.paint_and_rect_flag & PAINT_TEXTURE_INDEX_MASK;
+            let paint_tex_idx = paint_and_rect_flag & PAINT_TEXTURE_INDEX_MASK;
             let gradient_texel0 = load_encoded_paint_texel(paint_tex_idx, 0u);
             let gradient_texel1 = load_encoded_paint_texel(paint_tex_idx, 1u);
             let gradient_texel2 = load_encoded_paint_texel(paint_tex_idx, 2u);
             
             // Calculate fragment position and apply affine transform
-            let fragment_pos = in.sample_xy;
+            let fragment_pos = sample_xy;
             var grad_pos = apply_gradient_transform(gradient_texel0, gradient_texel1, fragment_pos);
 
             // Before passing the position to the angle calculation, we bias
@@ -558,14 +566,14 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
             );
             final_color = alpha * gradient_color;
         } else if paint_type == PAINT_TYPE_BLURRED_ROUNDED_RECT {
-            let paint_tex_idx = in.paint_and_rect_flag & PAINT_TEXTURE_INDEX_MASK;
+            let paint_tex_idx = paint_and_rect_flag & PAINT_TEXTURE_INDEX_MASK;
             let blurred_texel0 = load_encoded_paint_texel(paint_tex_idx, 0u);
             let blurred_texel1 = load_encoded_paint_texel(paint_tex_idx, 1u);
             let blurred_texel2 = load_encoded_paint_texel(paint_tex_idx, 2u);
             let blurred_texel3 = load_encoded_paint_texel(paint_tex_idx, 3u);
             let blurred_texel4 = load_encoded_paint_texel(paint_tex_idx, 4u);
             final_color = alpha * calculate_blurred_rounded_rect(
-                in.sample_xy,
+                sample_xy,
                 blurred_texel0,
                 blurred_texel1,
                 blurred_texel2,
@@ -578,7 +586,7 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
         // assumes a `y-up` or `y-down` coordinate system. However, for slot textures, we need the original
         // coordinate in the `y-down` system. Therefore, we invert the y-position _again_ in case we are
         // currently rendering to a y-up system, to get the original coordinate.
-        let sample_y = select(in.position.y, f32(config.height) - in.position.y, config.ndc_y_negate != 0u);
+        let sample_y = select(position.y, f32(config.height) - position.y, config.ndc_y_negate != 0u);
         // in.payload encodes a slot in the source clip texture.
         // This is a bit finicky: When copying from a texture slot, we already
         // know which slot to choose and where that slot is located. Therefore, we now
@@ -587,26 +595,26 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
         // strip offset is (2, 2), then the pixel (2, 2) should still map to (0, 0)
         // within the wide tile slot! Therefore, we need to subtract the strip
         // offset here.
-        let clip_x = u32(i32(in.position.x) - config.strip_offset_x) & 0xFFu;
-        let clip_y = (u32(i32(sample_y) - config.strip_offset_y) & 3u) + in.payload * config.strip_height;
+        let clip_x = u32(i32(position.x) - config.strip_offset_x) & 0xFFu;
+        let clip_y = (u32(i32(sample_y) - config.strip_offset_y) & 3u) + payload * config.strip_height;
         let clip_in_color = textureLoad(clip_input_texture, vec2(clip_x, clip_y), 0);
 
         // Extract opacity from first 8 bits (quantized from [0, 255])
-        let opacity = f32(in.paint_and_rect_flag & 0xFFu) * (1.0 / 255.0);
+        let opacity = f32(paint_and_rect_flag & 0xFFu) * (1.0 / 255.0);
 
         final_color = alpha * opacity * clip_in_color;
     } else if color_source == COLOR_SOURCE_BLEND {
         // See the comment above.
-        let sample_y = select(in.position.y, f32(config.height) - in.position.y, config.ndc_y_negate != 0u);
-        let opacity = f32((in.paint_and_rect_flag >> 16u) & 0xFFu) * (1.0 / 255.0);
-        let mix_mode = (in.paint_and_rect_flag >> 8u) & 0xFFu;
-        let compose_mode = in.paint_and_rect_flag & 0xFFu;
+        let sample_y = select(position.y, f32(config.height) - position.y, config.ndc_y_negate != 0u);
+        let opacity = f32((paint_and_rect_flag >> 16u) & 0xFFu) * (1.0 / 255.0);
+        let mix_mode = (paint_and_rect_flag >> 8u) & 0xFFu;
+        let compose_mode = paint_and_rect_flag & 0xFFu;
         
         // Read source color from slot
-        let src_slot = in.payload & 0xFFFFu;
-        let dest_slot = (in.payload >> 16u) & 0xFFFFu;
+        let src_slot = payload & 0xFFFFu;
+        let dest_slot = (payload >> 16u) & 0xFFFFu;
         // See the comment above for why we need to subtract the strip offset.
-        let clip_x = u32(i32(in.position.x) - config.strip_offset_x) & 0xFFu;
+        let clip_x = u32(i32(position.x) - config.strip_offset_x) & 0xFFu;
         let clip_y_in_strip = u32(i32(sample_y) - config.strip_offset_y) & 3u;
         let src_y = clip_y_in_strip + src_slot * config.strip_height;
         let src_color = textureLoad(clip_input_texture, vec2(clip_x, src_y), 0);


### PR DESCRIPTION
This is a continuation to #1619 and builds on top of it. With this PR in place, Vello Hybrid runs on Google Pixel 5 and Redmi Note 11 without any problems!