### PR TITLE
Sparse Strips: Ignore unimplemented filters rather than panicking

### DIFF
--- a/sparse_strips/vello_common/src/filter/mod.rs
+++ b/sparse_strips/vello_common/src/filter/mod.rs
@@ -34,16 +34,16 @@ pub enum PreparedFilter {
 
 impl PreparedFilter {
     /// Build a new prepared filter for the given transform.
-    pub fn new(filter: &Filter, transform: &Affine) -> Self {
+    pub fn new(filter: &Filter, transform: &Affine) -> Option<Self> {
         // Multi-primitive filter graphs are not yet implemented.
         if filter.graph.primitives.len() != 1 {
-            unimplemented!("Multi-primitive filter graphs are not yet supported");
+            return None;
         }
 
         match &filter.graph.primitives[0] {
             FilterPrimitive::Flood { color } => {
                 let flood = Flood::new(*color);
-                Self::Flood(flood)
+                Some(Self::Flood(flood))
             }
             FilterPrimitive::GaussianBlur {
                 std_deviation,
@@ -51,7 +51,7 @@ impl PreparedFilter {
             } => {
                 let scaled_std_dev = transform_blur_params(*std_deviation, transform);
                 let blur = GaussianBlur::new(scaled_std_dev, *edge_mode);
-                Self::GaussianBlur(blur)
+                Some(Self::GaussianBlur(blur))
             }
             FilterPrimitive::DropShadow {
                 dx,
@@ -65,18 +65,18 @@ impl PreparedFilter {
                 let drop_shadow =
                     DropShadow::new(scaled_dx, scaled_dy, scaled_std_dev, *edge_mode, *color);
 
-                Self::DropShadow(drop_shadow)
+                Some(Self::DropShadow(drop_shadow))
             }
             FilterPrimitive::Offset { dx, dy } => {
                 let (scaled_dx, scaled_dy) = transform_offset_params(*dx, *dy, transform);
                 let offset = Offset::new(scaled_dx, scaled_dy);
 
-                Self::Offset(offset)
+                Some(Self::Offset(offset))
             }
             _ => {
                 // Other primitives like Blend, ColorMatrix, ComponentTransfer, etc.
                 // are not yet implemented
-                unimplemented!("Other filter primitives not yet implemented");
+                None
             }
         }
     }

--- a/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
@@ -504,14 +504,11 @@ impl Dispatcher for MultiThreadedDispatcher {
         opacity: f32,
         aliasing_threshold: Option<u8>,
         mask: Option<Mask>,
-        filter: Option<Filter>,
+        _filter: Option<Filter>,
     ) {
         // TODO: Implement filter support in multi-threaded dispatcher.
         // The single-threaded dispatcher has full support via LayerManager and render graph execution,
         // but multi-threaded needs additional infrastructure for cross-thread layer coordination.
-        if filter.is_some() {
-            unimplemented!("Filter effects are not yet supported in multi-threaded rendering");
-        }
 
         let mapped_clip = clip_path.map(|c| {
             let start = self.allocation_group.path.len() as u32;

--- a/sparse_strips/vello_cpu/src/filter/mod.rs
+++ b/sparse_strips/vello_cpu/src/filter/mod.rs
@@ -63,7 +63,9 @@ pub(crate) fn filter_lowp(
     layer_manager: &mut LayerManager,
     transform: Affine,
 ) {
-    let prepared_filter = PreparedFilter::new(filter, &transform);
+    let Some(prepared_filter) = PreparedFilter::new(filter, &transform) else {
+        return;
+    };
 
     match prepared_filter {
         PreparedFilter::Flood(flood) => {
@@ -101,7 +103,9 @@ pub(crate) fn filter_highp(
     layer_manager: &mut LayerManager,
     transform: Affine,
 ) {
-    let prepared_filter = PreparedFilter::new(filter, &transform);
+    let Some(prepared_filter) = PreparedFilter::new(filter, &transform) else {
+        return;
+    };
 
     match prepared_filter {
         PreparedFilter::Flood(flood) => {

--- a/sparse_strips/vello_cpu/src/fine/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/mod.rs
@@ -651,7 +651,6 @@ impl<S: Simd, T: FineKernel<S>> Fine<S, T> {
             }
             Cmd::PushZeroClip(_) | Cmd::PopZeroClip => {
                 // These commands are handled by the dispatcher and should not reach fine rasterization
-                unreachable!();
             }
             Cmd::BatchEnd => {}
         }

--- a/sparse_strips/vello_hybrid/src/filter.rs
+++ b/sparse_strips/vello_hybrid/src/filter.rs
@@ -36,7 +36,7 @@ use vello_common::filter::drop_shadow::DropShadow;
 use vello_common::filter::flood::Flood;
 use vello_common::filter::gaussian_blur::{DecimationSizer, GaussianBlur, MAX_KERNEL_SIZE};
 use vello_common::filter::offset::Offset;
-use vello_common::filter_effects::EdgeMode;
+use vello_common::filter_effects::{EdgeMode, Filter, FilterPrimitive};
 use vello_common::kurbo::{Affine, Vec2};
 use vello_common::paint::{ImageId, ImageSource};
 use vello_common::peniko::{ImageQuality, ImageSampler};
@@ -770,7 +770,12 @@ impl FilterContext {
                 let width = wtile_bbox.width_px() as u32;
                 let height = wtile_bbox.height_px() as u32;
 
-                let instantiated = PreparedFilter::new(filter, transform);
+                let instantiated = PreparedFilter::new(filter, transform).unwrap_or_else(|| {
+                    // Removing filters from the graph is awkward, so we replace unsupported filters
+                    // with a zero-distance offset filter which has no effect on the output.
+                    let f = Filter::from_primitive(FilterPrimitive::Offset { dx: 0.0, dy: 0.0 });
+                    PreparedFilter::new(&f, transform).expect("Offset filter is known to be valid")
+                });
                 let gpu_filter = GpuFilterData::from(&instantiated);
                 let is_multi_pass = gpu_filter.is_multi_pass();
 


### PR DESCRIPTION
Changes made

- [x] Make Vello CPU (singlethreaded) ignore unimplemented filters instead of panicking
- [x] Make Vello Hybrid ignore unimplemented filters instead of panicking (replaces filters with 0.0 offset filter)
- [x] Make Vello CPU (multithreaded) ignore filter layers rather than panicking
