### PR TITLE
vello_cpu: Add a `is_multi_threaded` method

### DIFF
--- a/sparse_strips/vello_cpu/src/dispatch/mod.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/mod.rs
@@ -92,4 +92,5 @@ pub(crate) trait Dispatcher: Debug + Send + Sync {
         encoded_paints: &[EncodedPaint],
         image_resolver: &dyn ImageResolver,
     );
+    fn is_multi_threaded(&self) -> bool;
 }

--- a/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
@@ -656,6 +656,10 @@ impl Dispatcher for MultiThreadedDispatcher {
         self.flush_tasks();
         self.clip_context.pop_clip();
     }
+
+    fn is_multi_threaded(&self) -> bool {
+        true
+    }
 }
 
 impl Debug for MultiThreadedDispatcher {

--- a/sparse_strips/vello_cpu/src/dispatch/single_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/single_threaded.rs
@@ -863,6 +863,10 @@ impl Dispatcher for SingleThreadedDispatcher {
     fn pop_clip_path(&mut self) {
         self.clip_context.pop_clip();
     }
+
+    fn is_multi_threaded(&self) -> bool {
+        false
+    }
 }
 
 /// Saves a filtered pixmap to disk for debugging purposes.

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -758,6 +758,12 @@ impl RenderContext {
     pub fn restore_state(&mut self, state: RenderState) {
         self.state = state;
     }
+
+    /// Whether rendering is currently configured to run in multi-threaded mode.
+    #[doc(hidden)]
+    pub fn is_multi_threaded(&self) -> bool {
+        self.dispatcher.is_multi_threaded()
+    }
 }
 
 /// Image registry implementation.

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -760,7 +760,6 @@ impl RenderContext {
     }
 
     /// Whether rendering is currently configured to run in multi-threaded mode.
-    #[doc(hidden)]
     pub fn is_multi_threaded(&self) -> bool {
         self.dispatcher.is_multi_threaded()
     }


### PR DESCRIPTION
As an alternative to #1702.