### PR TITLE
vello_cpu: Support custom atlas size

### DIFF
--- a/glifo/src/atlas/cache.rs
+++ b/glifo/src/atlas/cache.rs
@@ -430,10 +430,10 @@ impl GlyphAtlas {
         self.cache_misses = 0;
     }
 
-    /// Reset the frame counter.
+    /// Resets the frame counter.
     ///
-    /// This is used when `vello_cpu` renders a large amount of text
-    /// and the old image is being grabbed by the new one.
+    /// This is used when `vello_cpu` renders a large amount of text to prevent
+    /// the new image from overwriting stale content from the previous one.
     pub fn clear_tick(&mut self) {
         self.serial = 0;
     }

--- a/glifo/src/atlas/cache.rs
+++ b/glifo/src/atlas/cache.rs
@@ -429,6 +429,13 @@ impl GlyphAtlas {
         self.cache_hits = 0;
         self.cache_misses = 0;
     }
+
+    /// Reset the frame counter.
+    ///
+    /// This is used when `vello_cpu` renders a large amount of text and the old image is being grabbed by the new one.
+    pub fn clear_tick(&mut self) {
+        self.serial = 0;
+    }
 }
 
 /// Queue a clear rect covering the full padded region of an evicted atlas slot.

--- a/glifo/src/atlas/cache.rs
+++ b/glifo/src/atlas/cache.rs
@@ -432,7 +432,8 @@ impl GlyphAtlas {
 
     /// Reset the frame counter.
     ///
-    /// This is used when `vello_cpu` renders a large amount of text and the old image is being grabbed by the new one.
+    /// This is used when `vello_cpu` renders a large amount of text
+    /// and the old image is being grabbed by the new one.
     pub fn clear_tick(&mut self) {
         self.serial = 0;
     }

--- a/glifo/src/atlas/key.rs
+++ b/glifo/src/atlas/key.rs
@@ -178,7 +178,7 @@ pub(crate) fn pack_color(color: AlphaColor<Srgb>) -> u32 {
     color.premultiply().to_rgba8().to_u32()
 }
 
-/// Quantize a fractional pixel offset into one of [`SUBPIXEL_BUCKETS`] buckets.
+/// Quantize a fractional pixel offset into one of `SUBPIXEL_BUCKETS` buckets.
 ///
 /// Values near 1.0 (>= 0.875 with 4 buckets) are clamped to the last bucket
 /// rather than wrapping to 0. Wrapping to bucket 0 without also incrementing the

--- a/glifo/src/atlas/key.rs
+++ b/glifo/src/atlas/key.rs
@@ -189,7 +189,7 @@ pub(crate) fn pack_color(color: AlphaColor<Srgb>) -> u32 {
     reason = "result is clamped to SUBPIXEL_BUCKETS-1 which fits in u8"
 )]
 #[inline]
