### PR TITLE
sparse_strips: Make tile size configurable, Variant 1

### DIFF
--- a/sparse_strips/vello_common/src/tile.rs
+++ b/sparse_strips/vello_common/src/tile.rs
@@ -205,7 +205,7 @@ impl CulledWindings {
 /// the compilation target.
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
-pub struct Tile {
+pub struct Tile<const WIDTH: usize = 4, const HEIGHT: usize = 4> {
     // The field ordering is important.
     //
     // The given ordering (variant over little and big endian compilation targets), ensures that
@@ -246,13 +246,23 @@ pub struct Tile {
     pub y: u16,
 }
 
-impl Tile {
+/// A 4x4 tile.
+pub type SmallTile = Tile<4, 4>;
+/// An 8x8 tile.
+pub type MediumTile = Tile<8, 8>;
+/// A 16x16 tile.
+pub type LargeTile = Tile<16, 16>;
+
+// TODO: Remove once we've made tiling generic over tile size.
+impl Tile<4, 4> {
     /// The width of a tile in pixels.
     pub const WIDTH: u16 = 4;
 
     /// The height of a tile in pixels.
     pub const HEIGHT: u16 = 4;
+}
 
+impl<const WIDTH: usize, const HEIGHT: usize> Tile<WIDTH, HEIGHT> {
     /// A special tile used to signal the end of a tile stream during rendering.
     pub const SENTINEL: Self = Self::new(u16::MAX, u16::MAX, 0, 0);
 
@@ -265,8 +275,8 @@ impl Tile {
         Self::new(
             // Make sure that x and y stay in range when multiplying
             // with the tile width and height during strips generation.
-            x.min(u16::MAX / Self::WIDTH),
-            y.min(u16::MAX / Self::HEIGHT),
+            x.min(u16::MAX / WIDTH as u16),
+            y.min(u16::MAX / HEIGHT as u16),
             line_idx,
             intersection_mask,
         )
@@ -385,28 +395,28 @@ impl Tile {
     }
 }
 
-impl PartialEq for Tile {
+impl<const WIDTH: usize, const HEIGHT: usize> PartialEq for Tile<WIDTH, HEIGHT> {
     #[inline(always)]
     fn eq(&self, other: &Self) -> bool {
         self.to_bits() == other.to_bits()
     }
 }
 
-impl Ord for Tile {
+impl<const WIDTH: usize, const HEIGHT: usize> Ord for Tile<WIDTH, HEIGHT> {
     #[inline(always)]
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         self.to_bits().cmp(&other.to_bits())
     }
 }
 
-impl PartialOrd for Tile {
+impl<const WIDTH: usize, const HEIGHT: usize> PartialOrd for Tile<WIDTH, HEIGHT> {
     #[inline(always)]
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl Eq for Tile {}
+impl<const WIDTH: usize, const HEIGHT: usize> Eq for Tile<WIDTH, HEIGHT> {}
 
 /// Handles the tiling of paths.
 #[derive(Clone, Debug)]

--- a/sparse_strips/vello_cpu/src/fine/highp/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/highp/mod.rs
@@ -13,6 +13,7 @@
 //! - Debugging and reference implementations
 //! - Platforms where SIMD f32 operations are well-optimized
 
+use crate::Tile;
 use crate::filter::filter_highp;
 use crate::fine::FineKernel;
 use crate::fine::{COLOR_COMPONENTS, Painter, Splat4thExt};
@@ -25,7 +26,6 @@ use vello_common::kurbo::Affine;
 use vello_common::mask::Mask;
 use vello_common::paint::{PremulColor, Tint, TintMode};
 use vello_common::pixmap::Pixmap;
-use vello_common::tile::Tile;
 
 pub(crate) mod blend;
 pub(crate) mod compose;

--- a/sparse_strips/vello_cpu/src/fine/lowp/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/lowp/mod.rs
@@ -12,6 +12,7 @@ mod compose;
 mod gradient;
 mod image;
 
+use crate::Tile;
 use crate::filter::filter_lowp;
 use crate::fine::lowp::image::{BilinearImagePainter, PlainBilinearImagePainter};
 use crate::fine::{COLOR_COMPONENTS, Painter, SCRATCH_BUF_SIZE, Splat4thExt};
@@ -31,7 +32,6 @@ use vello_common::kurbo::Affine;
 use vello_common::mask::Mask;
 use vello_common::paint::{PremulColor, Tint, TintMode};
 use vello_common::pixmap::Pixmap;
-use vello_common::tile::Tile;
 use vello_common::util::{Div255Ext, f32_to_u8};
 
 /// The kernel for doing rendering using u8/u16.

--- a/sparse_strips/vello_cpu/src/fine/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/mod.rs
@@ -11,6 +11,7 @@ mod common;
 mod highp;
 mod lowp;
 
+use crate::Tile;
 use crate::fine::common::gradient::linear::SimdLinearKind;
 use crate::fine::common::gradient::radial::SimdRadialKind;
 use crate::fine::common::gradient::sweep::SimdSweepKind;
@@ -39,7 +40,6 @@ use vello_common::mask::Mask;
 use vello_common::paint::{ImageResolver, ImageSource, Paint, PremulColor, Tint};
 use vello_common::pixmap::Pixmap;
 use vello_common::simd::Splat4thExt;
-use vello_common::tile::Tile;
 use vello_common::util::f32_to_u8;
 
 pub use highp::F32Kernel;

--- a/sparse_strips/vello_cpu/src/lib.rs
+++ b/sparse_strips/vello_cpu/src/lib.rs
@@ -134,6 +134,9 @@
 
 extern crate alloc;
 extern crate core;
+
+pub(crate) type Tile = vello_common::tile::SmallTile;
+
 // Unused in release mode because it's only used directly in the `text_debug` module
 // (or transitively in vello_common).
 #[cfg(feature = "png")]

--- a/sparse_strips/vello_cpu/src/region.rs
+++ b/sparse_strips/vello_cpu/src/region.rs
@@ -3,11 +3,11 @@
 
 //! Splitting a single mutable buffer into regions that can be accessed concurrently.
 
+use crate::Tile;
 use crate::fine::COLOR_COMPONENTS;
 use alloc::vec::Vec;
 use vello_common::coarse::WideTile;
 use vello_common::pixmap::Pixmap;
-use vello_common::tile::Tile;
 
 #[derive(Debug)]
 pub struct Regions<'a> {

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -839,15 +839,14 @@ impl ImageResolver for ImageRegistry {
 
 #[cfg(test)]
 mod tests {
-    use crate::RenderContext;
     #[cfg(feature = "text")]
     use crate::peniko::{Blob, FontData};
+    use crate::{RenderContext, Tile};
     #[cfg(feature = "text")]
     use alloc::sync::Arc;
     #[cfg(feature = "text")]
     use glifo::Glyph;
     use vello_common::kurbo::{Rect, Shape};
-    use vello_common::tile::Tile;
 
     #[test]
     fn clip_overflow() {

--- a/sparse_strips/vello_hybrid/src/filter.rs
+++ b/sparse_strips/vello_hybrid/src/filter.rs
@@ -41,8 +41,8 @@ use vello_common::kurbo::{Affine, Vec2};
 use vello_common::paint::{ImageId, ImageSource};
 use vello_common::peniko::{ImageQuality, ImageSampler};
 use vello_common::render_graph::{LayerId, RenderGraph, RenderNodeKind};
-use vello_common::tile::Tile;
 
+use crate::Tile;
 use crate::render::common::IMAGE_PADDING;
 use crate::util::{IntOffset, IntRect, IntSize};
 use vello_common::image_cache::ImageCache;

--- a/sparse_strips/vello_hybrid/src/lib.rs
+++ b/sparse_strips/vello_hybrid/src/lib.rs
@@ -45,6 +45,8 @@
 
 extern crate alloc;
 
+pub(crate) type Tile = vello_common::tile::SmallTile;
+
 pub(crate) mod filter;
 mod gradient_cache;
 mod render;
@@ -100,6 +102,6 @@ pub enum RenderError {
 }
 
 #[cfg(test)]
-const _: () = if vello_common::tile::Tile::HEIGHT != 4 {
+const _: () = if Tile::HEIGHT != 4 {
     panic!("`vello_hybrid` shaders currently require `Tile::HEIGHT` to be `4`");
 };

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -22,7 +22,7 @@ only break in edge cases, and some of them are also only related to conversions 
 
 use crate::render::common::IMAGE_PADDING;
 use crate::{
-    GpuStrip, RenderError, RenderSettings, RenderSize, Resources,
+    GpuStrip, RenderError, RenderSettings, RenderSize, Resources, Tile,
     filter::{FilterContext, FilterInstanceData, FilterPassState, FilterPassTarget},
     gradient_cache::GradientRampCache,
     render::{
@@ -64,7 +64,6 @@ use vello_common::{
     paint::{ImageId, ImageSource},
     peniko::{self},
     pixmap::Pixmap,
-    tile::Tile,
 };
 use vello_sparse_shaders::{clear_slots, filters, render_strips};
 use web_sys::wasm_bindgen::{JsCast, JsValue};

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -20,7 +20,7 @@ only break in edge cases, and some of them are also only related to conversions 
 
 use crate::render::common::IMAGE_PADDING;
 use crate::{
-    GpuStrip, RenderError, RenderSettings, RenderSize, Resources,
+    GpuStrip, RenderError, RenderSettings, RenderSize, Resources, Tile,
     filter::{FilterContext, FilterInstanceData, FilterPassState, FilterPassTarget},
     gradient_cache::GradientRampCache,
     render::{
@@ -60,7 +60,6 @@ use vello_common::{
     paint::ImageSource,
     peniko,
     pixmap::Pixmap,
-    tile::Tile,
 };
 use wgpu::{
     BindGroup, BindGroupLayout, BlendState, Buffer, ColorTargetState, ColorWrites, CommandEncoder,

--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -178,7 +178,7 @@ only break in edge cases, and some of them are also only related to conversions 
 
 use crate::filter::FilterContext;
 use crate::scene::{FastPathRect, FastStripCommand, FastStripsPath, StripPathMode};
-use crate::{GpuStrip, RenderError, Scene};
+use crate::{GpuStrip, RenderError, Scene, Tile};
 use alloc::collections::VecDeque;
 use alloc::vec::Vec;
 use core::ops::Range;
@@ -194,7 +194,6 @@ use vello_common::{
     coarse::{Cmd, WideTile},
     encode::EncodedPaint,
     paint::{ImageSource, Paint},
-    tile::Tile,
 };
 
 // Constants used for bit packing, matching `render_strips.wgsl`


### PR DESCRIPTION
We've on various occasions discussed that we want to experiment with different tile sizes. This is especially relevant for vello_hybrid, but also at least worth trying for vello_cpu.

Before we can do that, the first step is to make tile sizes more configurable. Right now, the width and height of 4 is hardcoded as an associated constant in vello_common. This PR changes it so that they become const generics instead, such that different crates can choose their own sizes. In order to keep the diff small for now, we simply define type aliases in vello_hybrid and vello_cpu that link to the existing 4x4 tile. The main algorithms (tiling, strip rendering) for now also still assume 4x4, changing this will be a follow-up PR.