### PR TITLE
vello_hybrid: Remove outdated debug assertion

### DIFF
--- a/sparse_strips/vello_hybrid/src/schedule.rs
+++ b/sparse_strips/vello_hybrid/src/schedule.rs
@@ -1820,10 +1820,6 @@ impl Scheduler {
         match paint {
             Paint::Solid(color) => {
                 let rgba = color.as_premul_rgba8().to_u32();
-                debug_assert!(
-                    has_non_zero_alpha(rgba),
-                    "Color fields with 0 alpha are reserved for clipping"
-                );
                 let paint_packed = (COLOR_SOURCE_PAYLOAD << 30) | (PAINT_TYPE_SOLID << 27);
                 ProcessedPaint {
                     payload: rgba,

--- a/sparse_strips/vello_sparse_tests/snapshots/issue_1707_transparent_solid_fill.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/issue_1707_transparent_solid_fill.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56f57423e0ff37d0284ae02f3dfa6ceffad893302f86b5aa4d17dabb5ba1b25d
+size 82

--- a/sparse_strips/vello_sparse_tests/tests/issues.rs
+++ b/sparse_strips/vello_sparse_tests/tests/issues.rs
@@ -744,6 +744,12 @@ fn issue_1528(ctx: &mut impl Renderer) {
 }
 
 #[vello_test]
+fn issue_1707_transparent_solid_fill(ctx: &mut impl Renderer) {
+    ctx.set_paint(Color::from_rgb8(0, 0, 0).with_alpha(0.001));
+    ctx.fill_rect(&Rect::new(0.0, 0.0, 100.0, 100.0));
+}
+
+#[vello_test]
 fn issue_fast_path_strips_in_later_round(ctx: &mut impl Renderer) {
     ctx.push_layer(None, None, None, None, None);
     ctx.push_layer(None, None, None, None, None);


### PR DESCRIPTION
Fixes #1707. I'm still not sure how they are able to trigger this assertion, but since it's anyway outdated we should still remove it.

This assertion was introduced in https://github.com/linebender/vello/pull/957. Back then, in the shader the information whether to use a slot or not was stored in the same field that stores the RGBA color for solid fills:

<img width="634" height="142" alt="image" src="https://github.com/user-attachments/assets/e037f9e0-f4a8-4073-b041-bdd88ac47811" />

However, this is not the case anymore. Now we have two separate flags, `payload` which stores the RGBA values and `paint_and_rect_flag` which stores what kind of paint is actually used (including whether slots should be used). 

https://github.com/linebender/vello/blob/da699dec733ee5aa54b6f5f0e351fa6b894bdf56/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl#L217-L220

Therefore, this debug assertion is not relevant anymore.