### PR TITLE
vello_hybrid: Use RAII pattern for handling WebGL resources

### DIFF
--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -46,6 +46,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 use bytemuck::{Pod, Zeroable};
 use core::fmt::Debug;
+use core::ops::Deref;
 #[cfg(feature = "text")]
 use glifo::{GLYPH_PADDING, PendingClearRect};
 use resource::{Buffer, FragmentShader, Framebuffer, Program, Texture, VertexArray, VertexShader};
@@ -1974,7 +1975,7 @@ fn launch_probe(
     );
     gl.bind_framebuffer(
         WebGl2RenderingContext::FRAMEBUFFER,
-        Some(&resources.framebuffer),
+        Some(framebuffer.deref()),
     );
     gl.read_pixels_with_i32(
         0,

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -46,6 +46,8 @@ use alloc::vec;
 use alloc::vec::Vec;
 use bytemuck::{Pod, Zeroable};
 use core::fmt::Debug;
+#[cfg(feature = "probe")]
+use core::ops::Deref;
 #[cfg(feature = "text")]
 use glifo::{GLYPH_PADDING, PendingClearRect};
 use resource::{Buffer, FragmentShader, Framebuffer, Program, Texture, VertexArray, VertexShader};

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -575,8 +575,11 @@ impl WebGlRenderer {
             ),
         );
 
-        let previous_view_framebuffer = self.programs.resources.view_framebuffer_override.take();
-        self.programs.resources.view_framebuffer_override = Some(probe_framebuffer);
+        let previous_view_framebuffer = self
+            .programs
+            .resources
+            .view_framebuffer_override
+            .replace(probe_framebuffer);
         let render_result = self.render_scene(
             &scene,
             &mut probe_image_cache,
@@ -1284,8 +1287,8 @@ impl WebGlPrograms {
             // Replace the old resources
             self.resources.atlas_texture_array = new_atlas_texture_array;
             // Cached FBOs were attached to the old texture; drop them so we recreate on next use.
-            let _ = self.resources.atlas_render_framebuffer.take();
-            let _ = self.resources.filter_main_atlas_framebuffer.take();
+            self.resources.atlas_render_framebuffer = None;
+            self.resources.filter_main_atlas_framebuffer = None;
         }
     }
 
@@ -3004,7 +3007,7 @@ impl RendererBackend for WebGlRendererContext<'_> {
                         .filter_main_atlas_framebuffer
                         .get_or_insert_with(|| Framebuffer::new(self.gl));
                     self.gl
