### PR TITLE
vello_cpu: Add u8 fast path for some blend modes

### DIFF
--- a/sparse_strips/vello_cpu/src/fine/lowp/blend.rs
+++ b/sparse_strips/vello_cpu/src/fine/lowp/blend.rs
@@ -7,7 +7,7 @@ use vello_common::fearless_simd::*;
 use vello_common::util::{Div255Ext, f32_to_u8, normalized_mul_u8x32};
 
 pub(crate) fn mix<S: Simd>(src_c: u8x32<S>, bg_c: u8x32<S>, blend_mode: BlendMode) -> u8x32<S> {
-    if let Some(res) = blend_mode.mix(src_c, bg_c) {
+    if let Some(res) = try_u8_mix(blend_mode, src_c, bg_c) {
         return res;
     }
 
@@ -40,37 +40,31 @@ pub(crate) fn mix<S: Simd>(src_c: u8x32<S>, bg_c: u8x32<S>, blend_mode: BlendMod
     to_u8(src_1, src_2)
 }
 
-trait MixExt {
-    fn mix<S: Simd>(&self, src_c: u8x32<S>, bg_c: u8x32<S>) -> Option<u8x32<S>>;
-}
-
-impl MixExt for BlendMode {
-    fn mix<S: Simd>(&self, src_c: u8x32<S>, bg_c: u8x32<S>) -> Option<u8x32<S>> {
-        // We implement the u8 fast path for blend modes that
-        // 1) are separable.
-        // 2) don't have too many divisions, since integer normalization is
-        // relatively expensive.
-        // In the future, it's possible to do further experimentation to see whether
-        // some more blend modes are worth doing in integer space.
-        Some(match self.mix {
-            Mix::Normal => src_c,
-            Mix::Multiply => Multiply::mix(src_c, bg_c),
-            Mix::Screen => Screen::mix(src_c, bg_c),
-            Mix::Overlay => Overlay::mix(src_c, bg_c),
-            Mix::Darken => Darken::mix(src_c, bg_c),
-            Mix::Lighten => Lighten::mix(src_c, bg_c),
-            Mix::HardLight => HardLight::mix(src_c, bg_c),
-            Mix::Difference => Difference::mix(src_c, bg_c),
-            Mix::Exclusion => Exclusion::mix(src_c, bg_c),
-            Mix::ColorDodge
-            | Mix::ColorBurn
-            | Mix::SoftLight
-            | Mix::Luminosity
-            | Mix::Color
-            | Mix::Hue
-            | Mix::Saturation => return None,
-        })
-    }
+fn try_u8_mix<S: Simd>(blend_mode: BlendMode, src_c: u8x32<S>, bg_c: u8x32<S>) -> Option<u8x32<S>> {
+    // We implement the u8 fast path for blend modes that
+    // 1) are separable.
+    // 2) don't have too many divisions, since integer normalization is
+    // relatively expensive.
+    // In the future, it's possible to do further experimentation to see whether
+    // some more blend modes are worth doing in integer space.
+    Some(match blend_mode.mix {
+        Mix::Normal => src_c,
+        Mix::Multiply => Multiply::mix(src_c, bg_c),
+        Mix::Screen => Screen::mix(src_c, bg_c),
+        Mix::Overlay => Overlay::mix(src_c, bg_c),
+        Mix::Darken => Darken::mix(src_c, bg_c),
+        Mix::Lighten => Lighten::mix(src_c, bg_c),
+        Mix::HardLight => HardLight::mix(src_c, bg_c),
+        Mix::Difference => Difference::mix(src_c, bg_c),
+        Mix::Exclusion => Exclusion::mix(src_c, bg_c),
+        Mix::ColorDodge
+        | Mix::ColorBurn
+        | Mix::SoftLight
+        | Mix::Luminosity
+        | Mix::Color
+        | Mix::Hue
+        | Mix::Saturation => return None,
+    })
 }
 
 macro_rules! u8_mix {

--- a/sparse_strips/vello_cpu/src/fine/lowp/blend.rs
+++ b/sparse_strips/vello_cpu/src/fine/lowp/blend.rs
@@ -6,6 +6,7 @@ use crate::peniko::{BlendMode, Mix};
 use vello_common::fearless_simd::*;
 use vello_common::util::{Div255Ext, f32_to_u8, normalized_mul_u8x32};
 
+// TODO: Make sure this vectorizes properly (also the f32 pipeline) by inlining if needed.
 pub(crate) fn mix<S: Simd>(src_c: u8x32<S>, bg_c: u8x32<S>, blend_mode: BlendMode) -> u8x32<S> {
     if let Some(res) = try_u8_mix(blend_mode, src_c, bg_c) {
         return res;

--- a/sparse_strips/vello_cpu/src/fine/lowp/blend.rs
+++ b/sparse_strips/vello_cpu/src/fine/lowp/blend.rs
@@ -1,0 +1,229 @@
+// Copyright 2025 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::fine::{Splat4thExt, highp, u8_to_f32};
+use crate::peniko::{BlendMode, Mix};
+use vello_common::fearless_simd::*;
+use vello_common::util::{Div255Ext, f32_to_u8, normalized_mul_u8x32};
+
+pub(crate) fn mix<S: Simd>(src_c: u8x32<S>, bg_c: u8x32<S>, blend_mode: BlendMode) -> u8x32<S> {
+    if let Some(res) = blend_mode.mix(src_c, bg_c) {
+        return res;
+    }
+
+    // Fallback for blend modes that aren't supported in u8.
+
+    let to_f32 = |val: u8x32<S>| {
+        let (a, b) = src_c.simd.split_u8x32(val);
+        let mut a = u8_to_f32(a);
+        let mut b = u8_to_f32(b);
+        a *= f32x16::splat(src_c.simd, 1.0 / 255.0);
+        b *= f32x16::splat(src_c.simd, 1.0 / 255.0);
+        (a, b)
+    };
+
+    let to_u8 = |val1: f32x16<S>, val2: f32x16<S>| {
+        let val1 =
+            f32_to_u8(f32x16::splat(val1.simd, 255.0).mul_add(val1, f32x16::splat(val1.simd, 0.5)));
+        let val2 =
+            f32_to_u8(f32x16::splat(val2.simd, 255.0).mul_add(val2, f32x16::splat(val2.simd, 0.5)));
+
+        val1.simd.combine_u8x16(val1, val2)
+    };
+
+    let (mut src_1, mut src_2) = to_f32(src_c);
+    let (bg_1, bg_2) = to_f32(bg_c);
+
+    src_1 = highp::blend::mix(src_1, bg_1, blend_mode);
+    src_2 = highp::blend::mix(src_2, bg_2, blend_mode);
+
+    to_u8(src_1, src_2)
+}
+
+trait MixExt {
+    fn mix<S: Simd>(&self, src_c: u8x32<S>, bg_c: u8x32<S>) -> Option<u8x32<S>>;
+}
+
+impl MixExt for BlendMode {
+    fn mix<S: Simd>(&self, src_c: u8x32<S>, bg_c: u8x32<S>) -> Option<u8x32<S>> {
+        // We implement the u8 fast path for blend modes that
+        // 1) are separable.
+        // 2) don't have too many divisions, since integer normalization is
+        // relatively expensive.
+        // In the future, it's possible to do further experimentation to see whether
+        // some more blend modes are worth doing in integer space.
+        Some(match self.mix {
+            Mix::Normal => src_c,
+            Mix::Multiply => Multiply::mix(src_c, bg_c),
+            Mix::Screen => Screen::mix(src_c, bg_c),
+            Mix::Overlay => Overlay::mix(src_c, bg_c),
+            Mix::Darken => Darken::mix(src_c, bg_c),
+            Mix::Lighten => Lighten::mix(src_c, bg_c),
+            Mix::HardLight => HardLight::mix(src_c, bg_c),
+            Mix::Difference => Difference::mix(src_c, bg_c),
+            Mix::Exclusion => Exclusion::mix(src_c, bg_c),
+            Mix::ColorDodge
+            | Mix::ColorBurn
+            | Mix::SoftLight
+            | Mix::Luminosity
+            | Mix::Color
+            | Mix::Hue
+            | Mix::Saturation => return None,
+        })
+    }
+}
+
+macro_rules! u8_mix {
+    ($name:ident, $calc:expr) => {
+        struct $name;
+
+        impl $name {
+            #[inline(always)]
+            fn mix<S: Simd>(src_c: u8x32<S>, bg_c: u8x32<S>) -> u8x32<S> {
+                let simd = src_c.simd;
+                let res = $calc(src_c, bg_c);
+
+                with_src_alpha(simd, res, src_c)
+            }
+        }
+    };
+}
+
+// Formula for blending is (see https://www.w3.org/TR/compositing-1/#generalformula):
+//   Cs' = (1 - Ab) * Cs + Ab * B(Cb, Cs)
+// Since vello_cpu expects premultiplied colors, we need to return:
+//   M = As * Cs'
+//     = As * ((1 - Ab) * Cs + Ab * B(Cb, Cs))
+//     = As * (1 - Ab) * Cs + As * Ab * B(Cb, Cs)
+//     = S * (1 - Ab) + As * Ab * B(Cb, Cs)
+// where S = As * Cs and D = Ab * Cb (so just the premultiplied color).
+
+// Multiply:
+//   B(Cb, Cs) = Cb * Cs
+//   M = S * (1 - Ab) + As * Ab * Cb * Cs
+//     = S * (1 - Ab) + S * D
+u8_mix!(Multiply, |src_c: u8x32<S>, bg_c: u8x32<S>| {
+    let simd = src_c.simd;
+    let one_minus_bg_a = 255 - bg_c.splat_4th();
+    let p1 = normalized_mul_u8x32(src_c, one_minus_bg_a);
+    let p2 = normalized_mul_u8x32(src_c, bg_c);
+
+    simd.narrow_u16x32(p1 + p2)
+});
+
+// Screen:
+//   B(Cb, Cs) = Cb + Cs - Cb * Cs
+//   M = S * (1 - Ab) + As * D + S * Ab - S * D
+//     = S + As * D - S * D
+u8_mix!(Screen, |src_c: u8x32<S>, bg_c: u8x32<S>| {
+    let simd = src_c.simd;
+    let p1 = normalized_mul_u8x32(src_c.splat_4th(), bg_c);
+    let p2 = normalized_mul_u8x32(src_c, bg_c);
+    let res = simd.widen_u8x32(src_c) + p1 - p2;
+
+    simd.narrow_u16x32(res)
+});
+
+// Overlay is hard-light with source and backdrop swapped.
+u8_mix!(Overlay, |src_c: u8x32<S>, bg_c: u8x32<S>| {
+    hard_light_inner(src_c, bg_c, bg_c)
+});
+
+// Darken:
+//   B(Cb, Cs) = min(Cb, Cs)
+//   M = S * (1 - Ab) + min(S * Ab, D * As)
+u8_mix!(Darken, |src_c: u8x32<S>, bg_c: u8x32<S>| {
+    let simd = src_c.simd;
+    let src_a = src_c.splat_4th();
+    let bg_a = bg_c.splat_4th();
+    let p1 = normalized_mul_u8x32(src_c, 255 - bg_a);
+    let p2 = normalized_mul_u8x32(src_c, bg_a).min(normalized_mul_u8x32(bg_c, src_a));
+
+    simd.narrow_u16x32(p1 + p2)
+});
+
+// Lighten:
+//   B(Cb, Cs) = max(Cb, Cs)
+//   M = S * (1 - Ab) + max(S * Ab, D * As)
+u8_mix!(Lighten, |src_c: u8x32<S>, bg_c: u8x32<S>| {
+    let simd = src_c.simd;
+    let src_a = src_c.splat_4th();
+    let bg_a = bg_c.splat_4th();
+    let p1 = normalized_mul_u8x32(src_c, 255 - bg_a);
+    let p2 = normalized_mul_u8x32(src_c, bg_a).max(normalized_mul_u8x32(bg_c, src_a));
+
+    simd.narrow_u16x32(p1 + p2)
+});
+
+// Hard-light:
+//   if Cs <= 0.5: B(Cb, Cs) = 2 * Cb * Cs
+//   otherwise:    B(Cb, Cs) = 1 - 2 * (1 - Cb) * (1 - Cs)
+u8_mix!(HardLight, |src_c: u8x32<S>, bg_c: u8x32<S>| {
+    hard_light_inner(src_c, bg_c, src_c)
+});
+
+// Difference:
+//   B(Cb, Cs) = abs(Cb - Cs)
+//   M = S * (1 - Ab) + abs(S * Ab - D * As)
+u8_mix!(Difference, |src_c: u8x32<S>, bg_c: u8x32<S>| {
+    let simd = src_c.simd;
+    let src_a = src_c.splat_4th();
+    let bg_a = bg_c.splat_4th();
+    let p1 = normalized_mul_u8x32(src_c, 255 - bg_a);
+    let p2 = normalized_mul_u8x32(src_c, bg_a);
+    let p3 = normalized_mul_u8x32(bg_c, src_a);
+    let diff = p2.max(p3) - p2.min(p3);
+
+    simd.narrow_u16x32(p1 + diff)
+});
+
+// Exclusion:
+//   B(Cb, Cs) = Cb + Cs - 2 * Cb * Cs
+//   M = S * (1 - Ab) + As * D + S * Ab - 2 * S * D
+//     = S + As * D - 2 * S * D
+u8_mix!(Exclusion, |src_c: u8x32<S>, bg_c: u8x32<S>| {
+    let simd = src_c.simd;
+    let p1 = normalized_mul_u8x32(src_c.splat_4th(), bg_c);
+    let p2 = normalized_mul_u8x32(src_c, bg_c);
+    let res = simd.widen_u8x32(src_c) + p1;
+    let sub = p2 + p2;
+    let res = simd.select_u16x32(res.simd_ge(sub), res - sub, u16x32::splat(simd, 0));
+
+    simd.narrow_u16x32(res)
+});
+
+#[inline(always)]
+fn hard_light_inner<S: Simd>(src_c: u8x32<S>, bg_c: u8x32<S>, condition: u8x32<S>) -> u8x32<S> {
+    let simd = src_c.simd;
+    let src = simd.widen_u8x32(src_c);
+    let bg = simd.widen_u8x32(bg_c);
+    let src_a = simd.widen_u8x32(src_c.splat_4th());
+    let bg_a = simd.widen_u8x32(bg_c.splat_4th());
+    let condition_a = simd.widen_u8x32(condition.splat_4th());
+    let condition = simd.widen_u8x32(condition);
+
+    let base = src * (255 - bg_a);
+    // Multiply branch: As * Ab * 2 * Cb * Cs = 2 * S * D.
+    let multiply = 2 * src * bg;
+    // Screen branch: As * Ab * (1 - 2 * (1 - Cb) * (1 - Cs))
+    //              = As * Ab - 2 * (As - S) * (Ab - D).
+    let screen = src_a * bg_a - 2 * (src_a - src) * (bg_a - bg);
+    let blended = simd.select_u16x32(
+        // The spec condition is `Cs <= 0.5` but on unpremultiplied color.
+        // Since `Cs = S / As`, we avoid division by multiplying both sides
+        // by alpha: `Cs <= 0.5` => `S <= 0.5 * As` => `2 * S <= As`.
+        (condition + condition).simd_le(condition_a),
+        multiply,
+        screen,
+    );
+    let res = (base + blended).div_255();
+
+    simd.narrow_u16x32(res)
+}
+
+#[inline(always)]
+fn with_src_alpha<S: Simd>(simd: S, rgb: u8x32<S>, src_c: u8x32<S>) -> u8x32<S> {
+    let alpha_mask = u32x8::splat(simd, u32::from_ne_bytes([0, 0, 0, 255])).to_bytes();
+
+    (rgb & !alpha_mask) | (src_c & alpha_mask)
+}

--- a/sparse_strips/vello_cpu/src/fine/lowp/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/lowp/mod.rs
@@ -8,14 +8,15 @@
 //! performance on many architectures compared to floating-point operations, while
 //! maintaining sufficient precision for most rendering tasks.
 
+pub(crate) mod blend;
 mod compose;
 mod gradient;
 mod image;
 
 use crate::filter::filter_lowp;
+use crate::fine::FineKernel;
 use crate::fine::lowp::image::{BilinearImagePainter, PlainBilinearImagePainter};
 use crate::fine::{COLOR_COMPONENTS, Painter, SCRATCH_BUF_SIZE, Splat4thExt};
-use crate::fine::{FineKernel, highp, u8_to_f32};
 use crate::layer_manager::LayerManager;
 use crate::peniko::BlendMode;
 use crate::region::Region;
@@ -32,7 +33,7 @@ use vello_common::mask::Mask;
 use vello_common::paint::{PremulColor, Tint, TintMode};
 use vello_common::pixmap::Pixmap;
 use vello_common::tile::Tile;
-use vello_common::util::{Div255Ext, f32_to_u8};
+use vello_common::util::Div255Ext;
 
 /// The kernel for doing rendering using u8/u16.
 #[derive(Clone, Copy, Debug)]
@@ -350,8 +351,8 @@ mod fill {
     //! using only the source alpha channel for compositing.
 
     use crate::fine::Splat4thExt;
+    use crate::fine::lowp::blend;
     use crate::fine::lowp::compose::ComposeExt;
-    use crate::fine::lowp::mix;
     use crate::peniko::{BlendMode, Mix};
     use vello_common::fearless_simd::*;
     use vello_common::util::normalized_mul_u8x32;
@@ -372,7 +373,7 @@ mod fill {
                     let src_v = if default_mix {
                         next_src
                     } else {
-                        mix(next_src, bg_v, blend_mode)
+                        blend::mix(next_src, bg_v, blend_mode)
                     };
                     let res = blend_mode.compose(simd, src_v, bg_v, None);
                     res.store_slice(next_dest);
@@ -449,7 +450,7 @@ mod alpha_fill {
 
     use crate::fine::Splat4thExt;
     use crate::fine::lowp::compose::ComposeExt;
-    use crate::fine::lowp::{extract_masks, mix};
+    use crate::fine::lowp::{blend, extract_masks};
     use crate::peniko::{BlendMode, Mix};
     use vello_common::fearless_simd::*;
     use vello_common::util::{Div255Ext, normalized_mul_u8x32};
@@ -474,7 +475,7 @@ mod alpha_fill {
                     let src_c = if default_mix {
                         next_src
                     } else {
-                        mix(next_src, bg_v, blend_mode)
+                        blend::mix(next_src, bg_v, blend_mode)
                     };
                     let masks = extract_masks(simd, &next_mask);
                     let res = blend_mode.compose(simd, src_c, bg_v, Some(masks));
@@ -563,38 +564,6 @@ mod alpha_fill {
             },
         );
     }
-}
-
-/// Applies blend mode mixing by converting to f32, mixing, then converting back to u8.
-///
-/// TODO: Add a proper lowp mix pipeline that operates entirely in integer space
-/// for better performance (currently converts through f32 which is slower).
-fn mix<S: Simd>(src_c: u8x32<S>, bg_c: u8x32<S>, blend_mode: BlendMode) -> u8x32<S> {
-    let to_f32 = |val: u8x32<S>| {
-        let (a, b) = src_c.simd.split_u8x32(val);
-        let mut a = u8_to_f32(a);
-        let mut b = u8_to_f32(b);
-        a *= f32x16::splat(src_c.simd, 1.0 / 255.0);
-        b *= f32x16::splat(src_c.simd, 1.0 / 255.0);
-        (a, b)
-    };
-
-    let to_u8 = |val1: f32x16<S>, val2: f32x16<S>| {
-        let val1 =
-            f32_to_u8(f32x16::splat(val1.simd, 255.0).mul_add(val1, f32x16::splat(val1.simd, 0.5)));
-        let val2 =
-            f32_to_u8(f32x16::splat(val2.simd, 255.0).mul_add(val2, f32x16::splat(val2.simd, 0.5)));
-
-        val1.simd.combine_u8x16(val1, val2)
-    };
-
-    let (mut src_1, mut src_2) = to_f32(src_c);
-    let (bg_1, bg_2) = to_f32(bg_c);
-
-    src_1 = highp::blend::mix(src_1, bg_1, blend_mode);
-    src_2 = highp::blend::mix(src_2, bg_2, blend_mode);
-
-    to_u8(src_1, src_2)
 }
 
 /// Expands 8 mask bytes into a 32-byte SIMD vector where each pixel's 4 components


### PR DESCRIPTION
Mostly generated with codex, but I did look at it myself and make some adjustments, so I hope it's good now. Since we do have quite a few tests for blending (both manual ones as well as via COLR), not too concerned about correctness issues here.

Note that this does not address https://github.com/linebender/vello/pull/1579 yet so it's possible this won't have much effect on AVX2. However, on NEON I'm seeing 4x-5x speedups for blending now:

```
fine/blend/normal_u8_neon
                        time:   [40.096 ns 40.297 ns 40.521 ns]
                        change: [-1.1748% +0.8265% +3.1392%] (p = 0.45 > 0.05)
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe

fine/blend/multiply_u8_neon
                        time:   [976.39 ns 978.78 ns 981.34 ns]
                        change: [-80.790% -80.728% -80.664%] (p = 0.00 < 0.05)
                        Performance has improved.

fine/blend/screen_u8_neon
                        time:   [1.0140 µs 1.0167 µs 1.0199 µs]
                        change: [-80.496% -80.407% -80.320%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

fine/blend/overlay_u8_neon
                        time:   [1.3631 µs 1.3667 µs 1.3701 µs]
                        change: [-74.682% -74.592% -74.499%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

fine/blend/darken_u8_neon
                        time:   [1.1359 µs 1.1385 µs 1.1412 µs]
                        change: [-77.273% -77.197% -77.125%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

fine/blend/lighten_u8_neon
                        time:   [1.1535 µs 1.1557 µs 1.1582 µs]
                        change: [-77.013% -76.936% -76.857%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

fine/blend/color_dodge_u8_neon
                        time:   [5.6951 µs 5.7070 µs 5.7195 µs]
                        change: [+1.6232% +1.9789% +2.3529%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

fine/blend/color_burn_u8_neon
                        time:   [5.6208 µs 5.6334 µs 5.6466 µs]
                        change: [+1.5668% +1.9000% +2.2646%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

fine/blend/hard_light_u8_neon
                        time:   [1.3581 µs 1.3602 µs 1.3626 µs]
                        change: [-75.426% -75.345% -75.265%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

fine/blend/soft_light_u8_neon
                        time:   [6.0497 µs 6.0630 µs 6.0768 µs]
                        change: [+1.2844% +1.7849% +2.2700%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

fine/blend/difference_u8_neon
                        time:   [1.2694 µs 1.2720 µs 1.2747 µs]
                        change: [-75.605% -75.514% -75.423%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

fine/blend/exclusion_u8_neon
                        time:   [1.0596 µs 1.0614 µs 1.0634 µs]
                        change: [-80.316% -80.250% -80.184%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

fine/blend/hue_u8_neon  time:   [8.5128 µs 8.5387 µs 8.5659 µs]
                        change: [+1.5041% +1.9534% +2.4143%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild

fine/blend/saturation_u8_neon
                        time:   [8.5693 µs 8.6052 µs 8.6431 µs]
                        change: [+1.7844% +2.2460% +2.6872%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

fine/blend/color_u8_neon
                        time:   [7.5338 µs 7.5591 µs 7.5869 µs]
                        change: [+0.7948% +1.2293% +1.6653%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

fine/blend/luminosity_u8_neon
                        time:   [7.5325 µs 7.5531 µs 7.5772 µs]
                        change: [+0.8659% +1.3864% +1.8684%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
```