### PR TITLE
Tweaks to WASM CI for sparse strips

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,9 +321,19 @@ jobs:
         run: cargo test --doc --workspace --locked --all-features --no-fail-fast
 
   test-stable-wasm:
-    name: cargo test (wasm32)
+    name: cargo test (wasm32, ${{ matrix.name }})
     needs: prime-lfs-cache
-    runs-on: ubuntu-latest
+    # We use MacOS because for some reason the Ubuntu-based runners
+    # have trouble handling things like `requestAnimationFrame` or
+    # `setTimeout` in our testing code.
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        include:
+          - name: default
+            rustflags: ""
+          - name: simd128
+            rustflags: "-Ctarget-feature=+simd128"
     steps:
       - uses: actions/checkout@v6
         # We intentionally do not use lfs: true here, instead using the caching method to save LFS bandwidth.
@@ -363,6 +373,36 @@ jobs:
         with:
           tool: wasm-pack
 
+      - name: Run vello_sparse_tests on Chrome
+        # We need to run in release mode, because otherwise wasm_parser can't read the
+        # blob, see <https://github.com/linebender/vello/pull/1078#issuecomment-3029336905>
+        run: wasm-pack test --headless --chrome --features webgl --release
+        working-directory: sparse_strips/vello_sparse_tests
+        env:
+          RUSTFLAGS: ${{ matrix.rustflags }}
+
+  check-stable-wasm-webgl-examples:
+    name: cargo check (wasm32 webgl examples)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE_VER }}
+          targets: wasm32-unknown-unknown
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name != 'merge_group' }}
+
+      - name: install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
+
       - name: check vello_hybrid is wgpu webgl compatible
         run: wasm-pack test --headless --chrome
         working-directory: sparse_strips/vello_hybrid/examples/wgpu_webgl
@@ -370,16 +410,6 @@ jobs:
       - name: check vello_hybrid is native webgl compatible
         run: wasm-pack test --headless --chrome
         working-directory: sparse_strips/vello_hybrid/examples/native_webgl
-
-      - name: Run vello_sparse_tests on Chrome
-        # We need to run in release mode, because otherwise wasm_parser can't read the
-        # blob, see <https://github.com/linebender/vello/pull/1078#issuecomment-3029336905>
-        run: wasm-pack test --headless --chrome --features webgl --release
-        working-directory: sparse_strips/vello_sparse_tests
-
-      - name: Run vello_sparse_tests (+simd128) on Chrome
-        run: RUSTFLAGS=-Ctarget-feature=+simd128 wasm-pack test --headless --chrome --features webgl --release
-        working-directory: sparse_strips/vello_sparse_tests
 
 
   check-stable-android:


### PR DESCRIPTION
This PR introduces two changes to our CI for testing sparse strips in CI:

1) Instead of having one single job, we split them up into three jobs: The first job for checking the examples, the second for running the tests without WASM and the third for running the tests with WASM. This cuts the "bottleneck" time for this test specifically from around 13 minutes to around 6-7 minutes. This won't have an immediate effect since the overall bottleneck is still Windows CI, but it's an easy change and will likely be worth it in the future once we reduce the time of Windows CI.

2) Use MacOS-based runners instead of Ubuntu for running the WASM tests. When working on #1671, I have encountered the problem that the probe test does not pass anymore [due to some weird timeout](https://github.com/linebender/vello/actions/runs/26457569847/job/77896141078).

<img width="1318" height="443" alt="image" src="https://github.com/user-attachments/assets/d1b4264b-30a2-4eb8-b3a8-7f2a55d624d9" />

I've spent more than a day trying to debug this now, but have not gotten further than concluding that for some reason, invoking asynchronous methods like `setTimeout` or `requestAnimationFrame` causes those timeouts to occur, regardless of what happens in there (even when removing the actual probing, it still happened when I invoked those methods). Locally everything works fine, and apparently it also works fine when switching to a MacOS-based runners. I'm fairly certain that this is some weirdness with the Github CI runners and not with probing failing completely on Linux (though I admittedly haven't tested it since I don't have a linux laptop), so I think this is the easiest thing to do for now. I'd also like to get to the bottom of this, but I've already spent more time on this than I can really justify, so I hope that this is fine doing for now.