### PR TITLE
vello: mark override image atlas entries dirty

### DIFF
--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -538,10 +538,20 @@ impl Renderer {
         image: &ImageData,
         texture: Option<wgpu::TexelCopyTextureInfoBase<wgpu::Texture>>,
     ) -> Option<wgpu::TexelCopyTextureInfoBase<wgpu::Texture>> {
+        self.resolver.mark_image_dirty(image);
         match texture {
             Some(texture) => self.engine.image_overrides.insert(image.data.id(), texture),
             None => self.engine.image_overrides.remove(&image.data.id()),
         }
+    }
+
+    /// Marks `image` as dirty in the atlas cache, so its override texture will be recopied on
+    /// the next render that uses it.
+    ///
+    /// Call this for any `image` whose existing override texture has changed since the last render.
+    /// Otherwise, stale image data from the atlas may be used.
+    pub fn mark_override_image_dirty(&mut self, image: &ImageData) {
+        self.resolver.mark_image_dirty(image);
     }
 
     /// Register a [`wgpu::Texture`] with Vello, to allow drawing GPU-resident data.
@@ -581,17 +591,15 @@ impl Renderer {
             aspect: wgpu::TextureAspect::All,
         };
 
-        // We overwrite any attempt to use the fake blob, instead reading from the texture
-        self.engine
-            .image_overrides
-            .insert(image.data.id(), texture_base);
+        // We overwrite any attempt to use the fake blob, instead reading from the texture.
+        self.override_image(&image, Some(texture_base));
 
         image
     }
 
     /// Unregister a [`wgpu::Texture`] that was registered with [`register_texture`](Self::register_texture).
     pub fn unregister_texture(&mut self, handle: ImageData) {
-        self.engine.image_overrides.remove(&handle.data.id());
+        self.override_image(&handle, None);
     }
 
     /// Reload the shaders. This should only be used during `vello` development

--- a/vello_encoding/src/image_cache.rs
+++ b/vello_encoding/src/image_cache.rs
@@ -153,6 +153,12 @@ impl ImageCache {
         }
     }
 
+    pub(crate) fn mark_dirty(&mut self, image: &ImageData) {
+        if let Some(resident) = self.map.get_mut(&image.data.id()) {
+            resident.dirty = true;
+        }
+    }
+
     pub(crate) fn can_fit_image(&self, image: &ImageData) -> bool {
         image.width <= self.atlas.size().width as u32
             && image.height <= self.atlas.size().height as u32
@@ -241,6 +247,47 @@ mod tests {
         assert_eq!(first, second);
         assert_eq!(cache.images.len(), 0);
         assert_eq!(cache.map.len(), 1);
+    }
+
+    #[test]
+    fn marked_dirty_resident_entries_are_uploaded_again() {
+        let mut cache = ImageCache::new_with_sizes(32, 64);
+        let image = image(7, 8, 8);
+
+        cache.begin_resolve();
+        let first = cache.get_or_insert(&image).unwrap();
+        cache.finish_resolve();
+
+        cache.mark_dirty(&image);
+        cache.begin_resolve();
+        let second = cache.get_or_insert(&image).unwrap();
+        assert_eq!(first, second);
+        assert_eq!(cache.images.len(), 1);
+        assert_eq!(cache.images[0].0.data.id(), image.data.id());
+        assert_eq!((cache.images[0].1, cache.images[0].2), first);
+        cache.finish_resolve();
+
+        cache.begin_resolve();
+        assert_eq!(cache.get_or_insert(&image), Some(first));
+        assert_eq!(cache.images.len(), 0);
+    }
+
+    #[test]
+    fn marked_dirty_unused_entries_stay_dirty() {
+        let mut cache = ImageCache::new_with_sizes(32, 64);
+        let image = image(7, 8, 8);
+
+        cache.begin_resolve();
+        let xy = cache.get_or_insert(&image).unwrap();
+        cache.finish_resolve();
+
+        cache.mark_dirty(&image);
+        cache.begin_resolve();
+        cache.finish_resolve();
+
+        cache.begin_resolve();
+        assert_eq!(cache.get_or_insert(&image), Some(xy));
+        assert_eq!(cache.images.len(), 1);
     }
 
     #[test]

--- a/vello_encoding/src/resolve.rs
+++ b/vello_encoding/src/resolve.rs
@@ -170,6 +170,14 @@ impl Resolver {
         Self::default()
     }
 
+    /// Marks the atlas entry for `image` as dirty.
+    ///
+    /// If `image` is already resident in the atlas and appears in a later resolve pass,
+    /// that pass will include it in the returned image uploads.
+    pub fn mark_image_dirty(&mut self, image: &ImageData) {
+        self.image_cache.mark_dirty(image);
+    }
+
     /// Resolves late bound resources and packs an encoding. Returns the packed
     /// layout and computed ramp data.
     pub fn resolve<'a>(


### PR DESCRIPTION
Expose an explicit renderer method for callers to refresh atlas entries when an override texture's contents change. Also dirty resident entries when overrides are inserted or removed so switching between CPU image data and override textures refreshes the atlas.