### PR TITLE
Add explicit kurbo dependency to glifo and vello_encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,6 +1281,7 @@ dependencies = [
  "core_maths",
  "foldhash 0.2.0",
  "hashbrown 0.17.0",
+ "kurbo 0.13.1",
  "log",
  "peniko 0.6.0",
  "png",
@@ -4045,6 +4046,7 @@ version = "0.8.0"
 dependencies = [
  "bytemuck",
  "guillotiere",
+ "kurbo 0.13.1",
  "peniko 0.6.0",
  "skrifa 0.42.0",
  "smallvec",

--- a/glifo/Cargo.toml
+++ b/glifo/Cargo.toml
@@ -31,6 +31,7 @@ core_maths = { workspace = true, optional = true }
 hashbrown = { workspace = true }
 log = { workspace = true }
 peniko = { workspace = true }
+kurbo = { workspace = true }
 skrifa = { workspace = true }
 smallvec = { workspace = true }
 vello_common = { workspace = true }

--- a/glifo/src/lib.rs
+++ b/glifo/src/lib.rs
@@ -35,7 +35,9 @@ use png as _;
 #[cfg(feature = "std")]
 extern crate std;
 
-use peniko::{self, color, kurbo};
+#[allow(clippy::single_component_path_imports, reason = "false positive")]
+use kurbo;
+use peniko::{self, color};
 use vello_common::pixmap::Pixmap;
 
 pub mod atlas;

--- a/vello_encoding/Cargo.toml
+++ b/vello_encoding/Cargo.toml
@@ -28,5 +28,6 @@ workspace = true
 bytemuck = { workspace = true }
 skrifa = { workspace = true, features = ["std"] }
 peniko = { workspace = true, default-features = true }
+kurbo = { workspace = true, default-features = true }
 guillotiere = { workspace = true, features = ["std"] }
 smallvec = { workspace = true }

--- a/vello_encoding/src/encoding.rs
+++ b/vello_encoding/src/encoding.rs
@@ -262,7 +262,7 @@ impl Encoding {
     /// closed. Returns `true` if a non-zero number of segments were encoded.
     pub fn encode_path_elements(
         &mut self,
-        path: impl Iterator<Item = peniko::kurbo::PathEl>,
+        path: impl Iterator<Item = kurbo::PathEl>,
         is_fill: bool,
     ) -> bool {
         let mut encoder = self.encode_path(is_fill);

--- a/vello_encoding/src/glyph_cache.rs
+++ b/vello_encoding/src/glyph_cache.rs
@@ -203,11 +203,11 @@ impl GlyphCacheSession<'_> {
         } else {
             DrawSettings::unhinted(self.size, self.coords)
         };
-        let n_path_segments = if self.embolden.amount != peniko::kurbo::Diagonal2::new(0.0, 0.0) {
+        let n_path_segments = if self.embolden.amount != kurbo::Diagonal2::new(0.0, 0.0) {
             self.outline_buf.truncate(0);
             let mut path = BezPathOutline(&mut self.outline_buf);
             outline.draw(draw_settings, &mut path).ok()?;
-            let path = peniko::kurbo::expand_path(
+            let path = kurbo::expand_path(
                 &self.outline_buf,
                 self.embolden.amount,
                 self.embolden.join,

--- a/vello_encoding/src/path.rs
+++ b/vello_encoding/src/path.rs
@@ -657,8 +657,8 @@ impl<'a> PathEncoder<'a> {
     }
 
     /// Encodes a path iterator
-    pub fn path_elements(&mut self, path: impl Iterator<Item = peniko::kurbo::PathEl>) {
-        use peniko::kurbo::PathEl;
+    pub fn path_elements(&mut self, path: impl Iterator<Item = kurbo::PathEl>) {
+        use kurbo::PathEl;
         for el in path {
             match el {
                 PathEl::MoveTo(p0) => self.move_to(p0.x as f32, p0.y as f32),


### PR DESCRIPTION
Ensures we are requiring kurbo `0.13.1` which we need for font embolden functionality.

The import chages were required by linebender's linting settings.