### PR TITLE
ci: cancel superseded workflow runs for PR pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,11 @@ on:
     branches:
       - main
 
+# Cancel superseded CI runs for the same PR to save runner time.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   fmt:
     name: formatting


### PR DESCRIPTION
Adds a concurrency block to `.github/workflows/ci.yml` that cancels an in-flight workflow run when a newer commit is pushed to the same pull request. This avoids burning runner minutes on commits that have already been superseded.

Any concerns with adding this?

[Control the concurrency of workflows and jobs](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency)