### PR TITLE
Prepare for publishing.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ env:
   RUST_MIN_VER: "1.88"
   # List of packages that will be checked with the minimum supported Rust version.
   # This should be limited to packages that are intended for publishing.
-  RUST_MIN_VER_PKGS: "-p vello -p vello_encoding -p vello_shaders -p vello_api -p vello_common -p vello_cpu -p vello_hybrid"
+  RUST_MIN_VER_PKGS: "-p vello -p vello_encoding -p vello_shaders -p vello_api -p vello_common -p vello_cpu -p vello_hybrid -p glifo"
   # List of packages that will be checked for `no_std` builds.
   # This should be limited to packages that are intended for publishing.
-  RUST_NO_STD_PKGS: "-p vello_api -p vello_common -p vello_cpu"
+  RUST_NO_STD_PKGS: "-p vello_api -p vello_common -p vello_cpu -p glifo"
   # List of features that depend on the standard library and will be excluded from no_std checks.
   FEATURES_DEPENDING_ON_STD: "std,default,png,pico_svg,multithreading,probe"
   # List of packages that can not target Wasm.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 # Changelog
 
-The latest published Vello release is [0.8.0](#080---2026-03-20) which was released on 2026-03-20.
-You can find its changes [documented below](#080---2026-03-20).
-
 ## [Unreleased]
+
+This release has an [MSRV][] of 1.88.
+
+## [0.9.0][] - 2026-05-15
 
 This release has an [MSRV][] of 1.88.
 
@@ -439,7 +440,8 @@ This release has an [MSRV][] of 1.75.
 [#1638]: https://github.com/linebender/vello/pull/1638
 [#1643]: https://github.com/linebender/vello/pull/1643
 
-[Unreleased]: https://github.com/linebender/vello/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/linebender/vello/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/linebender/vello/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/linebender/vello/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/linebender/vello/compare/v0.6.0...v0.7.0
 <!-- Note that this still comparing against 0.5.0, because 0.5.1 is a cherry-picked patch -->

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "glifo"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "bytemuck",
  "core_maths",
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "native_webgl"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "console_error_panic_hook",
  "console_log",
@@ -4093,7 +4093,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vello"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bytemuck",
  "futures-intrusive",
@@ -4111,7 +4111,7 @@ dependencies = [
 
 [[package]]
 name = "vello_api"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "bytemuck",
  "peniko",
@@ -4135,7 +4135,7 @@ dependencies = [
 
 [[package]]
 name = "vello_common"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "bytemuck",
  "fearless_simd",
@@ -4152,7 +4152,7 @@ dependencies = [
 
 [[package]]
 name = "vello_cpu"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "bytemuck",
  "crossbeam-channel",
@@ -4187,7 +4187,7 @@ dependencies = [
 
 [[package]]
 name = "vello_encoding"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bytemuck",
  "guillotiere",
@@ -4215,11 +4215,11 @@ dependencies = [
 
 [[package]]
 name = "vello_filters_cpu"
-version = "0.8.0"
+version = "0.9.0"
 
 [[package]]
 name = "vello_hybrid"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "bytemuck",
  "glifo",
@@ -4250,7 +4250,7 @@ dependencies = [
 
 [[package]]
 name = "vello_shaders"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bytemuck",
  "log",
@@ -4261,7 +4261,7 @@ dependencies = [
 
 [[package]]
 name = "vello_sparse_shaders"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "naga",
 ]
@@ -4504,7 +4504,7 @@ dependencies = [
 
 [[package]]
 name = "wasm_cpu"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bytemuck",
  "console_error_panic_hook",
@@ -4867,7 +4867,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu_webgl"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ members = [
 # NOTE: When bumping this, remember to also bump the aforementioned other packages'
 #       version in the dependencies section at the bottom of this file.
 #       Additionally, bump the Vello dependency version in the 'simple' example.
-version = "0.8.0"
+version = "0.9.0"
 
 edition = "2024"
 # Keep in sync with RUST_MIN_VER in .github/workflows/ci.yml, with the relevant README.md files
@@ -96,9 +96,9 @@ clippy.wildcard_dependencies = "warn"
 # END LINEBENDER LINT SET
 
 [workspace.dependencies]
-vello = { version = "0.8.0", path = "vello" }
-vello_encoding = { version = "0.8.0", path = "vello_encoding" }
-vello_shaders = { version = "0.8.0", path = "vello_shaders" }
+vello = { version = "0.9.0", path = "vello" }
+vello_encoding = { version = "0.9.0", path = "vello_encoding" }
+vello_shaders = { version = "0.9.0", path = "vello_shaders" }
 bytemuck = { version = "1.25.0", features = ["derive"] }
 skrifa = { version = "0.42.1", default-features = false, features = ["autohint_shaping"] }
 # The version of kurbo used below should be kept in sync
@@ -123,12 +123,12 @@ ordered-channel = { version = "1.2.0", features = ["crossbeam-channel"] }
 fearless_simd = { version = "0.4.0", default-features = false }
 
 # The below crates are experimental!
-vello_api = { version = "0.0.7", path = "sparse_strips/vello_api", default-features = false }
-vello_common = { version = "0.0.7", path = "sparse_strips/vello_common", default-features = false }
-vello_cpu = { version = "0.0.7", path = "sparse_strips/vello_cpu" }
-vello_hybrid = { version = "0.0.7", path = "sparse_strips/vello_hybrid" }
-vello_sparse_shaders = { version = "0.0.7", path = "sparse_strips/vello_sparse_shaders" }
-glifo = { path = "glifo", default-features = false }
+vello_api = { version = "0.0.8", path = "sparse_strips/vello_api", default-features = false }
+vello_common = { version = "0.0.8", path = "sparse_strips/vello_common", default-features = false }
+vello_cpu = { version = "0.0.8", path = "sparse_strips/vello_cpu" }
+vello_hybrid = { version = "0.0.8", path = "sparse_strips/vello_hybrid" }
+vello_sparse_shaders = { version = "0.0.8", path = "sparse_strips/vello_sparse_shaders" }
+glifo = { version = "0.1.0", path = "glifo", default-features = false }
 vello_example_scenes = { path = "sparse_strips/vello_example_scenes" }
 vello_dev_macros = { path = "sparse_strips/vello_dev_macros" }
 

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 # When using this example outside of the original Vello workspace,
 # remove the path property of the following Vello dependency requirement.
-vello = { version = "0.8.0", path = "../../vello" }
+vello = { version = "0.9.0", path = "../../vello" }
 anyhow = "1.0.102"
 pollster = "0.4.0"
 winit = "0.30.13"

--- a/examples/simple_sdl2/Cargo.toml
+++ b/examples/simple_sdl2/Cargo.toml
@@ -12,6 +12,6 @@ workspace = true
 [dependencies]
 # When using this example outside of the original Vello workspace,
 # remove the path property of the following Vello dependency requirement.
-vello = { version = "0.8.0", path = "../../vello" }
+vello = { version = "0.9.0", path = "../../vello" }
 pollster = "0.4.0"
 sdl2 = { version = "0.37.0", features = ["raw-window-handle", "bundled"] }

--- a/glifo/CHANGELOG.md
+++ b/glifo/CHANGELOG.md
@@ -12,6 +12,10 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 This release has an [MSRV][] of 1.88.
 
+## [0.1.0][] - 2026-05-15
+
+This release has an [MSRV][] of 1.88.
+
 The first release of Glifo!
 
 Glifo moved to the Vello repo in [#1539][] and was prepared for release by [@conor-93][], [@grebmeg][], [@jrmoulton][], [@LaurenzV][], [@nicoburns][], [@oscargus][], [@taj-p][], and [@xStrom][].
@@ -27,6 +31,7 @@ Glifo moved to the Vello repo in [#1539][] and was prepared for release by [@con
 
 [#1539]: https://github.com/linebender/vello/pull/1539
 
-[Unreleased]: https://github.com/linebender/vello/commits/main/glifo
+[Unreleased]: https://github.com/linebender/vello/compare/glifo-v0.1.0...HEAD
+[0.1.0]: https://github.com/linebender/vello/compare/246912ae692cff7719cd95026107cc1aa077f205...glifo-v0.1.0
 
 [MSRV]: README.md#minimum-supported-rust-version-msrv

--- a/glifo/Cargo.toml
+++ b/glifo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glifo"
-version = "0.0.0"
+version = "0.1.0"
 description = "Glifo provides APIs for efficiently rendering text."
 keywords = ["text", "layout"]
 categories = ["gui", "graphics"]
@@ -8,8 +8,6 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-
-publish = false # When enabling, add it to the MSRV package list in CI
 
 [package.metadata.docs.rs]
 all-features = true

--- a/sparse_strips/vello_api/Cargo.toml
+++ b/sparse_strips/vello_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vello_api"
-version = "0.0.7"
+version = "0.0.8"
 description = "Defines the public API types for Vello, providing a stable interface for CPU and Hybrid rendering implementations."
 categories = ["rendering", "graphics"]
 keywords = ["2d", "vector-graphics"]

--- a/sparse_strips/vello_common/CHANGELOG.md
+++ b/sparse_strips/vello_common/CHANGELOG.md
@@ -8,10 +8,11 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 # Changelog
 
-The latest published vello_common release is [0.0.7](#007---2026-03-24) which was released on 2026-03-24.
-You can find its changes [documented below](#007---2026-03-24).
-
 ## [Unreleased]
+
+This release has an [MSRV][] of 1.88.
+
+## [0.0.8][] - 2026-05-15
 
 This release has an [MSRV][] of 1.88.
 
@@ -232,7 +233,8 @@ See also the [vello_cpu 0.0.1](../vello_cpu/CHANGELOG.md#001---2025-05-10) relea
 [#1616]: https://github.com/linebender/vello/pull/1616
 [#1634]: https://github.com/linebender/vello/pull/1634
 
-[Unreleased]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.7...HEAD
+[Unreleased]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.8...HEAD
+[0.0.8]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.7...sparse-strips-v0.0.8
 [0.0.7]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.6...sparse-strips-v0.0.7
 [0.0.6]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.5...sparse-strips-v0.0.6
 [0.0.5]: https://github.com/linebender/vello/compare/sparse-stips-v0.0.4...sparse-strips-v0.0.5

--- a/sparse_strips/vello_common/Cargo.toml
+++ b/sparse_strips/vello_common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vello_common"
 # When updating, also update the version in the workspace dependency in the root Cargo.toml
-version = "0.0.7"
+version = "0.0.8"
 description = "Core data structures and utilities shared across the Vello rendering, including geometry processing and tiling logic."
 categories = ["rendering", "graphics"]
 keywords = ["2d", "vector-graphics"]

--- a/sparse_strips/vello_cpu/CHANGELOG.md
+++ b/sparse_strips/vello_cpu/CHANGELOG.md
@@ -8,10 +8,11 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 # Changelog
 
-The latest published vello_cpu release is [0.0.7](#007---2026-03-24) which was released on 2026-03-24.
-You can find its changes [documented below](#007---2026-03-24).
-
 ## [Unreleased]
+
+This release has an [MSRV][] of 1.88.
+
+## [0.0.8][] - 2026-05-15
 
 This release has an [MSRV][] of 1.88.
 
@@ -191,7 +192,8 @@ See also the [vello_common 0.0.1](../vello_common/CHANGELOG.md#001---2025-05-10)
 [#1616]: https://github.com/linebender/vello/pull/1616
 [#1628]: https://github.com/linebender/vello/pull/1628
 
-[Unreleased]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.7...HEAD
+[Unreleased]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.8...HEAD
+[0.0.8]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.7...sparse-strips-v0.0.8
 [0.0.7]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.6...sparse-strips-v0.0.7
 [0.0.6]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.5...sparse-strips-v0.0.6
 [0.0.5]: https://github.com/linebender/vello/compare/sparse-stips-v0.0.4...sparse-strips-v0.0.5

--- a/sparse_strips/vello_cpu/Cargo.toml
+++ b/sparse_strips/vello_cpu/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vello_cpu"
 # When moving past 0.0.x, also update caveats in the README
-version = "0.0.7"
+version = "0.0.8"
 description = "A CPU-based renderer for Vello, optimized for SIMD and multithreaded execution."
 categories = ["rendering", "graphics"]
 keywords = ["2d", "vector-graphics"]

--- a/sparse_strips/vello_hybrid/CHANGELOG.md
+++ b/sparse_strips/vello_hybrid/CHANGELOG.md
@@ -8,10 +8,11 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 # Changelog
 
-The latest published vello_hybrid release is [0.0.7](#007---2026-03-24) which was released on 2026-03-24.
-You can find its changes [documented below](#007---2026-03-24).
-
 ## [Unreleased]
+
+This release has an [MSRV][] of 1.88.
+
+## [0.0.8][] - 2026-05-15
 
 This release has an [MSRV][] of 1.88.
 
@@ -195,7 +196,8 @@ See also the [vello_cpu 0.0.4](../vello_cpu/CHANGELOG.md#004---2025-10-17) and [
 [#1628]: https://github.com/linebender/vello/pull/1628
 [#1639]: https://github.com/linebender/vello/pull/1639
 
-[Unreleased]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.7...HEAD
+[Unreleased]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.8...HEAD
+[0.0.8]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.7...sparse-strips-v0.0.8
 [0.0.7]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.6...sparse-strips-v0.0.7
 [0.0.6]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.5...sparse-strips-v0.0.6
 [0.0.5]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.4...sparse-strips-v0.0.5

--- a/sparse_strips/vello_hybrid/Cargo.toml
+++ b/sparse_strips/vello_hybrid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vello_hybrid"
-version = "0.0.7"
+version = "0.0.8"
 description = "A hybrid CPU/GPU renderer for Vello, balancing computation between CPU and GPU for efficiency."
 categories = ["rendering", "graphics"]
 keywords = ["2d", "vector-graphics"]

--- a/sparse_strips/vello_sparse_shaders/Cargo.toml
+++ b/sparse_strips/vello_sparse_shaders/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vello_sparse_shaders"
 # When updating, also update the version in the workspace dependency in the root Cargo.toml
-version = "0.0.7"
+version = "0.0.8"
 description = "Provide compilation of wgsl to glsl to support the WebGL `vello_hybrid` backend."
 categories = ["rendering", "graphics"]
 keywords = ["2d", "vector-graphics"]


### PR DESCRIPTION
* Vello 0.9.0
* Sparse Strips 0.0.8
* Glifo 0.1.0

Also removed the triple-date header from changelogs, as it's low value but high friction and we haven't missed it in any of the other changelogs where we've already removed it.