### PR TITLE
vello_cpu: Fix potential overflows in new blending code

### DIFF
--- a/sparse_strips/vello_cpu/src/fine/lowp/blend.rs
+++ b/sparse_strips/vello_cpu/src/fine/lowp/blend.rs
@@ -222,3 +222,78 @@ fn with_src_alpha<S: Simd>(simd: S, rgb: u8x32<S>, src_c: u8x32<S>) -> u8x32<S> 
 
     (rgb & !alpha_mask) | (src_c & alpha_mask)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::peniko::Compose;
+    use vello_common::fearless_simd::Fallback;
+
+    fn lowp_first_pixel_for_mix(blend: Mix, src: [u8; 4], bg: [u8; 4]) -> [u8; 4] {
+        let simd = Fallback::new();
+        let src = u8x32::from_slice(simd, &src.repeat(8));
+        let bg = u8x32::from_slice(simd, &bg.repeat(8));
+        let blend_mode = BlendMode::new(blend, Compose::SrcOver);
+        let res = mix(src, bg, blend_mode);
+        let mut out = [0; 32];
+        res.store_slice(&mut out);
+        out[..4].try_into().unwrap()
+    }
+
+    fn highp_first_pixel_for_mix(mix: Mix, src: [u8; 4], bg: [u8; 4]) -> [u8; 4] {
+        let simd = Fallback::new();
+        let to_f32 = |pixel: [u8; 4]| {
+            let pixel = pixel.map(|component| component as f32 * (1.0 / 255.0));
+            f32x16::from_slice(simd, &pixel.repeat(4))
+        };
+        let src = to_f32(src);
+        let bg = to_f32(bg);
+        let blend_mode = BlendMode::new(mix, Compose::SrcOver);
+
+        let res = highp::blend::mix(src, bg, blend_mode);
+        let res = f32_to_u8(f32x16::splat(simd, 255.0).mul_add(res, f32x16::splat(simd, 0.5)));
+        let mut out = [0; 16];
+        res.store_slice(&mut out);
+        out[..4].try_into().unwrap()
+    }
+
+    fn assert_lowp_matches_highp(mix: Mix, src: [u8; 4], bg: [u8; 4]) {
+        const MAX_DELTA: u8 = 2;
+
+        let lowp = lowp_first_pixel_for_mix(mix, src, bg);
+        let highp = highp_first_pixel_for_mix(mix, src, bg);
+
+        for (component, (&lowp, &highp)) in lowp.iter().zip(highp.iter()).enumerate() {
+            let delta = lowp.abs_diff(highp);
+            assert!(
+                delta <= MAX_DELTA,
+                "{mix:?} component {component} differed by {delta}: lowp={lowp}, highp={highp}, src={src:?}, bg={bg:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn multiply_does_not_wrap() {
+        assert_lowp_matches_highp(Mix::Multiply, [128, 128, 128, 1], [255, 255, 255, 0]);
+    }
+
+    #[test]
+    fn lighten_does_not_wrap() {
+        assert_lowp_matches_highp(Mix::Lighten, [255, 255, 255, 1], [1, 1, 1, 0]);
+    }
+
+    #[test]
+    fn difference_does_not_wrap() {
+        assert_lowp_matches_highp(Mix::Difference, [255, 255, 255, 1], [1, 1, 1, 0]);
+    }
+
+    #[test]
+    fn hard_light_does_not_wrap() {
+        assert_lowp_matches_highp(Mix::HardLight, [255, 255, 255, 1], [128, 128, 128, 0]);
+    }
+
+    #[test]
+    fn overlay_does_not_wrap() {
+        assert_lowp_matches_highp(Mix::Overlay, [255, 255, 255, 1], [128, 128, 128, 0]);
+    }
+}

--- a/sparse_strips/vello_cpu/src/fine/lowp/blend.rs
+++ b/sparse_strips/vello_cpu/src/fine/lowp/blend.rs
@@ -68,6 +68,12 @@ fn try_u8_mix<S: Simd>(blend_mode: BlendMode, src_c: u8x32<S>, bg_c: u8x32<S>) -
     })
 }
 
