### PR TITLE
vello_shaders: Guard inactive clip_leaf lanes

### DIFF
--- a/vello_shaders/shader/clip_leaf.wgsl
+++ b/vello_shaders/shader/clip_leaf.wgsl
@@ -152,10 +152,18 @@ fn main(
     workgroupBarrier();
     // search for predecessor node
     bic = Bic();
-    var link = search_link(&bic, local_id.x);
+    var link = -1;
+    if global_id.x < config.n_clip {
+        link = search_link(&bic, local_id.x);
+    }
     sh_link[local_id.x] = link;
     workgroupBarrier();
-    let grandparent = select(link - 1, sh_link[link], link >= 0);
+    // Use explicit control flow rather than select here, as some backends may
+    // still materialize the indexed operand and expose invalid inactive lanes.
+    var grandparent = link - 1;
+    if link >= 0 {
+        grandparent = sh_link[link];
+    }
     var parent: i32;
     if link >= 0 {
         parent = i32(wg_id.x * WG_SIZE) + link;


### PR DESCRIPTION
This guards inactive `clip_leaf` shader lanes when the dispatch size is rounded up past `config.n_clip`.

`load_clip_path` already returns a sentinel value for lanes where `global_id.x >= config.n_clip`, but those lanes could still participate in the prefix/search logic and reach shared-memory link reads. In particular, `search_link` can produce values derived from inactive lane state, and the previous `select(link - 1, sh_link[link], link >= 0)` form still exposes a potentially invalid `sh_link[link]` expression to the shader compiler.

On Android/Vulkan, this was observed to make scenes involving clip layers fail to render, producing a black frame. A reduced WGPU reproduction showed the same pattern: even when a value is logically guarded, keeping a potentially invalid indexed read inside `select` can still be enough for the shader/backend to misbehave.

This change makes inactive lanes contribute a neutral `Bic`, skips predecessor lookup for them, and replaces the `select` with explicit control flow before reading `sh_link[link]`.

This avoids invalid accesses from inactive lanes while preserving the behavior for active clip entries. With this change applied, the affected Android/Vulkan clipping scene renders correctly again.

Verified locally with:

- `cargo fmt --all --check`
- `cargo check -p vello_shaders`
- `cargo test -p vello_shaders`
