### PR TITLE
glifo: Fix interaction with complex paints

### DIFF
--- a/glifo/src/glyph.rs
+++ b/glifo/src/glyph.rs
@@ -2114,7 +2114,7 @@ mod tests {
     use crate::peniko::Blob;
     use crate::peniko::color::{AlphaColor, Srgb};
     use alloc::sync::Arc;
-    use vello_common::paint::{Image, ImageId, ImageSource, Tint};
+    use vello_common::paint::{Image, ImageId, ImageSource, PaintType, Tint};
 
     const _NORMALISED_COORD_SIZE_MATCHES: () =
         assert!(size_of::<skrifa::instance::NormalizedCoord>() == size_of::<NormalizedCoord>());
@@ -2136,6 +2136,8 @@ mod tests {
 
     #[derive(Default)]
     struct NoopRenderer;
+
+    static BLACK_PAINT: PaintType = PaintType::Solid(BLACK);
 
     struct TestResources {
         renderer: NoopRenderer,
@@ -2201,6 +2203,10 @@ mod tests {
             BLACK
         }
 
+        fn current_paint(&self) -> &PaintType {
+            &BLACK_PAINT
+        }
+
         fn atlas_image_source(&self, atlas_slot: &AtlasSlot) -> ImageSource {
             ImageSource::opaque_id(ImageId::new(atlas_slot.page_index))
         }
@@ -2248,11 +2254,13 @@ mod tests {
             AtlasCacher::Disabled
         };
 
+        let transform = Affine::translate((0.0, 20.0));
         let mut run = GlyphRun {
             font: font.clone(),
             font_size: 20.0,
             font_embolden: FontEmbolden::default(),
-            transform: Affine::translate((0.0, 20.0)),
+            transform,
+            absolute_paint_transform: transform,
             glyph_transform: None,
             normalized_coords: &[],
             hint: false,

--- a/glifo/src/glyph.rs
+++ b/glifo/src/glyph.rs
@@ -394,6 +394,7 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
             // On a miss we keep both for reuse in the outline branch below.
             let outline_transform =
                 calculate_outline_transform(glyph, draw_props, hinting_instance);
+            let outline_draw_transform = outline_transform.pre_scale(scale_props.draw_scale);
 
             // We assume that the backend calculates the absolute paint transform
             // by concatenating scene transform and (relative) paint transform.
@@ -401,7 +402,8 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
             // also be assumed to be the case for any other potential backend.)
             // Therefore, we can calculate the relative paint transform for
             // the glyph by pre-concatenating it with the inverted outline transform.
-            let relative_paint_transform = outline_transform.inverse() * absolute_paint_transform;
+            let relative_paint_transform =
+                outline_draw_transform.inverse() * absolute_paint_transform;
             let outline_cache_key = outline_cache_enabled.then(|| {
                 let fractional_x = outline_transform.translation().x.fract() as f32;
                 GlyphCacheKey::new(

--- a/glifo/src/glyph.rs
+++ b/glifo/src/glyph.rs
@@ -152,7 +152,7 @@ pub(crate) struct PreparedGlyph<'a> {
     /// Per-glyph outline transform: maps the draw-unit glyph outline
     /// (after font-size absorption) to scene coordinates.
     pub(crate) outline_transform: Affine,
-    /// The transform of the paint, relative to [`PreparedGlyph::transform`] *
+    /// The transform of the paint, relative to [`PreparedGlyph::outline_transform`] *
     /// [`GlyphScaleProperties::draw_scale`].
     pub(crate) relative_paint_transform: Affine,
     /// Cache key for renderers that implement glyph caching.

--- a/glifo/src/glyph.rs
+++ b/glifo/src/glyph.rs
@@ -374,6 +374,8 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
             // we never cache stroked outlines for now. For COLR and bitmap, this doesn't matter
             // because they are always filled anyway.
             && style == Style::Fill
+            // We use image tinting to color cached glyphs, which is not 
+            // supported for complex paints.
             && matches!(renderer.current_paint(), PaintType::Solid(_));
 
         let context_color = renderer.get_context_color();

--- a/glifo/src/glyph.rs
+++ b/glifo/src/glyph.rs
@@ -149,8 +149,9 @@ pub(crate) enum CachedGlyphType {
 pub(crate) struct PreparedGlyph<'a> {
     /// The type of glyph.
     pub(crate) glyph_type: GlyphType<'a>,
-    /// The global transform of the glyph.
-    pub(crate) transform: Affine,
+    /// Per-glyph outline transform: maps the draw-unit glyph outline
+    /// (after font-size absorption) to scene coordinates.
+    pub(crate) outline_transform: Affine,
     /// The transform of the paint, relative to [`PreparedGlyph::transform`] *
     /// [`GlyphScaleProperties::draw_scale`].
     pub(crate) relative_paint_transform: Affine,
@@ -446,7 +447,7 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
                     &color_glyph,
                     location,
                 );
-                let transform = calculate_colr_transform(&metrics);
+                let outline_transform = calculate_colr_transform(&metrics);
 
                 // COLR glyphs are never hinted and have no sub-pixel offset;
                 // context_color is part of the key because it affects painted layers.
@@ -480,7 +481,7 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
                     render_cached_glyph(
                         renderer,
                         cached_slot,
-                        transform,
+                        outline_transform,
                         CachedGlyphType::Colr(area),
                     );
                     continue;
@@ -492,7 +493,7 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
 
                 let prepared_glyph = PreparedGlyph {
                     glyph_type,
-                    transform,
+                    outline_transform,
                     relative_paint_transform: Affine::IDENTITY,
                     cache_key,
                 };
@@ -523,7 +524,7 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
                 // Bitmaps use the strike's own ppem, not the run's, because the
                 // image was pre-rendered at that specific size.
                 let bitmap_ppem = bitmap_glyph.ppem_x;
-                let transform = calculate_bitmap_transform(
+                let outline_transform = calculate_bitmap_transform(
                     glyph,
                     &pixmap,
                     draw_props,
@@ -555,7 +556,12 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
                 if let Some(ref key) = cache_key
                     && let Some(cached_slot) = self.atlas_cacher.get(key)
                 {
-                    render_cached_glyph(renderer, cached_slot, transform, CachedGlyphType::Bitmap);
+                    render_cached_glyph(
+                        renderer,
+                        cached_slot,
+                        outline_transform,
+                        CachedGlyphType::Bitmap,
+                    );
                     continue;
                 }
 
@@ -564,7 +570,7 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
 
                 let prepared_glyph = PreparedGlyph {
                     glyph_type,
-                    transform,
+                    outline_transform,
                     relative_paint_transform: Affine::IDENTITY,
                     cache_key,
                 };
@@ -600,7 +606,7 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
 
             let prepared_glyph = PreparedGlyph {
                 glyph_type,
-                transform: outline_transform,
+                outline_transform,
                 relative_paint_transform,
                 cache_key: outline_cache_key,
             };

--- a/glifo/src/glyph.rs
+++ b/glifo/src/glyph.rs
@@ -151,7 +151,8 @@ pub(crate) struct PreparedGlyph<'a> {
     pub(crate) glyph_type: GlyphType<'a>,
     /// The global transform of the glyph.
     pub(crate) transform: Affine,
-    /// The transform of the paint, relative to [`PreparedGlyph::transform`].
+    /// The transform of the paint, relative to [`PreparedGlyph::transform`] *
+    /// [`GlyphScaleProperties::draw_scale`].
     pub(crate) relative_paint_transform: Affine,
     /// Cache key for renderers that implement glyph caching.
     /// This is `Some` for glyphs that can be cached, `None` otherwise.

--- a/glifo/src/glyph.rs
+++ b/glifo/src/glyph.rs
@@ -41,6 +41,7 @@ use skrifa::raw::TableProvider;
 use skrifa::{FontRef, OutlineGlyphCollection};
 use skrifa::{GlyphId, MetadataProvider};
 use smallvec::SmallVec;
+use vello_common::paint::PaintType;
 
 /// Positioned glyph.
 #[derive(Copy, Clone, Default, Debug)]
@@ -372,7 +373,8 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
             // Due to the various parameters that would need to be considered in the cache key,
             // we never cache stroked outlines for now. For COLR and bitmap, this doesn't matter
             // because they are always filled anyway.
-            && style == Style::Fill;
+            && style == Style::Fill
+            && matches!(renderer.current_paint(), PaintType::Solid(_));
 
         let context_color = renderer.get_context_color();
         let context_color_packed = pack_color(context_color);

--- a/glifo/src/glyph.rs
+++ b/glifo/src/glyph.rs
@@ -355,7 +355,7 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
         );
         let PreparedGlyphRun {
             draw_props,
-            absolute_paint_transform,
+            scene_paint_transform,
             run_size: _,
             font_embolden,
             normalized_coords,
@@ -406,8 +406,6 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
             // also be assumed to be the case for any other potential backend.)
             // Therefore, we can calculate the relative paint transform for
             // the glyph by pre-concatenating it with the inverted outline transform.
-            let relative_paint_transform =
-                outline_draw_transform.inverse() * absolute_paint_transform;
             let outline_cache_key = outline_cache_enabled.then(|| {
                 let fractional_x = outline_transform.translation().x.fract() as f32;
                 GlyphCacheKey::new(
@@ -603,6 +601,8 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
                 hinting_instance,
                 normalized_coords,
             );
+
+            let relative_paint_transform = outline_draw_transform.inverse() * scene_paint_transform;
 
             let prepared_glyph = PreparedGlyph {
                 glyph_type,
@@ -816,7 +816,7 @@ impl<'a, B> GlyphRunBuilder<'a, B> {
                 font_size: 16.0,
                 font_embolden: FontEmbolden::default(),
                 transform,
-                absolute_paint_transform: transform * paint_transform,
+                scene_paint_transform: transform * paint_transform,
                 glyph_transform: None,
                 hint: true,
                 normalized_coords: &[],
@@ -1386,8 +1386,8 @@ pub struct GlyphRun<'a> {
     font_embolden: FontEmbolden,
     /// Global transform.
     transform: Affine,
-    /// Absolute paint transform for the glyph run.
-    absolute_paint_transform: Affine,
+    /// Paint transform for the glyph run in scene space.
+    scene_paint_transform: Affine,
     /// Per-glyph transform. Use [`Affine::skew`] with horizontal-skew only to simulate italic
     /// text.
     glyph_transform: Option<Affine>,
@@ -1432,8 +1432,8 @@ struct PreparedGlyphRun<'a> {
     // Therefore, we need to track a separate set of fields for glyph-drawing operations.
     /// Properties for turning glyph-local positions into final draw transforms.
     draw_props: DrawProps,
-    /// The original absolute transform for the paint.
-    absolute_paint_transform: Affine,
+    /// The original transform for the paint in scene space.
+    scene_paint_transform: Affine,
     normalized_coords: &'a [skrifa::instance::NormalizedCoord],
     hinting_instance: Option<&'a HintingInstance>,
 }
@@ -1590,7 +1590,7 @@ fn prepare_glyph_run<'a>(run: GlyphRun<'a>, hint_cache: &'a mut HintCache) -> Pr
             effective_transform,
             font_size: draw_font_size,
         },
-        absolute_paint_transform: run.absolute_paint_transform,
+        scene_paint_transform: run.scene_paint_transform,
         normalized_coords: run.normalized_coords,
         hinting_instance,
     }
@@ -2267,7 +2267,7 @@ mod tests {
             font_size: 20.0,
             font_embolden: FontEmbolden::default(),
             transform,
-            absolute_paint_transform: transform,
+            scene_paint_transform: transform,
             glyph_transform: None,
             normalized_coords: &[],
             hint: false,

--- a/glifo/src/glyph.rs
+++ b/glifo/src/glyph.rs
@@ -150,6 +150,8 @@ pub(crate) struct PreparedGlyph<'a> {
     pub(crate) glyph_type: GlyphType<'a>,
     /// The global transform of the glyph.
     pub(crate) transform: Affine,
+    /// The transform of the paint, relative to [`PreparedGlyph::transform`].
+    pub(crate) relative_paint_transform: Affine,
     /// Cache key for renderers that implement glyph caching.
     /// This is `Some` for glyphs that can be cached, `None` otherwise.
     ///
@@ -350,6 +352,7 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
         );
         let PreparedGlyphRun {
             draw_props,
+            absolute_paint_transform,
             run_size: _,
             font_embolden,
             normalized_coords,
@@ -389,6 +392,14 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
             // On a miss we keep both for reuse in the outline branch below.
             let outline_transform =
                 calculate_outline_transform(glyph, draw_props, hinting_instance);
+
+            // We assume that the backend calculates the absolute paint transform
+            // by concatenating scene transform and (relative) paint transform.
+            // (This is currently the case for Vello CPU / Vello Hybrid, but will
+            // also be assumed to be the case for any other potential backend.)
+            // Therefore, we can calculate the relative paint transform for
+            // the glyph by pre-concatenating it with the inverted outline transform.
+            let relative_paint_transform = outline_transform.inverse() * absolute_paint_transform;
             let outline_cache_key = outline_cache_enabled.then(|| {
                 let fractional_x = outline_transform.translation().x.fract() as f32;
                 GlyphCacheKey::new(
@@ -475,6 +486,7 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
                 let prepared_glyph = PreparedGlyph {
                     glyph_type,
                     transform,
+                    relative_paint_transform: Affine::IDENTITY,
                     cache_key,
                 };
                 match style {
@@ -546,6 +558,7 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
                 let prepared_glyph = PreparedGlyph {
                     glyph_type,
                     transform,
+                    relative_paint_transform: Affine::IDENTITY,
                     cache_key,
                 };
                 match style {
@@ -581,6 +594,7 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
             let prepared_glyph = PreparedGlyph {
                 glyph_type,
                 transform: outline_transform,
+                relative_paint_transform,
                 cache_key: outline_cache_key,
             };
             match style {
@@ -780,8 +794,8 @@ pub struct GlyphRunBuilder<'a, B> {
 }
 
 impl<'a, B> GlyphRunBuilder<'a, B> {
-    /// Creates a new builder for drawing glyphs with a pre-bound backend.
-    pub fn new(font: FontData, transform: Affine, backend: B) -> Self {
+    /// Creates a new builder for drawing glyphs with a pre-bound backend and paint transform.
+    pub fn new(font: FontData, transform: Affine, paint_transform: Affine, backend: B) -> Self {
         Self {
             // Note: This needs to be kept in sync with the default in vello_common!
             run: GlyphRun {
@@ -789,6 +803,7 @@ impl<'a, B> GlyphRunBuilder<'a, B> {
                 font_size: 16.0,
                 font_embolden: FontEmbolden::default(),
                 transform,
+                absolute_paint_transform: transform * paint_transform,
                 glyph_transform: None,
                 hint: true,
                 normalized_coords: &[],
@@ -1358,6 +1373,8 @@ pub struct GlyphRun<'a> {
     font_embolden: FontEmbolden,
     /// Global transform.
     transform: Affine,
+    /// Absolute paint transform for the glyph run.
+    absolute_paint_transform: Affine,
     /// Per-glyph transform. Use [`Affine::skew`] with horizontal-skew only to simulate italic
     /// text.
     glyph_transform: Option<Affine>,
@@ -1402,6 +1419,8 @@ struct PreparedGlyphRun<'a> {
     // Therefore, we need to track a separate set of fields for glyph-drawing operations.
     /// Properties for turning glyph-local positions into final draw transforms.
     draw_props: DrawProps,
+    /// The original absolute transform for the paint.
+    absolute_paint_transform: Affine,
     normalized_coords: &'a [skrifa::instance::NormalizedCoord],
     hinting_instance: Option<&'a HintingInstance>,
 }
@@ -1558,6 +1577,7 @@ fn prepare_glyph_run<'a>(run: GlyphRun<'a>, hint_cache: &'a mut HintCache) -> Pr
             effective_transform,
             font_size: draw_font_size,
         },
+        absolute_paint_transform: run.absolute_paint_transform,
         normalized_coords: run.normalized_coords,
         hinting_instance,
     }

--- a/glifo/src/glyph.rs
+++ b/glifo/src/glyph.rs
@@ -800,7 +800,7 @@ pub struct GlyphRunBuilder<'a, B> {
 }
 
 impl<'a, B> GlyphRunBuilder<'a, B> {
-    /// Creates a new builder for drawing glyphs with a pre-bound backend and paint transform.
+    /// Creates a new builder for drawing glyphs with a pre-bound backend.
     pub fn new(font: FontData, transform: Affine, paint_transform: Affine, backend: B) -> Self {
         Self {
             // Note: This needs to be kept in sync with the default in vello_common!

--- a/glifo/src/interface.rs
+++ b/glifo/src/interface.rs
@@ -7,7 +7,7 @@ use crate::atlas::{AtlasPaint, AtlasSlot};
 use crate::color::{AlphaColor, Srgb};
 use crate::kurbo::{Affine, BezPath, Rect};
 use crate::peniko::BlendMode;
-use vello_common::paint::{Image, ImageSource, Tint};
+use vello_common::paint::{Image, ImageSource, PaintType, Tint};
 
 // TODO: This trait is only temporary and will hopefully be replaced once we have a better
 // unifying imaging API.
@@ -78,6 +78,9 @@ pub trait GlyphRenderer: DrawSink {
     /// Get the context color from the renderer's current paint, used for resolving the
     /// context-dependent colors of COLR glyphs.
     fn get_context_color(&self) -> AlphaColor<Srgb>;
+
+    /// Get the currently active paint.
+    fn current_paint(&self) -> &PaintType;
 
     // Hopefully we can get rid of those below in the future.
 

--- a/glifo/src/renderer.rs
+++ b/glifo/src/renderer.rs
@@ -50,7 +50,13 @@ pub(crate) fn fill_glyph(
 
         return match prepared_glyph.glyph_type {
             GlyphType::Outline(glyph) => {
-                fill_uncached_outline_glyph(renderer, &glyph.path, glyph.scale, transform, paint_transform);
+                fill_uncached_outline_glyph(
+                    renderer,
+                    &glyph.path,
+                    glyph.scale,
+                    transform,
+                    paint_transform,
+                );
             }
             GlyphType::Bitmap(glyph) => render_uncached_bitmap_glyph(renderer, glyph, transform),
             GlyphType::Colr(glyph) => {
@@ -81,7 +87,13 @@ pub(crate) fn fill_glyph(
                 return;
             }
 
-            fill_uncached_outline_glyph(renderer, &glyph.path, glyph.scale, transform, paint_transform);
+            fill_uncached_outline_glyph(
+                renderer,
+                &glyph.path,
+                glyph.scale,
+                transform,
+                paint_transform,
+            );
         }
         GlyphType::Bitmap(glyph) => {
             if let Some(key) = cache_key.take()
@@ -131,7 +143,13 @@ pub(crate) fn stroke_glyph(
         let paint_transform = prepared_glyph.relative_paint_transform;
         return match prepared_glyph.glyph_type {
             GlyphType::Outline(glyph) => {
-                stroke_uncached_outline_glyph(renderer, &glyph.path, glyph.scale, transform, paint_transform);
+                stroke_uncached_outline_glyph(
+                    renderer,
+                    &glyph.path,
+                    glyph.scale,
+                    transform,
+                    paint_transform,
+                );
             }
             GlyphType::Bitmap(_) | GlyphType::Colr(_) => {
                 fill_glyph(renderer, prepared_glyph, atlas_cacher);
@@ -160,7 +178,13 @@ pub(crate) fn stroke_glyph(
                 return;
             }
 
-            stroke_uncached_outline_glyph(renderer, &glyph.path, glyph.scale, transform, paint_transform);
+            stroke_uncached_outline_glyph(
+                renderer,
+                &glyph.path,
+                glyph.scale,
+                transform,
+                paint_transform,
+            );
         }
         GlyphType::Bitmap(_) | GlyphType::Colr(_) => {
             fill_glyph(renderer, prepared_glyph, atlas_cacher);

--- a/glifo/src/renderer.rs
+++ b/glifo/src/renderer.rs
@@ -46,10 +46,11 @@ pub(crate) fn fill_glyph(
 ) {
     let AtlasCacher::Enabled(glyph_atlas, image_cache) = atlas_cacher else {
         let transform = prepared_glyph.transform;
+        let paint_transform = prepared_glyph.relative_paint_transform;
 
         return match prepared_glyph.glyph_type {
             GlyphType::Outline(glyph) => {
-                fill_uncached_outline_glyph(renderer, &glyph.path, glyph.scale, transform);
+                fill_uncached_outline_glyph(renderer, &glyph.path, glyph.scale, transform, paint_transform);
             }
             GlyphType::Bitmap(glyph) => render_uncached_bitmap_glyph(renderer, glyph, transform),
             GlyphType::Colr(glyph) => {
@@ -61,6 +62,7 @@ pub(crate) fn fill_glyph(
 
     let mut cache_key = prepared_glyph.cache_key;
     let transform = prepared_glyph.transform;
+    let paint_transform = prepared_glyph.relative_paint_transform;
 
     match prepared_glyph.glyph_type {
         GlyphType::Outline(glyph) => {
@@ -79,7 +81,7 @@ pub(crate) fn fill_glyph(
                 return;
             }
 
-            fill_uncached_outline_glyph(renderer, &glyph.path, glyph.scale, transform);
+            fill_uncached_outline_glyph(renderer, &glyph.path, glyph.scale, transform, paint_transform);
         }
         GlyphType::Bitmap(glyph) => {
             if let Some(key) = cache_key.take()
@@ -126,9 +128,10 @@ pub(crate) fn stroke_glyph(
 ) {
     let AtlasCacher::Enabled(glyph_atlas, image_cache) = atlas_cacher else {
         let transform = prepared_glyph.transform;
+        let paint_transform = prepared_glyph.relative_paint_transform;
         return match prepared_glyph.glyph_type {
             GlyphType::Outline(glyph) => {
-                stroke_uncached_outline_glyph(renderer, &glyph.path, glyph.scale, transform);
+                stroke_uncached_outline_glyph(renderer, &glyph.path, glyph.scale, transform, paint_transform);
             }
             GlyphType::Bitmap(_) | GlyphType::Colr(_) => {
                 fill_glyph(renderer, prepared_glyph, atlas_cacher);
@@ -140,6 +143,7 @@ pub(crate) fn stroke_glyph(
         GlyphType::Outline(glyph) => {
             let mut cache_key = prepared_glyph.cache_key;
             let transform = prepared_glyph.transform;
+            let paint_transform = prepared_glyph.relative_paint_transform;
             let tint_color = renderer.get_context_color();
 
             if let Some(key) = cache_key.take()
@@ -156,7 +160,7 @@ pub(crate) fn stroke_glyph(
                 return;
             }
 
-            stroke_uncached_outline_glyph(renderer, &glyph.path, glyph.scale, transform);
+            stroke_uncached_outline_glyph(renderer, &glyph.path, glyph.scale, transform, paint_transform);
         }
         GlyphType::Bitmap(_) | GlyphType::Colr(_) => {
             fill_glyph(renderer, prepared_glyph, atlas_cacher);
@@ -169,9 +173,11 @@ fn fill_uncached_outline_glyph(
     path: &BezPath,
     scale: f64,
     transform: Affine,
+    paint_transform: Affine,
 ) {
     let state = renderer.save_state();
     renderer.set_transform(transform.pre_scale(scale));
+    renderer.set_paint_transform(paint_transform);
     renderer.fill_path(path);
     renderer.restore_state(state);
 }
@@ -181,9 +187,11 @@ fn stroke_uncached_outline_glyph(
     path: &BezPath,
     scale: f64,
     transform: Affine,
+    paint_transform: Affine,
 ) {
     let state = renderer.save_state();
     renderer.set_transform(transform.pre_scale(scale));
+    renderer.set_paint_transform(paint_transform);
     renderer.stroke_path(path);
     renderer.restore_state(state);
 }

--- a/glifo/src/renderer.rs
+++ b/glifo/src/renderer.rs
@@ -45,7 +45,7 @@ pub(crate) fn fill_glyph(
     atlas_cacher: &mut AtlasCacher<'_>,
 ) {
     let AtlasCacher::Enabled(glyph_atlas, image_cache) = atlas_cacher else {
-        let transform = prepared_glyph.transform;
+        let transform = prepared_glyph.outline_transform;
         let paint_transform = prepared_glyph.relative_paint_transform;
 
         return match prepared_glyph.glyph_type {
@@ -67,7 +67,7 @@ pub(crate) fn fill_glyph(
     };
 
     let mut cache_key = prepared_glyph.cache_key;
-    let transform = prepared_glyph.transform;
+    let transform = prepared_glyph.outline_transform;
     let paint_transform = prepared_glyph.relative_paint_transform;
 
     match prepared_glyph.glyph_type {
@@ -139,7 +139,7 @@ pub(crate) fn stroke_glyph(
     atlas_cacher: &mut AtlasCacher<'_>,
 ) {
     let AtlasCacher::Enabled(glyph_atlas, image_cache) = atlas_cacher else {
-        let transform = prepared_glyph.transform;
+        let outline_transform = prepared_glyph.outline_transform;
         let paint_transform = prepared_glyph.relative_paint_transform;
         return match prepared_glyph.glyph_type {
             GlyphType::Outline(glyph) => {
@@ -147,7 +147,7 @@ pub(crate) fn stroke_glyph(
                     renderer,
                     &glyph.path,
                     glyph.scale,
-                    transform,
+                    outline_transform,
                     paint_transform,
                 );
             }
@@ -160,7 +160,7 @@ pub(crate) fn stroke_glyph(
     match prepared_glyph.glyph_type {
         GlyphType::Outline(glyph) => {
             let mut cache_key = prepared_glyph.cache_key;
-            let transform = prepared_glyph.transform;
+            let outline_transform = prepared_glyph.outline_transform;
             let paint_transform = prepared_glyph.relative_paint_transform;
             let tint_color = renderer.get_context_color();
 
@@ -168,7 +168,7 @@ pub(crate) fn stroke_glyph(
                 && let CacheResult::CachedAndRendered = insert_and_render_outline(
                     renderer,
                     &glyph,
-                    transform,
+                    outline_transform,
                     key,
                     glyph_atlas,
                     image_cache,
@@ -182,7 +182,7 @@ pub(crate) fn stroke_glyph(
                 renderer,
                 &glyph.path,
                 glyph.scale,
-                transform,
+                outline_transform,
                 paint_transform,
             );
         }
@@ -196,11 +196,11 @@ fn fill_uncached_outline_glyph(
     renderer: &mut impl GlyphRenderer,
     path: &BezPath,
     scale: f64,
-    transform: Affine,
+    outline_transform: Affine,
     paint_transform: Affine,
 ) {
     let state = renderer.save_state();
-    renderer.set_transform(transform.pre_scale(scale));
+    renderer.set_transform(outline_transform.pre_scale(scale));
     renderer.set_paint_transform(paint_transform);
     renderer.fill_path(path);
     renderer.restore_state(state);
@@ -210,11 +210,11 @@ fn stroke_uncached_outline_glyph(
     renderer: &mut impl GlyphRenderer,
     path: &BezPath,
     scale: f64,
-    transform: Affine,
+    outline_transform: Affine,
     paint_transform: Affine,
 ) {
     let state = renderer.save_state();
-    renderer.set_transform(transform.pre_scale(scale));
+    renderer.set_transform(outline_transform.pre_scale(scale));
     renderer.set_paint_transform(paint_transform);
     renderer.stroke_path(path);
     renderer.restore_state(state);
@@ -223,20 +223,20 @@ fn stroke_uncached_outline_glyph(
 fn render_uncached_bitmap_glyph(
     renderer: &mut impl GlyphRenderer,
     glyph: GlyphBitmap,
-    transform: Affine,
+    outline_transform: Affine,
 ) {
     let image = Image {
         image: ImageSource::Pixmap(glyph.pixmap),
         sampler: ImageSampler {
             x_extend: Extend::Pad,
             y_extend: Extend::Pad,
-            quality: quality_for_scale(&transform),
+            quality: quality_for_scale(&outline_transform),
             alpha: 1.0,
         },
     };
 
     let state = renderer.save_state();
-    renderer.set_transform(transform);
+    renderer.set_transform(outline_transform);
     renderer.set_paint_image(image);
     renderer.fill_rect(&glyph.area);
     renderer.restore_state(state);
@@ -245,11 +245,11 @@ fn render_uncached_bitmap_glyph(
 fn render_uncached_colr_glyph(
     renderer: &mut impl GlyphRenderer,
     glyph: &GlyphColr<'_>,
-    transform: Affine,
+    outline_transform: Affine,
     context_color: AlphaColor<Srgb>,
 ) {
     let state = renderer.save_state();
-    renderer.set_transform(transform);
+    renderer.set_transform(outline_transform);
     // Two reasons why we wrap COLR glyphs in a clip layer:
     // 1) We need a layer to make sure they are isolated and don't blend into the main surface (unless
     // the glyph is guaranteed to only use default blending, in which case we don't need this).
@@ -384,13 +384,13 @@ fn render_colr_to_atlas(
 fn insert_and_render_outline(
     renderer: &mut impl GlyphRenderer,
     glyph: &GlyphOutline,
-    transform: Affine,
+    outline_transform: Affine,
     cache_key: GlyphCacheKey,
     glyph_atlas: &mut GlyphAtlas,
     image_cache: &mut ImageCache,
     tint_color: AlphaColor<Srgb>,
 ) -> CacheResult {
-    if !supports_atlas_caching(&transform, CachedGlyphType::Outline) {
+    if !supports_atlas_caching(&outline_transform, CachedGlyphType::Outline) {
         return CacheResult::UnsupportedTransform;
     }
 
@@ -413,7 +413,7 @@ fn insert_and_render_outline(
         raster_metrics,
     );
 
-    render_outline_glyph_from_atlas(renderer, atlas_slot, transform, tint_color);
+    render_outline_glyph_from_atlas(renderer, atlas_slot, outline_transform, tint_color);
     CacheResult::CachedAndRendered
 }
 
@@ -463,12 +463,12 @@ fn insert_and_render_bitmap(
 fn insert_and_render_colr(
     renderer: &mut impl GlyphRenderer,
     glyph: &GlyphColr<'_>,
-    transform: Affine,
+    outline_transform: Affine,
     cache_key: GlyphCacheKey,
     glyph_atlas: &mut GlyphAtlas,
     image_cache: &mut ImageCache,
 ) -> CacheResult {
-    if !supports_atlas_caching(&transform, CachedGlyphType::Colr(Rect::ZERO)) {
+    if !supports_atlas_caching(&outline_transform, CachedGlyphType::Colr(Rect::ZERO)) {
         return CacheResult::UnsupportedTransform;
     }
 
@@ -495,9 +495,9 @@ fn insert_and_render_colr(
     render_from_atlas(
         renderer,
         atlas_slot,
-        transform,
+        outline_transform,
         area,
-        quality_for_skew(&transform),
+        quality_for_skew(&outline_transform),
         None,
     );
     CacheResult::CachedAndRendered
@@ -508,10 +508,10 @@ fn insert_and_render_colr(
 fn render_outline_glyph_from_atlas(
     renderer: &mut impl GlyphRenderer,
     atlas_slot: AtlasSlot,
-    transform: Affine,
+    outline_transform: Affine,
     tint_color: AlphaColor<Srgb>,
 ) {
-    let [_, _, _, _, tx, ty] = transform.as_coeffs();
+    let [_, _, _, _, tx, ty] = outline_transform.as_coeffs();
     let rect_transform = Affine::translate((
         tx.floor() + atlas_slot.bearing_x as f64,
         ty.floor() + atlas_slot.bearing_y as f64,

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -360,6 +360,7 @@ impl RenderContext {
         glifo::GlyphRunBuilder::new(
             font.clone(),
             self.state.transform,
+            self.state.paint_transform,
             crate::text::CpuGlyphRunBackend {
                 ctx: self,
                 resources,

--- a/sparse_strips/vello_cpu/src/text.rs
+++ b/sparse_strips/vello_cpu/src/text.rs
@@ -437,6 +437,11 @@ impl glifo::GlyphRenderer for RenderContext {
     }
 
     #[inline]
+    fn current_paint(&self) -> &PaintType {
+        self.paint()
+    }
+
+    #[inline]
     fn atlas_image_source(&self, atlas_slot: &AtlasSlot) -> ImageSource {
         ImageSource::opaque_id(atlas_page_image_id(atlas_slot.page_index))
     }

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -807,6 +807,7 @@ impl Scene {
         glifo::GlyphRunBuilder::new(
             font.clone(),
             self.render_state.transform,
+            self.render_state.paint_transform,
             crate::text::HybridGlyphRunBackend {
                 scene: self,
                 resources,

--- a/sparse_strips/vello_hybrid/src/text.rs
+++ b/sparse_strips/vello_hybrid/src/text.rs
@@ -325,6 +325,11 @@ impl glifo::GlyphRenderer for Scene {
     }
 
     #[inline]
+    fn current_paint(&self) -> &PaintType {
+        self.paint()
+    }
+
+    #[inline]
     fn atlas_image_source(&self, atlas_slot: &AtlasSlot) -> ImageSource {
         ImageSource::opaque_id(atlas_slot.image_id)
     }

--- a/sparse_strips/vello_sparse_tests/snapshots/glyphs_with_gradient.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/glyphs_with_gradient.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6d92b98452d9316a70c415b2ab762698f10e1d7061dbf627bf82426fe15be751
-size 11204
+oid sha256:612b4f3ed443624037d0ea60030f22d33ea893ebc37af999766bd4f9b3ef3384
+size 11804

--- a/sparse_strips/vello_sparse_tests/snapshots/glyphs_with_gradient.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/glyphs_with_gradient.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d92b98452d9316a70c415b2ab762698f10e1d7061dbf627bf82426fe15be751
+size 11204

--- a/sparse_strips/vello_sparse_tests/snapshots/glyphs_with_gradient.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/glyphs_with_gradient.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:612b4f3ed443624037d0ea60030f22d33ea893ebc37af999766bd4f9b3ef3384
-size 11804
+oid sha256:c4e784371665ef48063ed2fbb9cf569944f21b9d283b16cacb2e44ede8cf1a66
+size 11897

--- a/sparse_strips/vello_sparse_tests/snapshots/glyphs_with_gradient_cached.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/glyphs_with_gradient_cached.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e35e1e11790b20728910d0b9d0e8bc3cad90b570b87da48d7e48b5cb718261f6
+size 1786

--- a/sparse_strips/vello_sparse_tests/snapshots/glyphs_with_gradient_cached.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/glyphs_with_gradient_cached.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e35e1e11790b20728910d0b9d0e8bc3cad90b570b87da48d7e48b5cb718261f6
-size 1786
+oid sha256:612b4f3ed443624037d0ea60030f22d33ea893ebc37af999766bd4f9b3ef3384
+size 11804

--- a/sparse_strips/vello_sparse_tests/snapshots/glyphs_with_gradient_cached.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/glyphs_with_gradient_cached.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:612b4f3ed443624037d0ea60030f22d33ea893ebc37af999766bd4f9b3ef3384
-size 11804
+oid sha256:c4e784371665ef48063ed2fbb9cf569944f21b9d283b16cacb2e44ede8cf1a66
+size 11897

--- a/sparse_strips/vello_sparse_tests/snapshots/glyphs_with_gradient_stroked.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/glyphs_with_gradient_stroked.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b52256668364e828935dbf05936f78857a184cec4c9e735367eb9fe509697e4
+size 18267

--- a/sparse_strips/vello_sparse_tests/snapshots/glyphs_with_gradient_stroked.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/glyphs_with_gradient_stroked.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7b52256668364e828935dbf05936f78857a184cec4c9e735367eb9fe509697e4
-size 18267
+oid sha256:f120361f0e9f8ab93181d075eee16ef1d1e127143225bd41b7eaeb952e69afcb
+size 19514

--- a/sparse_strips/vello_sparse_tests/snapshots/glyphs_with_gradient_stroked_cached.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/glyphs_with_gradient_stroked_cached.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b52256668364e828935dbf05936f78857a184cec4c9e735367eb9fe509697e4
+size 18267

--- a/sparse_strips/vello_sparse_tests/snapshots/glyphs_with_gradient_stroked_cached.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/glyphs_with_gradient_stroked_cached.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7b52256668364e828935dbf05936f78857a184cec4c9e735367eb9fe509697e4
-size 18267
+oid sha256:f120361f0e9f8ab93181d075eee16ef1d1e127143225bd41b7eaeb952e69afcb
+size 19514

--- a/sparse_strips/vello_sparse_tests/snapshots/glyphs_with_image.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/glyphs_with_image.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d024b0971da0ab4705a064252f4f84f41b61175b57def89052a4a1a19f2f462
+size 9292

--- a/sparse_strips/vello_sparse_tests/snapshots/glyphs_with_image_cached.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/glyphs_with_image_cached.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d024b0971da0ab4705a064252f4f84f41b61175b57def89052a4a1a19f2f462
+size 9292

--- a/sparse_strips/vello_sparse_tests/tests/glyph.rs
+++ b/sparse_strips/vello_sparse_tests/tests/glyph.rs
@@ -6,14 +6,17 @@
 use crate::renderer::Renderer;
 #[cfg(target_os = "macos")]
 use crate::util::layout_glyphs_apple_color_emoji;
-use crate::util::{layout_glyphs_noto_cbtf, layout_glyphs_noto_colr, layout_glyphs_roboto};
+use crate::util::{
+    layout_glyphs_noto_cbtf, layout_glyphs_noto_colr, layout_glyphs_roboto,
+    stops_blue_green_red_yellow,
+};
 use glifo::{FontEmbolden, Glyph};
 use std::f64::consts::FRAC_PI_4;
 use std::iter;
 use std::sync::Arc;
 use vello_common::color::palette::css::{BLACK, BLUE, GREEN, REBECCA_PURPLE};
-use vello_common::kurbo::{Affine, Diagonal2, Stroke};
-use vello_common::peniko::{Blob, FontData};
+use vello_common::kurbo::{Affine, Diagonal2, Point, Stroke};
+use vello_common::peniko::{Blob, FontData, Gradient, LinearGradientPosition};
 use vello_dev_macros::vello_test;
 
 fn render_transform_composition_rows(
@@ -415,6 +418,88 @@ fn glyphs_glyph_transform_unhinted(ctx: &mut impl Renderer, enable_caching: bool
         .glyph_transform(Affine::translate((10., 10.)))
         .hint(false)
         .fill_glyphs(glyphs.into_iter());
+}
+
+fn glyphs_with_gradient_inner(ctx: &mut impl Renderer, enable_caching: bool, mode: DrawMode) {
+    const SCENE_WIDTH: f64 = 300.0;
+    const GRADIENT_WIDTH: f64 = SCENE_WIDTH / 2.0;
+    const BASELINE_DELTA: f64 = 40.0;
+
+    let font_size = 36.0_f32;
+    let (font, glyphs) = layout_glyphs_roboto("Hello World", font_size);
+    let text_width = glyphs
+        .last()
+        .map_or(0.0, |glyph| f64::from(glyph.x) + f64::from(font_size) * 0.6);
+    let centered_x = ((SCENE_WIDTH - text_width) / 2.0) as f32;
+    let gradient = Gradient {
+        kind: LinearGradientPosition {
+            start: Point::new(0.0, 0.0),
+            end: Point::new(GRADIENT_WIDTH, 0.0),
+        }
+        .into(),
+        stops: stops_blue_green_red_yellow(),
+        ..Default::default()
+    };
+
+    ctx.set_paint(gradient);
+    ctx.set_stroke(Stroke {
+        width: 1.5,
+        ..Stroke::default()
+    });
+
+    let mut baseline_y = 42.0;
+    // 1) Visible gradient starts at green since we only translate the
+    // glyph X, which shouldn't affect the paint transform.
+    // 2) Visible gradient starts at 2, since paint is transformed along with
+    // the path transform.
+    // 3) Same as 2), just that the source is the paint transform instead of the
+    // scene transform.
+    // 4) Gradient should be shifted to the right, since it's affected by
+    // scene transform + paint transform.
+    for (use_render_transform, shift_gradient) in
+        [(false, false), (true, false), (false, true), (true, true)]
+    {
+        let (transform, glyph_x) = if use_render_transform {
+            (Affine::translate((centered_x as f64, baseline_y)), 0.0)
+        } else {
+            (Affine::translate((0.0, baseline_y)), centered_x)
+        };
+        let paint_transform = if shift_gradient {
+            Affine::translate((centered_x as f64, 0.0))
+        } else {
+            Affine::IDENTITY
+        };
+        let row_glyphs = glyphs.iter().map(|glyph| Glyph {
+            id: glyph.id,
+            x: glyph.x + glyph_x,
+            y: glyph.y,
+        });
+
+        ctx.set_transform(transform);
+        ctx.set_paint_transform(paint_transform);
+        let builder = ctx
+            .glyph_run(&font)
+            .font_size(font_size)
+            .atlas_cache(enable_caching)
+            .hint(false);
+
+        match mode {
+            DrawMode::Fill => builder.fill_glyphs(row_glyphs),
+            DrawMode::Stroke => builder.stroke_glyphs(row_glyphs),
+        }
+
+        baseline_y += BASELINE_DELTA;
+    }
+}
+
+#[vello_test(width = 300, height = 180, glyph)]
+fn glyphs_with_gradient(ctx: &mut impl Renderer, enable_caching: bool) {
+    glyphs_with_gradient_inner(ctx, enable_caching, DrawMode::Fill);
+}
+
+#[vello_test(width = 300, height = 180, glyph)]
+fn glyphs_with_gradient_stroked(ctx: &mut impl Renderer, enable_caching: bool) {
+    glyphs_with_gradient_inner(ctx, enable_caching, DrawMode::Stroke);
 }
 
 #[vello_test(width = 110, height = 410, glyph, hybrid_tolerance = 1)]

--- a/sparse_strips/vello_sparse_tests/tests/glyph.rs
+++ b/sparse_strips/vello_sparse_tests/tests/glyph.rs
@@ -14,9 +14,14 @@ use glifo::{FontEmbolden, Glyph};
 use std::f64::consts::FRAC_PI_4;
 use std::iter;
 use std::sync::Arc;
+use vello_common::color::Srgb;
 use vello_common::color::palette::css::{BLACK, BLUE, GREEN, REBECCA_PURPLE};
 use vello_common::kurbo::{Affine, Diagonal2, Point, Stroke};
-use vello_common::peniko::{Blob, FontData, Gradient, LinearGradientPosition};
+use vello_common::paint::{Image, PaintType, PremulColor};
+use vello_common::peniko::{
+    Blob, Extend, FontData, Gradient, ImageQuality, ImageSampler, LinearGradientPosition,
+};
+use vello_common::pixmap::Pixmap;
 use vello_dev_macros::vello_test;
 
 fn render_transform_composition_rows(
@@ -24,7 +29,7 @@ fn render_transform_composition_rows(
     enable_caching: bool,
     hint: bool,
     reverse_x_shift: f64,
-    paint: impl Into<vello_common::paint::PaintType>,
+    paint: impl Into<PaintType>,
     layout: impl Fn(f32) -> (FontData, Vec<Glyph>),
 ) {
     let rows = [
@@ -420,9 +425,20 @@ fn glyphs_glyph_transform_unhinted(ctx: &mut impl Renderer, enable_caching: bool
         .fill_glyphs(glyphs.into_iter());
 }
 
-fn glyphs_with_gradient_inner(ctx: &mut impl Renderer, enable_caching: bool, mode: DrawMode) {
+enum GlyphPaint {
+    Gradient,
+    Image,
+}
+
+fn glyphs_with_transformed_paint_inner(
+    ctx: &mut impl Renderer,
+    enable_caching: bool,
+    mode: DrawMode,
+    glyph_paint: GlyphPaint,
+) {
     const SCENE_WIDTH: f64 = 300.0;
     const GRADIENT_WIDTH: f64 = SCENE_WIDTH / 2.0;
+    const IMAGE_WIDTH: f64 = 4.0;
     const BASELINE_DELTA: f64 = 40.0;
 
     let font_size = 36.0_f32;
@@ -431,17 +447,42 @@ fn glyphs_with_gradient_inner(ctx: &mut impl Renderer, enable_caching: bool, mod
         .last()
         .map_or(0.0, |glyph| f64::from(glyph.x) + f64::from(font_size) * 0.6);
     let centered_x = ((SCENE_WIDTH - text_width) / 2.0) as f32;
-    let gradient = Gradient {
-        kind: LinearGradientPosition {
-            start: Point::new(0.0, 0.0),
-            end: Point::new(GRADIENT_WIDTH, 0.0),
+    let paint = match glyph_paint {
+        GlyphPaint::Gradient => PaintType::from(Gradient {
+            kind: LinearGradientPosition {
+                start: Point::new(0.0, 0.0),
+                end: Point::new(GRADIENT_WIDTH, 0.0),
+            }
+            .into(),
+            stops: stops_blue_green_red_yellow(),
+            ..Default::default()
+        }),
+        GlyphPaint::Image => {
+            let color_strip = stops_blue_green_red_yellow();
+            let pixels = color_strip
+                .0
+                .iter()
+                .map(|stop| {
+                    PremulColor::from_alpha_color(stop.color.to_alpha_color::<Srgb>())
+                        .as_premul_rgba8()
+                })
+                .collect();
+            let image = ctx.get_image_source(Arc::new(Pixmap::from_parts(pixels, 4, 1)));
+            PaintType::from(Image {
+                image,
+                sampler: ImageSampler {
+                    x_extend: Extend::Pad,
+                    y_extend: Extend::Pad,
+                    // TODO: There seems to be a mismatch when using `Medium` here between Hybrid and CPU,
+                    // so let's use `Low` for now.
+                    quality: ImageQuality::Low,
+                    alpha: 1.0,
+                },
+            })
         }
-        .into(),
-        stops: stops_blue_green_red_yellow(),
-        ..Default::default()
     };
 
-    ctx.set_paint(gradient);
+    ctx.set_paint(paint);
     ctx.set_stroke(Stroke {
         width: 1.5,
         ..Stroke::default()
@@ -464,10 +505,22 @@ fn glyphs_with_gradient_inner(ctx: &mut impl Renderer, enable_caching: bool, mod
         } else {
             (Affine::translate((0.0, baseline_y)), centered_x)
         };
-        let paint_transform = if shift_gradient {
-            Affine::translate((centered_x as f64, 0.0))
-        } else {
-            Affine::IDENTITY
+        let paint_transform = match glyph_paint {
+            GlyphPaint::Gradient => {
+                if shift_gradient {
+                    Affine::translate((centered_x as f64, 0.0))
+                } else {
+                    Affine::IDENTITY
+                }
+            }
+            GlyphPaint::Image => {
+                let image_transform = Affine::scale_non_uniform(GRADIENT_WIDTH / IMAGE_WIDTH, 1.0);
+                if shift_gradient {
+                    Affine::translate((centered_x as f64, 0.0)) * image_transform
+                } else {
+                    image_transform
+                }
+            }
         };
         let row_glyphs = glyphs.iter().map(|glyph| Glyph {
             id: glyph.id,
@@ -494,12 +547,22 @@ fn glyphs_with_gradient_inner(ctx: &mut impl Renderer, enable_caching: bool, mod
 
 #[vello_test(width = 300, height = 180, glyph)]
 fn glyphs_with_gradient(ctx: &mut impl Renderer, enable_caching: bool) {
-    glyphs_with_gradient_inner(ctx, enable_caching, DrawMode::Fill);
+    glyphs_with_transformed_paint_inner(ctx, enable_caching, DrawMode::Fill, GlyphPaint::Gradient);
 }
 
 #[vello_test(width = 300, height = 180, glyph)]
 fn glyphs_with_gradient_stroked(ctx: &mut impl Renderer, enable_caching: bool) {
-    glyphs_with_gradient_inner(ctx, enable_caching, DrawMode::Stroke);
+    glyphs_with_transformed_paint_inner(
+        ctx,
+        enable_caching,
+        DrawMode::Stroke,
+        GlyphPaint::Gradient,
+    );
+}
+
+#[vello_test(width = 300, height = 180, glyph)]
+fn glyphs_with_image(ctx: &mut impl Renderer, enable_caching: bool) {
+    glyphs_with_transformed_paint_inner(ctx, enable_caching, DrawMode::Fill, GlyphPaint::Image);
 }
 
 #[vello_test(width = 110, height = 410, glyph, hybrid_tolerance = 1)]


### PR DESCRIPTION
As part of our migration of glifo, we've basically completely broken the interaction between glyphs and complex paint transforms. This PR makes two changes to restore the expected behavior:
1) In a glyph run, we keep track of the original paint transform and later on apply a correction to make sure that each glyph is drawn with the correct paint transform.
2) We disable glyph caching for glyphs with complex paints since our image tinting API only supports solid color fills.

I added some more new tests to prevent future regressions. Thanks to @waywardmonkeys for finding this.