-pub(crate) fn quantize_subpixel(frac: f32) -> u8 {
+pub fn quantize_subpixel(frac: f32) -> u8 {
     let normalized = frac.fract();
     let normalized = if normalized < 0.0 {
         normalized + 1.0

--- a/glifo/src/atlas/key.rs
+++ b/glifo/src/atlas/key.rs
@@ -116,13 +116,13 @@ impl GlyphCacheKey {
         }
     }
 
-    /// Returns a [`GlyphCacheKey`] for a COLR glyph.
+    /// Converts the cache key to a COLR glyph cache key.
     pub const fn to_colr(mut self) -> Self {
         self.subpixel_x = SUBPIXEL_COLR;
         self
     }
 
-    /// Returns a [`GlyphCacheKey`] for a bitmap glyph.
+    /// Converts the cache key to a bitmap glyph cache key.
     pub const fn to_bitmap(mut self) -> Self {
         self.subpixel_x = SUBPIXEL_BITMAP;
         self

--- a/glifo/src/atlas/key.rs
+++ b/glifo/src/atlas/key.rs
@@ -164,7 +164,7 @@ impl PartialEq for GlyphCacheKey {
 impl Eq for GlyphCacheKey {}
 
 /// Pre-packed `BLACK` color as a `u32` for use in `GlyphCacheKey`.
-const BLACK_PACKED: u32 = PremulRgba8 {
+pub(crate) const BLACK_PACKED: u32 = PremulRgba8 {
     r: 0,
     g: 0,
     b: 0,

--- a/glifo/src/atlas/key.rs
+++ b/glifo/src/atlas/key.rs
@@ -8,9 +8,8 @@
 //! COLR context color, and variable-font coordinates. Two keys that compare
 //! equal produce identical bitmaps and can safely share a single atlas entry.
 
-use crate::color::{AlphaColor, Srgb};
+use crate::color::{AlphaColor, PremulRgba8, Srgb, palette::css::BLACK};
 use crate::glyph::FontEmbolden;
-use crate::kurbo::Join;
 use core::hash::{Hash, Hasher};
 #[cfg(not(feature = "std"))]
 use core_maths::CoreFloat as _;
@@ -65,21 +64,27 @@ pub struct GlyphCacheKey {
     pub context_color: AlphaColor<Srgb>,
     /// Pre-packed context color (premultiplied RGBA8 as u32) used in Hash/Eq.
     pub context_color_packed: u32,
-    /// Synthetic embolden amount. Only non-zero for outline glyphs.
-    pub embolden_x_bits: u32,
-    /// Synthetic embolden amount. Only non-zero for outline glyphs.
-    pub embolden_y_bits: u32,
-    /// Join style for synthetic embolden. Only meaningful for outline glyphs.
-    pub embolden_join_bits: u8,
-    /// Miter limit for synthetic embolden. Only meaningful for outline glyphs.
-    pub embolden_miter_limit_bits: u32,
-    /// Tolerance for synthetic embolden. Only meaningful for outline glyphs.
-    pub embolden_tolerance_bits: u32,
+    /// Synthetic embolden settings for outline glyphs.
+    pub embolden: [u32; 5],
     /// Variation coordinates for variable fonts.
     pub var_coords: SmallVec<[NormalizedCoord; 4]>,
 }
 
 impl GlyphCacheKey {
+    /// A default value of [`GlyphCacheKey`].
+    pub const DEFAULT: Self = Self {
+        font_id: 0,
+        font_index: 0,
+        glyph_id: 0,
+        size_bits: 0,
+        hinted: false,
+        subpixel_x: SUBPIXEL_BUCKETS,
+        context_color: BLACK,
+        context_color_packed: BLACK_PACKED,
+        embolden: FontEmbolden::DEFAULT.to_array(),
+        var_coords: SmallVec::new_const(),
+    };
+
     /// Creates a new cache key.
     ///
     /// `fractional_x` (the fractional pixel offset) is quantized into
@@ -106,13 +111,21 @@ impl GlyphCacheKey {
             subpixel_x: quantize_subpixel(fractional_x),
             context_color,
             context_color_packed,
-            embolden_x_bits: f32_bits(embolden.amount.xx),
-            embolden_y_bits: f32_bits(embolden.amount.yy),
-            embolden_join_bits: join_bits(embolden.join),
-            embolden_miter_limit_bits: f32_bits(embolden.miter_limit),
-            embolden_tolerance_bits: f32_bits(embolden.tolerance),
+            embolden: embolden.to_array(),
             var_coords: SmallVec::from_slice(var_coords),
         }
+    }
+
+    /// Returns a [`GlyphCacheKey`] for a COLR glyph.
+    pub const fn to_colr(mut self) -> Self {
+        self.subpixel_x = SUBPIXEL_COLR;
+        self
+    }
+
+    /// Returns a [`GlyphCacheKey`] for a bitmap glyph.
+    pub const fn to_bitmap(mut self) -> Self {
+        self.subpixel_x = SUBPIXEL_BITMAP;
+        self
     }
 }
 
@@ -130,11 +143,7 @@ impl Hash for GlyphCacheKey {
         self.hinted.hash(state);
         self.subpixel_x.hash(state);
         self.context_color_packed.hash(state);
-        self.embolden_x_bits.hash(state);
-        self.embolden_y_bits.hash(state);
-        self.embolden_join_bits.hash(state);
-        self.embolden_miter_limit_bits.hash(state);
-        self.embolden_tolerance_bits.hash(state);
+        self.embolden.hash(state);
     }
 }
 
@@ -148,33 +157,20 @@ impl PartialEq for GlyphCacheKey {
             && self.size_bits == other.size_bits
             && self.hinted == other.hinted
             && self.context_color_packed == other.context_color_packed
-            && self.embolden_x_bits == other.embolden_x_bits
-            && self.embolden_y_bits == other.embolden_y_bits
-            && self.embolden_join_bits == other.embolden_join_bits
-            && self.embolden_miter_limit_bits == other.embolden_miter_limit_bits
-            && self.embolden_tolerance_bits == other.embolden_tolerance_bits
+            && self.embolden == other.embolden
     }
 }
 
 impl Eq for GlyphCacheKey {}
 
-#[inline(always)]
-fn join_bits(join: Join) -> u8 {
-    match join {
-        Join::Bevel => 0,
-        Join::Miter => 1,
-        Join::Round => 2,
-    }
+/// Pre-packed `BLACK` color as a `u32` for use in `GlyphCacheKey`.
+const BLACK_PACKED: u32 = PremulRgba8 {
+    r: 0,
+    g: 0,
+    b: 0,
+    a: 255,
 }
-
-#[expect(
-    clippy::cast_possible_truncation,
-    reason = "Cache keys intentionally store embolden parameters at f32 precision."
-)]
-#[inline(always)]
-fn f32_bits(value: f64) -> u32 {
-    (value as f32).to_bits()
-}
+.to_u32();
 
 /// Premultiply and pack an RGBA color into a `u32` for bitwise hashing/comparison.
 #[inline]
@@ -193,7 +189,7 @@ pub(crate) fn pack_color(color: AlphaColor<Srgb>) -> u32 {
     reason = "result is clamped to SUBPIXEL_BUCKETS-1 which fits in u8"
 )]
 #[inline]
-fn quantize_subpixel(frac: f32) -> u8 {
+pub(crate) fn quantize_subpixel(frac: f32) -> u8 {
     let normalized = frac.fract();
     let normalized = if normalized < 0.0 {
         normalized + 1.0
@@ -293,11 +289,7 @@ mod tests {
             subpixel_x: SUBPIXEL_COLR,
             context_color: BLACK,
             context_color_packed: packed,
-            embolden_x_bits: 0,
-            embolden_y_bits: 0,
-            embolden_join_bits: join_bits(Join::Miter),
-            embolden_miter_limit_bits: 4.0_f32.to_bits(),
-            embolden_tolerance_bits: 0.1_f32.to_bits(),
+            embolden: FontEmbolden::DEFAULT.to_array(),
             var_coords: SmallVec::new(),
         };
         let bitmap_key = GlyphCacheKey {
@@ -309,11 +301,7 @@ mod tests {
             subpixel_x: SUBPIXEL_BITMAP,
             context_color: BLACK,
             context_color_packed: packed,
-            embolden_x_bits: 0,
-            embolden_y_bits: 0,
-            embolden_join_bits: join_bits(Join::Miter),
-            embolden_miter_limit_bits: 4.0_f32.to_bits(),
-            embolden_tolerance_bits: 0.1_f32.to_bits(),
+            embolden: FontEmbolden::DEFAULT.to_array(),
             var_coords: SmallVec::new(),
         };
         assert_ne!(outline_key, colr_key);

--- a/glifo/src/glyph.rs
+++ b/glifo/src/glyph.rs
@@ -380,6 +380,8 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
             ..
         } = self.prepared_run;
 
+        let font_id = font_info.id;
+        let font_index = font_info.index;
         let hinted = hinting_instance.is_some();
 
         let colr_bitmap_cache_enabled = self
@@ -400,13 +402,6 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
         let scale_props =
             GlyphScaleProperties::new(draw_props.font_size, font_info.upem, hinted, style);
 
-        // A temporary glyph cache key.
-        let temp_glyph_cache_key = GlyphCacheKey {
-            font_id: font_info.id,
-            font_index: font_info.index,
-            ..GlyphCacheKey::DEFAULT
-        };
-
         for glyph in self.glyph_iterator.clone() {
             // TODO: Add a mechanism such that glyphs that are completely outside of the viewport
             // (especially for more expensive COLR glyphs), we don't do any processing in the
@@ -415,8 +410,10 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
 
             // A temporary glyph cache key.
             let temp_glyph_cache_key = GlyphCacheKey {
+                font_id,
+                font_index,
                 glyph_id: glyph.id,
-                ..temp_glyph_cache_key.clone()
+                ..GlyphCacheKey::DEFAULT
             };
 
             // ── Speculative outline cache check ─────────────────────────

--- a/glifo/src/glyph.rs
+++ b/glifo/src/glyph.rs
@@ -400,6 +400,13 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
         let scale_props =
             GlyphScaleProperties::new(draw_props.font_size, font_info.upem, hinted, style);
 
+        // A temporary glyph cache key.
+        let temp_glyph_cache_key = GlyphCacheKey {
+            font_id: font_info.id,
+            font_index: font_info.index,
+            ..GlyphCacheKey::DEFAULT
+        };
+
         for glyph in self.glyph_iterator.clone() {
             // TODO: Add a mechanism such that glyphs that are completely outside of the viewport
             // (especially for more expensive COLR glyphs), we don't do any processing in the
@@ -408,10 +415,8 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
 
             // A temporary glyph cache key.
             let temp_glyph_cache_key = GlyphCacheKey {
-                font_id: font_info.id,
-                font_index: font_info.index,
                 glyph_id: glyph.id,
-                ..GlyphCacheKey::DEFAULT
+                ..temp_glyph_cache_key.clone()
             };
 
             // ── Speculative outline cache check ─────────────────────────

--- a/glifo/src/glyph.rs
+++ b/glifo/src/glyph.rs
@@ -12,10 +12,8 @@ only break in edge cases, and some of them are also only related to conversions 
 use crate::Pixmap;
 use crate::atlas::AtlasSlot;
 use crate::atlas::GlyphCacheKey;
-use crate::atlas::key::{SUBPIXEL_BITMAP, SUBPIXEL_COLR, pack_color};
+use crate::atlas::key::{pack_color, quantize_subpixel};
 use crate::atlas::{GlyphAtlas, ImageCache};
-use crate::color::PremulRgba8;
-use crate::color::palette::css::BLACK;
 use crate::colr::{convert_bounding_box, get_colr_info};
 use crate::kurbo::Point;
 use crate::kurbo::Rect;
@@ -71,6 +69,14 @@ pub struct FontEmbolden {
 }
 
 impl FontEmbolden {
+    /// A default value of [`FontEmbolden`].
+    pub const DEFAULT: Self = Self {
+        amount: Diagonal2::new(0.0, 0.0),
+        join: Join::Miter,
+        miter_limit: 4.0,
+        tolerance: 0.1,
+    };
+
     /// Create synthetic embolden settings with default expansion controls.
     pub fn new(amount: Diagonal2) -> Self {
         Self {
@@ -96,27 +102,24 @@ impl FontEmbolden {
         self.tolerance = tolerance;
         self
     }
+
+    /// Converts `self` to `[xx, yy, join, miter_limit, tolerance]`.
+    pub const fn to_array(self) -> [u32; 5] {
+        [
+            f32_bits(self.amount.xx),
+            f32_bits(self.amount.yy),
+            join_bits(self.join),
+            f32_bits(self.miter_limit),
+            f32_bits(self.tolerance),
+        ]
+    }
 }
 
 impl Default for FontEmbolden {
     fn default() -> Self {
-        Self {
-            amount: Diagonal2::new(0.0, 0.0),
-            join: Join::Miter,
-            miter_limit: 4.0,
-            tolerance: 0.1,
-        }
+        Self::DEFAULT
     }
 }
-
-/// Pre-packed `BLACK` color as a `u32` for use in `GlyphCacheKey`.
-const BLACK_PACKED: u32 = PremulRgba8 {
-    r: 0,
-    g: 0,
-    b: 0,
-    a: 255,
-}
-.to_u32();
 
 /// A type of glyph.
 #[derive(Debug)]
@@ -403,6 +406,14 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
             // first place and cull them.
             let glyph_id = GlyphId::new(glyph.id);
 
+            // A temporary glyph cache key.
+            let temp_glyph_cache_key = GlyphCacheKey {
+                font_id: font_info.id,
+                font_index: font_info.index,
+                glyph_id: glyph.id,
+                ..GlyphCacheKey::DEFAULT
+            };
+
             // ── Speculative outline cache check ─────────────────────────
             // ~99% of glyphs are outlines. The transform and cache key are
             // pure arithmetic, so we probe the cache before the expensive
@@ -420,18 +431,14 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
             // the glyph by pre-concatenating it with the inverted outline transform.
             let outline_cache_key = outline_cache_enabled.then(|| {
                 let fractional_x = outline_transform.translation().x.fract() as f32;
-                GlyphCacheKey::new(
-                    font_info.id,
-                    font_info.index,
-                    glyph.id,
-                    draw_props.font_size,
+                GlyphCacheKey {
+                    size_bits: draw_props.font_size.to_bits(),
                     hinted,
-                    fractional_x,
-                    BLACK,
-                    BLACK_PACKED,
-                    font_embolden,
-                    normalized_coords,
-                )
+                    subpixel_x: quantize_subpixel(fractional_x),
+                    embolden: font_embolden.to_array(),
+                    var_coords: SmallVec::from_slice(normalized_coords),
+                    ..temp_glyph_cache_key
+                }
             });
             if let Some(ref key) = outline_cache_key
                 && let Some(cached_slot) = self.atlas_cacher.get(key)
@@ -463,20 +470,11 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
                 // COLR glyphs are never hinted and have no sub-pixel offset;
                 // context_color is part of the key because it affects painted layers.
                 let cache_key = colr_bitmap_cache_enabled.then(|| GlyphCacheKey {
-                    font_id: font_info.id,
-                    font_index: font_info.index,
-                    glyph_id: glyph.id,
                     size_bits: draw_props.font_size.to_bits(),
-                    hinted: false,
-                    subpixel_x: SUBPIXEL_COLR,
                     context_color,
                     context_color_packed,
-                    embolden_x_bits: 0,
-                    embolden_y_bits: 0,
-                    embolden_join_bits: join_bits(Join::Miter),
-                    embolden_miter_limit_bits: 4.0_f32.to_bits(),
-                    embolden_tolerance_bits: 0.1_f32.to_bits(),
                     var_coords: SmallVec::from_slice(normalized_coords),
+                    ..temp_glyph_cache_key.to_colr()
                 });
 
                 if let Some(ref key) = cache_key
@@ -563,20 +561,8 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
                 // Bitmaps are not hinted and have no sub-pixel offset or
                 // context color; variation coords are irrelevant for fixed strikes.
                 let cache_key = colr_bitmap_cache_enabled.then(|| GlyphCacheKey {
-                    font_id: font_info.id,
-                    font_index: font_info.index,
-                    glyph_id: glyph.id,
                     size_bits: bitmap_ppem.to_bits(),
-                    hinted: false,
-                    subpixel_x: SUBPIXEL_BITMAP,
-                    context_color: BLACK,
-                    context_color_packed: BLACK_PACKED,
-                    embolden_x_bits: 0,
-                    embolden_y_bits: 0,
-                    embolden_join_bits: join_bits(Join::Miter),
-                    embolden_miter_limit_bits: 4.0_f32.to_bits(),
-                    embolden_tolerance_bits: 0.1_f32.to_bits(),
-                    var_coords: SmallVec::new(),
+                    ..temp_glyph_cache_key.to_bitmap()
                 });
 
                 if let Some(ref key) = cache_key
@@ -1761,16 +1747,12 @@ struct OutlineKey {
     font_index: u32,
     glyph_id: u32,
     size_bits: u32,
-    embolden_x_bits: u32,
-    embolden_y_bits: u32,
-    embolden_join_bits: u8,
-    embolden_miter_limit_bits: u32,
-    embolden_tolerance_bits: u32,
+    embolden: [u32; 5],
     hint: bool,
 }
 
 #[inline(always)]
-fn join_bits(join: Join) -> u8 {
+const fn join_bits(join: Join) -> u32 {
     match join {
         Join::Bevel => 0,
         Join::Miter => 1,
@@ -1783,7 +1765,7 @@ fn join_bits(join: Join) -> u8 {
     reason = "Cache keys intentionally store embolden parameters at f32 precision."
 )]
 #[inline(always)]
-fn f32_bits(value: f64) -> u32 {
+const fn f32_bits(value: f64) -> u32 {
     (value as f32).to_bits()
 }
 
@@ -1948,11 +1930,7 @@ impl<'a> OutlineCacheSession<'a> {
             font_id: font_info.id,
             font_index: font_info.index,
             size_bits: size.to_bits(),
-            embolden_x_bits: f32_bits(embolden.amount.xx),
-            embolden_y_bits: f32_bits(embolden.amount.yy),
-            embolden_join_bits: join_bits(embolden.join),
-            embolden_miter_limit_bits: f32_bits(embolden.miter_limit),
-            embolden_tolerance_bits: f32_bits(embolden.tolerance),
+            embolden: embolden.to_array(),
             hint: hinting_instance.is_some(),
         };
 
@@ -2181,7 +2159,7 @@ mod tests {
     use crate::interface::{DrawSink, GlyphRenderer};
     use crate::peniko::BlendMode;
     use crate::peniko::Blob;
-    use crate::peniko::color::{AlphaColor, Srgb};
+    use crate::peniko::color::{AlphaColor, Srgb, palette::css::BLACK};
     use alloc::sync::Arc;
     use vello_common::paint::{Image, ImageId, ImageSource, PaintType, Tint};
 

--- a/glifo/src/renderer.rs
+++ b/glifo/src/renderer.rs
@@ -448,7 +448,7 @@ fn insert_and_render_bitmap(
         width,
         height,
         bearing_x: 0,
-        bearing_y: 0,
+        bearing_y: -(height as i16),
     };
 
     // Bitmap glyphs already have pixel data — no draw commands to record,

--- a/glifo/src/renderer.rs
+++ b/glifo/src/renderer.rs
@@ -448,7 +448,7 @@ fn insert_and_render_bitmap(
         width,
         height,
         bearing_x: 0,
-        bearing_y: -(height as i16),
+        bearing_y: 0,
     };
 
     // Bitmap glyphs already have pixel data — no draw commands to record,

--- a/glifo/src/renderer.rs
+++ b/glifo/src/renderer.rs
@@ -472,6 +472,10 @@ fn insert_and_render_bitmap(
     CacheResult::CachedAndRendered
 }
 
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "f64→i16 truncation is acceptable for pixel coordinates"
+)]
 fn insert_and_render_colr(
     renderer: &mut impl GlyphRenderer,
     glyph: &GlyphColr<'_>,
@@ -485,17 +489,11 @@ fn insert_and_render_colr(
         return CacheResult::UnsupportedTransform;
     }
 
-    let width = glyph.pix_width;
-    let height = glyph.pix_height;
-
-    let raster_metrics = RasterMetrics {
-        width,
-        height,
-        bearing_x: 0,
-        bearing_y: 0,
-    };
-
     let area = glyph.area;
+    let [_, _, _, _, tx, ty] = glyph.draw_transform.as_coeffs();
+    let mut raster_metrics = calculate_raster_metrics(&area);
+    raster_metrics.bearing_x -= tx.ceil() as i16;
+    raster_metrics.bearing_y += ty.floor() as i16;
 
     let context_color = cache_key.context_color;
     let Some((atlas_slot, recorder)) = glyph_atlas.insert(image_cache, cache_key, raster_metrics)

--- a/glifo/src/renderer.rs
+++ b/glifo/src/renderer.rs
@@ -472,10 +472,6 @@ fn insert_and_render_bitmap(
     CacheResult::CachedAndRendered
 }
 
-#[expect(
-    clippy::cast_possible_truncation,
-    reason = "f64→i16 truncation is acceptable for pixel coordinates"
-)]
 fn insert_and_render_colr(
     renderer: &mut impl GlyphRenderer,
     glyph: &GlyphColr<'_>,
@@ -489,11 +485,15 @@ fn insert_and_render_colr(
         return CacheResult::UnsupportedTransform;
     }
 
-    let area = glyph.area;
-    let [_, _, _, _, tx, ty] = glyph.draw_transform.as_coeffs();
-    let mut raster_metrics = calculate_raster_metrics(&area);
-    raster_metrics.bearing_x -= tx.ceil() as i16;
-    raster_metrics.bearing_y += ty.floor() as i16;
+    let width = glyph.pix_width;
+    let height = glyph.pix_height;
+
+    let raster_metrics = RasterMetrics {
+        width,
+        height,
+        bearing_x: 0,
+        bearing_y: 0,
+    };
 
     let context_color = cache_key.context_color;
     let Some((atlas_slot, recorder)) = glyph_atlas.insert(image_cache, cache_key, raster_metrics)
@@ -507,7 +507,7 @@ fn insert_and_render_colr(
         renderer,
         atlas_slot,
         outline_transform,
-        area,
+        glyph.area,
         quality_for_skew(&outline_transform),
         None,
     );

--- a/sparse_strips/vello_common/src/image_cache.rs
+++ b/sparse_strips/vello_common/src/image_cache.rs
@@ -52,6 +52,12 @@ pub struct ImageCache {
     free_idxs: Vec<usize>,
 }
 
+impl Default for ImageCache {
+    fn default() -> Self {
+        Self::new_with_config(AtlasConfig::default())
+    }
+}
+
 impl core::fmt::Debug for ImageCache {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let atlas_stats = self.atlas_manager.atlas_stats();

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -12,6 +12,11 @@ use crate::text::{GlyphAtlasResources, GlyphRunBuilder};
 #[cfg(feature = "text")]
 use glifo::GlyphPrepCache;
 
+#[cfg(feature = "text")]
+use vello_common::image_cache::ImageCache;
+#[cfg(feature = "text")]
+use vello_common::multi_atlas::AtlasConfig;
+
 use crate::dispatch::single_threaded::SingleThreadedDispatcher;
 use crate::kurbo::{PathEl, Point};
 use crate::record::FilterData;
@@ -33,8 +38,6 @@ use vello_common::pixmap::{Pixmap, PixmapMut};
 use vello_common::render_state::RenderState;
 use vello_common::util::is_axis_aligned;
 
-#[cfg(feature = "text")]
-pub(crate) const DEFAULT_GLYPH_ATLAS_SIZE: u16 = 4096;
 // Why do we need this? The reason is that the way uploaded images work in Vello Hybrid
 // is different from how they work in Vello CPU.
 //
@@ -60,6 +63,8 @@ pub(crate) const ATLAS_IMAGE_ID_BASE: u32 = u32::MAX / 2;
 pub struct Resources {
     pub(crate) image_registry: ImageRegistry,
     #[cfg(feature = "text")]
+    pub(crate) image_cache: ImageCache,
+    #[cfg(feature = "text")]
     pub(crate) glyph_prep_cache: GlyphPrepCache,
     // Will be initialized lazily on first use.
     #[cfg(feature = "text")]
@@ -70,6 +75,15 @@ impl Resources {
     /// Create a new set of renderer resources.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Create a new set of renderer resources with a custom [`AtlasConfig`].
+    #[cfg(feature = "text")]
+    pub fn new_with_atlas_config(atlas_config: AtlasConfig) -> Self {
+        Self {
+            image_cache: ImageCache::new_with_config(atlas_config),
+            ..Self::default()
+        }
     }
 
     pub(crate) fn before_render(&mut self, render_mode: RenderMode) {
@@ -958,7 +972,7 @@ mod tests {
     use alloc::sync::Arc;
     use alloc::vec;
     #[cfg(feature = "text")]
-    use glifo::Glyph;
+    use glifo::{AtlasConfig, Glyph};
     use vello_common::color::PremulRgba8;
     use vello_common::color::palette::css::{BLUE, RED};
     use vello_common::kurbo::{Rect, Shape};
@@ -1255,5 +1269,36 @@ mod tests {
             .fill_glyphs(glyphs.into_iter());
 
         assert!(resources.glyph_resources.is_some());
+    }
+
+    #[cfg(feature = "text")]
+    #[test]
+    fn custom_atlas_size() {
+        const ROBOTO_FONT: &[u8] =
+            include_bytes!("../../../examples/assets/roboto/Roboto-Regular.ttf");
+
+        let font = FontData::new(Blob::new(Arc::new(ROBOTO_FONT)), 0);
+        let glyphs = [Glyph {
+            id: 1,
+            x: 0.0,
+            y: 0.0,
+        }];
+
+        let mut resources = Resources::new_with_atlas_config(AtlasConfig {
+            atlas_size: (100, 100),
+            ..AtlasConfig::default()
+        });
+        let mut ctx = RenderContext::new(100, 100);
+
+        ctx.glyph_run(&mut resources, &font)
+            .atlas_cache(true)
+            .fill_glyphs(glyphs.into_iter());
+
+        assert_eq!(resources.image_cache.atlas_count(), 1);
+
+        let stats = resources.image_cache.atlas_manager().atlas_stats()[0].1;
+        assert!(stats.allocated_area > 0);
+        assert_eq!(stats.total_area, 100 * 100);
+        assert_eq!(stats.allocated_count, 1);
     }
 }

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -77,7 +77,7 @@ impl Resources {
         Self::default()
     }
 
-    /// Create a new set of renderer resources with a custom [`AtlasConfig`].
+    /// Creates a new set of renderer resources with a custom [`AtlasConfig`].
     #[cfg(feature = "text")]
     pub fn new_with_atlas_config(atlas_config: AtlasConfig) -> Self {
         Self {
@@ -105,7 +105,7 @@ impl Resources {
         &self.image_cache
     }
 
-    /// Returns atlas pages.
+    /// Returns glyph atlas pages.
     #[cfg(feature = "text")]
     pub fn pixmaps(&self) -> Option<Vec<Arc<Pixmap>>> {
         self.glyph_resources
@@ -1322,6 +1322,9 @@ mod tests {
 
         resources.prepare_glyph_cache(crate::RenderMode::OptimizeQuality);
         resources.maintain_glyph_cache();
+        if let Some(glyph_atlas) = resources.glyph_atlas_mut() {
+            glyph_atlas.clear_tick();
+        }
 
         assert_eq!(resources.image_cache.atlas_count(), 1);
 

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -995,10 +995,12 @@ mod tests {
     use alloc::vec;
     #[cfg(feature = "text")]
     use glifo::{AtlasConfig, FontEmbolden, Glyph, GlyphCacheKey};
-    use vello_common::color::PremulRgba8;
     #[cfg(feature = "text")]
     use vello_common::color::palette::css::BLACK;
-    use vello_common::color::palette::css::{BLUE, RED};
+    use vello_common::color::{
+        PremulRgba8,
+        palette::css::{BLUE, RED},
+    };
     use vello_common::kurbo::{Rect, Shape};
     use vello_common::pixmap::{Pixmap, PixmapMut};
     use vello_common::tile::Tile;

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -99,6 +99,12 @@ impl Resources {
         self.maintain_glyph_cache();
     }
 
+    /// Returns image cache.
+    #[cfg(feature = "text")]
+    pub fn image_cache(&self) -> &ImageCache {
+        &self.image_cache
+    }
+
     /// Returns atlas pages.
     #[cfg(feature = "text")]
     pub fn pixmaps(&self) -> Option<Vec<Arc<Pixmap>>> {

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -9,9 +9,8 @@ use crate::dispatch::Dispatcher;
 use crate::dispatch::multi_threaded::MultiThreadedDispatcher;
 #[cfg(feature = "text")]
 use crate::text::{GlyphAtlasResources, GlyphRunBuilder};
-use glifo::GlyphAtlas;
 #[cfg(feature = "text")]
-use glifo::GlyphPrepCache;
+use glifo::{GlyphAtlas, GlyphPrepCache};
 
 #[cfg(feature = "text")]
 use vello_common::image_cache::ImageCache;
@@ -101,6 +100,7 @@ impl Resources {
     }
 
     /// Returns atlas pages.
+    #[cfg(feature = "text")]
     pub fn pixmaps(&self) -> Option<Vec<Arc<Pixmap>>> {
         self.glyph_resources
             .as_ref()
@@ -108,6 +108,7 @@ impl Resources {
     }
 
     /// Returns glyph atlas cache data.
+    #[cfg(feature = "text")]
     pub fn glyph_atlas_mut(&mut self) -> Option<&mut GlyphAtlas> {
         self.glyph_resources
             .as_mut()

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -9,6 +9,7 @@ use crate::dispatch::Dispatcher;
 use crate::dispatch::multi_threaded::MultiThreadedDispatcher;
 #[cfg(feature = "text")]
 use crate::text::{GlyphAtlasResources, GlyphRunBuilder};
+use glifo::GlyphAtlas;
 #[cfg(feature = "text")]
 use glifo::GlyphPrepCache;
 
@@ -97,6 +98,20 @@ impl Resources {
     pub(crate) fn after_render(&mut self) {
         #[cfg(feature = "text")]
         self.maintain_glyph_cache();
+    }
+
+    /// Returns atlas pages.
+    pub fn pixmaps(&self) -> Option<Vec<Arc<Pixmap>>> {
+        self.glyph_resources
+            .as_ref()
+            .map(|glyph_resources| glyph_resources.pixmaps.clone())
+    }
+
+    /// Returns glyph atlas cache data.
+    pub fn glyph_atlas_mut(&mut self) -> Option<&mut GlyphAtlas> {
+        self.glyph_resources
+            .as_mut()
+            .map(|glyph_resources| &mut glyph_resources.glyph_atlas)
     }
 }
 
@@ -972,8 +987,10 @@ mod tests {
     use alloc::sync::Arc;
     use alloc::vec;
     #[cfg(feature = "text")]
-    use glifo::{AtlasConfig, Glyph};
+    use glifo::{AtlasConfig, FontEmbolden, Glyph, GlyphCacheKey};
     use vello_common::color::PremulRgba8;
+    #[cfg(feature = "text")]
+    use vello_common::color::palette::css::BLACK;
     use vello_common::color::palette::css::{BLUE, RED};
     use vello_common::kurbo::{Rect, Shape};
     use vello_common::pixmap::{Pixmap, PixmapMut};
@@ -1294,11 +1311,41 @@ mod tests {
             .atlas_cache(true)
             .fill_glyphs(glyphs.into_iter());
 
+        resources.prepare_glyph_cache(crate::RenderMode::OptimizeQuality);
+        resources.maintain_glyph_cache();
+
         assert_eq!(resources.image_cache.atlas_count(), 1);
 
         let stats = resources.image_cache.atlas_manager().atlas_stats()[0].1;
         assert!(stats.allocated_area > 0);
         assert_eq!(stats.total_area, 100 * 100);
         assert_eq!(stats.allocated_count, 1);
+
+        let glyph_atlas_mut = resources.glyph_atlas_mut().unwrap();
+
+        const BLACK_PACKED: u32 = PremulRgba8 {
+            r: 0,
+            g: 0,
+            b: 0,
+            a: 255,
+        }
+        .to_u32();
+
+        assert!(
+            glyph_atlas_mut
+                .get(&GlyphCacheKey::new(
+                    0,
+                    0,
+                    1,
+                    16.0,
+                    true,
+                    0.0,
+                    BLACK,
+                    BLACK_PACKED,
+                    FontEmbolden::default(),
+                    &[],
+                ))
+                .is_some()
+        );
     }
 }

--- a/sparse_strips/vello_cpu/src/text.rs
+++ b/sparse_strips/vello_cpu/src/text.rs
@@ -96,13 +96,15 @@ fn ensure_page(
 }
 
 impl Resources {
-    pub(crate) fn prepare_glyph_cache(&mut self, render_mode: RenderMode) {
+    /// Prepare the glyph cache.
+    pub fn prepare_glyph_cache(&mut self, render_mode: RenderMode) {
         if self.glyph_resources.is_some() {
             self.sync_glyph_cache(render_mode);
         }
     }
 
-    pub(crate) fn maintain_glyph_cache(&mut self) {
+    /// Maintain the glyph cache.
+    pub fn maintain_glyph_cache(&mut self) {
         self.glyph_prep_cache.maintain();
 
         if let Some(glyph_resources) = self.glyph_resources.as_mut() {

--- a/sparse_strips/vello_cpu/src/text.rs
+++ b/sparse_strips/vello_cpu/src/text.rs
@@ -11,7 +11,7 @@
 //! [`Arc<Pixmap>`]s here, so the CPU renderer can read pixels directly without
 //! any GPU upload step.
 
-use crate::render::{ATLAS_IMAGE_ID_BASE, DEFAULT_GLYPH_ATLAS_SIZE};
+use crate::render::ATLAS_IMAGE_ID_BASE;
 use crate::{
     CompositeMode, Image, ImageSource, PaintType, Pixmap, RasterizerSettings, RenderContext,
     RenderMode, RenderSettings, Resources, color, kurbo, peniko,
@@ -22,9 +22,7 @@ use alloc::vec::Vec;
 use color::palette::css::BLACK;
 use core::fmt::Debug;
 use core::ops::RangeInclusive;
-use glifo::atlas::{
-    AtlasConfig, AtlasSlot, GlyphAtlas, GlyphCacheConfig, ImageCache, PendingClearRect,
-};
+use glifo::atlas::{AtlasSlot, GlyphAtlas, GlyphCacheConfig, ImageCache, PendingClearRect};
 use glifo::{AtlasCacher, DrawSink, GlyphRunBackend};
 use glifo::{Glyph, renderer};
 use kurbo::{Affine, BezPath, Rect};
@@ -40,7 +38,6 @@ fn atlas_page_image_id(page_index: u32) -> ImageId {
 #[derive(Debug)]
 pub(crate) struct GlyphAtlasResources {
     pub(crate) glyph_atlas: GlyphAtlas,
-    pub(crate) image_cache: ImageCache,
     pub(crate) glyph_renderer: Box<RenderContext>,
     /// One `Pixmap` per atlas page, grown on demand.
     // It's a bit annoying to have this in an `Arc`, but it needs to be this way. During fine
@@ -67,7 +64,6 @@ impl GlyphAtlasResources {
     ) -> Self {
         Self {
             glyph_atlas: GlyphAtlas::with_config(eviction_config),
-            image_cache: ImageCache::new_with_config(AtlasConfig::default()),
             glyph_renderer: Box::new(RenderContext::new_with(
                 page_width,
                 page_height,
@@ -82,8 +78,8 @@ impl GlyphAtlasResources {
         }
     }
 
-    pub(crate) fn maintain(&mut self) {
-        self.glyph_atlas.maintain(&mut self.image_cache);
+    pub(crate) fn maintain(&mut self, image_cache: &mut ImageCache) {
+        self.glyph_atlas.maintain(image_cache);
     }
 }
 
@@ -110,7 +106,7 @@ impl Resources {
         self.glyph_prep_cache.maintain();
 
         if let Some(glyph_resources) = self.glyph_resources.as_mut() {
-            glyph_resources.maintain();
+            glyph_resources.maintain(&mut self.image_cache);
             let page_count = glyph_resources.pixmaps.len();
             for page_index in 0..page_count {
                 self.image_registry.destroy_atlas_page(page_index as u32);
@@ -121,9 +117,17 @@ impl Resources {
 
     fn ensure_glyph_resources(&mut self, level: Level) {
         if self.glyph_resources.is_none() {
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "atlas dimensions are configured to fit in u16"
+            )]
+            let (atlas_width, atlas_height) = {
+                let (width, height) = self.image_cache.atlas_manager().config().atlas_size;
+                (width as u16, height as u16)
+            };
             self.glyph_resources = Some(GlyphAtlasResources::with_config(
-                DEFAULT_GLYPH_ATLAS_SIZE,
-                DEFAULT_GLYPH_ATLAS_SIZE,
+                atlas_width,
+                atlas_height,
                 level,
                 GlyphCacheConfig::default(),
             ));
@@ -234,7 +238,7 @@ impl<'a> CpuGlyphRunBackend<'a> {
                 .expect("glyph atlas resources must exist after initialization");
             AtlasCacher::Enabled(
                 &mut glyph_resources.glyph_atlas,
-                &mut glyph_resources.image_cache,
+                &mut self.resources.image_cache,
             )
         } else {
             AtlasCacher::Disabled

--- a/sparse_strips/vello_cpu/src/text.rs
+++ b/sparse_strips/vello_cpu/src/text.rs
@@ -96,14 +96,14 @@ fn ensure_page(
 }
 
 impl Resources {
-    /// Prepare the glyph cache.
+    /// Prepares the glyph cache.
     pub fn prepare_glyph_cache(&mut self, render_mode: RenderMode) {
         if self.glyph_resources.is_some() {
             self.sync_glyph_cache(render_mode);
         }
     }
 
-    /// Maintain the glyph cache.
+    /// Maintains the glyph cache.
     pub fn maintain_glyph_cache(&mut self) {
         self.glyph_prep_cache.maintain();
 


### PR DESCRIPTION
- Add `ImageCache` into `Resources`, so the atlas size can be customized
- Expose `image_cache` `pixmaps` `glyph_atlas_mut` methods, users can read glyphs
- Simplify the initialization of `GlyphCacheKey`