-                        .bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, Some(&*fb));
+                        .bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, Some(fb));
                     self.gl.framebuffer_texture_layer(
                         WebGl2RenderingContext::FRAMEBUFFER,
                         WebGl2RenderingContext::COLOR_ATTACHMENT0,

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -46,7 +46,6 @@ use alloc::vec;
 use alloc::vec::Vec;
 use bytemuck::{Pod, Zeroable};
 use core::fmt::Debug;
-use core::ops::Deref;
 #[cfg(feature = "text")]
 use glifo::{GLYPH_PADDING, PendingClearRect};
 use resource::{Buffer, FragmentShader, Framebuffer, Program, Texture, VertexArray, VertexShader};

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -1602,14 +1602,9 @@ impl WebGlPrograms {
         // Temporarily pad the length of the alphas to the texture size before uploading.
         alphas.resize(total_size, 0);
 
-        gl.active_texture(WebGl2RenderingContext::TEXTURE0);
-        gl.bind_texture(
-            WebGl2RenderingContext::TEXTURE_2D,
-            Some(&self.resources.alphas_texture),
-        );
-
         upload_data_to_rgba32_texture(
             gl,
+            &self.resources.alphas_texture,
             bytemuck::cast_slice::<u8, u32>(alphas),
             alpha_texture_width,
             alpha_texture_height,
@@ -1631,14 +1626,9 @@ impl WebGlPrograms {
 
             GpuEncodedPaint::serialize_to_buffer(encoded_paints, &mut self.encoded_paints_data);
 
-            gl.active_texture(WebGl2RenderingContext::TEXTURE0);
-            gl.bind_texture(
-                WebGl2RenderingContext::TEXTURE_2D,
-                Some(&self.resources.encoded_paints_texture),
-            );
-
             upload_data_to_rgba32_texture(
                 gl,
+                &self.resources.encoded_paints_texture,
                 bytemuck::cast_slice::<u8, u32>(&self.encoded_paints_data),
                 encoded_paints_texture_width,
                 encoded_paints_texture_height,
@@ -3318,10 +3308,14 @@ fn copy_to_texture_array_layer(
 // Upload the data to the currently bound texture assuming a RGBA32UI format.
 fn upload_data_to_rgba32_texture(
     gl: &WebGl2RenderingContext,
+    texture: &WebGlTexture,
     data: &[u32],
     texture_width: u32,
     texture_height: u32,
 ) {
+    gl.active_texture(WebGl2RenderingContext::TEXTURE0);
+    gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, Some(texture));
+
     // Safety: This calling `Uint32Array::view` is unsafe because it provides a view into
     // WASM linear memory, and any additional allocations might invalidate that view.
     // In our case, this is not an issue because we only use this view once for uploading

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -135,14 +135,6 @@ pub struct WebGlPendingProbe {
     height: u16,
 }
 
-#[cfg(feature = "probe")]
-#[derive(Debug)]
-struct WebGlProbeResources {
-    framebuffer: Framebuffer,
-    _texture: Texture,
-    _atlas_texture_array: WebGlTextureArray,
-}
-
 /// Error returned while running a WebGL probe.
 #[cfg(feature = "probe")]
 #[derive(Debug, Clone, Error)]
@@ -600,17 +592,11 @@ impl WebGlRenderer {
             &mut probe_atlas_texture_array,
         );
 
-        let probe_resources = WebGlProbeResources {
-            framebuffer: probe_framebuffer,
-            _texture: probe_texture,
-            _atlas_texture_array: probe_atlas_texture_array,
-        };
-
         // We do this here instead of above such that in case the render result is not
         // valid, we still properly restore the state (e.g. the old atlas texture array).
         render_result?;
 
-        let pending = launch_probe(&self.gl, probe_resources, width, height);
+        let pending = launch_probe(&self.gl, &probe_framebuffer, width, height);
 
         Ok(pending)
     }
@@ -1970,7 +1956,7 @@ struct WebGlStateConfig {
 #[cfg(feature = "probe")]
 fn launch_probe(
     gl: &WebGl2RenderingContext,
-    resources: WebGlProbeResources,
+    framebuffer: &Framebuffer,
     width: u16,
     height: u16,
 ) -> WebGlPendingProbe {

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -48,6 +48,7 @@ use bytemuck::{Pod, Zeroable};
 use core::fmt::Debug;
 #[cfg(feature = "text")]
 use glifo::{GLYPH_PADDING, PendingClearRect};
+use resource::{Buffer, FragmentShader, Framebuffer, Program, Texture, VertexArray, VertexShader};
 #[cfg(feature = "probe")]
 use thiserror::Error;
 use vello_common::image_cache::{ImageCache, ImageResource};
@@ -74,7 +75,7 @@ use web_sys::WebGlSync;
 use web_sys::wasm_bindgen::{JsCast, JsValue};
 use web_sys::{
     HtmlCanvasElement, WebGl2RenderingContext, WebGlBuffer, WebGlFramebuffer, WebGlProgram,
-    WebGlTexture, WebGlUniformLocation, WebGlVertexArrayObject,
+    WebGlShader, WebGlTexture, WebGlUniformLocation, WebGlVertexArrayObject,
 };
 
 /// Placeholder value for uninitialized GPU encoded paints.
@@ -137,20 +138,9 @@ pub struct WebGlPendingProbe {
 #[cfg(feature = "probe")]
 #[derive(Debug)]
 struct WebGlProbeResources {
-    gl: WebGl2RenderingContext,
-    framebuffer: WebGlFramebuffer,
-    texture: WebGlTexture,
-    atlas_texture_array: WebGlTextureArray,
-}
-
-#[cfg(feature = "probe")]
-impl Drop for WebGlProbeResources {
-    fn drop(&mut self) {
-        self.gl.delete_framebuffer(Some(&self.framebuffer));
-        self.gl.delete_texture(Some(&self.texture));
-        self.gl
-            .delete_texture(Some(&self.atlas_texture_array.texture));
-    }
+    framebuffer: Framebuffer,
+    _texture: Texture,
+    _atlas_texture_array: WebGlTextureArray,
 }
 
 /// Error returned while running a WebGL probe.
@@ -443,7 +433,7 @@ impl WebGlRenderer {
             .resources
             .atlas_render_framebuffer
             .take()
-            .unwrap_or_else(|| self.gl.create_framebuffer().unwrap());
+            .unwrap_or_else(|| Framebuffer::new(&self.gl));
         self.gl.bind_framebuffer(
             WebGl2RenderingContext::FRAMEBUFFER,
             Some(&atlas_framebuffer),
@@ -585,11 +575,8 @@ impl WebGlRenderer {
             ),
         );
 
-        let previous_view_framebuffer = self
-            .programs
-            .resources
-            .view_framebuffer_override
-            .replace(probe_framebuffer.clone());
+        let previous_view_framebuffer = self.programs.resources.view_framebuffer_override.take();
+        self.programs.resources.view_framebuffer_override = Some(probe_framebuffer);
         let render_result = self.render_scene(
             &scene,
             &mut probe_image_cache,
@@ -597,6 +584,12 @@ impl WebGlRenderer {
             true,
             RootRenderTarget::AtlasLayer,
         );
+        let probe_framebuffer = self
+            .programs
+            .resources
+            .view_framebuffer_override
+            .take()
+            .expect("probe framebuffer must be restored after rendering");
         self.programs.resources.view_framebuffer_override = previous_view_framebuffer;
 
         core::mem::swap(
@@ -605,10 +598,9 @@ impl WebGlRenderer {
         );
 
         let probe_resources = WebGlProbeResources {
-            gl: self.gl.clone(),
             framebuffer: probe_framebuffer,
-            texture: probe_texture,
-            atlas_texture_array: probe_atlas_texture_array,
+            _texture: probe_texture,
+            _atlas_texture_array: probe_atlas_texture_array,
         };
 
         // We do this here instead of above such that in case the render result is not
@@ -697,7 +689,7 @@ impl WebGlRenderer {
         if self.programs.resources.depth_cleared_this_frame {
             self.gl.bind_framebuffer(
                 WebGl2RenderingContext::FRAMEBUFFER,
-                self.programs.resources.view_framebuffer_override.as_ref(),
+                self.programs.resources.view_framebuffer_override.as_deref(),
             );
             self.gl
                 .invalidate_framebuffer(
@@ -807,7 +799,7 @@ impl WebGlRenderer {
     /// Clear a specific region of the atlas texture array.
     fn clear_atlas_region(&mut self, atlas_id: AtlasId, offset: [u32; 2], width: u32, height: u32) {
         let _state_guard = WebGlStateGuard::for_clear_atlas_region(&self.gl);
-        let temp_framebuffer = self.gl.create_framebuffer().unwrap();
+        let temp_framebuffer = Framebuffer::new(&self.gl);
 
         // Bind our temporary framebuffer
         self.gl
@@ -839,9 +831,6 @@ impl WebGlRenderer {
         // Clear the region to transparent (0, 0, 0, 0)
         self.gl.clear_color(0.0, 0.0, 0.0, 0.0);
         self.gl.clear(WebGl2RenderingContext::COLOR_BUFFER_BIT);
-
-        // Clean up temporary framebuffer
-        self.gl.delete_framebuffer(Some(&temp_framebuffer));
     }
 
     fn prepare_gpu_encoded_paints(
@@ -1030,15 +1019,15 @@ fn clear_atlas_region(renderer: &mut WebGlRenderer, rect: &PendingClearRect) {
 #[derive(Debug)]
 struct WebGlPrograms {
     /// Program for rendering wide tile commands.
-    strip_program: WebGlProgram,
+    strip_program: Program,
     /// Uniform locations for the strip program
     strip_uniforms: StripUniforms,
     /// Program for clearing slots in slot textures.
-    clear_program: WebGlProgram,
+    clear_program: Program,
     /// Uniform locations for the `clear_program`.
     clear_uniforms: ClearUniforms,
     /// Program for filter passes.
-    filter_program: WebGlProgram,
+    filter_program: Program,
     /// Uniform locations for the filter program.
     filter_uniforms: FilterPassUniforms,
     /// WebGL resources for rendering.
@@ -1094,48 +1083,48 @@ struct ClearUniforms {
 #[derive(Debug)]
 struct WebGlResources {
     /// VAO for strip rendering.
-    strip_vao: WebGlVertexArrayObject,
+    strip_vao: VertexArray,
     /// Buffer for [`GpuStrip`] data.
-    strips_buffer: WebGlBuffer,
+    strips_buffer: Buffer,
     /// Texture for alpha values (used by both view and slot rendering).
-    alphas_texture: WebGlTexture,
+    alphas_texture: Texture,
     /// Height of alpha texture.
     alpha_texture_height: u32,
     /// Texture array for atlas data (multiple atlases supported)
     atlas_texture_array: WebGlTextureArray,
     /// Encoded paints texture for image metadata.
-    encoded_paints_texture: WebGlTexture,
+    encoded_paints_texture: Texture,
     /// Height of encoded paints texture.
     encoded_paints_texture_height: u32,
     /// Gradient texture for gradient ramp data.
-    gradient_texture: WebGlTexture,
+    gradient_texture: Texture,
     /// Placeholder texture bound to the strip shader's `external_texture` sampler.
-    placeholder_external_texture: WebGlTexture,
+    placeholder_external_texture: Texture,
     /// Height of gradient texture.
     gradient_texture_height: u32,
 
     /// Config buffer for rendering wide tile commands into the view texture.
-    view_config_buffer: WebGlBuffer,
+    view_config_buffer: Buffer,
     /// Config buffer for rendering wide tile commands into a slot texture.
-    slot_config_buffer: WebGlBuffer,
+    slot_config_buffer: Buffer,
 
     /// Buffer for slot indices used in `clear_slots`.
-    clear_slot_indices_buffer: WebGlBuffer,
+    clear_slot_indices_buffer: Buffer,
     /// VAO for clear slots program.
-    clear_vao: WebGlVertexArrayObject,
+    clear_vao: VertexArray,
     /// Config buffer for clear program.
-    clear_config_buffer: WebGlBuffer,
+    clear_config_buffer: Buffer,
 
-    view_framebuffer_override: Option<WebGlFramebuffer>,
+    view_framebuffer_override: Option<Framebuffer>,
     /// Whether the depth buffer has been cleared this frame.
     depth_cleared_this_frame: bool,
     /// Pre-allocated JS array for `invalidateFramebuffer` calls.
     depth_attachment_array: js_sys::Array,
 
     /// Slot textures.
-    slot_textures: [WebGlTexture; 2],
+    slot_textures: [Texture; 2],
     /// Framebuffers for slot textures.
-    slot_framebuffers: [WebGlFramebuffer; 2],
+    slot_framebuffers: [Framebuffer; 2],
 
     /// Cached result from querying `WebGl2RenderingContext::MAX_TEXTURE_SIZE` which is a blocking
     /// WebGL call.
@@ -1147,26 +1136,26 @@ struct WebGlResources {
 
     /// Cached framebuffer for rendering into an atlas layer in `render_to_atlas`.
     /// Reused to avoid create/delete overhead on every call.
-    atlas_render_framebuffer: Option<WebGlFramebuffer>,
+    atlas_render_framebuffer: Option<Framebuffer>,
 
     /// Cached framebuffer for filter passes that write back to the main atlas.
     /// Reused to avoid create/delete overhead on every filter application.
-    filter_main_atlas_framebuffer: Option<WebGlFramebuffer>,
+    filter_main_atlas_framebuffer: Option<Framebuffer>,
 
     /// Individual 2D textures for filter intermediate results.
-    filter_atlas_textures: Vec<WebGlTexture>,
+    filter_atlas_textures: Vec<Texture>,
     /// Framebuffers for each filter atlas texture.
-    filter_atlas_framebuffers: Vec<WebGlFramebuffer>,
+    filter_atlas_framebuffers: Vec<Framebuffer>,
     /// RGBA32UI texture storing filter parameters.
-    filter_data_texture: WebGlTexture,
+    filter_data_texture: Texture,
     /// Current height of filter data texture.
     filter_data_texture_height: u32,
     /// Per-instance vertex data buffer for filter draws.
-    filter_instance_buffer: WebGlBuffer,
+    filter_instance_buffer: Buffer,
     /// VAO for filter rendering.
-    filter_vao: WebGlVertexArrayObject,
+    filter_vao: VertexArray,
     /// Config buffer for rendering filter layers.
-    filter_config_buffer: WebGlBuffer,
+    filter_config_buffer: Buffer,
     /// Cached atlas width for creating new filter atlas textures.
     filter_atlas_width: u32,
     /// Cached atlas height for creating new filter atlas textures.
@@ -1295,12 +1284,8 @@ impl WebGlPrograms {
             // Replace the old resources
             self.resources.atlas_texture_array = new_atlas_texture_array;
             // Cached FBOs were attached to the old texture; drop them so we recreate on next use.
-            if let Some(fb) = self.resources.atlas_render_framebuffer.take() {
-                gl.delete_framebuffer(Some(&fb));
-            }
-            if let Some(fb) = self.resources.filter_main_atlas_framebuffer.take() {
-                gl.delete_framebuffer(Some(&fb));
-            }
+            let _ = self.resources.atlas_render_framebuffer.take();
+            let _ = self.resources.filter_main_atlas_framebuffer.take();
         }
     }
 
@@ -1709,7 +1694,7 @@ impl WebGlPrograms {
     fn clear_view_framebuffer(&mut self, gl: &WebGl2RenderingContext) {
         gl.bind_framebuffer(
             WebGl2RenderingContext::FRAMEBUFFER,
-            self.resources.view_framebuffer_override.as_ref(),
+            self.resources.view_framebuffer_override.as_deref(),
         );
         gl.clear_color(0.0, 0.0, 0.0, 0.0);
         gl.clear(WebGl2RenderingContext::COLOR_BUFFER_BIT);
@@ -2047,11 +2032,9 @@ fn create_shader_program(
     gl: &WebGl2RenderingContext,
     vertex_src: &str,
     fragment_src: &str,
-) -> WebGlProgram {
+) -> Program {
     // Compile vertex shader.
-    let vertex_shader = gl
-        .create_shader(WebGl2RenderingContext::VERTEX_SHADER)
-        .unwrap();
+    let vertex_shader = VertexShader::new(gl);
     gl.shader_source(&vertex_shader, vertex_src);
     gl.compile_shader(&vertex_shader);
 
@@ -2067,9 +2050,7 @@ fn create_shader_program(
     }
 
     // Compile fragment shader.
-    let fragment_shader = gl
-        .create_shader(WebGl2RenderingContext::FRAGMENT_SHADER)
-        .unwrap();
+    let fragment_shader = FragmentShader::new(gl);
     gl.shader_source(&fragment_shader, fragment_src);
     gl.compile_shader(&fragment_shader);
 
@@ -2085,7 +2066,7 @@ fn create_shader_program(
     }
 
     // Create and link the program.
-    let program = gl.create_program().unwrap();
+    let program = Program::new(gl);
     gl.attach_shader(&program, &vertex_shader);
     gl.attach_shader(&program, &fragment_shader);
     gl.link_program(&program);
@@ -2101,14 +2082,11 @@ fn create_shader_program(
         panic!("Failed to link program: {info}");
     }
 
-    gl.delete_shader(Some(&vertex_shader));
-    gl.delete_shader(Some(&fragment_shader));
-
     program
 }
 
 /// Get the  uniform locations for the `render_strips` program.
-fn get_strip_uniforms(gl: &WebGl2RenderingContext, program: &WebGlProgram) -> StripUniforms {
+fn get_strip_uniforms(gl: &WebGl2RenderingContext, program: &Program) -> StripUniforms {
     let config_vs_name = render_strips::vertex::CONFIG;
     let config_vs_block_index = gl.get_uniform_block_index(program, config_vs_name);
 
@@ -2167,7 +2145,7 @@ fn get_strip_uniforms(gl: &WebGl2RenderingContext, program: &WebGlProgram) -> St
 }
 
 /// Get the uniform locations for the `clear_slots` program.
-fn get_clear_uniforms(gl: &WebGl2RenderingContext, program: &WebGlProgram) -> ClearUniforms {
+fn get_clear_uniforms(gl: &WebGl2RenderingContext, program: &Program) -> ClearUniforms {
     let config_name = clear_slots::vertex::CONFIG;
     let config_block_index = gl.get_uniform_block_index(program, config_name);
 
@@ -2183,10 +2161,7 @@ fn get_clear_uniforms(gl: &WebGl2RenderingContext, program: &WebGlProgram) -> Cl
     ClearUniforms { config_block_index }
 }
 
-fn get_filter_pass_uniforms(
-    gl: &WebGl2RenderingContext,
-    program: &WebGlProgram,
-) -> FilterPassUniforms {
+fn get_filter_pass_uniforms(gl: &WebGl2RenderingContext, program: &Program) -> FilterPassUniforms {
     let filter_data = gl
         .get_uniform_location(program, filters::fragment::FILTER_DATA)
         .unwrap();
@@ -2203,12 +2178,8 @@ fn get_filter_pass_uniforms(
     }
 }
 
-fn create_filter_atlas_texture(
-    gl: &WebGl2RenderingContext,
-    width: u32,
-    height: u32,
-) -> WebGlTexture {
-    let texture = gl.create_texture().unwrap();
+fn create_filter_atlas_texture(gl: &WebGl2RenderingContext, width: u32, height: u32) -> Texture {
+    let texture = Texture::new(gl);
     gl.active_texture(WebGl2RenderingContext::TEXTURE0);
     gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, Some(&texture));
     gl.tex_parameteri(
@@ -2285,18 +2256,18 @@ fn initialize_filter_vao(gl: &WebGl2RenderingContext, resources: &WebGlResources
 }
 
 /// Create a texture with nearest neighbor sampling and clamp-to-edge wrapping.
-fn create_texture(gl: &WebGl2RenderingContext) -> WebGlTexture {
+fn create_texture(gl: &WebGl2RenderingContext) -> Texture {
     create_texture_inner(gl, WebGl2RenderingContext::TEXTURE_2D)
 }
 
 /// Create a texture array with nearest neighbor sampling and
 /// clamp-to-edge wrapping.
-fn create_texture_array(gl: &WebGl2RenderingContext) -> WebGlTexture {
+fn create_texture_array(gl: &WebGl2RenderingContext) -> Texture {
     create_texture_inner(gl, WebGl2RenderingContext::TEXTURE_2D_ARRAY)
 }
 
-fn create_texture_inner(gl: &WebGl2RenderingContext, target: u32) -> WebGlTexture {
-    let texture = gl.create_texture().unwrap();
+fn create_texture_inner(gl: &WebGl2RenderingContext, target: u32) -> Texture {
+    let texture = Texture::new(gl);
     gl.active_texture(WebGl2RenderingContext::TEXTURE0);
     gl.bind_texture(target, Some(&texture));
     // The filter and wrap modes are irrelevant because the shader
@@ -2330,7 +2301,7 @@ fn create_texture_inner(gl: &WebGl2RenderingContext, target: u32) -> WebGlTextur
 }
 
 /// Create a 1x1 RGBA8 placeholder texture.
-fn create_placeholder_texture(gl: &WebGl2RenderingContext) -> WebGlTexture {
+fn create_placeholder_texture(gl: &WebGl2RenderingContext) -> Texture {
     let texture = create_texture(gl);
     gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_u8_array(
         WebGl2RenderingContext::TEXTURE_2D,
@@ -2354,16 +2325,16 @@ fn create_webgl_resources(
     filter_context: &FilterContext,
     slot_count: usize,
 ) -> WebGlResources {
-    let strip_vao = gl.create_vertex_array().unwrap();
-    let clear_vao = gl.create_vertex_array().unwrap();
-    let filter_vao = gl.create_vertex_array().unwrap();
-    let filter_instance_buffer = gl.create_buffer().unwrap();
+    let strip_vao = VertexArray::new(gl);
+    let clear_vao = VertexArray::new(gl);
+    let filter_vao = VertexArray::new(gl);
+    let filter_instance_buffer = Buffer::new(gl);
 
-    let strips_buffer = gl.create_buffer().unwrap();
-    let view_config_buffer = gl.create_buffer().unwrap();
-    let slot_config_buffer = gl.create_buffer().unwrap();
-    let clear_slot_indices_buffer = gl.create_buffer().unwrap();
-    let clear_config_buffer = gl.create_buffer().unwrap();
+    let strips_buffer = Buffer::new(gl);
+    let view_config_buffer = Buffer::new(gl);
+    let slot_config_buffer = Buffer::new(gl);
+    let clear_slot_indices_buffer = Buffer::new(gl);
+    let clear_config_buffer = Buffer::new(gl);
 
     // Create and configure alpha texture.
     let alphas_texture = create_texture(gl);
@@ -2388,12 +2359,12 @@ fn create_webgl_resources(
     let placeholder_external_texture = create_placeholder_texture(gl);
 
     // Create slot textures and framebuffers.
-    let slot_textures: [WebGlTexture; 2] = [
+    let slot_textures: [Texture; 2] = [
         create_slot_texture(gl, slot_count),
         create_slot_texture(gl, slot_count),
     ];
 
-    let slot_framebuffers: [WebGlFramebuffer; 2] = [
+    let slot_framebuffers: [Framebuffer; 2] = [
         create_framebuffer_for_texture(gl, &slot_textures[0]),
         create_framebuffer_for_texture(gl, &slot_textures[1]),
     ];
@@ -2401,7 +2372,7 @@ fn create_webgl_resources(
     let max_texture_dimension_2d = get_max_texture_dimension_2d(gl);
 
     let filter_data_texture = create_texture(gl);
-    let filter_config_buffer = gl.create_buffer().unwrap();
+    let filter_config_buffer = Buffer::new(gl);
 
     let AtlasConfig {
         atlas_size: (filter_atlas_width, filter_atlas_height),
@@ -2476,7 +2447,7 @@ fn create_atlas_texture_array(
 }
 
 /// Create a texture for slot rendering.
-fn create_slot_texture(gl: &WebGl2RenderingContext, slot_count: usize) -> WebGlTexture {
+fn create_slot_texture(gl: &WebGl2RenderingContext, slot_count: usize) -> Texture {
     let texture = create_texture(gl);
 
     gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_array_buffer_view(
@@ -2499,8 +2470,8 @@ fn create_slot_texture(gl: &WebGl2RenderingContext, slot_count: usize) -> WebGlT
 fn create_framebuffer_for_texture(
     gl: &WebGl2RenderingContext,
     texture: &WebGlTexture,
-) -> WebGlFramebuffer {
-    let framebuffer = gl.create_framebuffer().unwrap();
+) -> Framebuffer {
+    let framebuffer = Framebuffer::new(gl);
     gl.bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, Some(&framebuffer));
 
     gl.framebuffer_texture_2d(
@@ -2669,7 +2640,7 @@ impl WebGlRendererContext<'_> {
             StripPassRenderTarget::Root(_) => {
                 self.gl.bind_framebuffer(
                     WebGl2RenderingContext::FRAMEBUFFER,
-                    self.programs.resources.view_framebuffer_override.as_ref(),
+                    self.programs.resources.view_framebuffer_override.as_deref(),
                 );
                 let width = self.programs.render_size.width;
                 let height = self.programs.render_size.height;
@@ -3041,9 +3012,9 @@ impl RendererBackend for WebGlRendererContext<'_> {
                         .programs
                         .resources
                         .filter_main_atlas_framebuffer
-                        .get_or_insert_with(|| self.gl.create_framebuffer().unwrap());
+                        .get_or_insert_with(|| Framebuffer::new(self.gl));
                     self.gl
-                        .bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, Some(fb));
+                        .bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, Some(&*fb));
                     self.gl.framebuffer_texture_layer(
                         WebGl2RenderingContext::FRAMEBUFFER,
                         WebGl2RenderingContext::COLOR_ATTACHMENT0,
@@ -3267,14 +3238,14 @@ impl WebGlAtlasWriter for WebGlTextureWithDimensions {
 #[derive(Debug)]
 struct WebGlTextureArray {
     /// The WebGL texture array.
-    texture: WebGlTexture,
+    texture: Texture,
     /// The size of the texture array.
     size: WebGlTextureSize,
 }
 
 impl WebGlTextureArray {
     /// Create a new WebGL texture array wrapper.
-    fn new(texture: WebGlTexture, width: u32, height: u32, depth_or_array_layers: u32) -> Self {
+    fn new(texture: Texture, width: u32, height: u32, depth_or_array_layers: u32) -> Self {
         Self {
             texture,
             size: WebGlTextureSize {
@@ -3312,7 +3283,7 @@ fn copy_to_texture_array_layer(
     copy_size: [u32; 2],
 ) {
     let _state_guard = WebGlStateGuard::for_texture_copy(gl);
-    let read_framebuffer = gl.create_framebuffer().unwrap();
+    let read_framebuffer = Framebuffer::new(gl);
 
     // Bind destination texture array
     gl.active_texture(WebGl2RenderingContext::TEXTURE0);
@@ -3342,9 +3313,6 @@ fn copy_to_texture_array_layer(
         copy_size[0] as i32,
         copy_size[1] as i32,
     );
-
-    // Clean up
-    gl.delete_framebuffer(Some(&read_framebuffer));
 }
 
 // Upload the data to the currently bound texture assuming a RGBA32UI format.
@@ -3386,4 +3354,174 @@ fn upload_data_to_rgba32_texture(
         Some(&packed_array),
     )
     .unwrap();
+}
+
+mod resource {
+    use core::ops::Deref;
+
+    use super::{
+        WebGl2RenderingContext, WebGlBuffer, WebGlFramebuffer, WebGlProgram, WebGlShader,
+        WebGlTexture, WebGlVertexArrayObject,
+    };
+
+    pub(super) trait GlResource {
+        const LABEL: &'static str;
+
+        fn create(gl: &WebGl2RenderingContext) -> Option<Self>
+        where
+            Self: Sized;
+
+        fn delete(gl: &WebGl2RenderingContext, raw: &Self);
+    }
+
+    #[derive(Debug)]
+    pub(super) struct Resource<T: GlResource> {
+        gl: WebGl2RenderingContext,
+        raw: T,
+    }
+
+    // `Resource` intentionally does not implement `Clone`. There should
+    // only be a single handle to a given resources, such that it has
+    // unique ownership and we don't end up deleting the same resource
+    // twice.
+    impl<T: GlResource> Resource<T> {
+        pub(super) fn new(gl: &WebGl2RenderingContext) -> Self {
+            let raw =
+                T::create(gl).unwrap_or_else(|| panic!("failed to create WebGL {}", T::LABEL));
+            Self {
+                gl: gl.clone(),
+                raw,
+            }
+        }
+    }
+
+    impl<T: GlResource> Drop for Resource<T> {
+        fn drop(&mut self) {
+            T::delete(&self.gl, &self.raw);
+        }
+    }
+
+    impl<T: GlResource> Deref for Resource<T> {
+        type Target = T;
+
+        fn deref(&self) -> &Self::Target {
+            &self.raw
+        }
+    }
+
+    #[derive(Debug)]
+    pub(super) struct WebGlVertexShader(WebGlShader);
+
+    impl Deref for WebGlVertexShader {
+        type Target = WebGlShader;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    #[derive(Debug)]
+    pub(super) struct WebGlFragmentShader(WebGlShader);
+
+    impl Deref for WebGlFragmentShader {
+        type Target = WebGlShader;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    impl GlResource for WebGlTexture {
+        const LABEL: &'static str = "texture";
+
+        fn create(gl: &WebGl2RenderingContext) -> Option<Self> {
+            gl.create_texture()
+        }
+
+        fn delete(gl: &WebGl2RenderingContext, raw: &Self) {
+            gl.delete_texture(Some(raw));
+        }
+    }
+
+    impl GlResource for WebGlBuffer {
+        const LABEL: &'static str = "buffer";
+
+        fn create(gl: &WebGl2RenderingContext) -> Option<Self> {
+            gl.create_buffer()
+        }
+
+        fn delete(gl: &WebGl2RenderingContext, raw: &Self) {
+            gl.delete_buffer(Some(raw));
+        }
+    }
+
+    impl GlResource for WebGlFramebuffer {
+        const LABEL: &'static str = "framebuffer";
+
+        fn create(gl: &WebGl2RenderingContext) -> Option<Self> {
+            gl.create_framebuffer()
+        }
+
+        fn delete(gl: &WebGl2RenderingContext, raw: &Self) {
+            gl.delete_framebuffer(Some(raw));
+        }
+    }
+
+    impl GlResource for WebGlProgram {
+        const LABEL: &'static str = "program";
+
+        fn create(gl: &WebGl2RenderingContext) -> Option<Self> {
+            gl.create_program()
+        }
+
+        fn delete(gl: &WebGl2RenderingContext, raw: &Self) {
+            gl.delete_program(Some(raw));
+        }
+    }
+
+    impl GlResource for WebGlVertexShader {
+        const LABEL: &'static str = "vertex shader";
+
+        fn create(gl: &WebGl2RenderingContext) -> Option<Self> {
+            gl.create_shader(WebGl2RenderingContext::VERTEX_SHADER)
+                .map(Self)
+        }
+
+        fn delete(gl: &WebGl2RenderingContext, raw: &Self) {
+            gl.delete_shader(Some(raw));
+        }
+    }
+
+    impl GlResource for WebGlFragmentShader {
+        const LABEL: &'static str = "fragment shader";
+
+        fn create(gl: &WebGl2RenderingContext) -> Option<Self> {
+            gl.create_shader(WebGl2RenderingContext::FRAGMENT_SHADER)
+                .map(Self)
+        }
+
+        fn delete(gl: &WebGl2RenderingContext, raw: &Self) {
+            gl.delete_shader(Some(raw));
+        }
+    }
+
+    impl GlResource for WebGlVertexArrayObject {
+        const LABEL: &'static str = "vertex array";
+
+        fn create(gl: &WebGl2RenderingContext) -> Option<Self> {
+            gl.create_vertex_array()
+        }
+
+        fn delete(gl: &WebGl2RenderingContext, raw: &Self) {
+            gl.delete_vertex_array(Some(raw));
+        }
+    }
+
+    pub(super) type Texture = Resource<WebGlTexture>;
+    pub(super) type Buffer = Resource<WebGlBuffer>;
+    pub(super) type Framebuffer = Resource<WebGlFramebuffer>;
+    pub(super) type Program = Resource<WebGlProgram>;
+    pub(super) type VertexShader = Resource<WebGlVertexShader>;
+    pub(super) type FragmentShader = Resource<WebGlFragmentShader>;
+    pub(super) type VertexArray = Resource<WebGlVertexArrayObject>;
 }


### PR DESCRIPTION
This is a new PR, which does basically the same as #1574 but is based on the newest main, which has had quite a few changes. To explain the motivation again:

# Motivation

Right now, the WebGL backend of Vello Hybrid creates various resources, such as buffers, textures, etc., but we never actually destroy them once they go out-of-scope. This means that we are essentially relying on the garbage collector to properly clean those up. This _might_ be fine if we are only creating a single Vello Hybrid instance, but 1) it's bad practice and 2) might cause problems in case you want to have the ability to create multiple Vello Hybrid (for example to recreate it after a WebGL context loss).

# Implementation

Basically, what this PR proposes is to create a wrapper type for all resources, each resource implementing a trait that defines how to create the resource and how to drop it. We then make use of the `Drop` implementation of `Resource` to manually delete the resource again. This way, as soon as the variable goes out-of-scope (since it's not used anymore), the bound resource will be deleted as well. This way, we don't have to worry about manually deleting them anymore.

I should note that there is a small footgun we need to be careful about: It is still possible to write code that for example assumes that some resource has been bound previously and then acts on that. It could happen that we create a new resource, bind it in WebGL, then the variable goes out-of-scope and some other function later on still acts on that binding, assuming that it's still alive. I'm not sure what would happen in such a case, but it's certainly not good. As far as I can tell, we currently don't have any such code (I rewrote the `upload_data_to_rgba32_texture` method to let it take care of binding the resource it needs explicitly), but it's still something we should keep in mind when extending the backend in the future. I'm not sure if there is any way of preventing such code at compile-time via a different design. Nevertheless, I think this is a good start.

# Testing

I have tried the WebGL example scenes on my machine and also ran vello_bench2 on a couple of devices, and didn't observe any problems.