### PR TITLE
Increase coarse winding histogram to i16

### DIFF
--- a/sparse_strips/vello_common/src/tile.rs
+++ b/sparse_strips/vello_common/src/tile.rs
@@ -45,7 +45,7 @@ pub const MAX_LINES_PER_PATH: u32 = 1 << (32 - INT_MASK_SHIFT);
 pub struct CulledWindings {
     /// Fractional winding coverage for each individual scanline in a row.
     pub partial: Vec<[f32; Tile::HEIGHT as usize]>,
-    // Note that this will cause issues if we have windings greater/less than i8,
+    // Note that this will cause issues if we have windings greater/less than i6,
     // but this should only occur in pathological cases.
     /// Accumulated integer winding deltas for each tile row.
     pub coarse: Vec<i16>,

--- a/sparse_strips/vello_common/src/tile.rs
+++ b/sparse_strips/vello_common/src/tile.rs
@@ -45,7 +45,7 @@ pub const MAX_LINES_PER_PATH: u32 = 1 << (32 - INT_MASK_SHIFT);
 pub struct CulledWindings {
     /// Fractional winding coverage for each individual scanline in a row.
     pub partial: Vec<[f32; Tile::HEIGHT as usize]>,
-    // Note that this will cause issues if we have windings greater/less than i6,
+    // Note that this will cause issues if we have windings greater/less than i16,
     // but this should only occur in pathological cases.
     /// Accumulated integer winding deltas for each tile row.
     pub coarse: Vec<i16>,

--- a/sparse_strips/vello_common/src/tile.rs
+++ b/sparse_strips/vello_common/src/tile.rs
@@ -48,7 +48,7 @@ pub struct CulledWindings {
     // Note that this will cause issues if we have windings greater/less than i8,
     // but this should only occur in pathological cases.
     /// Accumulated integer winding deltas for each tile row.
-    pub coarse: Vec<i8>,
+    pub coarse: Vec<i16>,
     /// Bitmask tracking which rows contain active geometry or winding data.
     pub active: Vec<u32>,
     /// Flag indicating if any geometry was early-culled outside the viewport.


### PR DESCRIPTION
Unfortunately this regresses performance. I ran it a couple times to be sure with the same results.

On tile_aaa/Ghostscript_Tiger (no culling):

Before:
time:   [40.833 µs 41.494 µs 42.172 µs]
                                       
After:
time:   [47.977 µs 48.304 µs 48.724 µs]

On tile_aaa_shift50/Ghostscript_Tiger (with culling):

Before:
time:   [34.752 µs 34.898 µs 35.071 µs]

After:
time:   [38.035 µs 38.533 µs 39.224 µs]