### PR TITLE
glifo: Add font embolden

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1825,8 +1825,9 @@ dependencies = [
 
 [[package]]
 name = "kurbo"
-version = "0.13.0"
-source = "git+https://github.com/linebender/kurbo.git?rev=6836244be0b280ff68728f100fca0a5fcf62638a#6836244be0b280ff68728f100fca0a5fcf62638a"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
 dependencies = [
  "arrayvec",
  "euclid",
@@ -2664,7 +2665,7 @@ checksum = "9a2b6aadb221872732e87d465213e9be5af2849b0e8cc5300a8ba98fffa2e00a"
 dependencies = [
  "bytemuck",
  "color",
- "kurbo 0.13.0",
+ "kurbo 0.13.1",
  "linebender_resource_handle",
  "smallvec",
 ]
@@ -2761,7 +2762,8 @@ checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 [[package]]
 name = "polycool"
 version = "0.4.0"
-source = "git+https://github.com/linebender/kurbo.git?rev=6836244be0b280ff68728f100fca0a5fcf62638a#6836244be0b280ff68728f100fca0a5fcf62638a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
 dependencies = [
  "arrayvec",
  "libm",
@@ -5245,7 +5247,7 @@ dependencies = [
  "env_logger",
  "getrandom",
  "jni",
- "kurbo 0.13.0",
+ "kurbo 0.13.1",
  "log",
  "notify-debouncer-full",
  "pollster",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1826,12 +1826,12 @@ dependencies = [
 [[package]]
 name = "kurbo"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7564e90fe3c0d5771e1f0bc95322b21baaeaa0d9213fa6a0b61c99f8b17b3bfb"
+source = "git+https://github.com/linebender/kurbo.git?rev=6836244be0b280ff68728f100fca0a5fcf62638a#6836244be0b280ff68728f100fca0a5fcf62638a"
 dependencies = [
  "arrayvec",
  "euclid",
  "libm",
+ "polycool",
  "schemars",
  "smallvec",
 ]
@@ -2757,6 +2757,15 @@ name = "pollster"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
+name = "polycool"
+version = "0.4.0"
+source = "git+https://github.com/linebender/kurbo.git?rev=6836244be0b280ff68728f100fca0a5fcf62638a#6836244be0b280ff68728f100fca0a5fcf62638a"
+dependencies = [
+ "arrayvec",
+ "libm",
+]
 
 [[package]]
 name = "portable-atomic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ skrifa = { version = "0.42.0", default-features = false, features = ["autohint_s
 # with the version of kurbo used by peniko.
 peniko = { version = "0.6.0", default-features = false }
 # FIXME: This can be removed once peniko supports the schemars feature.
-kurbo = { version = "0.13.0", default-features = false }
+kurbo = { version = "0.13.1", default-features = false }
 futures-intrusive = "0.5.0"
 guillotiere = { version = "0.7.0", default-features = false }
 hashbrown = { version = "0.17.0", default-features = false, features = ["default-hasher"] }
@@ -161,9 +161,6 @@ syn = { version = "2.0.117", features = ["full", "extra-traits"] }
 quote = "1.0.45"
 serde = { version = "1.0.228", default-features = false }
 serde_json = "1.0.149"
-
-[patch.crates-io]
-kurbo = { git = "https://github.com/linebender/kurbo.git", rev = "6836244be0b280ff68728f100fca0a5fcf62638a" }
 
 [profile.instrument]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,6 +162,9 @@ quote = "1.0.45"
 serde = { version = "1.0.228", default-features = false }
 serde_json = "1.0.149"
 
+[patch.crates-io]
+kurbo = { git = "https://github.com/linebender/kurbo.git", rev = "6836244be0b280ff68728f100fca0a5fcf62638a" }
+
 [profile.instrument]
 inherits = "release"
 debug = true

--- a/glifo/src/atlas/key.rs
+++ b/glifo/src/atlas/key.rs
@@ -63,6 +63,10 @@ pub struct GlyphCacheKey {
     pub context_color: AlphaColor<Srgb>,
     /// Pre-packed context color (premultiplied RGBA8 as u32) used in Hash/Eq.
     pub context_color_packed: u32,
+    /// Synthetic embolden amount. Only non-zero for outline glyphs.
+    pub embolden_x_bits: u64,
+    /// Synthetic embolden amount. Only non-zero for outline glyphs.
+    pub embolden_y_bits: u64,
     /// Variation coordinates for variable fonts.
     pub var_coords: SmallVec<[NormalizedCoord; 4]>,
 }
@@ -82,6 +86,8 @@ impl GlyphCacheKey {
         fractional_x: f32,
         context_color: AlphaColor<Srgb>,
         context_color_packed: u32,
+        embolden_x: f64,
+        embolden_y: f64,
         var_coords: &[NormalizedCoord],
     ) -> Self {
         Self {
@@ -93,6 +99,8 @@ impl GlyphCacheKey {
             subpixel_x: quantize_subpixel(fractional_x),
             context_color,
             context_color_packed,
+            embolden_x_bits: embolden_x.to_bits(),
+            embolden_y_bits: embolden_y.to_bits(),
             var_coords: SmallVec::from_slice(var_coords),
         }
     }
@@ -112,6 +120,8 @@ impl Hash for GlyphCacheKey {
         self.hinted.hash(state);
         self.subpixel_x.hash(state);
         self.context_color_packed.hash(state);
+        self.embolden_x_bits.hash(state);
+        self.embolden_y_bits.hash(state);
     }
 }
 
@@ -125,6 +135,8 @@ impl PartialEq for GlyphCacheKey {
             && self.size_bits == other.size_bits
             && self.hinted == other.hinted
             && self.context_color_packed == other.context_color_packed
+            && self.embolden_x_bits == other.embolden_x_bits
+            && self.embolden_y_bits == other.embolden_y_bits
     }
 }
 
@@ -196,15 +208,16 @@ mod tests {
     #[test]
     fn test_key_equality() {
         let packed = pack_color(BLACK);
-        let key1 = GlyphCacheKey::new(1, 0, 42, 16.0, true, 0.3, BLACK, packed, &[]);
-        let key2 = GlyphCacheKey::new(1, 0, 42, 16.0, true, 0.3, BLACK, packed, &[]);
+        let key1 = GlyphCacheKey::new(1, 0, 42, 16.0, true, 0.3, BLACK, packed, 0.0, 0.0, &[]);
+        let key2 = GlyphCacheKey::new(1, 0, 42, 16.0, true, 0.3, BLACK, packed, 0.0, 0.0, &[]);
         assert_eq!(key1, key2);
     }
 
     #[test]
     fn test_outline_colr_bitmap_keys_never_collide() {
         let packed = pack_color(BLACK);
-        let outline_key = GlyphCacheKey::new(1, 0, 42, 16.0, false, 0.0, BLACK, packed, &[]);
+        let outline_key =
+            GlyphCacheKey::new(1, 0, 42, 16.0, false, 0.0, BLACK, packed, 0.0, 0.0, &[]);
         let colr_key = GlyphCacheKey {
             font_id: 1,
             font_index: 0,
@@ -214,6 +227,8 @@ mod tests {
             subpixel_x: SUBPIXEL_COLR,
             context_color: BLACK,
             context_color_packed: packed,
+            embolden_x_bits: 0,
+            embolden_y_bits: 0,
             var_coords: SmallVec::new(),
         };
         let bitmap_key = GlyphCacheKey {
@@ -225,6 +240,8 @@ mod tests {
             subpixel_x: SUBPIXEL_BITMAP,
             context_color: BLACK,
             context_color_packed: packed,
+            embolden_x_bits: 0,
+            embolden_y_bits: 0,
             var_coords: SmallVec::new(),
         };
         assert_ne!(outline_key, colr_key);
@@ -246,7 +263,7 @@ mod tests {
         let packed = pack_color(BLACK);
         // var_coords is excluded from Hash/Eq (two-level map handles it),
         // so keys differing only in var_coords are considered equal.
-        let key1 = GlyphCacheKey::new(1, 0, 42, 16.0, true, 0.3, BLACK, packed, &[]);
+        let key1 = GlyphCacheKey::new(1, 0, 42, 16.0, true, 0.3, BLACK, packed, 0.0, 0.0, &[]);
         let key2 = GlyphCacheKey::new(
             1,
             0,
@@ -256,6 +273,8 @@ mod tests {
             0.3,
             BLACK,
             packed,
+            0.0,
+            0.0,
             &[NormalizedCoord::from_bits(100)],
         );
         assert_eq!(key1, key2);

--- a/glifo/src/atlas/key.rs
+++ b/glifo/src/atlas/key.rs
@@ -9,6 +9,7 @@
 //! equal produce identical bitmaps and can safely share a single atlas entry.
 
 use crate::color::{AlphaColor, Srgb};
+use crate::glyph::FontEmbolden;
 use crate::kurbo::Join;
 use core::hash::{Hash, Hasher};
 #[cfg(not(feature = "std"))]
@@ -93,11 +94,7 @@ impl GlyphCacheKey {
         fractional_x: f32,
         context_color: AlphaColor<Srgb>,
         context_color_packed: u32,
-        embolden_x: f64,
-        embolden_y: f64,
-        embolden_join: Join,
-        embolden_miter_limit: f64,
-        embolden_tolerance: f64,
+        embolden: FontEmbolden,
         var_coords: &[NormalizedCoord],
     ) -> Self {
         Self {
@@ -109,11 +106,11 @@ impl GlyphCacheKey {
             subpixel_x: quantize_subpixel(fractional_x),
             context_color,
             context_color_packed,
-            embolden_x_bits: f32_bits(embolden_x),
-            embolden_y_bits: f32_bits(embolden_y),
-            embolden_join_bits: join_bits(embolden_join),
-            embolden_miter_limit_bits: f32_bits(embolden_miter_limit),
-            embolden_tolerance_bits: f32_bits(embolden_tolerance),
+            embolden_x_bits: f32_bits(embolden.amount.xx),
+            embolden_y_bits: f32_bits(embolden.amount.yy),
+            embolden_join_bits: join_bits(embolden.join),
+            embolden_miter_limit_bits: f32_bits(embolden.miter_limit),
+            embolden_tolerance_bits: f32_bits(embolden.tolerance),
             var_coords: SmallVec::from_slice(var_coords),
         }
     }
@@ -161,6 +158,7 @@ impl PartialEq for GlyphCacheKey {
 
 impl Eq for GlyphCacheKey {}
 
+#[inline(always)]
 fn join_bits(join: Join) -> u8 {
     match join {
         Join::Bevel => 0,
@@ -173,6 +171,7 @@ fn join_bits(join: Join) -> u8 {
     clippy::cast_possible_truncation,
     reason = "Cache keys intentionally store embolden parameters at f32 precision."
 )]
+#[inline(always)]
 fn f32_bits(value: f64) -> u32 {
     (value as f32).to_bits()
 }
@@ -252,11 +251,7 @@ mod tests {
             0.3,
             BLACK,
             packed,
-            0.0,
-            0.0,
-            Join::Miter,
-            4.0,
-            0.1,
+            FontEmbolden::default(),
             &[],
         );
         let key2 = GlyphCacheKey::new(
@@ -268,11 +263,7 @@ mod tests {
             0.3,
             BLACK,
             packed,
-            0.0,
-            0.0,
-            Join::Miter,
-            4.0,
-            0.1,
+            FontEmbolden::default(),
             &[],
         );
         assert_eq!(key1, key2);
@@ -290,11 +281,7 @@ mod tests {
             0.0,
             BLACK,
             packed,
-            0.0,
-            0.0,
-            Join::Miter,
-            4.0,
-            0.1,
+            FontEmbolden::default(),
             &[],
         );
         let colr_key = GlyphCacheKey {
@@ -357,11 +344,7 @@ mod tests {
             0.3,
             BLACK,
             packed,
-            0.0,
-            0.0,
-            Join::Miter,
-            4.0,
-            0.1,
+            FontEmbolden::default(),
             &[],
         );
         let key2 = GlyphCacheKey::new(
@@ -373,11 +356,7 @@ mod tests {
             0.3,
             BLACK,
             packed,
-            0.0,
-            0.0,
-            Join::Miter,
-            4.0,
-            0.1,
+            FontEmbolden::default(),
             &[NormalizedCoord::from_bits(100)],
         );
         assert_eq!(key1, key2);

--- a/glifo/src/atlas/key.rs
+++ b/glifo/src/atlas/key.rs
@@ -65,15 +65,15 @@ pub struct GlyphCacheKey {
     /// Pre-packed context color (premultiplied RGBA8 as u32) used in Hash/Eq.
     pub context_color_packed: u32,
     /// Synthetic embolden amount. Only non-zero for outline glyphs.
-    pub embolden_x_bits: u64,
+    pub embolden_x_bits: u32,
     /// Synthetic embolden amount. Only non-zero for outline glyphs.
-    pub embolden_y_bits: u64,
+    pub embolden_y_bits: u32,
     /// Join style for synthetic embolden. Only meaningful for outline glyphs.
     pub embolden_join_bits: u8,
     /// Miter limit for synthetic embolden. Only meaningful for outline glyphs.
-    pub embolden_miter_limit_bits: u64,
+    pub embolden_miter_limit_bits: u32,
     /// Tolerance for synthetic embolden. Only meaningful for outline glyphs.
-    pub embolden_tolerance_bits: u64,
+    pub embolden_tolerance_bits: u32,
     /// Variation coordinates for variable fonts.
     pub var_coords: SmallVec<[NormalizedCoord; 4]>,
 }
@@ -109,11 +109,11 @@ impl GlyphCacheKey {
             subpixel_x: quantize_subpixel(fractional_x),
             context_color,
             context_color_packed,
-            embolden_x_bits: embolden_x.to_bits(),
-            embolden_y_bits: embolden_y.to_bits(),
+            embolden_x_bits: f32_bits(embolden_x),
+            embolden_y_bits: f32_bits(embolden_y),
             embolden_join_bits: join_bits(embolden_join),
-            embolden_miter_limit_bits: embolden_miter_limit.to_bits(),
-            embolden_tolerance_bits: embolden_tolerance.to_bits(),
+            embolden_miter_limit_bits: f32_bits(embolden_miter_limit),
+            embolden_tolerance_bits: f32_bits(embolden_tolerance),
             var_coords: SmallVec::from_slice(var_coords),
         }
     }
@@ -167,6 +167,14 @@ fn join_bits(join: Join) -> u8 {
         Join::Miter => 1,
         Join::Round => 2,
     }
+}
+
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "Cache keys intentionally store embolden parameters at f32 precision."
+)]
+fn f32_bits(value: f64) -> u32 {
+    (value as f32).to_bits()
 }
 
 /// Premultiply and pack an RGBA color into a `u32` for bitwise hashing/comparison.
@@ -301,8 +309,8 @@ mod tests {
             embolden_x_bits: 0,
             embolden_y_bits: 0,
             embolden_join_bits: join_bits(Join::Miter),
-            embolden_miter_limit_bits: 4.0_f64.to_bits(),
-            embolden_tolerance_bits: 0.1_f64.to_bits(),
+            embolden_miter_limit_bits: 4.0_f32.to_bits(),
+            embolden_tolerance_bits: 0.1_f32.to_bits(),
             var_coords: SmallVec::new(),
         };
         let bitmap_key = GlyphCacheKey {
@@ -317,8 +325,8 @@ mod tests {
             embolden_x_bits: 0,
             embolden_y_bits: 0,
             embolden_join_bits: join_bits(Join::Miter),
-            embolden_miter_limit_bits: 4.0_f64.to_bits(),
-            embolden_tolerance_bits: 0.1_f64.to_bits(),
+            embolden_miter_limit_bits: 4.0_f32.to_bits(),
+            embolden_tolerance_bits: 0.1_f32.to_bits(),
             var_coords: SmallVec::new(),
         };
         assert_ne!(outline_key, colr_key);

--- a/glifo/src/atlas/key.rs
+++ b/glifo/src/atlas/key.rs
@@ -9,6 +9,7 @@
 //! equal produce identical bitmaps and can safely share a single atlas entry.
 
 use crate::color::{AlphaColor, Srgb};
+use crate::kurbo::Join;
 use core::hash::{Hash, Hasher};
 #[cfg(not(feature = "std"))]
 use core_maths::CoreFloat as _;
@@ -67,6 +68,12 @@ pub struct GlyphCacheKey {
     pub embolden_x_bits: u64,
     /// Synthetic embolden amount. Only non-zero for outline glyphs.
     pub embolden_y_bits: u64,
+    /// Join style for synthetic embolden. Only meaningful for outline glyphs.
+    pub embolden_join_bits: u8,
+    /// Miter limit for synthetic embolden. Only meaningful for outline glyphs.
+    pub embolden_miter_limit_bits: u64,
+    /// Tolerance for synthetic embolden. Only meaningful for outline glyphs.
+    pub embolden_tolerance_bits: u64,
     /// Variation coordinates for variable fonts.
     pub var_coords: SmallVec<[NormalizedCoord; 4]>,
 }
@@ -88,6 +95,9 @@ impl GlyphCacheKey {
         context_color_packed: u32,
         embolden_x: f64,
         embolden_y: f64,
+        embolden_join: Join,
+        embolden_miter_limit: f64,
+        embolden_tolerance: f64,
         var_coords: &[NormalizedCoord],
     ) -> Self {
         Self {
@@ -101,6 +111,9 @@ impl GlyphCacheKey {
             context_color_packed,
             embolden_x_bits: embolden_x.to_bits(),
             embolden_y_bits: embolden_y.to_bits(),
+            embolden_join_bits: join_bits(embolden_join),
+            embolden_miter_limit_bits: embolden_miter_limit.to_bits(),
+            embolden_tolerance_bits: embolden_tolerance.to_bits(),
             var_coords: SmallVec::from_slice(var_coords),
         }
     }
@@ -122,6 +135,9 @@ impl Hash for GlyphCacheKey {
         self.context_color_packed.hash(state);
         self.embolden_x_bits.hash(state);
         self.embolden_y_bits.hash(state);
+        self.embolden_join_bits.hash(state);
+        self.embolden_miter_limit_bits.hash(state);
+        self.embolden_tolerance_bits.hash(state);
     }
 }
 
@@ -137,10 +153,21 @@ impl PartialEq for GlyphCacheKey {
             && self.context_color_packed == other.context_color_packed
             && self.embolden_x_bits == other.embolden_x_bits
             && self.embolden_y_bits == other.embolden_y_bits
+            && self.embolden_join_bits == other.embolden_join_bits
+            && self.embolden_miter_limit_bits == other.embolden_miter_limit_bits
+            && self.embolden_tolerance_bits == other.embolden_tolerance_bits
     }
 }
 
 impl Eq for GlyphCacheKey {}
+
+fn join_bits(join: Join) -> u8 {
+    match join {
+        Join::Bevel => 0,
+        Join::Miter => 1,
+        Join::Round => 2,
+    }
+}
 
 /// Premultiply and pack an RGBA color into a `u32` for bitwise hashing/comparison.
 #[inline]
@@ -208,16 +235,60 @@ mod tests {
     #[test]
     fn test_key_equality() {
         let packed = pack_color(BLACK);
-        let key1 = GlyphCacheKey::new(1, 0, 42, 16.0, true, 0.3, BLACK, packed, 0.0, 0.0, &[]);
-        let key2 = GlyphCacheKey::new(1, 0, 42, 16.0, true, 0.3, BLACK, packed, 0.0, 0.0, &[]);
+        let key1 = GlyphCacheKey::new(
+            1,
+            0,
+            42,
+            16.0,
+            true,
+            0.3,
+            BLACK,
+            packed,
+            0.0,
+            0.0,
+            Join::Miter,
+            4.0,
+            0.1,
+            &[],
+        );
+        let key2 = GlyphCacheKey::new(
+            1,
+            0,
+            42,
+            16.0,
+            true,
+            0.3,
+            BLACK,
+            packed,
+            0.0,
+            0.0,
+            Join::Miter,
+            4.0,
+            0.1,
+            &[],
+        );
         assert_eq!(key1, key2);
     }
 
     #[test]
     fn test_outline_colr_bitmap_keys_never_collide() {
         let packed = pack_color(BLACK);
-        let outline_key =
-            GlyphCacheKey::new(1, 0, 42, 16.0, false, 0.0, BLACK, packed, 0.0, 0.0, &[]);
+        let outline_key = GlyphCacheKey::new(
+            1,
+            0,
+            42,
+            16.0,
+            false,
+            0.0,
+            BLACK,
+            packed,
+            0.0,
+            0.0,
+            Join::Miter,
+            4.0,
+            0.1,
+            &[],
+        );
         let colr_key = GlyphCacheKey {
             font_id: 1,
             font_index: 0,
@@ -229,6 +300,9 @@ mod tests {
             context_color_packed: packed,
             embolden_x_bits: 0,
             embolden_y_bits: 0,
+            embolden_join_bits: join_bits(Join::Miter),
+            embolden_miter_limit_bits: 4.0_f64.to_bits(),
+            embolden_tolerance_bits: 0.1_f64.to_bits(),
             var_coords: SmallVec::new(),
         };
         let bitmap_key = GlyphCacheKey {
@@ -242,6 +316,9 @@ mod tests {
             context_color_packed: packed,
             embolden_x_bits: 0,
             embolden_y_bits: 0,
+            embolden_join_bits: join_bits(Join::Miter),
+            embolden_miter_limit_bits: 4.0_f64.to_bits(),
+            embolden_tolerance_bits: 0.1_f64.to_bits(),
             var_coords: SmallVec::new(),
         };
         assert_ne!(outline_key, colr_key);
@@ -263,7 +340,22 @@ mod tests {
         let packed = pack_color(BLACK);
         // var_coords is excluded from Hash/Eq (two-level map handles it),
         // so keys differing only in var_coords are considered equal.
-        let key1 = GlyphCacheKey::new(1, 0, 42, 16.0, true, 0.3, BLACK, packed, 0.0, 0.0, &[]);
+        let key1 = GlyphCacheKey::new(
+            1,
+            0,
+            42,
+            16.0,
+            true,
+            0.3,
+            BLACK,
+            packed,
+            0.0,
+            0.0,
+            Join::Miter,
+            4.0,
+            0.1,
+            &[],
+        );
         let key2 = GlyphCacheKey::new(
             1,
             0,
@@ -275,6 +367,9 @@ mod tests {
             packed,
             0.0,
             0.0,
+            Join::Miter,
+            4.0,
+            0.1,
             &[NormalizedCoord::from_bits(100)],
         );
         assert_eq!(key1, key2);

--- a/glifo/src/glyph.rs
+++ b/glifo/src/glyph.rs
@@ -57,6 +57,58 @@ pub struct Glyph {
     pub y: f32,
 }
 
+/// Synthetic embolden settings for a glyph run.
+#[derive(Clone, Copy, Debug)]
+pub struct FontEmbolden {
+    /// Synthetic embolden amount.
+    pub amount: Diagonal2,
+    /// Join style used when expanding outlines.
+    pub join: Join,
+    /// Miter limit used when expanding outlines.
+    pub miter_limit: f64,
+    /// Tolerance used when expanding outlines.
+    pub tolerance: f64,
+}
+
+impl FontEmbolden {
+    /// Create synthetic embolden settings with default expansion controls.
+    pub fn new(amount: Diagonal2) -> Self {
+        Self {
+            amount,
+            ..Self::default()
+        }
+    }
+
+    /// Set the join style used when expanding outlines.
+    pub fn with_join(mut self, join: Join) -> Self {
+        self.join = join;
+        self
+    }
+
+    /// Set the miter limit used when expanding outlines.
+    pub fn with_miter_limit(mut self, miter_limit: f64) -> Self {
+        self.miter_limit = miter_limit;
+        self
+    }
+
+    /// Set the tolerance used when expanding outlines.
+    pub fn with_tolerance(mut self, tolerance: f64) -> Self {
+        self.tolerance = tolerance;
+        self
+    }
+}
+
+impl Default for FontEmbolden {
+    fn default() -> Self {
+        Self {
+            amount: Diagonal2::new(0.0, 0.0),
+            join: Join::Miter,
+            miter_limit: 4.0,
+            tolerance: 0.1,
+        }
+    }
+}
+
 /// Pre-packed `BLACK` color as a `u32` for use in `GlyphCacheKey`.
 const BLACK_PACKED: u32 = PremulRgba8 {
     r: 0,
@@ -298,9 +350,6 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
             draw_props,
             run_size: _,
             font_embolden,
-            font_embolden_join,
-            font_embolden_miter_limit,
-            font_embolden_tolerance,
             normalized_coords,
             hinting_instance,
             ..
@@ -346,11 +395,7 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
                     fractional_x,
                     BLACK,
                     BLACK_PACKED,
-                    font_embolden.xx,
-                    font_embolden.yy,
-                    font_embolden_join,
-                    font_embolden_miter_limit,
-                    font_embolden_tolerance,
+                    font_embolden,
                     normalized_coords,
                 )
             });
@@ -522,9 +567,6 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
                 &mut outline_cache_session,
                 draw_props.font_size,
                 font_embolden,
-                font_embolden_join,
-                font_embolden_miter_limit,
-                font_embolden_tolerance,
                 &outline,
                 hinting_instance,
                 normalized_coords,
@@ -591,9 +633,6 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
         let PreparedGlyphRun {
             draw_props,
             font_embolden,
-            font_embolden_join,
-            font_embolden_miter_limit,
-            font_embolden_tolerance,
             hinting_instance,
             ..
         } = self.prepared_run;
@@ -646,9 +685,6 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
                 self.prepared_run.font.index,
                 draw_props.font_size,
                 font_embolden,
-                font_embolden_join,
-                font_embolden_miter_limit,
-                font_embolden_tolerance,
                 var_key,
                 &outline,
                 hinting_instance,
@@ -738,10 +774,7 @@ impl<'a, B> GlyphRunBuilder<'a, B> {
             run: GlyphRun {
                 font,
                 font_size: 16.0,
-                font_embolden: Diagonal2::new(0.0, 0.0),
-                font_embolden_join: Join::Miter,
-                font_embolden_miter_limit: 4.0,
-                font_embolden_tolerance: 0.1,
+                font_embolden: FontEmbolden::default(),
                 transform,
                 glyph_transform: None,
                 hint: true,
@@ -757,27 +790,9 @@ impl<'a, B> GlyphRunBuilder<'a, B> {
         self
     }
 
-    /// Set the synthetic embolden amount.
-    pub fn font_embolden(mut self, embolden: Diagonal2) -> Self {
+    /// Set synthetic embolden settings.
+    pub fn font_embolden(mut self, embolden: FontEmbolden) -> Self {
         self.run.font_embolden = embolden;
-        self
-    }
-
-    /// Set the join style for synthetic embolden.
-    pub fn font_embolden_join(mut self, join: Join) -> Self {
-        self.run.font_embolden_join = join;
-        self
-    }
-
-    /// Set the miter limit for synthetic embolden.
-    pub fn font_embolden_miter_limit(mut self, miter_limit: f64) -> Self {
-        self.run.font_embolden_miter_limit = miter_limit;
-        self
-    }
-
-    /// Set the tolerance for synthetic embolden.
-    pub fn font_embolden_tolerance(mut self, tolerance: f64) -> Self {
-        self.run.font_embolden_tolerance = tolerance;
         self
     }
 
@@ -994,10 +1009,7 @@ fn create_outline_glyph<'a>(
     font_index: u32,
     outline_cache: &'a mut OutlineCacheSession<'_>,
     size: f32,
-    embolden: Diagonal2,
-    embolden_join: Join,
-    embolden_miter_limit: f64,
-    embolden_tolerance: f64,
+    embolden: FontEmbolden,
     outline_glyph: &skrifa::outline::OutlineGlyph<'a>,
     hinting_instance: Option<&HintingInstance>,
     normalized_coords: &[skrifa::instance::NormalizedCoord],
@@ -1008,9 +1020,6 @@ fn create_outline_glyph<'a>(
         font_index,
         size,
         embolden,
-        embolden_join,
-        embolden_miter_limit,
-        embolden_tolerance,
         VarLookupKey(normalized_coords),
         outline_glyph,
         hinting_instance,
@@ -1299,14 +1308,8 @@ pub struct GlyphRun<'a> {
     font: FontData,
     /// Size of the font in pixels per em.
     font_size: f32,
-    /// Synthetic embolden amount.
-    font_embolden: Diagonal2,
-    /// Join style for synthetic embolden.
-    font_embolden_join: Join,
-    /// Miter limit for synthetic embolden.
-    font_embolden_miter_limit: f64,
-    /// Tolerance for synthetic embolden.
-    font_embolden_tolerance: f64,
+    /// Synthetic embolden settings.
+    font_embolden: FontEmbolden,
     /// Global transform.
     transform: Affine,
     /// Per-glyph transform. Use [`Affine::skew`] with horizontal-skew only to simulate italic
@@ -1329,14 +1332,8 @@ struct PreparedGlyphRun<'a> {
     // (for example handling of underlines).
     /// The original run size supplied by the caller.
     run_size: f32,
-    /// Synthetic embolden amount.
-    font_embolden: Diagonal2,
-    /// Join style for synthetic embolden.
-    font_embolden_join: Join,
-    /// Miter limit for synthetic embolden.
-    font_embolden_miter_limit: f64,
-    /// Tolerance for synthetic embolden.
-    font_embolden_tolerance: f64,
+    /// Synthetic embolden settings.
+    font_embolden: FontEmbolden,
     /// The original per-glyph transform supplied by the caller.
     glyph_transform: Option<Affine>,
     // Continuing the above comment, the problem is that we also need to precalculate data
@@ -1493,9 +1490,6 @@ fn prepare_glyph_run<'a>(run: GlyphRun<'a>, hint_cache: &'a mut HintCache) -> Pr
         font: run.font,
         run_size: run.font_size,
         font_embolden: run.font_embolden,
-        font_embolden_join: run.font_embolden_join,
-        font_embolden_miter_limit: run.font_embolden_miter_limit,
-        font_embolden_tolerance: run.font_embolden_tolerance,
         glyph_transform: run.glyph_transform,
         draw_props: DrawProps {
             positioning_transform: run
@@ -1830,10 +1824,7 @@ impl<'a> OutlineCacheSession<'a> {
         font_id: u64,
         font_index: u32,
         size: f32,
-        embolden: Diagonal2,
-        embolden_join: Join,
-        embolden_miter_limit: f64,
-        embolden_tolerance: f64,
+        embolden: FontEmbolden,
         var_key: VarLookupKey<'_>,
         outline_glyph: &skrifa::outline::OutlineGlyph<'_>,
         hinting_instance: Option<&HintingInstance>,
@@ -1843,11 +1834,11 @@ impl<'a> OutlineCacheSession<'a> {
             font_id,
             font_index,
             size_bits: size.to_bits(),
-            embolden_x_bits: f32_bits(embolden.xx),
-            embolden_y_bits: f32_bits(embolden.yy),
-            embolden_join_bits: join_bits(embolden_join),
-            embolden_miter_limit_bits: f32_bits(embolden_miter_limit),
-            embolden_tolerance_bits: f32_bits(embolden_tolerance),
+            embolden_x_bits: f32_bits(embolden.amount.xx),
+            embolden_y_bits: f32_bits(embolden.amount.yy),
+            embolden_join_bits: join_bits(embolden.join),
+            embolden_miter_limit_bits: f32_bits(embolden.miter_limit),
+            embolden_tolerance_bits: f32_bits(embolden.tolerance),
             hint: hinting_instance.is_some(),
         };
 
@@ -1872,13 +1863,13 @@ impl<'a> OutlineCacheSession<'a> {
 
                 drawing_buf.reuse();
                 outline_glyph.draw(draw_settings, &mut drawing_buf).unwrap();
-                if embolden != Diagonal2::new(0.0, 0.0) {
+                if embolden.amount != Diagonal2::new(0.0, 0.0) {
                     drawing_buf.path = kurbo::expand_path(
                         &drawing_buf.path,
-                        embolden,
-                        embolden_join,
-                        embolden_miter_limit,
-                        embolden_tolerance,
+                        embolden.amount,
+                        embolden.join,
+                        embolden.miter_limit,
+                        embolden.tolerance,
                     );
                     drawing_buf.bbox = drawing_buf.path.bounding_box();
                 }

--- a/glifo/src/glyph.rs
+++ b/glifo/src/glyph.rs
@@ -298,6 +298,9 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
             draw_props,
             run_size: _,
             font_embolden,
+            font_embolden_join,
+            font_embolden_miter_limit,
+            font_embolden_tolerance,
             normalized_coords,
             hinting_instance,
             ..
@@ -345,6 +348,9 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
                     BLACK_PACKED,
                     font_embolden.xx,
                     font_embolden.yy,
+                    font_embolden_join,
+                    font_embolden_miter_limit,
+                    font_embolden_tolerance,
                     normalized_coords,
                 )
             });
@@ -387,6 +393,9 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
                     context_color_packed,
                     embolden_x_bits: 0,
                     embolden_y_bits: 0,
+                    embolden_join_bits: join_bits(Join::Miter),
+                    embolden_miter_limit_bits: 4.0_f64.to_bits(),
+                    embolden_tolerance_bits: 0.1_f64.to_bits(),
                     var_coords: SmallVec::from_slice(normalized_coords),
                 });
 
@@ -468,6 +477,9 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
                     context_color_packed: BLACK_PACKED,
                     embolden_x_bits: 0,
                     embolden_y_bits: 0,
+                    embolden_join_bits: join_bits(Join::Miter),
+                    embolden_miter_limit_bits: 4.0_f64.to_bits(),
+                    embolden_tolerance_bits: 0.1_f64.to_bits(),
                     var_coords: SmallVec::new(),
                 });
 
@@ -510,6 +522,9 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
                 &mut outline_cache_session,
                 draw_props.font_size,
                 font_embolden,
+                font_embolden_join,
+                font_embolden_miter_limit,
+                font_embolden_tolerance,
                 &outline,
                 hinting_instance,
                 normalized_coords,
@@ -576,6 +591,9 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
         let PreparedGlyphRun {
             draw_props,
             font_embolden,
+            font_embolden_join,
+            font_embolden_miter_limit,
+            font_embolden_tolerance,
             hinting_instance,
             ..
         } = self.prepared_run;
@@ -628,6 +646,9 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
                 self.prepared_run.font.index,
                 draw_props.font_size,
                 font_embolden,
+                font_embolden_join,
+                font_embolden_miter_limit,
+                font_embolden_tolerance,
                 var_key,
                 &outline,
                 hinting_instance,
@@ -718,6 +739,9 @@ impl<'a, B> GlyphRunBuilder<'a, B> {
                 font,
                 font_size: 16.0,
                 font_embolden: Diagonal2::new(0.0, 0.0),
+                font_embolden_join: Join::Miter,
+                font_embolden_miter_limit: 4.0,
+                font_embolden_tolerance: 0.1,
                 transform,
                 glyph_transform: None,
                 hint: true,
@@ -736,6 +760,24 @@ impl<'a, B> GlyphRunBuilder<'a, B> {
     /// Set the synthetic embolden amount.
     pub fn font_embolden(mut self, embolden: Diagonal2) -> Self {
         self.run.font_embolden = embolden;
+        self
+    }
+
+    /// Set the join style for synthetic embolden.
+    pub fn font_embolden_join(mut self, join: Join) -> Self {
+        self.run.font_embolden_join = join;
+        self
+    }
+
+    /// Set the miter limit for synthetic embolden.
+    pub fn font_embolden_miter_limit(mut self, miter_limit: f64) -> Self {
+        self.run.font_embolden_miter_limit = miter_limit;
+        self
+    }
+
+    /// Set the tolerance for synthetic embolden.
+    pub fn font_embolden_tolerance(mut self, tolerance: f64) -> Self {
+        self.run.font_embolden_tolerance = tolerance;
         self
     }
 
@@ -953,6 +995,9 @@ fn create_outline_glyph<'a>(
     outline_cache: &'a mut OutlineCacheSession<'_>,
     size: f32,
     embolden: Diagonal2,
+    embolden_join: Join,
+    embolden_miter_limit: f64,
+    embolden_tolerance: f64,
     outline_glyph: &skrifa::outline::OutlineGlyph<'a>,
     hinting_instance: Option<&HintingInstance>,
     normalized_coords: &[skrifa::instance::NormalizedCoord],
@@ -963,6 +1008,9 @@ fn create_outline_glyph<'a>(
         font_index,
         size,
         embolden,
+        embolden_join,
+        embolden_miter_limit,
+        embolden_tolerance,
         VarLookupKey(normalized_coords),
         outline_glyph,
         hinting_instance,
@@ -1253,6 +1301,12 @@ pub struct GlyphRun<'a> {
     font_size: f32,
     /// Synthetic embolden amount.
     font_embolden: Diagonal2,
+    /// Join style for synthetic embolden.
+    font_embolden_join: Join,
+    /// Miter limit for synthetic embolden.
+    font_embolden_miter_limit: f64,
+    /// Tolerance for synthetic embolden.
+    font_embolden_tolerance: f64,
     /// Global transform.
     transform: Affine,
     /// Per-glyph transform. Use [`Affine::skew`] with horizontal-skew only to simulate italic
@@ -1277,6 +1331,12 @@ struct PreparedGlyphRun<'a> {
     run_size: f32,
     /// Synthetic embolden amount.
     font_embolden: Diagonal2,
+    /// Join style for synthetic embolden.
+    font_embolden_join: Join,
+    /// Miter limit for synthetic embolden.
+    font_embolden_miter_limit: f64,
+    /// Tolerance for synthetic embolden.
+    font_embolden_tolerance: f64,
     /// The original per-glyph transform supplied by the caller.
     glyph_transform: Option<Affine>,
     // Continuing the above comment, the problem is that we also need to precalculate data
@@ -1433,6 +1493,9 @@ fn prepare_glyph_run<'a>(run: GlyphRun<'a>, hint_cache: &'a mut HintCache) -> Pr
         font: run.font,
         run_size: run.font_size,
         font_embolden: run.font_embolden,
+        font_embolden_join: run.font_embolden_join,
+        font_embolden_miter_limit: run.font_embolden_miter_limit,
+        font_embolden_tolerance: run.font_embolden_tolerance,
         glyph_transform: run.glyph_transform,
         draw_props: DrawProps {
             positioning_transform: run
@@ -1590,7 +1653,18 @@ struct OutlineKey {
     size_bits: u32,
     embolden_x_bits: u64,
     embolden_y_bits: u64,
+    embolden_join_bits: u8,
+    embolden_miter_limit_bits: u64,
+    embolden_tolerance_bits: u64,
     hint: bool,
+}
+
+fn join_bits(join: Join) -> u8 {
+    match join {
+        Join::Bevel => 0,
+        Join::Miter => 1,
+        Join::Round => 2,
+    }
 }
 
 struct OutlineEntry {
@@ -1749,6 +1823,9 @@ impl<'a> OutlineCacheSession<'a> {
         font_index: u32,
         size: f32,
         embolden: Diagonal2,
+        embolden_join: Join,
+        embolden_miter_limit: f64,
+        embolden_tolerance: f64,
         var_key: VarLookupKey<'_>,
         outline_glyph: &skrifa::outline::OutlineGlyph<'_>,
         hinting_instance: Option<&HintingInstance>,
@@ -1760,6 +1837,9 @@ impl<'a> OutlineCacheSession<'a> {
             size_bits: size.to_bits(),
             embolden_x_bits: embolden.xx.to_bits(),
             embolden_y_bits: embolden.yy.to_bits(),
+            embolden_join_bits: join_bits(embolden_join),
+            embolden_miter_limit_bits: embolden_miter_limit.to_bits(),
+            embolden_tolerance_bits: embolden_tolerance.to_bits(),
             hint: hinting_instance.is_some(),
         };
 
@@ -1785,8 +1865,13 @@ impl<'a> OutlineCacheSession<'a> {
                 drawing_buf.reuse();
                 outline_glyph.draw(draw_settings, &mut drawing_buf).unwrap();
                 if embolden != Diagonal2::new(0.0, 0.0) {
-                    drawing_buf.path =
-                        kurbo::expand_path(&drawing_buf.path, embolden, Join::Miter, 4.0, 0.1);
+                    drawing_buf.path = kurbo::expand_path(
+                        &drawing_buf.path,
+                        embolden,
+                        embolden_join,
+                        embolden_miter_limit,
+                        embolden_tolerance,
+                    );
                     drawing_buf.bbox = drawing_buf.path.bounding_box();
                 }
 

--- a/glifo/src/glyph.rs
+++ b/glifo/src/glyph.rs
@@ -394,8 +394,8 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
                     embolden_x_bits: 0,
                     embolden_y_bits: 0,
                     embolden_join_bits: join_bits(Join::Miter),
-                    embolden_miter_limit_bits: 4.0_f64.to_bits(),
-                    embolden_tolerance_bits: 0.1_f64.to_bits(),
+                    embolden_miter_limit_bits: 4.0_f32.to_bits(),
+                    embolden_tolerance_bits: 0.1_f32.to_bits(),
                     var_coords: SmallVec::from_slice(normalized_coords),
                 });
 
@@ -478,8 +478,8 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
                     embolden_x_bits: 0,
                     embolden_y_bits: 0,
                     embolden_join_bits: join_bits(Join::Miter),
-                    embolden_miter_limit_bits: 4.0_f64.to_bits(),
-                    embolden_tolerance_bits: 0.1_f64.to_bits(),
+                    embolden_miter_limit_bits: 4.0_f32.to_bits(),
+                    embolden_tolerance_bits: 0.1_f32.to_bits(),
                     var_coords: SmallVec::new(),
                 });
 
@@ -1651,11 +1651,11 @@ struct OutlineKey {
     font_index: u32,
     glyph_id: u32,
     size_bits: u32,
-    embolden_x_bits: u64,
-    embolden_y_bits: u64,
+    embolden_x_bits: u32,
+    embolden_y_bits: u32,
     embolden_join_bits: u8,
-    embolden_miter_limit_bits: u64,
-    embolden_tolerance_bits: u64,
+    embolden_miter_limit_bits: u32,
+    embolden_tolerance_bits: u32,
     hint: bool,
 }
 
@@ -1665,6 +1665,14 @@ fn join_bits(join: Join) -> u8 {
         Join::Miter => 1,
         Join::Round => 2,
     }
+}
+
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "Cache keys intentionally store embolden parameters at f32 precision."
+)]
+fn f32_bits(value: f64) -> u32 {
+    (value as f32).to_bits()
 }
 
 struct OutlineEntry {
@@ -1835,11 +1843,11 @@ impl<'a> OutlineCacheSession<'a> {
             font_id,
             font_index,
             size_bits: size.to_bits(),
-            embolden_x_bits: embolden.xx.to_bits(),
-            embolden_y_bits: embolden.yy.to_bits(),
+            embolden_x_bits: f32_bits(embolden.xx),
+            embolden_y_bits: f32_bits(embolden.yy),
             embolden_join_bits: join_bits(embolden_join),
-            embolden_miter_limit_bits: embolden_miter_limit.to_bits(),
-            embolden_tolerance_bits: embolden_tolerance.to_bits(),
+            embolden_miter_limit_bits: f32_bits(embolden_miter_limit),
+            embolden_tolerance_bits: f32_bits(embolden_tolerance),
             hint: hinting_instance.is_some(),
         };
 

--- a/glifo/src/glyph.rs
+++ b/glifo/src/glyph.rs
@@ -20,7 +20,7 @@ use crate::colr::{convert_bounding_box, get_colr_info};
 use crate::kurbo::Point;
 use crate::kurbo::Rect;
 use crate::kurbo::Vec2;
-use crate::kurbo::{Affine, BezPath};
+use crate::kurbo::{self, Affine, BezPath, Diagonal2, Join, Shape};
 use crate::kurbo::{Line, ParamCurve as _, PathSeg};
 use crate::peniko::FontData;
 use crate::renderer::{fill_glyph, render_cached_glyph, stroke_glyph};
@@ -297,6 +297,7 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
         let PreparedGlyphRun {
             draw_props,
             run_size: _,
+            font_embolden,
             normalized_coords,
             hinting_instance,
             ..
@@ -342,6 +343,8 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
                     fractional_x,
                     BLACK,
                     BLACK_PACKED,
+                    font_embolden.xx,
+                    font_embolden.yy,
                     normalized_coords,
                 )
             });
@@ -382,6 +385,8 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
                     subpixel_x: SUBPIXEL_COLR,
                     context_color,
                     context_color_packed,
+                    embolden_x_bits: 0,
+                    embolden_y_bits: 0,
                     var_coords: SmallVec::from_slice(normalized_coords),
                 });
 
@@ -461,6 +466,8 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
                     subpixel_x: SUBPIXEL_BITMAP,
                     context_color: BLACK,
                     context_color_packed: BLACK_PACKED,
+                    embolden_x_bits: 0,
+                    embolden_y_bits: 0,
                     var_coords: SmallVec::new(),
                 });
 
@@ -502,6 +509,7 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
                 font_index,
                 &mut outline_cache_session,
                 draw_props.font_size,
+                font_embolden,
                 &outline,
                 hinting_instance,
                 normalized_coords,
@@ -567,6 +575,7 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
 
         let PreparedGlyphRun {
             draw_props,
+            font_embolden,
             hinting_instance,
             ..
         } = self.prepared_run;
@@ -618,6 +627,7 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
                 self.prepared_run.font.data.id(),
                 self.prepared_run.font.index,
                 draw_props.font_size,
+                font_embolden,
                 var_key,
                 &outline,
                 hinting_instance,
@@ -707,6 +717,7 @@ impl<'a, B> GlyphRunBuilder<'a, B> {
             run: GlyphRun {
                 font,
                 font_size: 16.0,
+                font_embolden: Diagonal2::new(0.0, 0.0),
                 transform,
                 glyph_transform: None,
                 hint: true,
@@ -719,6 +730,12 @@ impl<'a, B> GlyphRunBuilder<'a, B> {
     /// Set the font size in pixels per em.
     pub fn font_size(mut self, size: f32) -> Self {
         self.run.font_size = size;
+        self
+    }
+
+    /// Set the synthetic embolden amount.
+    pub fn font_embolden(mut self, embolden: Diagonal2) -> Self {
+        self.run.font_embolden = embolden;
         self
     }
 
@@ -935,6 +952,7 @@ fn create_outline_glyph<'a>(
     font_index: u32,
     outline_cache: &'a mut OutlineCacheSession<'_>,
     size: f32,
+    embolden: Diagonal2,
     outline_glyph: &skrifa::outline::OutlineGlyph<'a>,
     hinting_instance: Option<&HintingInstance>,
     normalized_coords: &[skrifa::instance::NormalizedCoord],
@@ -944,6 +962,7 @@ fn create_outline_glyph<'a>(
         font_id,
         font_index,
         size,
+        embolden,
         VarLookupKey(normalized_coords),
         outline_glyph,
         hinting_instance,
@@ -1232,6 +1251,8 @@ pub struct GlyphRun<'a> {
     font: FontData,
     /// Size of the font in pixels per em.
     font_size: f32,
+    /// Synthetic embolden amount.
+    font_embolden: Diagonal2,
     /// Global transform.
     transform: Affine,
     /// Per-glyph transform. Use [`Affine::skew`] with horizontal-skew only to simulate italic
@@ -1254,6 +1275,8 @@ struct PreparedGlyphRun<'a> {
     // (for example handling of underlines).
     /// The original run size supplied by the caller.
     run_size: f32,
+    /// Synthetic embolden amount.
+    font_embolden: Diagonal2,
     /// The original per-glyph transform supplied by the caller.
     glyph_transform: Option<Affine>,
     // Continuing the above comment, the problem is that we also need to precalculate data
@@ -1320,6 +1343,7 @@ impl Debug for PreparedGlyphRun<'_> {
         f.debug_struct("PreparedGlyphRun")
             .field("font", &self.font)
             .field("run_size", &self.run_size)
+            .field("font_embolden", &self.font_embolden)
             .field("glyph_transform", &self.glyph_transform)
             .field("transforms", &self.draw_props)
             .field("normalized_coords", &self.normalized_coords)
@@ -1408,6 +1432,7 @@ fn prepare_glyph_run<'a>(run: GlyphRun<'a>, hint_cache: &'a mut HintCache) -> Pr
     PreparedGlyphRun {
         font: run.font,
         run_size: run.font_size,
+        font_embolden: run.font_embolden,
         glyph_transform: run.glyph_transform,
         draw_props: DrawProps {
             positioning_transform: run
@@ -1563,6 +1588,8 @@ struct OutlineKey {
     font_index: u32,
     glyph_id: u32,
     size_bits: u32,
+    embolden_x_bits: u64,
+    embolden_y_bits: u64,
     hint: bool,
 }
 
@@ -1721,6 +1748,7 @@ impl<'a> OutlineCacheSession<'a> {
         font_id: u64,
         font_index: u32,
         size: f32,
+        embolden: Diagonal2,
         var_key: VarLookupKey<'_>,
         outline_glyph: &skrifa::outline::OutlineGlyph<'_>,
         hinting_instance: Option<&HintingInstance>,
@@ -1730,6 +1758,8 @@ impl<'a> OutlineCacheSession<'a> {
             font_id,
             font_index,
             size_bits: size.to_bits(),
+            embolden_x_bits: embolden.xx.to_bits(),
+            embolden_y_bits: embolden.yy.to_bits(),
             hint: hinting_instance.is_some(),
         };
 
@@ -1754,6 +1784,11 @@ impl<'a> OutlineCacheSession<'a> {
 
                 drawing_buf.reuse();
                 outline_glyph.draw(draw_settings, &mut drawing_buf).unwrap();
+                if embolden != Diagonal2::new(0.0, 0.0) {
+                    drawing_buf.path =
+                        kurbo::expand_path(&drawing_buf.path, embolden, Join::Miter, 4.0, 0.1);
+                    drawing_buf.bbox = drawing_buf.path.bounding_box();
+                }
 
                 let bbox = drawing_buf.bbox;
                 let entry = entry.insert(OutlineEntry::new(

--- a/glifo/src/glyph.rs
+++ b/glifo/src/glyph.rs
@@ -1653,6 +1653,7 @@ struct OutlineKey {
     hint: bool,
 }
 
+#[inline(always)]
 fn join_bits(join: Join) -> u8 {
     match join {
         Join::Bevel => 0,
@@ -1665,6 +1666,7 @@ fn join_bits(join: Join) -> u8 {
     clippy::cast_possible_truncation,
     reason = "Cache keys intentionally store embolden parameters at f32 precision."
 )]
+#[inline(always)]
 fn f32_bits(value: f64) -> u32 {
     (value as f32).to_bits()
 }

--- a/glifo/src/lib.rs
+++ b/glifo/src/lib.rs
@@ -50,8 +50,8 @@ pub use atlas::{
     GlyphAtlas, GlyphCacheConfig, GlyphCacheKey, ImageCache, PendingClearRect, RasterMetrics,
 };
 pub use glyph::{
-    AtlasCacher, Glyph, GlyphCaches, GlyphColr, GlyphPrepCache, GlyphPrepCacheMut, GlyphRun,
-    GlyphRunBackend, GlyphRunBuilder, GlyphRunRenderer, HintCache, HintKey, NormalizedCoord,
-    OutlineCache,
+    AtlasCacher, FontEmbolden, Glyph, GlyphCaches, GlyphColr, GlyphPrepCache, GlyphPrepCacheMut,
+    GlyphRun, GlyphRunBackend, GlyphRunBuilder, GlyphRunRenderer, HintCache, HintKey,
+    NormalizedCoord, OutlineCache,
 };
 pub use interface::{DrawSink, GlyphRenderer};

--- a/sparse_strips/vello_sparse_tests/snapshots/glyphs_emboldened.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/glyphs_emboldened.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89f57ab8140371353cc2f4ed1019be299c899f6d0ec82c52204cfa334c31f94c
+size 9629

--- a/sparse_strips/vello_sparse_tests/tests/glyph.rs
+++ b/sparse_strips/vello_sparse_tests/tests/glyph.rs
@@ -7,12 +7,12 @@ use crate::renderer::Renderer;
 #[cfg(target_os = "macos")]
 use crate::util::layout_glyphs_apple_color_emoji;
 use crate::util::{layout_glyphs_noto_cbtf, layout_glyphs_noto_colr, layout_glyphs_roboto};
-use glifo::Glyph;
+use glifo::{FontEmbolden, Glyph};
 use std::f64::consts::FRAC_PI_4;
 use std::iter;
 use std::sync::Arc;
 use vello_common::color::palette::css::{BLACK, BLUE, GREEN, REBECCA_PURPLE};
-use vello_common::kurbo::{Affine, Stroke};
+use vello_common::kurbo::{Affine, Diagonal2, Stroke};
 use vello_common::peniko::{Blob, FontData};
 use vello_dev_macros::vello_test;
 
@@ -123,6 +123,28 @@ fn glyphs_filled_unhinted(ctx: &mut impl Renderer, enable_caching: bool) {
         .font_size(font_size)
         .atlas_cache(enable_caching)
         .hint(false)
+        .fill_glyphs(glyphs.into_iter());
+}
+
+#[vello_test(width = 760, height = 140)]
+fn glyphs_emboldened(ctx: &mut impl Renderer) {
+    let font_size: f32 = 44_f32;
+    let (font, glyphs) = layout_glyphs_roboto("this is regular and emboldened text", font_size);
+
+    ctx.set_transform(Affine::translate((0., f64::from(font_size))));
+    ctx.set_paint(REBECCA_PURPLE.with_alpha(0.5));
+    ctx.glyph_run(&font)
+        .font_size(font_size)
+        .hint(true)
+        .fill_glyphs(glyphs.into_iter());
+
+    let (font, glyphs) = layout_glyphs_roboto("this is regular and emboldened text", font_size);
+
+    ctx.set_transform(Affine::translate((0., f64::from(font_size) + 58.0)));
+    ctx.glyph_run(&font)
+        .font_size(font_size)
+        .font_embolden(FontEmbolden::new(Diagonal2::new(1.0, 1.0)))
+        .hint(true)
         .fill_glyphs(glyphs.into_iter());
 }
 

--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -143,7 +143,7 @@ use peniko::ImageData;
 pub use wgpu;
 
 pub use scene::{DrawGlyphs, Scene};
-pub use vello_encoding::{Glyph, NormalizedCoord};
+pub use vello_encoding::{FontEmbolden, Glyph, NormalizedCoord};
 
 use low_level::ShaderId;
 #[cfg(feature = "wgpu")]

--- a/vello/src/scene.rs
+++ b/vello/src/scene.rs
@@ -8,7 +8,7 @@ use peniko::{
     BlendMode, Blob, Brush, BrushRef, Color, ColorStop, ColorStops, ColorStopsSource, Compose,
     Extend, Fill, FontData, Gradient, ImageBrush, ImageBrushRef, ImageData, StyleRef,
     color::{AlphaColor, DynamicColor, Srgb, palette},
-    kurbo::{Affine, BezPath, Point, Rect, Shape, Stroke, StrokeOpts, Vec2},
+    kurbo::{Affine, BezPath, Diagonal2, Point, Rect, Shape, Stroke, StrokeOpts, Vec2},
 };
 use png::{BitDepth, ColorType, Transformations};
 use skrifa::bitmap::BitmapFormat;
@@ -503,6 +503,7 @@ impl<'a> DrawGlyphs<'a> {
                 transform: Transform::IDENTITY,
                 glyph_transform: None,
                 font_size: 16.0,
+                font_embolden: Diagonal2::new(0.0, 0.0),
                 hint: false,
                 normalized_coords: coords_start..coords_start,
                 style: Fill::NonZero.into(),
@@ -541,6 +542,15 @@ impl<'a> DrawGlyphs<'a> {
     #[must_use]
     pub fn font_size(mut self, size: f32) -> Self {
         self.run.font_size = size;
+        self
+    }
+
+    /// Sets the synthetic embolden amount.
+    ///
+    /// The default value is zero.
+    #[must_use]
+    pub fn font_embolden(mut self, embolden: Diagonal2) -> Self {
+        self.run.font_embolden = embolden;
         self
     }
 

--- a/vello/src/scene.rs
+++ b/vello/src/scene.rs
@@ -8,7 +8,7 @@ use peniko::{
     BlendMode, Blob, Brush, BrushRef, Color, ColorStop, ColorStops, ColorStopsSource, Compose,
     Extend, Fill, FontData, Gradient, ImageBrush, ImageBrushRef, ImageData, StyleRef,
     color::{AlphaColor, DynamicColor, Srgb, palette},
-    kurbo::{Affine, BezPath, Diagonal2, Join, Point, Rect, Shape, Stroke, StrokeOpts, Vec2},
+    kurbo::{Affine, BezPath, Point, Rect, Shape, Stroke, StrokeOpts, Vec2},
 };
 use png::{BitDepth, ColorType, Transformations};
 use skrifa::bitmap::BitmapFormat;
@@ -22,7 +22,9 @@ use skrifa::{
 };
 #[cfg(feature = "bump_estimate")]
 use vello_encoding::BumpAllocatorMemory;
-use vello_encoding::{DrawBeginClip, Encoding, Glyph, GlyphRun, NormalizedCoord, Patch, Transform};
+use vello_encoding::{
+    DrawBeginClip, Encoding, FontEmbolden, Glyph, GlyphRun, NormalizedCoord, Patch, Transform,
+};
 
 // TODO - Document invariants and edge cases (#470)
 // - What happens when we pass a transform matrix with NaN values to the Scene?
@@ -503,10 +505,7 @@ impl<'a> DrawGlyphs<'a> {
                 transform: Transform::IDENTITY,
                 glyph_transform: None,
                 font_size: 16.0,
-                font_embolden: Diagonal2::new(0.0, 0.0),
-                font_embolden_join: Join::Miter,
-                font_embolden_miter_limit: 4.0,
-                font_embolden_tolerance: 0.1,
+                font_embolden: FontEmbolden::default(),
                 hint: false,
                 normalized_coords: coords_start..coords_start,
                 style: Fill::NonZero.into(),
@@ -548,39 +547,10 @@ impl<'a> DrawGlyphs<'a> {
         self
     }
 
-    /// Sets the synthetic embolden amount.
-    ///
-    /// The default value is zero.
+    /// Sets synthetic embolden settings.
     #[must_use]
-    pub fn font_embolden(mut self, embolden: Diagonal2) -> Self {
+    pub fn font_embolden(mut self, embolden: FontEmbolden) -> Self {
         self.run.font_embolden = embolden;
-        self
-    }
-
-    /// Sets the join style for synthetic embolden.
-    ///
-    /// The default value is [`Join::Miter`].
-    #[must_use]
-    pub fn font_embolden_join(mut self, join: Join) -> Self {
-        self.run.font_embolden_join = join;
-        self
-    }
-
-    /// Sets the miter limit for synthetic embolden.
-    ///
-    /// The default value is 4.0.
-    #[must_use]
-    pub fn font_embolden_miter_limit(mut self, miter_limit: f64) -> Self {
-        self.run.font_embolden_miter_limit = miter_limit;
-        self
-    }
-
-    /// Sets the tolerance for synthetic embolden.
-    ///
-    /// The default value is 0.1.
-    #[must_use]
-    pub fn font_embolden_tolerance(mut self, tolerance: f64) -> Self {
-        self.run.font_embolden_tolerance = tolerance;
         self
     }
 

--- a/vello/src/scene.rs
+++ b/vello/src/scene.rs
@@ -8,7 +8,7 @@ use peniko::{
     BlendMode, Blob, Brush, BrushRef, Color, ColorStop, ColorStops, ColorStopsSource, Compose,
     Extend, Fill, FontData, Gradient, ImageBrush, ImageBrushRef, ImageData, StyleRef,
     color::{AlphaColor, DynamicColor, Srgb, palette},
-    kurbo::{Affine, BezPath, Diagonal2, Point, Rect, Shape, Stroke, StrokeOpts, Vec2},
+    kurbo::{Affine, BezPath, Diagonal2, Join, Point, Rect, Shape, Stroke, StrokeOpts, Vec2},
 };
 use png::{BitDepth, ColorType, Transformations};
 use skrifa::bitmap::BitmapFormat;
@@ -504,6 +504,9 @@ impl<'a> DrawGlyphs<'a> {
                 glyph_transform: None,
                 font_size: 16.0,
                 font_embolden: Diagonal2::new(0.0, 0.0),
+                font_embolden_join: Join::Miter,
+                font_embolden_miter_limit: 4.0,
+                font_embolden_tolerance: 0.1,
                 hint: false,
                 normalized_coords: coords_start..coords_start,
                 style: Fill::NonZero.into(),
@@ -551,6 +554,33 @@ impl<'a> DrawGlyphs<'a> {
     #[must_use]
     pub fn font_embolden(mut self, embolden: Diagonal2) -> Self {
         self.run.font_embolden = embolden;
+        self
+    }
+
+    /// Sets the join style for synthetic embolden.
+    ///
+    /// The default value is [`Join::Miter`].
+    #[must_use]
+    pub fn font_embolden_join(mut self, join: Join) -> Self {
+        self.run.font_embolden_join = join;
+        self
+    }
+
+    /// Sets the miter limit for synthetic embolden.
+    ///
+    /// The default value is 4.0.
+    #[must_use]
+    pub fn font_embolden_miter_limit(mut self, miter_limit: f64) -> Self {
+        self.run.font_embolden_miter_limit = miter_limit;
+        self
+    }
+
+    /// Sets the tolerance for synthetic embolden.
+    ///
+    /// The default value is 0.1.
+    #[must_use]
+    pub fn font_embolden_tolerance(mut self, tolerance: f64) -> Self {
+        self.run.font_embolden_tolerance = tolerance;
         self
     }
 

--- a/vello_encoding/src/glyph.rs
+++ b/vello_encoding/src/glyph.rs
@@ -3,7 +3,7 @@
 
 use std::ops::Range;
 
-use peniko::{FontData, Style};
+use peniko::{FontData, Style, kurbo::Diagonal2};
 
 use super::{StreamOffsets, Transform};
 
@@ -29,6 +29,8 @@ pub struct GlyphRun {
     pub glyph_transform: Option<Transform>,
     /// Size of the font in pixels per em.
     pub font_size: f32,
+    /// Synthetic embolden amount.
+    pub font_embolden: Diagonal2,
     /// True if hinting is enabled.
     pub hint: bool,
     /// Range of normalized coordinates in the parent encoding.

--- a/vello_encoding/src/glyph.rs
+++ b/vello_encoding/src/glyph.rs
@@ -21,6 +21,58 @@ pub struct Glyph {
     pub y: f32,
 }
 
+/// Synthetic embolden settings for a glyph run.
+#[derive(Clone, Copy, Debug)]
+pub struct FontEmbolden {
+    /// Synthetic embolden amount.
+    pub amount: Diagonal2,
+    /// Join style used when expanding outlines.
+    pub join: Join,
+    /// Miter limit used when expanding outlines.
+    pub miter_limit: f64,
+    /// Tolerance used when expanding outlines.
+    pub tolerance: f64,
+}
+
+impl FontEmbolden {
+    /// Create synthetic embolden settings with default expansion controls.
+    pub fn new(amount: Diagonal2) -> Self {
+        Self {
+            amount,
+            ..Self::default()
+        }
+    }
+
+    /// Set the join style used when expanding outlines.
+    pub fn with_join(mut self, join: Join) -> Self {
+        self.join = join;
+        self
+    }
+
+    /// Set the miter limit used when expanding outlines.
+    pub fn with_miter_limit(mut self, miter_limit: f64) -> Self {
+        self.miter_limit = miter_limit;
+        self
+    }
+
+    /// Set the tolerance used when expanding outlines.
+    pub fn with_tolerance(mut self, tolerance: f64) -> Self {
+        self.tolerance = tolerance;
+        self
+    }
+}
+
+impl Default for FontEmbolden {
+    fn default() -> Self {
+        Self {
+            amount: Diagonal2::new(0.0, 0.0),
+            join: Join::Miter,
+            miter_limit: 4.0,
+            tolerance: 0.1,
+        }
+    }
+}
+
 /// Properties for a sequence of glyphs in an encoding.
 #[derive(Clone)]
 pub struct GlyphRun {
@@ -32,14 +84,8 @@ pub struct GlyphRun {
     pub glyph_transform: Option<Transform>,
     /// Size of the font in pixels per em.
     pub font_size: f32,
-    /// Synthetic embolden amount.
-    pub font_embolden: Diagonal2,
-    /// Join style for synthetic embolden.
-    pub font_embolden_join: Join,
-    /// Miter limit for synthetic embolden.
-    pub font_embolden_miter_limit: f64,
-    /// Tolerance for synthetic embolden.
-    pub font_embolden_tolerance: f64,
+    /// Synthetic embolden settings.
+    pub font_embolden: FontEmbolden,
     /// True if hinting is enabled.
     pub hint: bool,
     /// Range of normalized coordinates in the parent encoding.

--- a/vello_encoding/src/glyph.rs
+++ b/vello_encoding/src/glyph.rs
@@ -3,7 +3,10 @@
 
 use std::ops::Range;
 
-use peniko::{FontData, Style, kurbo::Diagonal2};
+use peniko::{
+    FontData, Style,
+    kurbo::{Diagonal2, Join},
+};
 
 use super::{StreamOffsets, Transform};
 
@@ -31,6 +34,12 @@ pub struct GlyphRun {
     pub font_size: f32,
     /// Synthetic embolden amount.
     pub font_embolden: Diagonal2,
+    /// Join style for synthetic embolden.
+    pub font_embolden_join: Join,
+    /// Miter limit for synthetic embolden.
+    pub font_embolden_miter_limit: f64,
+    /// Tolerance for synthetic embolden.
+    pub font_embolden_tolerance: f64,
     /// True if hinting is enabled.
     pub hint: bool,
     /// Range of normalized coordinates in the parent encoding.

--- a/vello_encoding/src/glyph_cache.rs
+++ b/vello_encoding/src/glyph_cache.rs
@@ -32,6 +32,9 @@ impl GlyphCache {
         coords: &'a [NormalizedCoord],
         size: f32,
         embolden: Diagonal2,
+        embolden_join: Join,
+        embolden_miter_limit: f64,
+        embolden_tolerance: f64,
         hint: bool,
         style: &'a Style,
     ) -> Option<GlyphCacheSession<'a>> {
@@ -81,6 +84,9 @@ impl GlyphCache {
             size,
             size_bits: size.ppem().unwrap().to_bits(),
             embolden,
+            embolden_join,
+            embolden_miter_limit,
+            embolden_tolerance,
             style,
             style_bits,
             outlines,
@@ -146,6 +152,9 @@ pub(crate) struct GlyphCacheSession<'a> {
     size: Size,
     size_bits: u32,
     embolden: Diagonal2,
+    embolden_join: Join,
+    embolden_miter_limit: f64,
+    embolden_tolerance: f64,
     style: &'a Style,
     style_bits: [u32; 2],
     outlines: OutlineGlyphCollection<'a>,
@@ -166,6 +175,9 @@ impl GlyphCacheSession<'_> {
             font_size_bits: self.size_bits,
             embolden_x_bits: self.embolden.xx.to_bits(),
             embolden_y_bits: self.embolden.yy.to_bits(),
+            embolden_join_bits: join_bits(self.embolden_join),
+            embolden_miter_limit_bits: self.embolden_miter_limit.to_bits(),
+            embolden_tolerance_bits: self.embolden_tolerance.to_bits(),
             style_bits: self.style_bits,
             hint: self.hinter.is_some(),
         };
@@ -201,7 +213,13 @@ impl GlyphCacheSession<'_> {
         let n_path_segments = if self.embolden != Diagonal2::new(0.0, 0.0) {
             let mut path = BezPathOutline(BezPath::new());
             outline.draw(draw_settings, &mut path).ok()?;
-            let path = peniko::kurbo::expand_path(&path.0, self.embolden, Join::Miter, 4.0, 0.1);
+            let path = peniko::kurbo::expand_path(
+                &path.0,
+                self.embolden,
+                self.embolden_join,
+                self.embolden_miter_limit,
+                self.embolden_tolerance,
+            );
             let mut encoder = encoding_ptr.encode_path(is_fill);
             encoder.path_elements(path.elements().iter().copied());
             encoder.finish(false)
@@ -235,8 +253,19 @@ struct GlyphKey {
     font_size_bits: u32,
     embolden_x_bits: u64,
     embolden_y_bits: u64,
+    embolden_join_bits: u8,
+    embolden_miter_limit_bits: u64,
+    embolden_tolerance_bits: u64,
     style_bits: [u32; 2],
     hint: bool,
+}
+
+fn join_bits(join: Join) -> u8 {
+    match join {
+        Join::Bevel => 0,
+        Join::Miter => 1,
+        Join::Round => 2,
+    }
 }
 
 struct BezPathOutline(BezPath);

--- a/vello_encoding/src/glyph_cache.rs
+++ b/vello_encoding/src/glyph_cache.rs
@@ -6,9 +6,12 @@ use std::sync::Arc;
 
 use super::{Encoding, StreamOffsets};
 
-use peniko::{FontData, Style};
+use peniko::{
+    FontData, Style,
+    kurbo::{BezPath, Diagonal2, Join, Point},
+};
 use skrifa::instance::{NormalizedCoord, Size};
-use skrifa::outline::{HintingInstance, HintingOptions, OutlineGlyphFormat};
+use skrifa::outline::{HintingInstance, HintingOptions, OutlineGlyphFormat, OutlinePen};
 use skrifa::{GlyphId, MetadataProvider, OutlineGlyphCollection};
 
 #[derive(Default)]
@@ -28,6 +31,7 @@ impl GlyphCache {
         font: &'a FontData,
         coords: &'a [NormalizedCoord],
         size: f32,
+        embolden: Diagonal2,
         hint: bool,
         style: &'a Style,
     ) -> Option<GlyphCacheSession<'a>> {
@@ -76,6 +80,7 @@ impl GlyphCache {
             coords,
             size,
             size_bits: size.ppem().unwrap().to_bits(),
+            embolden,
             style,
             style_bits,
             outlines,
@@ -140,6 +145,7 @@ pub(crate) struct GlyphCacheSession<'a> {
     coords: &'a [NormalizedCoord],
     size: Size,
     size_bits: u32,
+    embolden: Diagonal2,
     style: &'a Style,
     style_bits: [u32; 2],
     outlines: OutlineGlyphCollection<'a>,
@@ -158,6 +164,8 @@ impl GlyphCacheSession<'_> {
             font_index: self.font_index,
             glyph_id,
             font_size_bits: self.size_bits,
+            embolden_x_bits: self.embolden.xx.to_bits(),
+            embolden_y_bits: self.embolden.yy.to_bits(),
             style_bits: self.style_bits,
             hint: self.hinter.is_some(),
         };
@@ -181,7 +189,6 @@ impl GlyphCacheSession<'_> {
             }
         };
         use skrifa::outline::DrawSettings;
-        let mut path = encoding_ptr.encode_path(is_fill);
         let draw_settings = if key.hint {
             if let Some(hinter) = self.hinter {
                 DrawSettings::hinted(hinter, false)
@@ -191,8 +198,19 @@ impl GlyphCacheSession<'_> {
         } else {
             DrawSettings::unhinted(self.size, self.coords)
         };
-        outline.draw(draw_settings, &mut path).ok()?;
-        if path.finish(false) == 0 {
+        let n_path_segments = if self.embolden != Diagonal2::new(0.0, 0.0) {
+            let mut path = BezPathOutline(BezPath::new());
+            outline.draw(draw_settings, &mut path).ok()?;
+            let path = peniko::kurbo::expand_path(&path.0, self.embolden, Join::Miter, 4.0, 0.1);
+            let mut encoder = encoding_ptr.encode_path(is_fill);
+            encoder.path_elements(path.elements().iter().copied());
+            encoder.finish(false)
+        } else {
+            let mut path = encoding_ptr.encode_path(is_fill);
+            outline.draw(draw_settings, &mut path).ok()?;
+            path.finish(false)
+        };
+        if n_path_segments == 0 {
             encoding_ptr.reset();
         }
         let stream_sizes = encoding_ptr.stream_offsets();
@@ -215,8 +233,41 @@ struct GlyphKey {
     font_index: u32,
     glyph_id: u32,
     font_size_bits: u32,
+    embolden_x_bits: u64,
+    embolden_y_bits: u64,
     style_bits: [u32; 2],
     hint: bool,
+}
+
+struct BezPathOutline(BezPath);
+
+impl OutlinePen for BezPathOutline {
+    fn move_to(&mut self, x: f32, y: f32) {
+        self.0.move_to(Point::new(x.into(), y.into()));
+    }
+
+    fn line_to(&mut self, x: f32, y: f32) {
+        self.0.line_to(Point::new(x.into(), y.into()));
+    }
+
+    fn quad_to(&mut self, cx0: f32, cy0: f32, x: f32, y: f32) {
+        self.0.quad_to(
+            Point::new(cx0.into(), cy0.into()),
+            Point::new(x.into(), y.into()),
+        );
+    }
+
+    fn curve_to(&mut self, cx0: f32, cy0: f32, cx1: f32, cy1: f32, x: f32, y: f32) {
+        self.0.curve_to(
+            Point::new(cx0.into(), cy0.into()),
+            Point::new(cx1.into(), cy1.into()),
+            Point::new(x.into(), y.into()),
+        );
+    }
+
+    fn close(&mut self) {
+        self.0.close_path();
+    }
 }
 
 /// Outer level key for variable font caches.

--- a/vello_encoding/src/glyph_cache.rs
+++ b/vello_encoding/src/glyph_cache.rs
@@ -173,11 +173,11 @@ impl GlyphCacheSession<'_> {
             font_index: self.font_index,
             glyph_id,
             font_size_bits: self.size_bits,
-            embolden_x_bits: self.embolden.xx.to_bits(),
-            embolden_y_bits: self.embolden.yy.to_bits(),
+            embolden_x_bits: f32_bits(self.embolden.xx),
+            embolden_y_bits: f32_bits(self.embolden.yy),
             embolden_join_bits: join_bits(self.embolden_join),
-            embolden_miter_limit_bits: self.embolden_miter_limit.to_bits(),
-            embolden_tolerance_bits: self.embolden_tolerance.to_bits(),
+            embolden_miter_limit_bits: f32_bits(self.embolden_miter_limit),
+            embolden_tolerance_bits: f32_bits(self.embolden_tolerance),
             style_bits: self.style_bits,
             hint: self.hinter.is_some(),
         };
@@ -251,11 +251,11 @@ struct GlyphKey {
     font_index: u32,
     glyph_id: u32,
     font_size_bits: u32,
-    embolden_x_bits: u64,
-    embolden_y_bits: u64,
+    embolden_x_bits: u32,
+    embolden_y_bits: u32,
     embolden_join_bits: u8,
-    embolden_miter_limit_bits: u64,
-    embolden_tolerance_bits: u64,
+    embolden_miter_limit_bits: u32,
+    embolden_tolerance_bits: u32,
     style_bits: [u32; 2],
     hint: bool,
 }
@@ -266,6 +266,14 @@ fn join_bits(join: Join) -> u8 {
         Join::Miter => 1,
         Join::Round => 2,
     }
+}
+
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "Cache keys intentionally store embolden parameters at f32 precision."
+)]
+fn f32_bits(value: f64) -> u32 {
+    (value as f32).to_bits()
 }
 
 struct BezPathOutline(BezPath);

--- a/vello_encoding/src/glyph_cache.rs
+++ b/vello_encoding/src/glyph_cache.rs
@@ -254,6 +254,7 @@ struct GlyphKey {
     hint: bool,
 }
 
+#[inline(always)]
 fn join_bits(join: Join) -> u8 {
     match join {
         Join::Bevel => 0,
@@ -266,6 +267,7 @@ fn join_bits(join: Join) -> u8 {
     clippy::cast_possible_truncation,
     reason = "Cache keys intentionally store embolden parameters at f32 precision."
 )]
+#[inline(always)]
 fn f32_bits(value: f64) -> u32 {
     (value as f32).to_bits()
 }

--- a/vello_encoding/src/glyph_cache.rs
+++ b/vello_encoding/src/glyph_cache.rs
@@ -4,11 +4,11 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use super::{Encoding, StreamOffsets};
+use super::{Encoding, FontEmbolden, StreamOffsets};
 
 use peniko::{
     FontData, Style,
-    kurbo::{BezPath, Diagonal2, Join, Point},
+    kurbo::{BezPath, Join, Point},
 };
 use skrifa::instance::{NormalizedCoord, Size};
 use skrifa::outline::{HintingInstance, HintingOptions, OutlineGlyphFormat, OutlinePen};
@@ -31,10 +31,7 @@ impl GlyphCache {
         font: &'a FontData,
         coords: &'a [NormalizedCoord],
         size: f32,
-        embolden: Diagonal2,
-        embolden_join: Join,
-        embolden_miter_limit: f64,
-        embolden_tolerance: f64,
+        embolden: FontEmbolden,
         hint: bool,
         style: &'a Style,
     ) -> Option<GlyphCacheSession<'a>> {
@@ -84,13 +81,11 @@ impl GlyphCache {
             size,
             size_bits: size.ppem().unwrap().to_bits(),
             embolden,
-            embolden_join,
-            embolden_miter_limit,
-            embolden_tolerance,
             style,
             style_bits,
             outlines,
             hinter,
+            outline_buf: BezPath::new(),
             serial: self.serial,
             cached_count: &mut self.cached_count,
         })
@@ -151,14 +146,12 @@ pub(crate) struct GlyphCacheSession<'a> {
     coords: &'a [NormalizedCoord],
     size: Size,
     size_bits: u32,
-    embolden: Diagonal2,
-    embolden_join: Join,
-    embolden_miter_limit: f64,
-    embolden_tolerance: f64,
+    embolden: FontEmbolden,
     style: &'a Style,
     style_bits: [u32; 2],
     outlines: OutlineGlyphCollection<'a>,
     hinter: Option<&'a HintingInstance>,
+    outline_buf: BezPath,
     serial: u64,
     cached_count: &'a mut usize,
 }
@@ -173,11 +166,11 @@ impl GlyphCacheSession<'_> {
             font_index: self.font_index,
             glyph_id,
             font_size_bits: self.size_bits,
-            embolden_x_bits: f32_bits(self.embolden.xx),
-            embolden_y_bits: f32_bits(self.embolden.yy),
-            embolden_join_bits: join_bits(self.embolden_join),
-            embolden_miter_limit_bits: f32_bits(self.embolden_miter_limit),
-            embolden_tolerance_bits: f32_bits(self.embolden_tolerance),
+            embolden_x_bits: f32_bits(self.embolden.amount.xx),
+            embolden_y_bits: f32_bits(self.embolden.amount.yy),
+            embolden_join_bits: join_bits(self.embolden.join),
+            embolden_miter_limit_bits: f32_bits(self.embolden.miter_limit),
+            embolden_tolerance_bits: f32_bits(self.embolden.tolerance),
             style_bits: self.style_bits,
             hint: self.hinter.is_some(),
         };
@@ -210,15 +203,16 @@ impl GlyphCacheSession<'_> {
         } else {
             DrawSettings::unhinted(self.size, self.coords)
         };
-        let n_path_segments = if self.embolden != Diagonal2::new(0.0, 0.0) {
-            let mut path = BezPathOutline(BezPath::new());
+        let n_path_segments = if self.embolden.amount != peniko::kurbo::Diagonal2::new(0.0, 0.0) {
+            self.outline_buf.truncate(0);
+            let mut path = BezPathOutline(&mut self.outline_buf);
             outline.draw(draw_settings, &mut path).ok()?;
             let path = peniko::kurbo::expand_path(
-                &path.0,
-                self.embolden,
-                self.embolden_join,
-                self.embolden_miter_limit,
-                self.embolden_tolerance,
+                &self.outline_buf,
+                self.embolden.amount,
+                self.embolden.join,
+                self.embolden.miter_limit,
+                self.embolden.tolerance,
             );
             let mut encoder = encoding_ptr.encode_path(is_fill);
             encoder.path_elements(path.elements().iter().copied());
@@ -276,9 +270,9 @@ fn f32_bits(value: f64) -> u32 {
     (value as f32).to_bits()
 }
 
-struct BezPathOutline(BezPath);
+struct BezPathOutline<'a>(&'a mut BezPath);
 
-impl OutlinePen for BezPathOutline {
+impl OutlinePen for BezPathOutline<'_> {
     fn move_to(&mut self, x: f32, y: f32) {
         self.0.move_to(Point::new(x.into(), y.into()));
     }

--- a/vello_encoding/src/lib.rs
+++ b/vello_encoding/src/lib.rs
@@ -57,7 +57,7 @@ pub use draw::{
     DrawImage, DrawLinearGradient, DrawMonoid, DrawRadialGradient, DrawSweepGradient, DrawTag,
 };
 pub use encoding::{Encoding, Resources, StreamOffsets};
-pub use glyph::{Glyph, GlyphRun};
+pub use glyph::{FontEmbolden, Glyph, GlyphRun};
 pub use mask::{make_mask_lut, make_mask_lut_16};
 pub use math::Transform;
 pub use monoid::Monoid;

--- a/vello_encoding/src/resolve.rs
+++ b/vello_encoding/src/resolve.rs
@@ -438,6 +438,7 @@ impl Resolver {
                         &run.font,
                         bytemuck::cast_slice(coords),
                         font_size,
+                        run.font_embolden,
                         hint,
                         &run.style,
                     ) else {

--- a/vello_encoding/src/resolve.rs
+++ b/vello_encoding/src/resolve.rs
@@ -439,6 +439,9 @@ impl Resolver {
                         bytemuck::cast_slice(coords),
                         font_size,
                         run.font_embolden,
+                        run.font_embolden_join,
+                        run.font_embolden_miter_limit,
+                        run.font_embolden_tolerance,
                         hint,
                         &run.style,
                     ) else {

--- a/vello_encoding/src/resolve.rs
+++ b/vello_encoding/src/resolve.rs
@@ -439,9 +439,6 @@ impl Resolver {
                         bytemuck::cast_slice(coords),
                         font_size,
                         run.font_embolden,
-                        run.font_embolden_join,
-                        run.font_embolden_miter_limit,
-                        run.font_embolden_tolerance,
                         hint,
                         &run.style,
                     ) else {


### PR DESCRIPTION
This PR bumps kurbo to latest main although it is currently a patch since peniko depends on the released kurbo 0.13. I can open a PR to peniko if we need to bump kurbo there first. 

This PR adds support for font embolden by getting the value through to the new kurbo `expand_path`. The default embolden value is (0, 0). The chosen miter limit is 4.0 and the tolerance is 0.1. I'm not sure if these are the best values to use or if we should maybe make them configurable but these seem to be reasonable defaults. 

@nicoburns 