+#[inline(always)]
+fn narrow_saturating_u16x32<S: Simd>(simd: S, val: u16x32<S>) -> u8x32<S> {
+    // In case we had an overflow, make sure to clamp back to `u8::MAX`.
+    simd.narrow_u16x32(val.min(u16x32::splat(simd, 255)))
+}
+
 macro_rules! u8_mix {
     ($name:ident, $calc:expr) => {
         struct $name;
@@ -103,7 +109,7 @@ u8_mix!(Multiply, |src_c: u8x32<S>, bg_c: u8x32<S>| {
     let p1 = normalized_mul_u8x32(src_c, one_minus_bg_a);
     let p2 = normalized_mul_u8x32(src_c, bg_c);
 
-    simd.narrow_u16x32(p1 + p2)
+    narrow_saturating_u16x32(simd, p1 + p2)
 });
 
 // Screen:
@@ -116,7 +122,7 @@ u8_mix!(Screen, |src_c: u8x32<S>, bg_c: u8x32<S>| {
     let p2 = normalized_mul_u8x32(src_c, bg_c);
     let res = simd.widen_u8x32(src_c) + p1 - p2;
 
-    simd.narrow_u16x32(res)
+    narrow_saturating_u16x32(simd, res)
 });
 
 // Overlay is hard-light with source and backdrop swapped.
@@ -134,7 +140,7 @@ u8_mix!(Darken, |src_c: u8x32<S>, bg_c: u8x32<S>| {
     let p1 = normalized_mul_u8x32(src_c, 255 - bg_a);
     let p2 = normalized_mul_u8x32(src_c, bg_a).min(normalized_mul_u8x32(bg_c, src_a));
 
-    simd.narrow_u16x32(p1 + p2)
+    narrow_saturating_u16x32(simd, p1 + p2)
 });
 
 // Lighten:
@@ -147,7 +153,7 @@ u8_mix!(Lighten, |src_c: u8x32<S>, bg_c: u8x32<S>| {
     let p1 = normalized_mul_u8x32(src_c, 255 - bg_a);
     let p2 = normalized_mul_u8x32(src_c, bg_a).max(normalized_mul_u8x32(bg_c, src_a));
 
-    simd.narrow_u16x32(p1 + p2)
+    narrow_saturating_u16x32(simd, p1 + p2)
 });
 
 // Hard-light:
@@ -169,7 +175,7 @@ u8_mix!(Difference, |src_c: u8x32<S>, bg_c: u8x32<S>| {
     let p3 = normalized_mul_u8x32(bg_c, src_a);
     let diff = p2.max(p3) - p2.min(p3);
 
-    simd.narrow_u16x32(p1 + diff)
+    narrow_saturating_u16x32(simd, p1 + diff)
 });
 
 // Exclusion:
@@ -184,7 +190,7 @@ u8_mix!(Exclusion, |src_c: u8x32<S>, bg_c: u8x32<S>| {
     let sub = p2 + p2;
     let res = simd.select_u16x32(res.simd_ge(sub), res - sub, u16x32::splat(simd, 0));
 
-    simd.narrow_u16x32(res)
+    narrow_saturating_u16x32(simd, res)
 });
 
 #[inline(always)]
@@ -213,12 +219,16 @@ fn hard_light_inner<S: Simd>(src_c: u8x32<S>, bg_c: u8x32<S>, condition: u8x32<S
     );
     let res = (base + blended).div_255();
 
-    simd.narrow_u16x32(res)
+    narrow_saturating_u16x32(simd, res)
 }
 
 #[inline(always)]
 fn with_src_alpha<S: Simd>(simd: S, rgb: u8x32<S>, src_c: u8x32<S>) -> u8x32<S> {
     let alpha_mask = u32x8::splat(simd, u32::from_ne_bytes([0, 0, 0, 255])).to_bytes();
+    // It can happen that we end up with an R/G/B larger than the alpha value due to
+    // arithmetic errors. We need to clamp to the alpha to ensure the color is still a valid
+    // premultiplied color.
+    let rgb = rgb.min(src_c.splat_4th());
 
     (rgb & !alpha_mask) | (src_c & alpha_mask)
 }
@@ -274,26 +284,26 @@ mod tests {
 
     #[test]
     fn multiply_does_not_wrap() {
-        assert_lowp_matches_highp(Mix::Multiply, [128, 128, 128, 1], [255, 255, 255, 0]);
+        assert_lowp_matches_highp(Mix::Multiply, [1, 1, 1, 1], [1, 1, 1, 129]);
     }
 
     #[test]
     fn lighten_does_not_wrap() {
-        assert_lowp_matches_highp(Mix::Lighten, [255, 255, 255, 1], [1, 1, 1, 0]);
+        assert_lowp_matches_highp(Mix::Lighten, [1, 1, 1, 2], [129, 129, 129, 131]);
     }
 
     #[test]
     fn difference_does_not_wrap() {
-        assert_lowp_matches_highp(Mix::Difference, [255, 255, 255, 1], [1, 1, 1, 0]);
+        assert_lowp_matches_highp(Mix::Difference, [1, 1, 1, 2], [129, 129, 129, 193]);
     }
 
     #[test]
     fn hard_light_does_not_wrap() {
-        assert_lowp_matches_highp(Mix::HardLight, [255, 255, 255, 1], [128, 128, 128, 0]);
+        assert_lowp_matches_highp(Mix::HardLight, [1, 1, 1, 2], [2, 2, 2, 2]);
     }
 
     #[test]
     fn overlay_does_not_wrap() {
-        assert_lowp_matches_highp(Mix::Overlay, [255, 255, 255, 1], [128, 128, 128, 0]);
+        assert_lowp_matches_highp(Mix::Overlay, [0, 0, 0, 1], [1, 1, 1, 1]);
     }
 }

--- a/sparse_strips/vello_cpu/src/fine/lowp/blend.rs
+++ b/sparse_strips/vello_cpu/src/fine/lowp/blend.rs
@@ -273,6 +273,14 @@ mod tests {
         let lowp = lowp_first_pixel_for_mix(mix, src, bg);
         let highp = highp_first_pixel_for_mix(mix, src, bg);
 
+        let lowp_alpha = lowp[3];
+        for (component, &component_value) in lowp[..3].iter().enumerate() {
+            assert!(
+                component_value <= lowp_alpha,
+                "{mix:?} component {component} exceeded alpha: lowp={lowp:?}, src={src:?}, bg={bg:?}"
+            );
+        }
+
         for (component, (&lowp, &highp)) in lowp.iter().zip(highp.iter()).enumerate() {
             let delta = lowp.abs_diff(highp);
             assert!(
@@ -288,6 +296,16 @@ mod tests {
     }
 
     #[test]
+    fn screen_does_not_wrap() {
+        assert_lowp_matches_highp(Mix::Screen, [255, 255, 255, 255], [255, 255, 255, 255]);
+    }
+
+    #[test]
+    fn darken_does_not_wrap() {
+        assert_lowp_matches_highp(Mix::Darken, [20, 20, 20, 20], [92, 92, 92, 92]);
+    }
+
+    #[test]
     fn lighten_does_not_wrap() {
         assert_lowp_matches_highp(Mix::Lighten, [1, 1, 1, 2], [129, 129, 129, 131]);
     }
@@ -295,6 +313,11 @@ mod tests {
     #[test]
     fn difference_does_not_wrap() {
         assert_lowp_matches_highp(Mix::Difference, [1, 1, 1, 2], [129, 129, 129, 193]);
+    }
+
+    #[test]
+    fn exclusion_does_not_wrap() {
+        assert_lowp_matches_highp(Mix::Exclusion, [128, 128, 128, 255], [128, 128, 128, 255]);
     }
 
     #[test]

--- a/sparse_strips/vello_cpu/src/fine/lowp/blend.rs
+++ b/sparse_strips/vello_cpu/src/fine/lowp/blend.rs
@@ -274,6 +274,7 @@ mod tests {
         let highp = highp_first_pixel_for_mix(mix, src, bg);
 
         let lowp_alpha = lowp[3];
+        assert_eq!(lowp_alpha, src[3]);
         for (component, &component_value) in lowp[..3].iter().enumerate() {
             assert!(
                 component_value <= lowp_alpha,


### PR DESCRIPTION
#1653 added a new fast path for performing blending with u8/u16. Something that was missed here was that in many cases, we can exceed the technically allowed maximum of 255. In the previous f32 path, this wasn't a problem because converting a float larger than 255.0 to u8 it will automatically be clamped to, but this is not the case when doing all of blending using u8. I noticed this when trying to use the newest version of vello_cpu in my PDF renderer, where some pixels turned black.

This PR fixes this by
1) Ensuring all pixels are clamped to 255.
2) Additionally, ensuring that all RGB values are <= the alpha, which is necessary for premultiplied colors.

With this fix applied, I didn't notice any other regressions in my test suite.

First commit adds failing tests, second commit fixes the issue.