### PR TITLE
vello_cpu: opt-in cooperative cancellation for rasterization

### DIFF
--- a/sparse_strips/vello_cpu/src/dispatch/mod.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/mod.rs
@@ -75,6 +75,11 @@ pub(crate) trait Dispatcher: Debug + Send {
         settings: RasterizerSettings,
         encoded_paints: &[EncodedPaint],
         image_resolver: &dyn ImageResolver,
+        // Polled between strip rows (and per region on the multi-threaded
+        // dispatcher); when it returns `true`, rasterization stops early and the
+        // target is left partially rendered. `Sync` because the multi-threaded
+        // dispatcher polls it from worker threads.
+        cancel: Option<&(dyn Fn() -> bool + Sync)>,
     );
     fn is_multi_threaded(&self) -> bool;
 }

--- a/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
@@ -12,7 +12,7 @@ use crate::fine::{Fine, FineKernel, FineRenderParams, FineResources, rasterize_r
 use crate::kurbo::{Affine, BezPath, PathEl, Point, Rect, Stroke};
 use crate::peniko::{BlendMode, Fill};
 use crate::record::{CommandRecorder, FilterData, LayerProps, PoppedLayer};
-use crate::region::Regions;
+use crate::region::{Region, Regions};
 use crate::{CompositeMode, RasterizerSettings};
 use alloc::boxed::Box;
 use alloc::sync::Arc;
@@ -174,9 +174,10 @@ impl MultiThreadedDispatcher {
         settings: RasterizerSettings,
         encoded_paints: &[EncodedPaint],
         image_resolver: &dyn ImageResolver,
+        cancel: Option<&(dyn Fn() -> bool + Sync)>,
     ) {
         use crate::fine::F32Kernel;
-        dispatch!(self.level, simd => self.rasterize_with::<_, F32Kernel>(simd, target, scene_width, scene_height, settings, encoded_paints, image_resolver));
+        dispatch!(self.level, simd => self.rasterize_with::<_, F32Kernel>(simd, target, scene_width, scene_height, settings, encoded_paints, image_resolver, cancel));
     }
 
     #[cfg(feature = "u8_pipeline")]
@@ -188,9 +189,10 @@ impl MultiThreadedDispatcher {
         settings: RasterizerSettings,
         encoded_paints: &[EncodedPaint],
         image_resolver: &dyn ImageResolver,
+        cancel: Option<&(dyn Fn() -> bool + Sync)>,
     ) {
         use crate::fine::U8Kernel;
-        dispatch!(self.level, simd => self.rasterize_with::<_, U8Kernel>(simd, target, scene_width, scene_height, settings, encoded_paints, image_resolver));
+        dispatch!(self.level, simd => self.rasterize_with::<_, U8Kernel>(simd, target, scene_width, scene_height, settings, encoded_paints, image_resolver, cancel));
     }
 
     fn init(&mut self) {
@@ -393,6 +395,7 @@ impl MultiThreadedDispatcher {
         settings: RasterizerSettings,
         encoded_paints: &[EncodedPaint],
         image_resolver: &dyn ImageResolver,
+        cancel: Option<&(dyn Fn() -> bool + Sync)>,
     ) {
         let mut bucketer = self.bucketer.lock().unwrap();
         let filters = FilterContext::new(0);
@@ -428,7 +431,7 @@ impl MultiThreadedDispatcher {
             );
             let fines = ThreadLocal::new();
             self.thread_pool.install(|| {
-                regions.update_par(|region| {
+                let render_region = |region: &mut Region<'_>| {
                     let mut fine = fines
                         .get_or(|| {
                             RefCell::new((
@@ -447,7 +450,15 @@ impl MultiThreadedDispatcher {
                         resources,
                         use_src_over,
                     );
-                });
+                };
+                // Per-region cancellation when a stop is set; otherwise the
+                // original zero-overhead parallel path.
+                match cancel {
+                    Some(cancel) => {
+                        regions.update_par_cancellable(cancel, render_region);
+                    }
+                    None => regions.update_par(render_region),
+                }
             });
         }
 
@@ -646,6 +657,7 @@ impl Dispatcher for MultiThreadedDispatcher {
         settings: RasterizerSettings,
         encoded_paints: &[EncodedPaint],
         image_resolver: &dyn ImageResolver,
+        cancel: Option<&(dyn Fn() -> bool + Sync)>,
     ) {
         assert!(self.flushed, "attempted to rasterize before flushing");
 
@@ -659,6 +671,7 @@ impl Dispatcher for MultiThreadedDispatcher {
                 settings,
                 encoded_paints,
                 image_resolver,
+                cancel,
             );
         }
         // Only f32 pipeline enabled
@@ -671,6 +684,7 @@ impl Dispatcher for MultiThreadedDispatcher {
                 settings,
                 encoded_paints,
                 image_resolver,
+                cancel,
             );
         }
 
@@ -685,6 +699,7 @@ impl Dispatcher for MultiThreadedDispatcher {
                     settings,
                     encoded_paints,
                     image_resolver,
+                    cancel,
                 );
             }
             crate::RenderMode::OptimizeQuality => {
@@ -695,6 +710,7 @@ impl Dispatcher for MultiThreadedDispatcher {
                     settings,
                     encoded_paints,
                     image_resolver,
+                    cancel,
                 );
             }
         }

--- a/sparse_strips/vello_cpu/src/dispatch/single_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/single_threaded.rs
@@ -13,7 +13,7 @@ use crate::peniko::{BlendMode, Fill};
 use crate::record::{
     CommandRecorder, FilterData, LayerProps, PoppedLayer, RecordedCmd, RecordedLayerKind,
 };
-use crate::region::Regions;
+use crate::region::{Region, Regions};
 use crate::{CompositeMode, RasterizerSettings};
 use alloc::vec::Vec;
 use core::cell::RefCell;
@@ -77,10 +77,11 @@ impl SingleThreadedDispatcher {
         settings: RasterizerSettings,
         encoded_paints: &[EncodedPaint],
         image_resolver: &dyn ImageResolver,
+        cancel: Option<&(dyn Fn() -> bool + Sync)>,
     ) {
         use crate::fine::F32Kernel;
         use vello_common::fearless_simd::dispatch;
-        dispatch!(self.level, simd => self.rasterize_with::<_, F32Kernel>(simd, target, scene_width, scene_height, settings, encoded_paints, image_resolver));
+        dispatch!(self.level, simd => self.rasterize_with::<_, F32Kernel>(simd, target, scene_width, scene_height, settings, encoded_paints, image_resolver, cancel));
     }
 
     /// Rasterizes the scene using u8 precision (fast).
@@ -96,10 +97,11 @@ impl SingleThreadedDispatcher {
         settings: RasterizerSettings,
         encoded_paints: &[EncodedPaint],
         image_resolver: &dyn ImageResolver,
+        cancel: Option<&(dyn Fn() -> bool + Sync)>,
     ) {
         use crate::fine::U8Kernel;
         use vello_common::fearless_simd::dispatch;
-        dispatch!(self.level, simd => self.rasterize_with::<_, U8Kernel>(simd, target, scene_width, scene_height, settings, encoded_paints, image_resolver));
+        dispatch!(self.level, simd => self.rasterize_with::<_, U8Kernel>(simd, target, scene_width, scene_height, settings, encoded_paints, image_resolver, cancel));
     }
 
     // Note: We purposefully don't add `vectorize` to each of these helpers,
@@ -113,8 +115,10 @@ impl SingleThreadedDispatcher {
         settings: RasterizerSettings,
         encoded_paints: &[EncodedPaint],
         image_resolver: &dyn ImageResolver,
+        cancel: Option<&(dyn Fn() -> bool + Sync)>,
     ) {
-        let filters = self.rasterize_filter_layers::<S, F>(simd, encoded_paints, image_resolver);
+        let filters =
+            self.rasterize_filter_layers::<S, F>(simd, encoded_paints, image_resolver, cancel);
         let use_src_over = settings.composite_mode == CompositeMode::SrcOver;
         let params = FineRenderParams {
             scene_size: (scene_width, scene_height),
@@ -131,6 +135,7 @@ impl SingleThreadedDispatcher {
             use_src_over,
             encoded_paints,
             image_resolver,
+            cancel,
         );
     }
 
@@ -145,6 +150,7 @@ impl SingleThreadedDispatcher {
         use_src_over: bool,
         encoded_paints: &[EncodedPaint],
         image_resolver: &dyn ImageResolver,
+        cancel: Option<&(dyn Fn() -> bool + Sync)>,
     ) {
         let mut bucketer = self.bucketer.borrow_mut();
         bucketer.reset(viewport);
@@ -169,7 +175,14 @@ impl SingleThreadedDispatcher {
             params.target_offset,
             bucketer.rows().len(),
         );
-        Self::rasterize_target::<S, F>(simd, &bucketer, resources, &mut regions, use_src_over);
+        Self::rasterize_target::<S, F>(
+            simd,
+            &bucketer,
+            resources,
+            &mut regions,
+            use_src_over,
+            cancel,
+        );
     }
 
     fn rasterize_target<S: Simd, F: FineKernel<S>>(
@@ -178,11 +191,12 @@ impl SingleThreadedDispatcher {
         resources: FineResources<'_>,
         regions: &mut Regions<'_>,
         use_src_over: bool,
+        cancel: Option<&(dyn Fn() -> bool + Sync)>,
     ) {
         // TODO: Reuse fine and depth buffer across targets?
         let mut fine = Fine::<S, F>::new(simd, bucketer.width());
         let mut depth = DepthBuffer::new(bucketer.width());
-        regions.update(|region| {
+        let render_region = |region: &mut Region<'_>| {
             rasterize_region::<S, F>(
                 &mut fine,
                 &mut depth,
@@ -191,7 +205,14 @@ impl SingleThreadedDispatcher {
                 resources,
                 use_src_over,
             );
-        });
+        };
+        // Keep the original zero-overhead path when there's nothing to cancel.
+        match cancel {
+            Some(cancel) => {
+                regions.update_cancellable(cancel, render_region);
+            }
+            None => regions.update(render_region),
+        }
     }
 
     fn record_fill(
@@ -217,6 +238,7 @@ impl SingleThreadedDispatcher {
         simd: S,
         encoded_paints: &[EncodedPaint],
         image_resolver: &dyn ImageResolver,
+        cancel: Option<&(dyn Fn() -> bool + Sync)>,
     ) -> FilterContext {
         // TODO: Reuse across frames so that pixmaps can be reused.
         let mut filter_ctx = FilterContext::new(self.recorder.layers.len());
@@ -259,6 +281,7 @@ impl SingleThreadedDispatcher {
                 false,
                 encoded_paints,
                 image_resolver,
+                cancel,
             );
 
             F::filter_layer(
@@ -459,6 +482,7 @@ impl Dispatcher for SingleThreadedDispatcher {
         settings: RasterizerSettings,
         encoded_paints: &[EncodedPaint],
         image_resolver: &dyn ImageResolver,
+        cancel: Option<&(dyn Fn() -> bool + Sync)>,
     ) {
         // If only the u8 pipeline is enabled, then use it.
         #[cfg(all(feature = "u8_pipeline", not(feature = "f32_pipeline")))]
@@ -470,6 +494,7 @@ impl Dispatcher for SingleThreadedDispatcher {
                 settings,
                 encoded_paints,
                 image_resolver,
+                cancel,
             );
         }
 
@@ -483,6 +508,7 @@ impl Dispatcher for SingleThreadedDispatcher {
                 settings,
                 encoded_paints,
                 image_resolver,
+                cancel,
             );
         }
 
@@ -498,6 +524,7 @@ impl Dispatcher for SingleThreadedDispatcher {
                     settings,
                     encoded_paints,
                     image_resolver,
+                    cancel,
                 );
             }
             crate::RenderMode::OptimizeQuality => {
@@ -509,6 +536,7 @@ impl Dispatcher for SingleThreadedDispatcher {
                     settings,
                     encoded_paints,
                     image_resolver,
+                    cancel,
                 );
             }
         }
@@ -524,6 +552,7 @@ impl Dispatcher for SingleThreadedDispatcher {
                 settings,
                 encoded_paints,
                 image_resolver,
+                cancel,
             );
         }
     }

--- a/sparse_strips/vello_cpu/src/region.rs
+++ b/sparse_strips/vello_cpu/src/region.rs
@@ -160,11 +160,59 @@ impl<'a> Regions<'a> {
         self.regions.iter_mut().for_each(func);
     }
 
+    /// Like `update`, but polls `cancel` before each strip-row region and stops
+    /// early — leaving the remaining regions unrendered — if it returns `true`.
+    /// Returns `true` if every region was rendered.
+    ///
+    /// Each region is one strip row (`Tile::HEIGHT` scanlines), so this bounds
+    /// cancellation latency to roughly one strip row's rasterization.
+    pub(crate) fn update_cancellable(
+        &mut self,
+        cancel: &(dyn Fn() -> bool + Sync),
+        mut func: impl FnMut(&mut Region<'_>),
+    ) -> bool {
+        for region in self.regions.iter_mut() {
+            if cancel() {
+                return false;
+            }
+            func(region);
+        }
+        true
+    }
+
     #[cfg(feature = "multithreading")]
     pub(crate) fn update_par(&mut self, func: impl Fn(&mut Region<'_>) + Send + Sync) {
         use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
 
         self.regions.par_iter_mut().for_each(func);
+    }
+
+    /// Like `update_par`, but polls `cancel` once per region from the worker
+    /// threads. The first region to observe a stop flips a shared flag; every
+    /// other region checks it and skips its work, so cancellation latency is
+    /// bounded by the regions already executing (one per worker thread).
+    /// Returns `true` if every region was rendered.
+    #[cfg(feature = "multithreading")]
+    pub(crate) fn update_par_cancellable(
+        &mut self,
+        cancel: &(dyn Fn() -> bool + Sync),
+        func: impl Fn(&mut Region<'_>) + Send + Sync,
+    ) -> bool {
+        use core::sync::atomic::{AtomicBool, Ordering};
+        use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
+
+        let cancelled = AtomicBool::new(false);
+        self.regions.par_iter_mut().for_each(|region| {
+            if cancelled.load(Ordering::Relaxed) {
+                return;
+            }
+            if cancel() {
+                cancelled.store(true, Ordering::Relaxed);
+                return;
+            }
+            func(region);
+        });
+        !cancelled.load(Ordering::Relaxed)
     }
 }
 

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -787,6 +787,45 @@ impl RenderContext {
         resources: &mut Resources,
         settings: RasterizerSettings,
     ) {
+        self.render_inner(target, resources, settings, None);
+    }
+
+    /// Render like [`RenderContext::render`], but poll `cancel` during
+    /// rasterization and stop early when it returns `true`.
+    ///
+    /// Returns `true` if the render completed, or `false` if it was cancelled —
+    /// in which case the target is left partially rendered and should be
+    /// discarded.
+    ///
+    /// Cancellation latency is bounded by a single strip row's rasterization on
+    /// the single-threaded dispatcher, and by the regions already in flight (one
+    /// per worker thread) on the multi-threaded dispatcher. `cancel` must be
+    /// `Sync` because the multi-threaded dispatcher polls it from worker threads,
+    /// and is assumed idempotent: it is re-checked once after rendering to
+    /// produce the return value (a cancellation request does not un-fire).
+    #[must_use = "the return value reports whether the render was cancelled"]
+    pub fn render_cancellable<'a>(
+        &self,
+        target: impl Into<PixmapMut<'a>>,
+        resources: &mut Resources,
+        cancel: &(dyn Fn() -> bool + Sync),
+    ) -> bool {
+        self.render_inner(
+            target,
+            resources,
+            RasterizerSettings::default(),
+            Some(cancel),
+        );
+        !cancel()
+    }
+
+    fn render_inner<'a>(
+        &self,
+        target: impl Into<PixmapMut<'a>>,
+        resources: &mut Resources,
+        settings: RasterizerSettings,
+        cancel: Option<&(dyn Fn() -> bool + Sync)>,
+    ) {
         // TODO: Maybe we should move those checks into the dispatcher.
         assert!(
             !self.dispatcher.has_layers(),
@@ -812,6 +851,7 @@ impl RenderContext {
             settings,
             &self.encoded_paints,
             &resources.image_registry,
+            cancel,
         );
         // TODO: We need to figure something out here API-wise. At the moment, the user can
         // theoretically rasterize the same `RenderContext` multiple times without resetting in-between.


### PR DESCRIPTION
Adds an opt-in way to abort a `vello_cpu` render partway through — for request
timeouts, interactive previews, and pathological-input guards where one
`render()` of a large scene runs long enough to want to bail.

### API (additive)

`cargo public-api` confirms this is the only public change (0 removed, 0 changed,
1 added):

```rust
#[must_use]
pub fn RenderContext::render_cancellable(
    &self,
    target: impl Into<PixmapMut<'_>>,
    resources: &mut Resources,
    cancel: &(dyn Fn() -> bool + Sync),
) -> bool
```

Polls `cancel` during rasterization, stops early when it returns `true`, and
returns `false` if it was cancelled (`true` if it completed). On cancellation the
target is left partially rendered.

### How it works

- **Single-threaded dispatcher:** `cancel` is polled before each strip row
  (`Regions::update_cancellable`), bounding latency to one strip row's
  rasterization.
- **Multi-threaded dispatcher:** `cancel` is polled once per region from the
  worker threads (`Regions::update_par_cancellable`); the first region to observe
  a stop flips a shared atomic flag and the remaining regions skip their work, so
  latency is bounded by the regions already in flight (one per worker thread).
- `cancel` is `Sync` so the multi-threaded dispatcher can poll it from worker
  threads, and assumed idempotent: it is re-checked once after rendering to
  produce the return value (a cancellation request does not un-fire).
- `render` / `render_with` are unchanged and keep the original zero-overhead
  `update()` / `update_par()` paths. The internal `Dispatcher` trait gains a
  `cancel` parameter, but that trait is `pub(crate)`.

### Notes

Draft for discussion — happy to reshape the API (a status enum instead of `bool`,
or a dedicated trait instead of the `Fn` predicate) to fit vello's conventions.

Motivation: cancellable rendering in the pure-Rust PDF renderer
[hayro](https://github.com/LaurenzV/hayro), where the final composite is the one
CPU-heavy step that interpretation-level cancellation can't reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
