### PR TITLE
sparse_strips: Add example scene for rendering COLR glyphs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4198,6 +4198,7 @@ dependencies = [
  "image",
  "log",
  "parley",
+ "skrifa",
  "smallvec",
  "vello_common",
  "vello_cpu",

--- a/sparse_strips/vello_cpu/examples/wasm_cpu/src/lib.rs
+++ b/sparse_strips/vello_cpu/examples/wasm_cpu/src/lib.rs
@@ -137,6 +137,14 @@ impl AppState {
         self.need_render = true;
     }
 
+    fn handle_key(&mut self, key: &str) {
+        if let Some(scene) = self.scenes.get_mut(self.current_scene)
+            && scene.handle_key(key)
+        {
+            self.need_render = true;
+        }
+    }
+
     fn handle_mouse_down(&mut self, x: f64, y: f64) {
         self.mouse_down = true;
         self.last_cursor_position = Some(Vec2::new(x, y));
@@ -328,15 +336,15 @@ pub async fn run_interactive(canvas_width: u16, canvas_height: u16) {
     {
         let app_state = app_state.clone();
         let document = web_sys::window().unwrap().document().unwrap();
-        let closure =
-            Closure::wrap(
-                Box::new(move |event: KeyboardEvent| match event.key().as_str() {
-                    "ArrowRight" => app_state.borrow_mut().next_scene(),
-                    "ArrowLeft" => app_state.borrow_mut().prev_scene(),
-                    " " => app_state.borrow_mut().reset_transform(),
-                    _ => {}
-                }) as Box<dyn FnMut(_)>,
-            );
+        let closure = Closure::wrap(Box::new(move |event: KeyboardEvent| {
+            let key = event.key();
+            match key.as_str() {
+                "ArrowRight" => app_state.borrow_mut().next_scene(),
+                "ArrowLeft" => app_state.borrow_mut().prev_scene(),
+                " " => app_state.borrow_mut().reset_transform(),
+                _ => app_state.borrow_mut().handle_key(key.as_str()),
+            }
+        }) as Box<dyn FnMut(_)>);
         document
             .add_event_listener_with_callback("keydown", closure.as_ref().unchecked_ref())
             .unwrap();

--- a/sparse_strips/vello_example_scenes/Cargo.toml
+++ b/sparse_strips/vello_example_scenes/Cargo.toml
@@ -17,6 +17,7 @@ cpu = ["dep:vello_cpu"]
 bytemuck = { workspace = true, features = [] }
 smallvec = { workspace = true }
 glifo = { workspace = true }
+skrifa = { workspace = true }
 vello_hybrid = { workspace = true }
 vello_common = { workspace = true, features = ["pico_svg", "png"] }
 image = { workspace = true, features = ["jpeg"] }

--- a/sparse_strips/vello_example_scenes/README.md
+++ b/sparse_strips/vello_example_scenes/README.md
@@ -17,3 +17,12 @@ The Emoji Grid scene uses the bundled Noto Color Emoji COLR subset by default.
 Native builds can render a different COLR font by setting `NOTO_COLR_PATH` to
 the font file path before running the example. For it to work in WASM, you have to
 change two lines in the source file, see there for more information.
+
+You can do something as follows to get it up and running (on Linux/MacOS):
+```bash
+curl -L -o /tmp/Noto-COLRv1.ttf https://github.com/googlefonts/noto-emoji/raw/main/fonts/Noto-COLRv1.ttf
+
+NOTO_COLR_PATH=/tmp/Noto-COLRv1.ttf cargo run -p vello_hybrid_winit --release
+# OR
+NOTO_COLR_PATH=/tmp/Noto-COLRv1.ttf cargo run -p vello_cpu_winit --release
+```

--- a/sparse_strips/vello_example_scenes/README.md
+++ b/sparse_strips/vello_example_scenes/README.md
@@ -9,3 +9,11 @@ This crate provides various scene implementations including:
 - Gradients and blending
 - SVG rendering
 - Clipping operations
+- COLR emoji stress testing
+
+## Emoji Grid Font
+
+The Emoji Grid scene uses the bundled Noto Color Emoji COLR subset by default.
+Native builds can render a different COLR font by setting `NOTO_COLR_PATH` to
+the font file path before running the example. For it to work in WASM, you have to
+change two lines in the source file, see there for more information.

--- a/sparse_strips/vello_example_scenes/src/emoji_grid.rs
+++ b/sparse_strips/vello_example_scenes/src/emoji_grid.rs
@@ -1,0 +1,280 @@
+// Copyright 2026 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Interactive COLR emoji grid scene.
+
+use core::fmt;
+use std::sync::Arc;
+
+use glifo::Glyph;
+use skrifa::instance::{LocationRef, Size};
+use skrifa::raw::FileRef;
+use skrifa::raw::TableProvider;
+use skrifa::{GlyphId, MetadataProvider};
+use vello_common::kurbo::{Affine, Rect};
+use vello_common::peniko::{Blob, FontData};
+
+use crate::{ExampleScene, RenderingContext};
+
+const FALLBACK_NOTO_COLR_FONT: &[u8] =
+    include_bytes!("../../../examples/assets/noto_color_emoji/NotoColorEmoji-Subset.ttf");
+// If you want wasm builds to embed a custom COLR font and can guarantee
+// `NOTO_COLR_PATH` is set at compile time, replace the constant above with:
+//
+// const FALLBACK_NOTO_COLR_FONT: &[u8] = include_bytes!(env!("NOTO_COLR_PATH"));
+#[cfg(not(target_arch = "wasm32"))]
+const NOTO_COLR_PATH_ENV: &str = "NOTO_COLR_PATH";
+const EMOJI_COLUMNS: usize = 30;
+const MIN_EMOJI_COUNT: usize = 1;
+const WINDOW_STEP: usize = 100;
+const INITIAL_EMOJI_COUNT: usize = 10;
+const SIDE_PADDING: f32 = 16.0;
+const TOP_PADDING: f32 = 24.0;
+const MIN_CELL_WIDTH: f32 = 8.0;
+
+/// Scene drawing a large adjustable grid of COLR emoji.
+pub struct EmojiGridScene {
+    font: FontData,
+    glyphs: Vec<EmojiGlyph>,
+    upem: f32,
+    unit_cell_width: f32,
+    unit_cell_height: f32,
+    emoji_count: usize,
+    window_start: usize,
+    glyph_caching_enabled: bool,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct EmojiGlyph {
+    id: u32,
+    bbox_x0: f32,
+    bbox_y1: f32,
+}
+
+impl fmt::Debug for EmojiGridScene {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EmojiGridScene")
+            .field("emoji_count", &self.emoji_count)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Default for EmojiGridScene {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EmojiGridScene {
+    /// Create a new `EmojiGridScene`.
+    pub fn new() -> Self {
+        let font = load_emoji_font();
+        let (glyphs, upem, unit_cell_width, unit_cell_height) = emoji_font_metrics(&font);
+        let emoji_count = INITIAL_EMOJI_COUNT.min(glyphs.len());
+        Self {
+            font,
+            glyphs,
+            upem,
+            unit_cell_width,
+            unit_cell_height,
+            emoji_count,
+            window_start: 0,
+            glyph_caching_enabled: false,
+        }
+    }
+
+    fn set_count(&mut self, emoji_count: usize) {
+        self.emoji_count = emoji_count.clamp(MIN_EMOJI_COUNT, self.glyphs.len());
+        self.window_start = self.clamp_window_start(self.window_start);
+    }
+
+    fn increase_step(&self) -> usize {
+        magnitude_step_at_or_below(self.emoji_count)
+    }
+
+    fn decrease_step(&self) -> usize {
+        magnitude_step_strictly_below(self.emoji_count)
+    }
+
+    fn shift_window_forward(&mut self) {
+        self.window_start = self.clamp_window_start(self.window_start.saturating_add(WINDOW_STEP));
+    }
+
+    fn shift_window_backward(&mut self) {
+        self.window_start = self.window_start.saturating_sub(WINDOW_STEP);
+    }
+
+    fn clamp_window_start(&self, window_start: usize) -> usize {
+        window_start.min(self.max_window_start())
+    }
+
+    fn max_window_start(&self) -> usize {
+        self.glyphs.len().saturating_sub(self.emoji_count)
+    }
+
+    fn build_glyphs(&self, width: f32) -> (f32, Vec<Glyph>) {
+        let available_width = (width - 2.0 * SIDE_PADDING).max(MIN_CELL_WIDTH);
+        let cell_width = (available_width / EMOJI_COLUMNS as f32).max(MIN_CELL_WIDTH);
+        let scale = cell_width / self.unit_cell_width.max(f32::EPSILON);
+        let font_size = self.upem * scale;
+        let cell_height = self.unit_cell_height * scale;
+        let glyphs = (0..self.emoji_count)
+            .map(|index| {
+                let column = index % EMOJI_COLUMNS;
+                let row = index / EMOJI_COLUMNS;
+                let glyph = self.glyphs[self.window_start + index];
+                Glyph {
+                    id: glyph.id,
+                    x: SIDE_PADDING + column as f32 * cell_width - glyph.bbox_x0 * scale,
+                    y: TOP_PADDING + row as f32 * cell_height + glyph.bbox_y1 * scale,
+                }
+            })
+            .collect();
+        (font_size, glyphs)
+    }
+}
+
+impl ExampleScene for EmojiGridScene {
+    fn render<T: RenderingContext>(
+        &mut self,
+        ctx: &mut T,
+        resources: &mut T::Resources,
+        root_transform: Affine,
+    ) {
+        ctx.set_transform(root_transform);
+        let (font_size, glyphs) = self.build_glyphs(f32::from(ctx.width()));
+        ctx.glyph_run(resources, &self.font)
+            .font_size(font_size)
+            .hint(false)
+            .atlas_cache(self.glyph_caching_enabled)
+            .fill_glyphs(glyphs.into_iter());
+    }
+
+    fn handle_key(&mut self, key: &str) -> bool {
+        match key {
+            "+" | "=" => {
+                self.set_count(self.emoji_count.saturating_add(self.increase_step()));
+                true
+            }
+            "-" => {
+                self.set_count(self.emoji_count.saturating_sub(self.decrease_step()));
+                true
+            }
+            "l" | "L" => {
+                self.shift_window_forward();
+                true
+            }
+            "k" | "K" => {
+                self.shift_window_backward();
+                true
+            }
+            "c" | "C" => {
+                self.glyph_caching_enabled = !self.glyph_caching_enabled;
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn status(&self) -> Option<String> {
+        let window_end = self.window_start + self.emoji_count;
+        Some(format!(
+            "Emoji grid: {} / {} glyphs | window: {}..{} | columns: {} | cache: {} | +/-: +{} / -{} | l/k: shift {} | c: toggle caching",
+            self.emoji_count,
+            self.glyphs.len(),
+            self.window_start,
+            window_end,
+            EMOJI_COLUMNS,
+            if self.glyph_caching_enabled {
+                "on"
+            } else {
+                "off"
+            },
+            self.increase_step(),
+            self.decrease_step(),
+            WINDOW_STEP
+        ))
+    }
+}
+
+fn magnitude_step_at_or_below(value: usize) -> usize {
+    let mut step = 1;
+    while step <= value / 10 {
+        step *= 10;
+    }
+    step
+}
+
+fn magnitude_step_strictly_below(value: usize) -> usize {
+    magnitude_step_at_or_below(value.saturating_sub(1).max(1))
+}
+
+fn load_emoji_font() -> FontData {
+    #[cfg(not(target_arch = "wasm32"))]
+    if let Some(bytes) =
+        std::env::var_os(NOTO_COLR_PATH_ENV).and_then(|path| std::fs::read(path).ok())
+    {
+        return FontData::new(Blob::new(Arc::new(bytes)), 0);
+    }
+
+    FontData::new(Blob::new(Arc::new(FALLBACK_NOTO_COLR_FONT)), 0)
+}
+
+fn emoji_font_metrics(font: &FontData) -> (Vec<EmojiGlyph>, f32, f32, f32) {
+    let font_ref = {
+        let file_ref = FileRef::new(font.data.as_ref()).expect("emoji font is valid");
+        match file_ref {
+            FileRef::Font(font_ref) => font_ref,
+            FileRef::Collection(collection) => collection
+                .get(font.index)
+                .expect("emoji font index is valid"),
+        }
+    };
+    let upem = f32::from(
+        font_ref
+            .head()
+            .expect("emoji font head table")
+            .units_per_em(),
+    );
+    let fallback_bbox = Rect::new(0.0, 0.0, f64::from(upem), f64::from(upem));
+    let color_glyphs = font_ref.color_glyphs();
+    let glyph_count = usize::from(font_ref.maxp().expect("emoji font maxp table").num_glyphs());
+
+    let mut glyphs = Vec::new();
+    let mut unit_cell_width = 0.0f32;
+    let mut unit_cell_height = 0.0f32;
+
+    for glyph_index in 0..glyph_count {
+        let glyph_id = GlyphId::new(glyph_index as u32);
+        let Some(color_glyph) = color_glyphs.get(glyph_id) else {
+            continue;
+        };
+        let bbox = color_glyph
+            .bounding_box(LocationRef::default(), Size::unscaled())
+            .map(convert_bbox)
+            .unwrap_or(fallback_bbox);
+        unit_cell_width = unit_cell_width.max(bbox.width() as f32);
+        unit_cell_height = unit_cell_height.max(bbox.height() as f32);
+        glyphs.push(EmojiGlyph {
+            id: glyph_id.to_u32(),
+            bbox_x0: bbox.x0 as f32,
+            bbox_y1: bbox.y1 as f32,
+        });
+    }
+
+    (
+        glyphs,
+        upem,
+        unit_cell_width.max(1.0),
+        unit_cell_height.max(1.0),
+    )
+}
+
+fn convert_bbox(bbox: skrifa::raw::types::BoundingBox<f32>) -> Rect {
+    Rect::new(
+        f64::from(bbox.x_min),
+        f64::from(bbox.y_min),
+        f64::from(bbox.x_max),
+        f64::from(bbox.y_max),
+    )
+}

--- a/sparse_strips/vello_example_scenes/src/emoji_grid.rs
+++ b/sparse_strips/vello_example_scenes/src/emoji_grid.rs
@@ -238,14 +238,14 @@ fn emoji_font_metrics(font: &FontData) -> (Vec<EmojiGlyph>, f32, f32, f32) {
     );
     let fallback_bbox = Rect::new(0.0, 0.0, f64::from(upem), f64::from(upem));
     let color_glyphs = font_ref.color_glyphs();
-    let glyph_count = usize::from(font_ref.maxp().expect("emoji font maxp table").num_glyphs());
+    let glyph_count = u32::from(font_ref.maxp().expect("emoji font maxp table").num_glyphs());
 
     let mut glyphs = Vec::new();
-    let mut unit_cell_width = 0.0f32;
-    let mut unit_cell_height = 0.0f32;
+    let mut unit_cell_width = 0.0_f32;
+    let mut unit_cell_height = 0.0_f32;
 
     for glyph_index in 0..glyph_count {
-        let glyph_id = GlyphId::new(glyph_index as u32);
+        let glyph_id = GlyphId::new(glyph_index);
         let Some(color_glyph) = color_glyphs.get(glyph_id) else {
             continue;
         };
@@ -253,12 +253,12 @@ fn emoji_font_metrics(font: &FontData) -> (Vec<EmojiGlyph>, f32, f32, f32) {
             .bounding_box(LocationRef::default(), Size::unscaled())
             .map(convert_bbox)
             .unwrap_or(fallback_bbox);
-        unit_cell_width = unit_cell_width.max(bbox.width() as f32);
-        unit_cell_height = unit_cell_height.max(bbox.height() as f32);
+        unit_cell_width = unit_cell_width.max(f64_to_f32(bbox.width()));
+        unit_cell_height = unit_cell_height.max(f64_to_f32(bbox.height()));
         glyphs.push(EmojiGlyph {
             id: glyph_id.to_u32(),
-            bbox_x0: bbox.x0 as f32,
-            bbox_y1: bbox.y1 as f32,
+            bbox_x0: f64_to_f32(bbox.x0),
+            bbox_y1: f64_to_f32(bbox.y1),
         });
     }
 
@@ -277,4 +277,12 @@ fn convert_bbox(bbox: skrifa::raw::types::BoundingBox<f32>) -> Rect {
         f64::from(bbox.x_max),
         f64::from(bbox.y_max),
     )
+}
+
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "emoji font metrics are small enough to fit in f32 for this demo scene"
+)]
+fn f64_to_f32(value: f64) -> f32 {
+    value as f32
 }

--- a/sparse_strips/vello_example_scenes/src/lib.rs
+++ b/sparse_strips/vello_example_scenes/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod blend;
 pub mod blurred_rounded_rect;
 pub mod clip;
+pub mod emoji_grid;
 pub mod filter;
 pub mod filter_elements;
 pub mod gradient;
@@ -486,6 +487,7 @@ where
     }
 
     scenes.push(AnyScene::new(text::TextScene::new("Hello, Vello!")));
+    scenes.push(AnyScene::new(emoji_grid::EmojiGridScene::new()));
     scenes.push(AnyScene::new(random_text::RandomTextScene::new()));
     scenes.push(AnyScene::new(simple::SimpleScene::new()));
     scenes.push(AnyScene::new(
@@ -529,6 +531,7 @@ where
     let mut scenes = vec![
         AnyScene::new(svg::SvgScene::tiger()),
         AnyScene::new(text::TextScene::new("Hello, Vello!")),
+        AnyScene::new(emoji_grid::EmojiGridScene::new()),
         AnyScene::new(random_text::RandomTextScene::new()),
         AnyScene::new(simple::SimpleScene::new()),
         AnyScene::new(blurred_rounded_rect::BlurredRoundedRectScene::new()),

--- a/sparse_strips/vello_hybrid/examples/native_webgl/src/lib.rs
+++ b/sparse_strips/vello_hybrid/examples/native_webgl/src/lib.rs
@@ -138,6 +138,14 @@ impl AppState {
         self.need_render = true;
     }
 
+    fn handle_key(&mut self, key: &str) {
+        if let Some(scene) = self.scenes.get_mut(self.current_scene)
+            && scene.handle_key(key)
+        {
+            self.need_render = true;
+        }
+    }
+
     fn handle_mouse_down(&mut self, x: f64, y: f64) {
         self.mouse_down = true;
         self.last_cursor_position = Some(Vec2::new(x, y));
@@ -410,15 +418,15 @@ pub async fn run_interactive(canvas_width: u16, canvas_height: u16) {
     {
         let app_state = app_state.clone();
         let document = web_sys::window().unwrap().document().unwrap();
-        let closure =
-            Closure::wrap(
-                Box::new(move |event: KeyboardEvent| match event.key().as_str() {
-                    "ArrowRight" => app_state.borrow_mut().next_scene(),
-                    "ArrowLeft" => app_state.borrow_mut().prev_scene(),
-                    " " => app_state.borrow_mut().reset_transform(),
-                    _ => {}
-                }) as Box<dyn FnMut(_)>,
-            );
+        let closure = Closure::wrap(Box::new(move |event: KeyboardEvent| {
+            let key = event.key();
+            match key.as_str() {
+                "ArrowRight" => app_state.borrow_mut().next_scene(),
+                "ArrowLeft" => app_state.borrow_mut().prev_scene(),
+                " " => app_state.borrow_mut().reset_transform(),
+                _ => app_state.borrow_mut().handle_key(key.as_str()),
+            }
+        }) as Box<dyn FnMut(_)>);
         document
             .add_event_listener_with_callback("keydown", closure.as_ref().unchecked_ref())
             .unwrap();

--- a/sparse_strips/vello_hybrid/examples/wgpu_webgl/src/lib.rs
+++ b/sparse_strips/vello_hybrid/examples/wgpu_webgl/src/lib.rs
@@ -266,6 +266,14 @@ impl AppState {
         self.need_render = true;
     }
 
+    fn handle_key(&mut self, key: &str) {
+        if let Some(scene) = self.scenes.get_mut(self.current_scene)
+            && scene.handle_key(key)
+        {
+            self.need_render = true;
+        }
+    }
+
     fn handle_mouse_down(&mut self, x: f64, y: f64) {
         self.mouse_down = true;
         self.last_cursor_position = Some(Point { x, y });
@@ -538,15 +546,15 @@ pub async fn run_interactive(canvas_width: u16, canvas_height: u16) {
     {
         let app_state = app_state.clone();
         let document = web_sys::window().unwrap().document().unwrap();
-        let closure =
-            Closure::wrap(
-                Box::new(move |event: KeyboardEvent| match event.key().as_str() {
-                    "ArrowRight" => app_state.borrow_mut().next_scene(),
-                    "ArrowLeft" => app_state.borrow_mut().prev_scene(),
-                    " " => app_state.borrow_mut().reset_transform(),
-                    _ => {}
-                }) as Box<dyn FnMut(_)>,
-            );
+        let closure = Closure::wrap(Box::new(move |event: KeyboardEvent| {
+            let key = event.key();
+            match key.as_str() {
+                "ArrowRight" => app_state.borrow_mut().next_scene(),
+                "ArrowLeft" => app_state.borrow_mut().prev_scene(),
+                " " => app_state.borrow_mut().reset_transform(),
+                _ => app_state.borrow_mut().handle_key(key.as_str()),
+            }
+        }) as Box<dyn FnMut(_)>);
         document
             .add_event_listener_with_callback("keydown", closure.as_ref().unchecked_ref())
             .unwrap();


### PR DESCRIPTION
As asked by @grebmeg, this PR adds a scene that allows rendering different COLR glyphs interactively. It also applies some fixes such that key inputs are registered properly in WebAssembly.


https://github.com/user-attachments/assets/d41a27fb-cd8e-44cc-8440-384b02955fc1

