### PR TITLE
Exempt `wasm-bindgen`-related crates from version requirements

### DIFF
--- a/.github/workflows/web-demo.yml
+++ b/.github/workflows/web-demo.yml
@@ -27,7 +27,7 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           # If updating, also update in examples/with_winit/Cargo.toml
-          tool: wasm-bindgen@0.2.121
+          tool: wasm-bindgen@0.2.114
 
       - name: build (wasm)
         run: cargo build -p with_winit --bin with_winit_bin --release --target wasm32-unknown-unknown

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1854,12 +1854,10 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
- "cfg-if",
- "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -4326,9 +4324,9 @@ dependencies = [
 
 [[package]]
 name = "walrus"
-version = "0.26.1"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e151599d689dac80e85c66a7cfa6ffd1b2ab79220517f9161040a87a5041aee3"
+checksum = "643cc295c2bf4c34d36c2bbaddee48c56a15de3a35e7021b95ceb6a936a493ac"
 dependencies = [
  "anyhow",
  "gimli",
@@ -4343,9 +4341,9 @@ dependencies = [
 
 [[package]]
 name = "walrus-macro"
-version = "0.26.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9b0525d7ea6e5f906aca581a172e5c91b4c595290dfa8ad4a2bc9ffef33b44"
+checksum = "cef8d704ff46ad931a2cd1f7a504fe43ffb8e968d931e179ff18d0dff4949bd5"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -4370,9 +4368,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4383,9 +4381,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-cli-support"
-version = "0.2.121"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea29d9c1f708939aba5ec705f9435af5d5e8ffbaeedff0561b8c9216780e3b5"
+checksum = "a468565fe14ad40511a77eb46b743d88c7a8dc6e2035a670abb4555a32d9a3e7"
 dependencies = [
  "anyhow",
  "base64",
@@ -4396,24 +4394,28 @@ dependencies = [
  "serde_json",
  "walrus",
  "wasm-bindgen-shared",
- "wasmparser 0.245.1",
+ "wasmparser 0.240.0",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4421,9 +4423,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4434,18 +4436,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.71"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af5ec93229ad9ccd0a545a516dec76dc276613f278f6a91aa6b463d5b33d42d0"
+checksum = "6311c867385cc7d5602463b31825d454d0837a3aba7cdb5e56d5201792a3f7fe"
 dependencies = [
  "async-trait",
  "cast",
@@ -4465,9 +4467,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.71"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c81b9fef827e575e0e54431736d1baa0d700315d8c62cfef1f61fa3aad0cbeb"
+checksum = "67008cdde4769831958536b0f11b3bdd0380bde882be17fff9c2f34bb4549abd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4476,9 +4478,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.121"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f4d8ae7ad5440360e9799dfd42857d126454a88441ddf72d288ef83fa47f527"
+checksum = "cfe29135b180b72b04c74aa97b2b4a2ef275161eff9a6c7955ea9eaedc7e1d4e"
 
 [[package]]
 name = "wasm-encoder"
@@ -4514,6 +4516,19 @@ name = "wasmparser"
 version = "0.235.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.240.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b722dcf61e0ea47440b53ff83ccb5df8efec57a69d150e4f24882e4eba7e24a4"
 dependencies = [
  "bitflags 2.11.1",
  "hashbrown 0.15.5",
@@ -4646,9 +4661,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,13 +120,14 @@ crossbeam-channel = "0.5.15"
 ordered-channel = { version = "1.2.0", features = ["crossbeam-channel"] }
 fearless_simd = { version = "0.4.0", default-features = false }
 
-# wasm-bindgen family of crates
-js-sys = "0.3.98"
+# Unlike the other crates, please do not update these before a release
+# unless absolutely necessary.
+js-sys = "0.3.91"
 # If updating, also update in .github/workflows/web-demo.yml.
-wasm-bindgen = "=0.2.121"
-wasm-bindgen-futures = "0.4.71"
-wasm-bindgen-test = "0.3.71"
-web-sys = "0.3.98"
+wasm-bindgen = "0.2.114"
+wasm-bindgen-futures = "0.4.64"
+wasm-bindgen-test = "0.3.64"
+web-sys = "0.3.91"
 
 # The below crates are experimental!
 vello_common = { version = "0.0.9", path = "sparse_strips/vello_common", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,14 @@ crossbeam-channel = "0.5.15"
 ordered-channel = { version = "1.2.0", features = ["crossbeam-channel"] }
 fearless_simd = { version = "0.4.0", default-features = false }
 
+# wasm-bindgen family of crates
+js-sys = "0.3.98"
+# If updating, also update in .github/workflows/web-demo.yml.
+wasm-bindgen = "=0.2.121"
+wasm-bindgen-futures = "0.4.71"
+wasm-bindgen-test = "0.3.71"
+web-sys = "0.3.98"
+
 # The below crates are experimental!
 vello_common = { version = "0.0.9", path = "sparse_strips/vello_common", default-features = false }
 vello_cpu = { version = "0.0.9", path = "sparse_strips/vello_cpu" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,6 @@ fearless_simd = { version = "0.4.0", default-features = false }
 # Unlike the other crates, please do not update these before a release
 # unless absolutely necessary.
 js-sys = "0.3.91"
-# If updating, also update in .github/workflows/web-demo.yml.
 wasm-bindgen = "0.2.114"
 wasm-bindgen-futures = "0.4.64"
 wasm-bindgen-test = "0.3.64"

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -76,6 +76,7 @@ console_log = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 web-sys = { workspace = true, features = ["HtmlCollection", "Text"] }
 web-time = { workspace = true }
+# If updating, also update in .github/workflows/web-demo.yml
 wasm-bindgen = "=0.2.114"
 
 [target.wasm32-unknown-unknown.dependencies]

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -73,11 +73,10 @@ jni = "0.21.1"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = { workspace = true }
 console_log = { workspace = true }
-wasm-bindgen-futures = "0.4.71"
-web-sys = { version = "0.3.98", features = ["HtmlCollection", "Text"] }
+wasm-bindgen-futures = { workspace = true }
+web-sys = { workspace = true, features = ["HtmlCollection", "Text"] }
 web-time = { workspace = true }
-# If updating, also update in .github/workflows/web-demo.yml
-wasm-bindgen = "=0.2.121"
+wasm-bindgen = { workspace = true }
 
 [target.wasm32-unknown-unknown.dependencies]
 # We have a transitive dependency on getrandom and it does not automatically

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -76,7 +76,7 @@ console_log = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 web-sys = { workspace = true, features = ["HtmlCollection", "Text"] }
 web-time = { workspace = true }
-wasm-bindgen = { workspace = true }
+wasm-bindgen = "=0.2.114"
 
 [target.wasm32-unknown-unknown.dependencies]
 # We have a transitive dependency on getrandom and it does not automatically

--- a/sparse_strips/vello_cpu/examples/wasm_cpu/Cargo.toml
+++ b/sparse_strips/vello_cpu/examples/wasm_cpu/Cargo.toml
@@ -17,14 +17,14 @@ workspace = true
 bytemuck = { workspace = true, features = [] }
 console_error_panic_hook = { workspace = true }
 console_log = { workspace = true }
-js-sys = "0.3.98"
+js-sys = { workspace = true }
 log = { workspace = true }
 vello_common = { workspace = true, features = ["pico_svg"] }
 vello_cpu = { workspace = true }
 vello_example_scenes = { workspace = true, features = ["cpu"] }
-wasm-bindgen = "0.2.121"
-wasm-bindgen-futures = "0.4.71"
-web-sys = { version = "0.3.98", features = [
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
+web-sys = { workspace = true, features = [
     "Window",
     "Document",
     "Element",
@@ -39,4 +39,4 @@ web-sys = { version = "0.3.98", features = [
 wgpu = { workspace = true, features = ["webgl"], default-features = true }
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.71"
+wasm-bindgen-test = { workspace = true }

--- a/sparse_strips/vello_hybrid/Cargo.toml
+++ b/sparse_strips/vello_hybrid/Cargo.toml
@@ -24,7 +24,6 @@ vello_sparse_shaders = { workspace = true, optional = true }
 log = { workspace = true }
 hashbrown = { workspace = true }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = { workspace = true, optional = true }
 web-sys = { workspace = true, features = [
     "HtmlCanvasElement",

--- a/sparse_strips/vello_hybrid/Cargo.toml
+++ b/sparse_strips/vello_hybrid/Cargo.toml
@@ -24,8 +24,9 @@ vello_sparse_shaders = { workspace = true, optional = true }
 log = { workspace = true }
 hashbrown = { workspace = true }
 
-js-sys = { version = "0.3.98", optional = true }
-web-sys = { version = "0.3.98", features = [
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+js-sys = { workspace = true, optional = true }
+web-sys = { workspace = true, features = [
     "HtmlCanvasElement",
     "WebGl2RenderingContext",
     "WebGlContextAttributes",

--- a/sparse_strips/vello_hybrid/examples/native_webgl/Cargo.toml
+++ b/sparse_strips/vello_hybrid/examples/native_webgl/Cargo.toml
@@ -16,14 +16,14 @@ workspace = true
 [dependencies]
 console_error_panic_hook = { workspace = true }
 console_log = { workspace = true }
-js-sys = "0.3.98"
+js-sys = { workspace = true }
 log = { workspace = true }
 vello_common = { workspace = true }
 vello_hybrid = { workspace = true, features = ["webgl"] }
 vello_example_scenes = { workspace = true }
-wasm-bindgen = "0.2.121"
-wasm-bindgen-futures = "0.4.71"
-web-sys = { version = "0.3.98", features = [
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
+web-sys = { workspace = true, features = [
     "AddEventListenerOptions",
     "Window",
     "Document",
@@ -39,4 +39,4 @@ web-sys = { version = "0.3.98", features = [
 ] }
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.71"
+wasm-bindgen-test = { workspace = true }

--- a/sparse_strips/vello_hybrid/examples/wgpu_webgl/Cargo.toml
+++ b/sparse_strips/vello_hybrid/examples/wgpu_webgl/Cargo.toml
@@ -16,14 +16,14 @@ workspace = true
 [dependencies]
 console_error_panic_hook = { workspace = true }
 console_log = { workspace = true }
-js-sys = "0.3.98"
+js-sys = { workspace = true }
 log = { workspace = true }
 vello_common = { workspace = true }
 vello_hybrid = { workspace = true }
 vello_example_scenes = { workspace = true }
-wasm-bindgen = "0.2.121"
-wasm-bindgen-futures = "0.4.71"
-web-sys = { version = "0.3.98", features = [
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
+web-sys = { workspace = true, features = [
     "Window",
     "Document",
     "Element",
@@ -38,4 +38,4 @@ web-sys = { version = "0.3.98", features = [
 wgpu = { workspace = true, default-features = true, features = ["webgl"] }
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.71"
+wasm-bindgen-test = { workspace = true }

--- a/sparse_strips/vello_sparse_tests/Cargo.toml
+++ b/sparse_strips/vello_sparse_tests/Cargo.toml
@@ -40,8 +40,8 @@ smallvec = { workspace = true }
 oxipng = { workspace = true, features = ["freestanding", "parallel"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen-test = "0.3.71"
-web-sys = { version = "0.3.98", features = [
+wasm-bindgen-test = { workspace = true }
+web-sys = { workspace = true, features = [
     "HtmlCanvasElement",
     "WebGl2RenderingContext",
     "Document",
@@ -54,8 +54,8 @@ web-sys = { version = "0.3.98", features = [
     "Url",
     "Response",
 ] }
-wasm-bindgen = "0.2.121"
-wasm-bindgen-futures = "0.4.71"
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
 # Required for introspecting the built WASM binary.
 wasmparser = "0.235.0"
 


### PR DESCRIPTION
We have a [policy](https://github.com/linebender/rfcs/blob/main/rfcs/0005-version-matrix.md#cargotoml-matches-cargolock) to 1) update all dependencies before a new release and 2) also specify the newest patch release that we use explicitly in the Cargo.toml. I think this makes sense in general, *but* I would like to propose that we except wasm-bindgen and the related crates from the second rule.

The reason for this is that `wasm-bindgen` is special, in the sense that there is an additional CLI tool you need to use **and the version of the CLI tool must exactly match the one used by the crate**. Therefore, by bumping wasm-bindgen with each version (which will become even more common assuming we start doing more regular releases), we create a lot of very unnecessary churn for consumers to update their wasm-bindgen CLI version, even though we don't really need any of the new features from a patch release. For example, I try to sync up my own repo vello_bench2 every once in a while with the newest git version. I also have a tendency to check out and run older revisions so I can test whether there has been any regression in a specific time frame. Because of this, I created an alias which allows me to easily switch between multiple versions, and while that works fine, I think it would be much better if we didn't force this kind of churn from the vello side in the first place. Curious to hear your thoughts. 🙏 

Therefore, in this PR I have
1) Put those crates in the root Cargo.toml so they are synced across the repo.
2) Relaxed the version requirement to what we had before the bump. Happy to go down even further or do it another way that allows us to achieve the same goal.