### PR TITLE
Enable bounds checks for the binning and coarse shaders

### DIFF
--- a/vello/src/wgpu_engine.rs
+++ b/vello/src/wgpu_engine.rs
@@ -842,14 +842,27 @@ impl WgpuEngine {
         entries: Vec<wgpu::BindGroupLayoutEntry>,
         cache: Option<&PipelineCache>,
     ) -> WgpuShader {
-        // SAFETY: We only call this with trusted shaders (written by Vello developers)
+        // SAFETY: We only call this with trusted shaders (written by Vello developers).
+        //
+        // #680: the `binning` and `coarse` stages index fixed-size per-bin arrays (sized
+        // N_TILE = 256) by the bin index, which exceeds that bound when the target is larger than
+        // 256 bins. With checks disabled those out-of-range accesses are undefined behavior that
+        // corrupts GPU memory and hangs the machine; with bounds checks enabled they are
+        // clamped/zeroed, so vello renders the first 256 bins and the overflow renders empty rather
+        // than crashing. Keep bounds checks on for just these two shaders; all others stay unchecked
+        // for performance. See https://github.com/linebender/vello/issues/680.
+        let runtime_checks = if label.ends_with("binning") || label.ends_with("coarse") {
+            wgpu::ShaderRuntimeChecks::checked()
+        } else {
+            wgpu::ShaderRuntimeChecks::unchecked()
+        };
         let shader_module = unsafe {
             device.create_shader_module_trusted(
                 wgpu::ShaderModuleDescriptor {
                     label: Some(label),
                     source: wgpu::ShaderSource::Wgsl(wgsl),
                 },
-                wgpu::ShaderRuntimeChecks::unchecked(),
+                runtime_checks,
             )
         };
         let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {


### PR DESCRIPTION
The binning and coarse stages index fixed-size per-bin workgroup arrays (sized N_TILE = 256) by the bin index `y * width_in_bins + x`. When the render target exceeds 256 bins (a bin is 256x256 px, e.g. a 16:9 backing store wider than ~5376px, or any target over 4096x4096), that index exceeds N_TILE:

  - binning.wgsl writes `sh_bitmaps[my_slice][y * width_in_bins + x]` out of bounds (workgroup memory);
  - coarse.wgsl reads `bin_headers[(partition_ix + local_id.x) * N_TILE + bin_ix]` past the end of the buffer.

All shaders are created with `ShaderRuntimeChecks::unchecked()`, so these are undefined behavior. The out-of-bounds workgroup write in particular corrupts GPU state and hangs the machine on some drivers (reproduced on Apple Silicon / Metal) instead of dropping the overflow bins as intended.

Create only the `binning` and `coarse` shaders with bounds checks enabled; every other shader keeps `unchecked()` for performance. With checks on, the out-of-range accesses are clamped/zeroed, so vello renders the first 256 bins and the overflow region renders empty rather than crashing.

This makes the existing 256-bin limit memory-safe; it does not lift the limit (tracked in #680).