### PR TITLE
[classic] Support more than 256 bins

### DIFF
--- a/vello_encoding/src/config.rs
+++ b/vello_encoding/src/config.rs
@@ -387,9 +387,13 @@ impl BufferSizes {
         let draw_bboxes = BufferSize::new(n_paths);
         let bump_alloc = BufferSize::new(1);
         let indirect_count = BufferSize::new(1);
-        let bin_headers = BufferSize::new(binning_wgs * 256);
         let n_paths_aligned = align_up(n_paths, 256);
         let paths = BufferSize::new(n_paths_aligned);
+        let width_in_bins = workgroups.coarse.0;
+        let height_in_bins = workgroups.coarse.1;
+        let n_bins = width_in_bins * height_in_bins;
+        let aligned_n_bins = align_up(n_bins, 256);
+        let bin_headers = BufferSize::new(binning_wgs * aligned_n_bins);
 
         // The following buffer sizes have been hand picked to accommodate the vello test scenes as
         // well as paris-30k. These should instead get derived from the scene layout using

--- a/vello_shaders/shader/binning.wgsl
+++ b/vello_shaders/shader/binning.wgsl
@@ -74,7 +74,7 @@ fn main(
         return;
     }
 
-    // Read inputs and determine coverage of bins
+    // Read inputs and determine coverage of bins for the draw object global_id.x
     let element_ix = global_id.x;
     var x0 = 0;
     var y0 = 0;
@@ -113,6 +113,9 @@ fn main(
     }
     let width_in_bins = i32((config.width_in_tiles + N_TILE_X - 1u) / N_TILE_X);
     let height_in_bins = i32((config.height_in_tiles + N_TILE_Y - 1u) / N_TILE_Y);
+    let n_bins = u32(width_in_bins * height_in_bins);
+    let aligned_n_bins = (n_bins + N_TILE - 1u) & ~(N_TILE - 1u);
+
     x0 = clamp(x0, 0, width_in_bins);
     y0 = clamp(y0, 0, height_in_bins);
     x1 = clamp(x1, 0, width_in_bins);
@@ -120,62 +123,84 @@ fn main(
     if x0 == x1 {
         y1 = y0;
     }
-    var x = x0;
-    var y = y0;
+
+    let y0_width = y0 * width_in_bins;
+    let y1_width = y1 * width_in_bins;
+
     let my_slice = local_id.x / 32u;
     let my_mask = 1u << (local_id.x & 31u);
-    while y < y1 {
-        atomicOr(&sh_bitmaps[my_slice][y * width_in_bins + x], my_mask);
-        x += 1;
-        if x == x1 {
-            x = x0;
-            y += 1;
-        }
-    }
 
-    workgroupBarrier();
-    // Allocate output segments
-    var element_count = 0u;
-    for (var i = 0u; i < N_SUBSLICE; i += 1u) {
-        element_count += countOneBits(atomicLoad(&sh_bitmaps[i * 2u][local_id.x]));
-        let element_count_lo = element_count;
-        element_count += countOneBits(atomicLoad(&sh_bitmaps[i * 2u + 1u][local_id.x]));
-        let element_count_hi = element_count;
-        let element_count_packed = element_count_lo | (element_count_hi << 16u);
-        sh_count[i][local_id.x] = element_count_packed;
-    }
-    // element_count is the number of draw objects covering this thread's bin
-    var chunk_offset = atomicAdd(&bump.binning, element_count);
-    if chunk_offset + element_count > config.binning_size {
-        chunk_offset = 0u;
-        atomicOr(&bump.failed, STAGE_BINNING);
-    }    
-    sh_chunk_offset[local_id.x] = chunk_offset;
-    bin_header[global_id.x].element_count = element_count;
-    bin_header[global_id.x].chunk_offset = chunk_offset;
-    workgroupBarrier();
+    // Loop over the blocks of bins in chunks of N_TILE (256)
+    for (var block_start = 0u; block_start < n_bins; block_start += N_TILE) {
+        let next_block = block_start + N_TILE;
 
-    // loop over bbox of bins touched by this draw object
-    x = x0;
-    y = y0;
-    while y < y1 {
-        let bin_ix = y * width_in_bins + x;
-        let out_mask = atomicLoad(&sh_bitmaps[my_slice][bin_ix]);
-        // I think this predicate will always be true...
-        if (out_mask & my_mask) != 0u {
-            var idx = countOneBits(out_mask & (my_mask - 1u));
-            if my_slice > 0u {
-                let count_ix = my_slice - 1u;
-                let count_packed = sh_count[count_ix / 2u][bin_ix];
-                idx += (count_packed >> (16u * (count_ix & 1u))) & 0xffffu;
+        // Write coverage for the current block
+        for (var y_offset = y0_width; y_offset < y1_width; y_offset += width_in_bins) {
+            let start_bin = u32(y_offset + x0);
+            let end_bin = u32(y_offset + x1);
+            for (var bin_ix = start_bin; bin_ix < end_bin; bin_ix += 1u) {
+                if bin_ix >= block_start && bin_ix < next_block {
+                    let sh_bin_ix = bin_ix - block_start;
+                    atomicOr(&sh_bitmaps[my_slice][sh_bin_ix], my_mask);
+                }
             }
-            let offset = config.bin_data_start + sh_chunk_offset[bin_ix];
-            bin_data[offset + idx] = element_ix;
         }
-        x += 1;
-        if x == x1 {
-            x = x0;
-            y += 1;
+        workgroupBarrier();
+
+        // Accumulate counts and allocate output segment for the bins in this block
+        let cur_bin_ix = block_start + local_id.x;
+        var element_count = 0u;
+        for (var i = 0u; i < N_SUBSLICE; i += 1u) {
+            element_count += countOneBits(atomicLoad(&sh_bitmaps[i * 2u][local_id.x]));
+            let element_count_lo = element_count;
+            element_count += countOneBits(atomicLoad(&sh_bitmaps[i * 2u + 1u][local_id.x]));
+            let element_count_hi = element_count;
+            let element_count_packed = element_count_lo | (element_count_hi << 16u);
+            sh_count[i][local_id.x] = element_count_packed;
+        }
+
+        // element_count is the number of draw objects covering this thread's bin
+        var chunk_offset = atomicAdd(&bump.binning, element_count);
+        if chunk_offset + element_count > config.binning_size {
+            chunk_offset = 0u;
+            atomicOr(&bump.failed, STAGE_BINNING);
+        }
+        sh_chunk_offset[local_id.x] = chunk_offset;
+
+        let header_ix = wg_id.x * aligned_n_bins + cur_bin_ix;
+        bin_header[header_ix].element_count = element_count;
+        bin_header[header_ix].chunk_offset = chunk_offset;
+        workgroupBarrier();
+
+        // Output the element indices to bin_data
+        for (var y_offset = y0_width; y_offset < y1_width; y_offset += width_in_bins) {
+            let start_bin = u32(y_offset + x0);
+            let end_bin = u32(y_offset + x1);
+            for (var bin_ix = start_bin; bin_ix < end_bin; bin_ix += 1u) {
+                if bin_ix >= block_start && bin_ix < next_block {
+                    let sh_bin_ix = bin_ix - block_start;
+                    let out_mask = atomicLoad(&sh_bitmaps[my_slice][sh_bin_ix]);
+                    // I think this predicate will always be true...
+                    if (out_mask & my_mask) != 0u {
+                        var idx = countOneBits(out_mask & (my_mask - 1u));
+                        if my_slice > 0u {
+                            let count_ix = my_slice - 1u;
+                            let count_packed = sh_count[count_ix / 2u][sh_bin_ix];
+                            idx += (count_packed >> (16u * (count_ix & 1u))) & 0xffffu;
+                        }
+                        let offset = config.bin_data_start + sh_chunk_offset[sh_bin_ix];
+                        bin_data[offset + idx] = element_ix;
+                    }
+                }
+            }
+        }
+
+        if next_block < aligned_n_bins {
+            workgroupBarrier();
+            for (var i = 0u; i < N_SLICE; i += 1u) {
+                atomicStore(&sh_bitmaps[i][local_id.x], 0u);
+            }
+            workgroupBarrier();
         }
     }
 }

--- a/vello_shaders/shader/binning.wgsl
+++ b/vello_shaders/shader/binning.wgsl
@@ -131,18 +131,15 @@ fn main(
     let my_mask = 1u << (local_id.x & 31u);
 
     // Loop over the blocks of bins in chunks of N_TILE (256)
-    for (var block_start = 0u; block_start < n_bins; block_start += N_TILE) {
-        let next_block = block_start + N_TILE;
-
+    var next_block = N_TILE;
+    for (var block_start = 0u; block_start < n_bins; ) {
         // Write coverage for the current block
         for (var y_offset = y0_width; y_offset < y1_width; y_offset += width_in_bins) {
-            let start_bin = u32(y_offset + x0);
-            let end_bin = u32(y_offset + x1);
+            let start_bin = max(u32(y_offset + x0), block_start);
+            let end_bin = min(u32(y_offset + x1), next_block);
             for (var bin_ix = start_bin; bin_ix < end_bin; bin_ix += 1u) {
-                if bin_ix >= block_start && bin_ix < next_block {
-                    let sh_bin_ix = bin_ix - block_start;
-                    atomicOr(&sh_bitmaps[my_slice][sh_bin_ix], my_mask);
-                }
+                let sh_bin_ix = bin_ix - block_start;
+                atomicOr(&sh_bitmaps[my_slice][sh_bin_ix], my_mask);
             }
         }
         workgroupBarrier();
@@ -174,33 +171,33 @@ fn main(
 
         // Output the element indices to bin_data
         for (var y_offset = y0_width; y_offset < y1_width; y_offset += width_in_bins) {
-            let start_bin = u32(y_offset + x0);
-            let end_bin = u32(y_offset + x1);
+            let start_bin = max(u32(y_offset + x0), block_start);
+            let end_bin = min(u32(y_offset + x1), next_block);
             for (var bin_ix = start_bin; bin_ix < end_bin; bin_ix += 1u) {
-                if bin_ix >= block_start && bin_ix < next_block {
-                    let sh_bin_ix = bin_ix - block_start;
-                    let out_mask = atomicLoad(&sh_bitmaps[my_slice][sh_bin_ix]);
-                    // I think this predicate will always be true...
-                    if (out_mask & my_mask) != 0u {
-                        var idx = countOneBits(out_mask & (my_mask - 1u));
-                        if my_slice > 0u {
-                            let count_ix = my_slice - 1u;
-                            let count_packed = sh_count[count_ix / 2u][sh_bin_ix];
-                            idx += (count_packed >> (16u * (count_ix & 1u))) & 0xffffu;
-                        }
-                        let offset = config.bin_data_start + sh_chunk_offset[sh_bin_ix];
-                        bin_data[offset + idx] = element_ix;
+                let sh_bin_ix = bin_ix - block_start;
+                let out_mask = atomicLoad(&sh_bitmaps[my_slice][sh_bin_ix]);
+                // I think this predicate will always be true...
+                if (out_mask & my_mask) != 0u {
+                    var idx = countOneBits(out_mask & (my_mask - 1u));
+                    if my_slice > 0u {
+                        let count_ix = my_slice - 1u;
+                        let count_packed = sh_count[count_ix / 2u][sh_bin_ix];
+                        idx += (count_packed >> (16u * (count_ix & 1u))) & 0xffffu;
                     }
+                    let offset = config.bin_data_start + sh_chunk_offset[sh_bin_ix];
+                    bin_data[offset + idx] = element_ix;
                 }
             }
         }
 
+        block_start = next_block;
         if next_block < aligned_n_bins {
             workgroupBarrier();
             for (var i = 0u; i < N_SLICE; i += 1u) {
                 atomicStore(&sh_bitmaps[i][local_id.x], 0u);
             }
             workgroupBarrier();
+            next_block += N_TILE;
         }
     }
 }

--- a/vello_shaders/shader/coarse.wgsl
+++ b/vello_shaders/shader/coarse.wgsl
@@ -179,6 +179,8 @@ fn main(
     }
     let width_in_bins = (config.width_in_tiles + N_TILE_X - 1u) / N_TILE_X;
     let bin_ix = width_in_bins * wg_id.y + wg_id.x;
+    let height_in_bins = (config.height_in_tiles + N_TILE_Y - 1u) / N_TILE_Y;
+    let aligned_n_bins = (width_in_bins * height_in_bins + N_TILE - 1u) & ~(N_TILE - 1u);
     let n_partitions = (config.n_drawobj + N_TILE - 1u) / N_TILE;
 
     // Coordinates of the top left of this bin, in tiles.
@@ -218,7 +220,7 @@ fn main(
                 part_start_ix = ready_ix;
                 var count = 0u;
                 if partition_ix + local_id.x < n_partitions {
-                    let in_ix = (partition_ix + local_id.x) * N_TILE + bin_ix;
+                    let in_ix = (partition_ix + local_id.x) * aligned_n_bins + bin_ix;
                     let bin_header = bin_headers[in_ix];
                     count = bin_header.element_count;
                     sh_part_offsets[local_id.x] = bin_header.chunk_offset;

--- a/vello_shaders/src/cpu/binning.rs
+++ b/vello_shaders/src/cpu/binning.rs
@@ -33,11 +33,12 @@ fn binning_main(
     bin_data: &mut [u32],
     bin_header: &mut [BinHeader],
 ) {
+    let width_in_bins = config.width_in_tiles.div_ceil(N_TILE_X as u32) as i32;
+    let height_in_bins = config.height_in_tiles.div_ceil(N_TILE_Y as u32) as i32;
+    let n_bins = (width_in_bins * height_in_bins) as usize;
     for wg in 0..n_wg as usize {
-        let mut counts = [0; WG_SIZE];
+        let mut counts = vec![0; n_bins];
         let mut bboxes = [[0, 0, 0, 0]; WG_SIZE];
-        let width_in_bins = config.width_in_tiles.div_ceil(N_TILE_X as u32) as i32;
-        let height_in_bins = config.height_in_tiles.div_ceil(N_TILE_Y as u32) as i32;
         for local_ix in 0..WG_SIZE {
             let element_ix = wg * WG_SIZE + local_ix;
             let mut x0 = 0;
@@ -78,9 +79,12 @@ fn binning_main(
             }
             bboxes[local_ix] = [x0, y0, x1, y1];
         }
-        let mut chunk_offset = [0; WG_SIZE];
-        for local_ix in 0..WG_SIZE {
-            let global_ix = wg * WG_SIZE + local_ix;
+        let mut chunk_offset = vec![0; n_bins];
+        let aligned_n_bins = (n_bins + 255) & !255;
+        // Looping on the number of bins instead of workgroup sized chunks, not idiomatic of gpus
+        // Oh well!
+        for local_ix in 0..n_bins {
+            let global_ix = wg * aligned_n_bins + local_ix;
             chunk_offset[local_ix] = bump.binning;
             bump.binning += counts[local_ix];
             bin_header[global_ix] = BinHeader {

--- a/vello_shaders/src/cpu/coarse.rs
+++ b/vello_shaders/src/cpu/coarse.rs
@@ -196,6 +196,7 @@ fn coarse_main(
     let width_in_bins = width_in_tiles.div_ceil(N_TILE_X as u32);
     let height_in_bins = height_in_tiles.div_ceil(N_TILE_Y as u32);
     let n_bins = width_in_bins * height_in_bins;
+    let aligned_n_bins = (n_bins + 255) & !255;
     let bin_data_start = config.layout.bin_data_start;
     let drawtag_base = config.layout.draw_tag_base;
     let mut compacted = vec![vec![]; N_TILE];
@@ -209,7 +210,7 @@ fn coarse_main(
         let bin_tile_x = N_TILE_X as u32 * bin_x;
         let bin_tile_y = N_TILE_Y as u32 * bin_y;
         for part in 0..n_partitions {
-            let in_ix = part * N_TILE as u32 + bin;
+            let in_ix = part * aligned_n_bins + bin;
             let bin_header = bin_headers[in_ix as usize];
             let start = bin_data_start + bin_header.chunk_offset;
             for i in 0..bin_header.element_count {

--- a/vello_tests/tests/compare_gpu_cpu.rs
+++ b/vello_tests/tests/compare_gpu_cpu.rs
@@ -98,3 +98,12 @@ fn compare_blurred_rounded_rect() {
     let params = TestParams::new("compare_blurred_rounded_rect", 1200, 1200);
     compare_test_scene(test_scene, params);
 }
+
+#[test]
+#[ignore = "This test takes a long time."]
+#[cfg_attr(skip_gpu_tests, ignore)]
+fn compare_large_bin_count() {
+    let test_scene = test_scenes::funky_paths();
+    let params = TestParams::new("compare_large_bin_count", 8192, 2304);
+    compare_test_scene(test_scene, params);
+}

--- a/vello_tests/tests/known_issues.rs
+++ b/vello_tests/tests/known_issues.rs
@@ -14,64 +14,8 @@
 
 use vello::Scene;
 use vello::kurbo::{Affine, Rect, Triangle};
-use vello::peniko::{ImageFormat, Mix, color::palette};
+use vello::peniko::{Mix, color::palette};
 use vello_tests::{TestParams, smoke_snapshot_test_sync, snapshot_test_sync};
-
-/// A reproduction of <https://github.com/linebender/vello/issues/680>
-fn many_bins(use_cpu: bool) {
-    let mut scene = Scene::new();
-    scene.fill(
-        vello::peniko::Fill::NonZero,
-        Affine::IDENTITY,
-        palette::css::RED,
-        None,
-        &Rect::new(-5., -5., 256. * 20., 256. * 20.),
-    );
-    let params = TestParams {
-        use_cpu,
-        ..TestParams::new("many_bins", 256 * 17, 256 * 17)
-    };
-    // To view, use VELLO_DEBUG_TEST=many_bins
-    let image = vello_tests::render_then_debug_sync(&scene, &params).unwrap();
-    assert_eq!(image.format, ImageFormat::Rgba8);
-    let mut red_count = 0;
-    let mut black_count = 0;
-    for pixel in image.data.data().chunks_exact(4) {
-        let &[r, g, b, a] = pixel else { unreachable!() };
-        let is_red = r == 255 && g == 0 && b == 0 && a == 255;
-        let is_black = r == 0 && g == 0 && b == 0 && a == 255;
-        if !is_red && !is_black {
-            panic!("{pixel:?}");
-        }
-        match (is_red, is_black) {
-            (true, true) => unreachable!(),
-            (true, false) => red_count += 1,
-            (false, true) => black_count += 1,
-            (false, false) => panic!("Got unexpected pixel {pixel:?}"),
-        }
-    }
-    // When #680 is fixed, this will become:
-    // let drawn_bins = 17 /* x bins */ * 17 /* y bins*/;
-
-    // The current maximum number of bins.
-    let drawn_bins = 256;
-    let expected_red_count = drawn_bins * 256 /* tiles per bin */ * 256 /* Pixels per tile */;
-    assert_eq!(red_count, expected_red_count);
-    assert!(black_count > 0);
-}
-
-#[test]
-#[cfg_attr(skip_gpu_tests, ignore)]
-fn many_bins_gpu() {
-    many_bins(false);
-}
-
-#[test]
-#[cfg_attr(skip_gpu_tests, ignore)]
-#[should_panic]
-fn many_bins_cpu() {
-    many_bins(true);
-}
 
 /// Test for <https://github.com/linebender/vello/issues/1061>
 #[test]

--- a/vello_tests/tests/regression.rs
+++ b/vello_tests/tests/regression.rs
@@ -9,7 +9,8 @@ use vello::{
     AaConfig, Scene,
     kurbo::{Affine, Rect, RoundedRect, Stroke},
     peniko::{
-        Color, ColorStop, Extend, Gradient, ImageQuality, InterpolationAlphaSpace, color::palette,
+        Color, ColorStop, Extend, Gradient, ImageFormat, ImageQuality, InterpolationAlphaSpace,
+        color::palette,
     },
 };
 use vello_tests::{TestParams, smoke_snapshot_test_sync, snapshot_test_sync};
@@ -206,4 +207,54 @@ fn test_gradient_color_alpha_unpremultiplied() {
     smoke_snapshot_test_sync(scene, &params)
         .unwrap()
         .assert_mean_less_than(0.001);
+}
+
+/// Test created from <https://github.com/linebender/vello/issues/680>
+fn many_bins(use_cpu: bool) {
+    let mut scene = Scene::new();
+    scene.fill(
+        vello::peniko::Fill::NonZero,
+        Affine::IDENTITY,
+        palette::css::RED,
+        None,
+        &Rect::new(-5., -5., 256. * 20., 256. * 20.),
+    );
+    let params = TestParams {
+        use_cpu,
+        ..TestParams::new("many_bins", 256 * 17, 256 * 17)
+    };
+    let image = vello_tests::render_then_debug_sync(&scene, &params).unwrap();
+    assert_eq!(image.format, ImageFormat::Rgba8);
+    let mut red_count = 0;
+    let mut black_count = 0;
+    for pixel in image.data.data().chunks_exact(4) {
+        let &[r, g, b, a] = pixel else { unreachable!() };
+        let is_red = r == 255 && g == 0 && b == 0 && a == 255;
+        let is_black = r == 0 && g == 0 && b == 0 && a == 255;
+        if !is_red && !is_black {
+            panic!("{pixel:?}");
+        }
+        match (is_red, is_black) {
+            (true, true) => unreachable!(),
+            (true, false) => red_count += 1,
+            (false, true) => black_count += 1,
+            (false, false) => panic!("Got unexpected pixel {pixel:?}"),
+        }
+    }
+    let drawn_bins = 17 /* x bins */ * 17 /* y bins*/;
+    let expected_red_count = drawn_bins * 256 /* tiles per bin */ * 256 /* Pixels per tile */;
+    assert_eq!(red_count, expected_red_count);
+    assert_eq!(black_count, 0);
+}
+
+#[test]
+#[cfg_attr(skip_gpu_tests, ignore)]
+fn many_bins_gpu() {
+    many_bins(false);
+}
+
+#[test]
+#[cfg_attr(skip_gpu_tests, ignore)]
+fn many_bins_cpu() {
+    many_bins(true);
 }

--- a/vello_tests/tests/regression.rs
+++ b/vello_tests/tests/regression.rs
@@ -224,7 +224,7 @@ fn many_bins(use_cpu: bool) {
         ..TestParams::new("many_bins", 256 * 17, 256 * 17)
     };
     let image = vello_tests::render_then_debug_sync(&scene, &params).unwrap();
-    assert_eq!(image.format, ImageFormat::Rgba8);
+    assert_eq!(image.format, ImageFormat::Rgba8, "image should be Rgba8");
     let mut red_count = 0;
     let mut black_count = 0;
     for pixel in image.data.data().chunks_exact(4) {
@@ -243,8 +243,14 @@ fn many_bins(use_cpu: bool) {
     }
     let drawn_bins = 17 /* x bins */ * 17 /* y bins*/;
     let expected_red_count = drawn_bins * 256 /* tiles per bin */ * 256 /* Pixels per tile */;
-    assert_eq!(red_count, expected_red_count);
-    assert_eq!(black_count, 0);
+    assert_eq!(
+        red_count, expected_red_count,
+        "number of drawn red pixels should match the expected pixel count for 17x17 bins"
+    );
+    assert_eq!(
+        black_count, 0,
+        "no black pixels should remain in the render"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Changes binning to accept more than 256 bins.

After intersecting with the clip, each workgroup processes the bins in blocks of 256. Although this can be a little slow, for almost all cases the binning will be resolved in <= 2 blocks.