### PR TITLE
[hybrid]: Truncate gradient luts after upload

### DIFF
--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -1539,6 +1539,7 @@ impl WebGlPrograms {
 
         // Take ownership of the luts to avoid copying, then resize for texture padding.
         let mut luts = gradient_cache.take_luts();
+        let old_luts_len = luts.len();
         luts.resize(total_capacity, 0);
 
         gl.active_texture(WebGl2RenderingContext::TEXTURE0);
@@ -1560,7 +1561,8 @@ impl WebGlPrograms {
         )
         .unwrap();
 
-        // Restore the luts back to the cache.
+        // Restore the luts back to the cache
+        luts.truncate(old_luts_len);
         gradient_cache.restore_luts(luts);
     }
 

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -1561,7 +1561,7 @@ impl WebGlPrograms {
         )
         .unwrap();
 
-        // Restore the luts back to the cache
+        // Restore the luts back to the cache.
         luts.truncate(old_luts_len);
         gradient_cache.restore_luts(luts);
     }


### PR DESCRIPTION
Like the WGPU implementation, shown below, we need to truncate the gradient luts:

https://github.com/linebender/vello/blob/3a021344a27f2c00553efcbc88a1f833edcbbbed/sparse_strips/vello_hybrid/src/render/wgpu.rs#L2394