### PR TITLE
vello_common: Use the maximum instead of the minimum as the start y position

### DIFF
--- a/sparse_strips/vello_common/src/clip.rs
+++ b/sparse_strips/vello_common/src/clip.rs
@@ -243,7 +243,7 @@ fn intersect_impl<S: Simd>(
 
     // Ignore any y values that are outside the bounding box of either of the two paths, as
     // those are guaranteed to have neither fill nor strip regions.
-    let mut cur_y = path_1.strips[0].strip_y().min(path_2.strips[0].strip_y());
+    let mut cur_y = path_1.strips[0].strip_y().max(path_2.strips[0].strip_y());
     let end_y = path_1.strips[path_1.strips.len() - 1]
         .strip_y()
         .min(path_2.strips[path_2.strips.len() - 1].strip_y());


### PR DESCRIPTION
Very big whoopsie. We should be using the _maximum_ as the start point, not the minimum. Any y-coordinate that is above either of the two path's top y is guaranteed to be clipped away, so no point in iterating over those, it's a lot of wasted work otherwise. I noticed this when profiling a PDF of mine:

Before: Clipping takes up ~10% of the whole render time
<img width="1672" height="623" alt="image" src="https://github.com/user-attachments/assets/5a3b3038-02fb-4f64-8f82-4be690dbbf9d" />

After: Clipping takes up ~4.4% of the render time
<img width="1675" height="618" alt="image" src="https://github.com/user-attachments/assets/61447586-7fac-414b-8dca-736c02994baa" />
