### PR TITLE
vello_hybrid: Let `TextureBindings` own its `TextureView`s

### DIFF
--- a/sparse_strips/vello_hybrid/examples/winit/src/main.rs
+++ b/sparse_strips/vello_hybrid/examples/winit/src/main.rs
@@ -389,12 +389,12 @@ impl ApplicationHandler for App<'_> {
                         .create_command_encoder(&wgpu::CommandEncoderDescriptor {
                             label: Some("Vello Render to Surface pass"),
                         });
-                let spritesheet_view = self.spritesheet_textures[surface.dev_id]
-                    .as_ref()
-                    .map(|t| t.create_view(&wgpu::TextureViewDescriptor::default()));
                 let mut texture_bindings = TextureBindings::new();
-                if let Some(view) = spritesheet_view.as_ref() {
-                    texture_bindings.insert(SPRITESHEET_TEXTURE_ID, view);
+                if let Some(texture) = self.spritesheet_textures[surface.dev_id].as_ref() {
+                    texture_bindings.insert(
+                        SPRITESHEET_TEXTURE_ID,
+                        texture.create_view(&wgpu::TextureViewDescriptor::default()),
+                    );
                 }
                 self.renderers[surface.dev_id]
                     .as_mut()

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -90,12 +90,12 @@ pub struct RenderTargetConfig {
 }
 
 /// Runtime bindings for [externally owned textures](`TextureId`) sampled by texture-rect draws.
-#[derive(Debug, Default)]
-pub struct TextureBindings<'a> {
-    views: HashMap<TextureId, &'a TextureView>,
+#[derive(Debug, Default, Clone)]
+pub struct TextureBindings {
+    views: HashMap<TextureId, TextureView>,
 }
 
-impl<'a> TextureBindings<'a> {
+impl TextureBindings {
     /// Create an empty binding map.
     #[inline]
     pub fn new() -> Self {
@@ -123,22 +123,22 @@ impl<'a> TextureBindings<'a> {
     /// formats are rejected by wgpu at bind time), the underlying texture must include
     /// [`wgpu::TextureUsages::TEXTURE_BINDING`], and only mip level 0 is read.
     #[inline]
-    pub fn insert(&mut self, texture_id: TextureId, view: &'a TextureView) {
+    pub fn insert(&mut self, texture_id: TextureId, view: TextureView) {
         self.views.insert(texture_id, view);
     }
 
     /// Get a texture binding.
     #[inline]
-    fn get(&self, texture_id: TextureId) -> Option<&'a TextureView> {
-        self.views.get(&texture_id).copied()
+    fn get(&self, texture_id: TextureId) -> Option<&TextureView> {
+        self.views.get(&texture_id)
     }
 
     /// Remove a texture binding.
     ///
-    /// Returns whether the binding existed.
+    /// This returns the removed [`TextureView`] binding if it existed.
     #[inline]
-    pub fn remove(&mut self, texture_id: TextureId) -> bool {
-        self.views.remove(&texture_id).is_some()
+    pub fn remove(&mut self, texture_id: TextureId) -> Option<TextureView> {
+        self.views.remove(&texture_id)
     }
 }
 
@@ -301,7 +301,7 @@ impl Renderer {
         encoder: &mut CommandEncoder,
         render_size: &RenderSize,
         view: &TextureView,
-        texture_bindings: &TextureBindings<'_>,
+        texture_bindings: &TextureBindings,
     ) -> Result<(), RenderError> {
         #[cfg(feature = "text")]
         {
@@ -394,7 +394,7 @@ impl Renderer {
         device: &Device,
         queue: &Queue,
         atlas_id: AtlasId,
-        texture_bindings: &TextureBindings<'_>,
+        texture_bindings: &TextureBindings,
     ) -> Result<(), RenderError> {
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
             label: Some("Render to Atlas Encoder"),
@@ -488,7 +488,7 @@ impl Renderer {
         encoded_paints: &[EncodedPaint],
         clear: bool,
         root_output_target: RootRenderTarget,
-        texture_bindings: &TextureBindings<'_>,
+        texture_bindings: &TextureBindings,
     ) -> Result<(), RenderError> {
         self.programs.depth_cleared_this_frame = false;
         self.prepare_gpu_encoded_paints(encoded_paints, image_cache, texture_bindings)?;
@@ -737,7 +737,7 @@ impl Renderer {
         &mut self,
         encoded_paints: &[EncodedPaint],
         image_cache: &ImageCache,
-        texture_bindings: &TextureBindings<'_>,
+        texture_bindings: &TextureBindings,
     ) -> Result<(), RenderError> {
         self.encoded_paints
             .resize_with(encoded_paints.len(), || GPU_PAINT_PLACEHOLDER);
@@ -2600,7 +2600,7 @@ struct RendererContext<'a> {
     image_cache: &'a ImageCache,
     filter_context: &'a FilterContext,
     filter_pass_state: &'a mut FilterPassState,
-    texture_bindings: &'a TextureBindings<'a>,
+    texture_bindings: &'a TextureBindings,
     external_paint_source_bind_groups: HashMap<TextureId, BindGroup>,
 }
 

--- a/sparse_strips/vello_sparse_tests/tests/renderer.rs
+++ b/sparse_strips/vello_sparse_tests/tests/renderer.rs
@@ -557,7 +557,7 @@ impl Renderer for HybridRenderer {
 
         let mut texture_bindings = vello_hybrid::TextureBindings::new();
         for (texture_id, texture) in &self.external_textures {
-            texture_bindings.insert(*texture_id, texture);
+            texture_bindings.insert(*texture_id, texture.clone());
         }
         // Copy texture to buffer
         let mut encoder = self


### PR DESCRIPTION
In https://github.com/linebender/vello/pull/1552 we introduced `TextureBindings` taking `&'a TextureView`, but that requires users to keep the `TextureView` around somewhere other than this binding struct for the duration of the render call, and makes it hard to hold onto `TextureBindings` across frames, which makes the API somewhat awkward to use (thanks Nico for raising this!). These views are relatively cheap to clone with a refcount bump, so we can just store them owned instead.

Alternatively, we could introduce something like

```rust
pub trait TextureBindings {
    fn get(&self, id: TextureId) -> Option<&TextureView>;
}
```

allowing the user to abstract over their own storage, and we could provide a hash map implementation as we have now and perhaps an implementation for `Fn(TextureId) -> Option<&TextureView>`. We'd probably take it as `&dyn TextureBindings` then.

In the meantime, the form in this PR should be an improvement.