### PR TITLE
vello_cpu: Always redraw in the winit example

### DIFF
--- a/sparse_strips/vello_cpu/examples/winit/src/main.rs
+++ b/sparse_strips/vello_cpu/examples/winit/src/main.rs
@@ -476,9 +476,7 @@ impl ApplicationHandler for App {
                 buffer.present().unwrap();
 
                 // Request continuous redraw for FPS measurement
-                if self.rotating || self.shearing {
-                    window.request_redraw();
-                }
+                window.request_redraw();
             }
             _ => {}
         }


### PR DESCRIPTION
This makes it consistent with how vello_hybrid is handled and easier to observe the FPS of a scene. Otherwise, you need to keep panning to actually see the FPS.