### PR TITLE
Export webgl features even on non-wasm32

### DIFF
--- a/sparse_strips/vello_common/src/probe.rs
+++ b/sparse_strips/vello_common/src/probe.rs
@@ -6,6 +6,8 @@
 
 use crate::color::{AlphaColor, palette::css};
 use crate::filter_effects::{EdgeMode, Filter, FilterPrimitive};
+#[cfg(not(feature = "std"))]
+use crate::kurbo::common::FloatFuncs as _;
 use crate::kurbo::{Affine, BezPath, Circle, Point, Rect, Shape};
 use crate::paint::{Image, ImageSource, PaintType};
 use crate::peniko::{

--- a/sparse_strips/vello_cpu/Cargo.toml
+++ b/sparse_strips/vello_cpu/Cargo.toml
@@ -35,7 +35,7 @@ std = ["vello_common/std", "glifo?/std"]
 # Use floating point implementations from libm.
 libm = ["vello_common/libm", "glifo?/libm"]
 # Allow loading Pixmap from PNG, and drawing png glyphs.
-png = ["dep:png", "vello_common/png", "glifo?/png"]
+png = ["std", "dep:png", "vello_common/png", "glifo?/png"]
 # Enable multi-threaded rendering.
 multithreading = [
     "std",

--- a/sparse_strips/vello_hybrid/Cargo.toml
+++ b/sparse_strips/vello_hybrid/Cargo.toml
@@ -24,7 +24,6 @@ vello_sparse_shaders = { workspace = true, optional = true }
 log = { workspace = true }
 hashbrown = { workspace = true }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = { version = "0.3.98", optional = true }
 web-sys = { version = "0.3.98", features = [
     "HtmlCanvasElement",

--- a/sparse_strips/vello_hybrid/src/lib.rs
+++ b/sparse_strips/vello_hybrid/src/lib.rs
@@ -51,7 +51,7 @@ mod render;
 mod resources;
 mod sampling;
 mod scene;
-#[cfg(any(all(target_arch = "wasm32", feature = "webgl"), feature = "wgpu"))]
+#[cfg(any(feature = "webgl", feature = "wgpu"))]
 mod schedule;
 #[cfg(feature = "text")]
 mod text;
@@ -61,11 +61,11 @@ pub mod util;
 #[cfg(feature = "wgpu")]
 pub use render::{AtlasWriter, RenderTargetConfig, Renderer, TextureBindings};
 pub use render::{Config, GpuStrip, RenderSize};
-#[cfg(all(target_arch = "wasm32", feature = "webgl", feature = "probe"))]
+#[cfg(all(feature = "webgl", feature = "probe"))]
 pub use render::{Probe, ProbeResult};
-#[cfg(all(target_arch = "wasm32", feature = "webgl"))]
+#[cfg(feature = "webgl")]
 pub use render::{WebGlAtlasWriter, WebGlRenderer, WebGlTextureWithDimensions};
-#[cfg(all(target_arch = "wasm32", feature = "webgl", feature = "probe"))]
+#[cfg(all(feature = "webgl", feature = "probe"))]
 pub use render::{WebGlPendingProbe, WebGlProbeError, WebGlProbeStatus};
 pub use resources::Resources;
 pub use sampling::SampleRect;

--- a/sparse_strips/vello_hybrid/src/render/common.rs
+++ b/sparse_strips/vello_hybrid/src/render/common.rs
@@ -405,7 +405,7 @@ For optimal performance and binary size on web targets, use only the dedicated W
 }
 
 #[cfg(all(
-    any(all(target_arch = "wasm32", feature = "webgl"), feature = "wgpu"),
+    any(feature = "webgl", feature = "wgpu"),
     not(all(target_arch = "wasm32", feature = "webgl", feature = "wgpu"))
 ))]
 pub(crate) fn maybe_warn_about_webgl_feature_conflict() {}

--- a/sparse_strips/vello_hybrid/src/render/mod.rs
+++ b/sparse_strips/vello_hybrid/src/render/mod.rs
@@ -11,18 +11,18 @@
 pub(crate) mod common;
 #[cfg(feature = "probe")]
 mod probe;
-#[cfg(all(target_arch = "wasm32", feature = "webgl"))]
+#[cfg(feature = "webgl")]
 mod webgl;
 #[cfg(feature = "wgpu")]
 mod wgpu;
 
 pub use common::{Config, GpuStrip, RenderSize};
 
