### PR TITLE
sparse_strips: Distinguish between sentinel strips and zero-width delimiter strips

### DIFF
--- a/sparse_strips/vello_common/src/clip.rs
+++ b/sparse_strips/vello_common/src/clip.rs
@@ -324,13 +324,11 @@ fn intersect_impl<S: Simd>(
         cur_y += 1;
     }
 
-    // Push the sentinel strip, if one wasn't already pushed.
-    if !target.strips.last().is_some_and(Strip::is_sentinel) {
-        target.strips.push(Strip::new(
-            u16::MAX,
+    // Push the sentinel strip if the intersection is not empty.
+    if !target.strips.is_empty() {
+        target.strips.push(Strip::sentinel(
             end_y * Tile::HEIGHT,
             target.alphas.len() as u32,
-            false,
         ));
     }
 }
@@ -512,42 +510,53 @@ impl<'a> Iterator for RowIterator<'a> {
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
-        // If we are currently not on a strip, we want to yield a filled region in case there is one.
-        if !self.on_strip {
-            // Flip boolean flag so we will yield a strip in the next iteration.
-            self.on_strip = true;
+        loop {
+            // If we are currently not on a strip, we want to yield a filled region in case there is one.
+            if !self.on_strip {
+                // Flip boolean flag so we will yield a strip in the next iteration.
+                self.on_strip = true;
 
-            // if we have a filled area, yield it and return. Otherwise, do nothing and we will
-            // instead yield the next strip below. In any case, we need to advance the current index
-            // so that we point to the next strip now.
-            if let Some(fill_area) = self.cur_strip_fill_area() {
-                *self.cur_idx += 1;
+                // if we have a filled area, yield it and return. Otherwise, do nothing and we will
+                // instead yield the next strip below. In any case, we need to advance the current index
+                // so that we point to the next strip now.
+                if let Some(fill_area) = self.cur_strip_fill_area() {
+                    *self.cur_idx += 1;
 
-                return Some(Region::Fill(fill_area));
-            } else {
-                *self.cur_idx += 1;
+                    return Some(Region::Fill(fill_area));
+                } else {
+                    *self.cur_idx += 1;
+                }
             }
+
+            // If we reached this point, we will yield a strip this iteration, so toggle the flag
+            // so that in the next iteration, we yield a filled region instead.
+            self.on_strip = false;
+
+            // If the current strip is sentinel or not within our target row, terminate.
+            if self.cur_strip().is_sentinel() || self.cur_strip().strip_y() != self.strip_y {
+                return None;
+            }
+
+            // Calculate the dimensions of the strip and yield it.
+            let x = self.cur_strip().x;
+            let width = self.cur_strip_width();
+
+            // Zero-width strips only act as markers for cheaply delimiting the width
+            // of filled regions, but are not actually relevant for clipping. This is assuming that
+            // zero-width strips can only appear at the end of a row, see the comment in
+            // `Strip::emit_culled_background`.
+            if width == 0 {
+                continue;
+            }
+
+            let alphas = self.cur_strip_alphas();
+
+            return Some(Region::Strip(StripRegion {
+                start: x,
+                width,
+                alphas,
+            }));
         }
-
-        // If we reached this point, we will yield a strip this iteration, so toggle the flag
-        // so that in the next iteration, we yield a filled region instead.
-        self.on_strip = false;
-
-        // If the current strip is sentinel or not within our target row, terminate.
-        if self.cur_strip().is_sentinel() || self.cur_strip().strip_y() != self.strip_y {
-            return None;
-        }
-
-        // Calculate the dimensions of the strip and yield it.
-        let x = self.cur_strip().x;
-        let width = self.cur_strip_width();
-        let alphas = self.cur_strip_alphas();
-
-        Some(Region::Strip(StripRegion {
-            start: x,
-            width,
-            alphas,
-        }))
     }
 }
 
@@ -726,25 +735,25 @@ mod tests {
     }
 
     #[test]
-    fn row_iterator_sentinel_fill_gap() {
+    fn row_iterator_row_end_fill_gap() {
         let path = StripBuilder::new()
             .add_strip(0, 0, Tile::WIDTH, false)
-            .finish_with_fill_gap_sentinel();
+            .finish_with_fill_gap_row_end(16);
         let path_ref = path_ref(&path);
 
         let mut idx = 0;
         let mut iter = RowIterator::new(path_ref, &mut idx, 0);
 
         assert_strip_region(iter.next(), 0, Tile::WIDTH);
-        assert_fill_region(iter.next(), Tile::WIDTH, u16::MAX - Tile::WIDTH);
+        assert_fill_region(iter.next(), Tile::WIDTH, 16 - Tile::WIDTH);
         assert!(iter.next().is_none());
     }
 
     #[test]
-    fn intersect_strip_with_sentinel_fill_gap() {
+    fn intersect_strip_with_row_end_fill_gap() {
         let path_1 = StripBuilder::new()
             .add_strip(0, 0, Tile::WIDTH, false)
-            .finish_with_fill_gap_sentinel();
+            .finish_with_fill_gap_row_end(16);
         let path_2 = StripBuilder::new().add_strip(8, 0, 12, false).finish();
         let expected = StripBuilder::new().add_strip(8, 0, 12, false).finish();
 
@@ -752,43 +761,34 @@ mod tests {
     }
 
     #[test]
-    fn intersect_two_sentinel_fill_gaps() {
+    fn intersect_two_row_end_fill_gaps() {
         let path_1 = StripBuilder::new()
             .add_strip(0, 0, 8, false)
-            .finish_with_fill_gap_sentinel();
+            .finish_with_fill_gap_row_end(16);
         let path_2 = StripBuilder::new()
             .add_strip(4, 0, 12, false)
-            .finish_with_fill_gap_sentinel();
+            .finish_with_fill_gap_row_end(20);
         let expected = StripBuilder::new()
             .add_strip(4, 0, 12, false)
-            .finish_with_fill_gap_sentinel();
+            .finish_with_fill_gap_row_end(16);
 
         run_test(expected, path_1, path_2);
     }
 
     #[test]
     fn row_iterator_fill_gap_stops_at_row_boundary() {
-        let mut path = StripBuilder::new()
+        let path = StripBuilder::new()
             .add_strip(0, 0, 4, false)
-            .finish_with_fill_gap_sentinel();
-        let idx = path.alphas.len();
-        path.strips
-            .push(Strip::new(0, Tile::HEIGHT, idx as u32, false));
-        path.alphas
-            .extend([0; Tile::HEIGHT as usize * Tile::WIDTH as usize]);
-        path.strips.push(Strip::new(
-            u16::MAX,
-            Tile::HEIGHT,
-            path.alphas.len() as u32,
-            false,
-        ));
+            .add_row_end(0, 16, true)
+            .add_strip(0, 1, 4, false)
+            .finish();
 
         let path_ref = path_ref(&path);
         let mut idx = 0;
         let mut iter = RowIterator::new(path_ref, &mut idx, 0);
 
         assert_strip_region(iter.next(), 0, 4);
-        assert_fill_region(iter.next(), 4, u16::MAX - 4);
+        assert_fill_region(iter.next(), 4, 12);
         assert!(iter.next().is_none());
 
         let mut iter = RowIterator::new(path_ref, &mut idx, 1);
@@ -846,7 +846,7 @@ mod tests {
         let mut path = StripStorage::default();
         path.strips.push(Strip::new(8, 0, 0, false));
         path.strips.push(Strip::new(16, 0, 0, true));
-        path.strips.push(Strip::new(u16::MAX, 0, 0, false));
+        path.strips.push(Strip::sentinel(0, 0));
         let path_ref = path_ref(&path);
 
         let mut idx = 0;
@@ -950,20 +950,24 @@ mod tests {
 
             self.storage
                 .strips
-                .push(Strip::new(u16::MAX, last_y, idx as u32, false));
+                .push(Strip::sentinel(last_y, idx as u32));
 
             self.storage
         }
 
-        fn finish_with_fill_gap_sentinel(mut self) -> StripStorage {
-            let last_y = self.storage.strips.last().unwrap().y;
+        fn add_row_end(mut self, strip_y: u16, x: u16, fill_gap: bool) -> Self {
             let idx = self.storage.alphas.len();
-
             self.storage
                 .strips
-                .push(Strip::new(u16::MAX, last_y, idx as u32, true));
+                .push(Strip::new(x, strip_y * Tile::HEIGHT, idx as u32, fill_gap));
 
-            self.storage
+            self
+        }
+
+        fn finish_with_fill_gap_row_end(self, x: u16) -> StripStorage {
+            let strip_y = self.storage.strips.last().unwrap().strip_y();
+
+            self.add_row_end(strip_y, x, true).finish()
         }
     }
 }

--- a/sparse_strips/vello_common/src/clip.rs
+++ b/sparse_strips/vello_common/src/clip.rs
@@ -547,8 +547,7 @@ impl<'a> Iterator for RowIterator<'a> {
             // `Strip::emit_culled_background`.
             if width == 0 {
                 debug_assert!(
-                    self.next_strip().is_sentinel()
-                        || self.next_strip().strip_y() != self.strip_y,
+                    self.next_strip().is_sentinel() || self.next_strip().strip_y() != self.strip_y,
                     "zero-width strips must only appear at the end of a row"
                 );
 

--- a/sparse_strips/vello_common/src/clip.rs
+++ b/sparse_strips/vello_common/src/clip.rs
@@ -546,6 +546,12 @@ impl<'a> Iterator for RowIterator<'a> {
             // zero-width strips can only appear at the end of a row, see the comment in
             // `Strip::emit_culled_background`.
             if width == 0 {
+                debug_assert!(
+                    self.next_strip().is_sentinel()
+                        || self.next_strip().strip_y() != self.strip_y,
+                    "zero-width strips must only appear at the end of a row"
+                );
+
                 continue;
             }
 

--- a/sparse_strips/vello_common/src/coarse.rs
+++ b/sparse_strips/vello_common/src/coarse.rs
@@ -1276,13 +1276,6 @@ impl<const MODE: u8> Wide<MODE> {
                         .clip_fill(x_rel, width);
                 }
 
-                // If the next strip is a sentinel, skip the fill
-                // It's a sentinel in the row if there is non-zero winding for the sparse fill
-                // Look more into this in the strip.rs render function
-                if x2 == u16::MAX {
-                    continue;
-                }
-
                 // If fill extends to next tile, pop current and handle next
                 if x2 > (cur_wtile_x + 1) * WideTile::WIDTH {
                     if core::mem::take(&mut pop_pending) {

--- a/sparse_strips/vello_common/src/rect.rs
+++ b/sparse_strips/vello_common/src/rect.rs
@@ -125,12 +125,7 @@ fn render_impl<S: Simd>(s: S, rect: Rect, strip_buf: &mut Vec<Strip>, alpha_buf:
 
     // Sentinel strip: marks the end of the strip list for this shape.
     let last_strip_y = ((tile_end_y - 1) * u32::from(Tile::HEIGHT)) as u16;
-    strip_buf.push(Strip::new(
-        u16::MAX,
-        last_strip_y,
-        alpha_buf.len() as u32,
-        false,
-    ));
+    strip_buf.push(Strip::sentinel(last_strip_y, alpha_buf.len() as u32));
 }
 
 /// Compute fractional pixel coverage for `N` consecutive pixels starting at `start`.

--- a/sparse_strips/vello_common/src/strip.rs
+++ b/sparse_strips/vello_common/src/strip.rs
@@ -44,6 +44,11 @@ impl Strip {
         }
     }
 
+    /// Creates a sentinel strip.
+    pub fn sentinel(y: u16, alpha_idx: u32) -> Self {
+        Self::new(u16::MAX, y, alpha_idx, false)
+    }
+
     /// Return whether the strip is a sentinel strip.
     pub fn is_sentinel(&self) -> bool {
         self.x == u16::MAX
@@ -112,6 +117,7 @@ impl Strip {
     fn emit_culled_background<F>(
         start: u16,
         end: u16,
+        viewport_width: u16,
         strips: &mut Vec<Self>,
         alphas: &mut Vec<u8>,
         windings: &crate::tile::CulledWindings,
@@ -123,10 +129,10 @@ impl Strip {
             if should_fill(windings.coarse[row] as i32) {
                 let y_pos = row as u16 * Tile::HEIGHT;
                 strips.push(Self::new(0, y_pos, alphas.len() as u32, false));
+                // TODO: Would be nice to get rid of this, but the current clipping code only
+                // allows zero-width strips as a row terminator, not in-between.
                 alphas.extend([255_u8; Tile::HEIGHT as usize * Tile::WIDTH as usize]);
-                // TODO: Clamp to the scene width instead of u16::MAX; in the future there might
-                // not be clamping on the x.
-                strips.push(Self::new(u16::MAX, y_pos, alphas.len() as u32, true));
+                strips.push(Self::new(viewport_width, y_pos, alphas.len() as u32, true));
             }
         });
     }
@@ -163,6 +169,18 @@ fn render_impl<S: Simd>(
 ) {
     let row_windings = &tiles.windings.coarse;
     let has_culled_tiles = tiles.has_culled_tiles();
+    let viewport_width = tiles
+        .width()
+        // We need to make sure strips are tile-aligned.
+        .checked_next_multiple_of(Tile::WIDTH)
+        .unwrap_or(u16::MAX);
+    let strip_start = strip_buf.len();
+    let maybe_emit_sentinel_strip = |strip_buf: &mut Vec<Strip>, alpha_buf: &Vec<u8>| {
+        // Emit the final sentinel strip, if we produced at least one strip.
+        if let Some(last_y) = strip_buf[strip_start..].last().map(|s| s.y) {
+            strip_buf.push(Strip::sentinel(last_y, alpha_buf.len() as u32));
+        }
+    };
 
     // If no tiles were culled and the tile buffer is empty, we can simply exit. If tiles were
     // culled, the tile buffer may be empty but there may be winding produced by culled geometry
@@ -224,12 +242,15 @@ fn render_impl<S: Simd>(
         Strip::emit_culled_background(
             0,
             row_max,
+            viewport_width,
             strip_buf,
             alpha_buf,
             &tiles.windings,
             should_fill,
         );
         if tiles.is_empty() {
+            maybe_emit_sentinel_strip(strip_buf, alpha_buf);
+
             return;
         }
         let (wd, acc) = emit_captive_strip(prev_tile.y, left_viewport, strip_buf, alpha_buf);
@@ -326,12 +347,10 @@ fn render_impl<S: Simd>(
             let is_sentinel = tile_idx == tiles.len() as usize;
             let left_viewport = tile.x == 0;
             if !prev_tile.same_row(&tile) {
-                // Emit a final strip in the row if there is non-zero winding for the sparse fill,
-                // or unconditionally if we've reached the sentinel tile to end the path (the
-                // `alpha_idx` field is used for width calculations).
-                if winding_delta != 0 || is_sentinel {
+                // Emit a final strip in the row if there is non-zero winding for the sparse fill
+                if winding_delta != 0 {
                     strip_buf.push(Strip::new(
-                        u16::MAX,
+                        viewport_width,
                         prev_tile.y * Tile::HEIGHT,
                         alpha_buf.len() as u32,
                         should_fill(winding_delta),
@@ -344,6 +363,7 @@ fn render_impl<S: Simd>(
                     Strip::emit_culled_background(
                         prev_tile.y + 1,
                         tile.y,
+                        viewport_width,
                         strip_buf,
                         alpha_buf,
                         &tiles.windings,
@@ -536,10 +556,13 @@ fn render_impl<S: Simd>(
         Strip::emit_culled_background(
             (prev_tile.y + 1).min(row_windings.len() as u16),
             row_windings.len() as u16,
+            viewport_width,
             strip_buf,
             alpha_buf,
             &tiles.windings,
             should_fill,
         );
     }
+
+    maybe_emit_sentinel_strip(strip_buf, alpha_buf);
 }

--- a/sparse_strips/vello_common/src/tile.rs
+++ b/sparse_strips/vello_common/src/tile.rs
@@ -455,6 +455,11 @@ impl Tiles {
         self.tile_buf.is_empty()
     }
 
+    /// Get the viewport width used for this tile buffer.
+    pub(crate) fn width(&self) -> u16 {
+        self.width
+    }
+
     /// Returns `true` if any geometry was early-culled outside the viewport.
     pub fn has_culled_tiles(&self) -> bool {
         self.windings.culled

--- a/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
@@ -322,7 +322,6 @@ impl MultiThreadedDispatcher {
                                 self.recorder.push_fill(
                                     strip_range,
                                     strips,
-                                    self.strip_generator.width(),
                                     paint.clone(),
                                     blend_mode,
                                     mask,

--- a/sparse_strips/vello_cpu/src/dispatch/single_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/single_threaded.rs
@@ -202,11 +202,9 @@ impl SingleThreadedDispatcher {
         mask: Option<Mask>,
     ) {
         let strip_end = self.strip_storage.strips.len();
-        let viewport_width = self.strip_generator.width();
         self.recorder.push_fill(
             strip_start..strip_end,
             &self.strip_storage.strips[strip_start..strip_end],
-            viewport_width,
             paint,
             blend_mode,
             mask,

--- a/sparse_strips/vello_cpu/src/record.rs
+++ b/sparse_strips/vello_cpu/src/record.rs
@@ -311,7 +311,6 @@ impl CommandRecorder {
         &mut self,
         strip_range: Range<usize>,
         strips: &[Strip],
-        viewport_width: u16,
         paint: Paint,
         blend_mode: BlendMode,
         mask: Option<Mask>,
@@ -325,7 +324,7 @@ impl CommandRecorder {
             mask,
         });
 
-        self.record_bbox(|| strip_bbox(strips, viewport_width));
+        self.record_bbox(|| strip_bbox(strips));
     }
 
     pub(crate) fn push_layer(&mut self, props: LayerProps, filter_plan: Option<FilterData>) {
@@ -432,7 +431,7 @@ pub(crate) enum PoppedLayer {
     Filter,
 }
 
-fn strip_bbox(strips: &[Strip], viewport_width: u16) -> RectU16 {
+fn strip_bbox(strips: &[Strip]) -> RectU16 {
     let mut bbox = RectU16::INVERTED;
 
     // Need at least one strip (and the sentinel one).
@@ -461,14 +460,7 @@ fn strip_bbox(strips: &[Strip], viewport_width: u16) -> RectU16 {
         }
 
         if next_strip.fill_gap() && strip_y == next_strip.strip_y() {
-            // TODO: We should probably not emit sentinel strips with fill_gap = true
-            // in the first place... Then we don't have to pass `viewport_width` to this
-            // method.
-            let fill_x1 = if next_strip.is_sentinel() {
-                viewport_width
-            } else {
-                next_strip.x
-            };
+            let fill_x1 = next_strip.x;
             if strip_x1 < fill_x1 {
                 bbox.union(RectU16::new(strip_x1, row_y, fill_x1, row_y1));
             }
@@ -492,12 +484,8 @@ mod tests {
         PopLayer,
     }
 
-    fn sentinel(y: u16, alpha_idx: u32) -> Strip {
-        Strip::new(u16::MAX, y, alpha_idx, false)
-    }
-
-    fn fill_gap_sentinel(y: u16, alpha_idx: u32) -> Strip {
-        Strip::new(u16::MAX, y, alpha_idx, true)
+    fn row_end(x: u16, y: u16, alpha_idx: u32, fill_gap: bool) -> Strip {
+        Strip::new(x, y, alpha_idx, fill_gap)
     }
 
     fn layer_props() -> LayerProps {
@@ -588,12 +576,12 @@ mod tests {
         recorder.push_layer(layer_props(), None);
 
         recorder.push_fill(
-            0..2,
+            0..3,
             &[
                 Strip::new(0, 0, 0, false),
-                Strip::new(u16::MAX, 0, 16, true),
+                row_end(64, 0, 16, true),
+                Strip::sentinel(0, 16),
             ],
-            64,
             Paint::Solid(PremulColor::from_alpha_color(BLACK)),
             BlendMode::default(),
             None,
@@ -605,12 +593,12 @@ mod tests {
 
         recorder.push_layer(layer_props(), None);
         recorder.push_fill(
-            0..2,
+            0..3,
             &[
                 Strip::new(0, 0, 16, false),
-                Strip::new(u16::MAX, 0, 32, true),
+                row_end(64, 0, 32, true),
+                Strip::sentinel(0, 32),
             ],
-            64,
             Paint::Solid(PremulColor::from_alpha_color(BLACK)),
             BlendMode::default(),
             None,
@@ -640,19 +628,19 @@ mod tests {
     }
     #[test]
     fn empty_strip_bbox() {
-        let strips = [sentinel(0, 0), sentinel(0, 0)];
+        let strips = [Strip::sentinel(0, 0), Strip::sentinel(0, 0)];
 
-        assert_eq!(strip_bbox(&strips, 32), RectU16::INVERTED);
+        assert_eq!(strip_bbox(&strips), RectU16::INVERTED);
     }
 
     #[test]
     fn single_strip_bbox() {
         let strips = [
             Strip::new(8, 4, 0, false),
-            sentinel(4, u32::from(Tile::HEIGHT) * 4),
+            Strip::sentinel(4, u32::from(Tile::HEIGHT) * 4),
         ];
 
-        assert_eq!(strip_bbox(&strips, 32), RectU16::new(8, 4, 12, 8));
+        assert_eq!(strip_bbox(&strips), RectU16::new(8, 4, 12, 8));
     }
 
     #[test]
@@ -660,31 +648,31 @@ mod tests {
         let strips = [
             Strip::new(4, 0, 0, false),
             Strip::new(20, 0, u32::from(Tile::HEIGHT) * 4, true),
-            sentinel(0, u32::from(Tile::HEIGHT) * 8),
+            Strip::sentinel(0, u32::from(Tile::HEIGHT) * 8),
         ];
 
-        assert_eq!(strip_bbox(&strips, 32), RectU16::new(4, 0, 24, 4));
+        assert_eq!(strip_bbox(&strips), RectU16::new(4, 0, 24, 4));
     }
 
     #[test]
-    fn strip_with_sentinel_fill_gap_bbox_is_clamped_to_viewport() {
+    fn strip_with_row_end_fill_gap_bbox_is_clamped_to_viewport() {
         let strips = [
             Strip::new(4, 0, 0, false),
-            fill_gap_sentinel(0, u32::from(Tile::HEIGHT) * 4),
+            row_end(32, 0, u32::from(Tile::HEIGHT) * 4, true),
+            Strip::sentinel(0, u32::from(Tile::HEIGHT) * 4),
         ];
 
-        assert_eq!(strip_bbox(&strips, 32), RectU16::new(4, 0, 32, 4));
+        assert_eq!(strip_bbox(&strips), RectU16::new(4, 0, 32, 4));
     }
 
     #[test]
     fn strips_with_multiple_rows_bbox() {
         let strips = [
             Strip::new(12, 0, 0, false),
-            sentinel(0, u32::from(Tile::HEIGHT) * 4),
             Strip::new(4, 8, u32::from(Tile::HEIGHT) * 4, false),
-            sentinel(8, u32::from(Tile::HEIGHT) * 8),
+            Strip::sentinel(8, u32::from(Tile::HEIGHT) * 8),
         ];
 
-        assert_eq!(strip_bbox(&strips, 32), RectU16::new(4, 0, 16, 12));
+        assert_eq!(strip_bbox(&strips), RectU16::new(4, 0, 16, 12));
     }
 }


### PR DESCRIPTION
This is based on top of #1705.

# Context

In the very early days, the so-called "sentinel strip" was simply used as to indicate "the final strip in a sequence of strips". It provided a way for us to avoid special casing handling the last real strip. In order to determine the width of a strip, we need to look at the `alpha_idx` of the next strip. So having this sentinel strip allows us to treat the last real strip like any other strip.

Starting with commit https://github.com/linebender/vello/commit/4a75eced and then also https://github.com/linebender/vello/commit/1b24e77b, we started to essentially have two versions of sentinel strips: One that, as was the original version, is used to terminate a sequence of strips and make it possible to _not_ have to special case the last strip. And another kind of sentinel strip which simply indicates "fill this area horizontally until the end of the viewport".

# Problem
For fine rasterization, it would be easier if we can assume that a strip never exceeds the viewport. This is generally the case, except in the case where such row-level sentinel strips are emitted, because their x position is set to `u16::MAX`. Therefore, during fine rasterization, we have to manually clamp strips to the viewport width.

# Solution
This PR proposes to solve this problem by
1) Adding a constructor for "sentinel strips" which is really just used terminate a sequence of strips.
2) Instead of also using sentinel strips as a marker of "fill this row across the whole viewport width", instead explicitly allow using zero-width strips as a terminator in the row, and make sure that this terminating strip itself is placed exactly at the viewport boundary.

# TODO
I still need to run this through my PDF test suite, but overall I think this is ready for review.