-#[cfg(all(target_arch = "wasm32", feature = "webgl", feature = "probe"))]
+#[cfg(all(feature = "webgl", feature = "probe"))]
 pub use vello_common::probe::{Probe, ProbeResult};
-#[cfg(all(target_arch = "wasm32", feature = "webgl"))]
+#[cfg(feature = "webgl")]
 pub use webgl::{WebGlAtlasWriter, WebGlRenderer, WebGlTextureWithDimensions};
-#[cfg(all(target_arch = "wasm32", feature = "webgl", feature = "probe"))]
+#[cfg(all(feature = "webgl", feature = "probe"))]
 pub use webgl::{WebGlPendingProbe, WebGlProbeError, WebGlProbeStatus};
 #[cfg(feature = "wgpu")]
 pub use wgpu::{AtlasWriter, RenderTargetConfig, Renderer, TextureBindings};

--- a/sparse_strips/vello_hybrid/src/render/mod.rs
+++ b/sparse_strips/vello_hybrid/src/render/mod.rs
@@ -6,7 +6,7 @@
 //! ## Renderer Backends
 //!
 //! - `wgpu` contains the default renderer backend, leveraging `wgpu`.
-//! - `webgl` contains a WebGL2 backend specifically for `wasm32` if the `webgl` feature is active.
+//! - `webgl` contains a WebGL2 backend if the `webgl` feature is active.
 
 pub(crate) mod common;
 #[cfg(feature = "probe")]

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -250,6 +250,10 @@ impl WebGlRenderer {
 
     /// Creates a new WebGL2 renderer with specific settings.
     pub fn new_with(canvas: &HtmlCanvasElement, settings: RenderSettings) -> Self {
+        debug_assert!(
+            cfg!(target_arch = "wasm32"),
+            "`WebGlRenderer` can only be constructed when targeting `wasm32`",
+        );
         super::common::maybe_warn_about_webgl_feature_conflict();
 
         // We do our own anti-aliasing, so no need to enable it in the WebGL

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -250,10 +250,13 @@ impl WebGlRenderer {
 
     /// Creates a new WebGL2 renderer with specific settings.
     pub fn new_with(canvas: &HtmlCanvasElement, settings: RenderSettings) -> Self {
-        debug_assert!(
-            cfg!(target_arch = "wasm32"),
-            "`WebGlRenderer` can only be constructed when targeting `wasm32`",
-        );
+        #[allow(clippy::assertions_on_constants, reason = "intentional guard against non-wasm32 use")]
+        {
+            debug_assert!(
+                cfg!(target_arch = "wasm32"),
+                "`WebGlRenderer` can only be constructed when targeting `wasm32`",
+            );
+        }
         super::common::maybe_warn_about_webgl_feature_conflict();
 
         // We do our own anti-aliasing, so no need to enable it in the WebGL

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -250,7 +250,10 @@ impl WebGlRenderer {
 
     /// Creates a new WebGL2 renderer with specific settings.
     pub fn new_with(canvas: &HtmlCanvasElement, settings: RenderSettings) -> Self {
-        #[allow(clippy::assertions_on_constants, reason = "intentional guard against non-wasm32 use")]
+        #[allow(
+            clippy::assertions_on_constants,
+            reason = "intentional guard against non-wasm32 use"
+        )]
         {
             debug_assert!(
                 cfg!(target_arch = "wasm32"),

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -3,7 +3,7 @@
 
 //! Native WebGL2 rendering module for the sparse strips CPU/GPU rendering engine.
 //!
-//! This module provides identical functionality as the [`render_wgpu`] module, however the graphics
+//! This module provides identical functionality as the [`wgpu`] module, however the graphics
 //! context is the browser's native [`WebGl2RenderingContext`]. Hence, this module is only available
 //! when targeting `wasm32` with the "webgl" feature flag active.
 //!


### PR DESCRIPTION
We need to be able to reference these without gating our code on `#[cfg(target_arch = "wasm32")]`.

Tested with

```
cargo hack check -p vello_encoding --feature-powerset
cargo hack check -p vello --feature-powerset
cargo hack check -p glifo --feature-powerset --at-least-one-of std,libm
cargo hack check -p vello_common --feature-powerset --at-least-one-of std,libm
cargo hack check -p vello_hybrid --feature-powerset --at-least-one-of std,libm
cargo hack check -p vello_cpu --feature-powerset --at-least-one-of std,libm --at-least-one-of u8_pipeline,f32_pipeline
```