### PR TITLE
sparse_strips: Implement inverse blurred rounded rectangles

### DIFF
--- a/sparse_strips/vello_bench/src/fine/rounded_blurred_rect.rs
+++ b/sparse_strips/vello_bench/src/fine/rounded_blurred_rect.rs
@@ -38,7 +38,7 @@ fn base<S: Simd, N: FineKernel<S>>(b: &mut Bencher<'_>, fine: &mut Fine<S, N>, t
         color: GREEN,
         radius: 30.0,
         std_dev: 10.0,
-        inverse: false,
+        invert: false,
     };
 
     let paint = rect.encode_into(&mut paints, transform, None);

--- a/sparse_strips/vello_bench/src/fine/rounded_blurred_rect.rs
+++ b/sparse_strips/vello_bench/src/fine/rounded_blurred_rect.rs
@@ -38,6 +38,7 @@ fn base<S: Simd, N: FineKernel<S>>(b: &mut Bencher<'_>, fine: &mut Fine<S, N>, t
         color: GREEN,
         radius: 30.0,
         std_dev: 10.0,
+        inverse: false,
     };
 
     let paint = rect.encode_into(&mut paints, transform, None);

--- a/sparse_strips/vello_common/src/blurred_rounded_rect.rs
+++ b/sparse_strips/vello_common/src/blurred_rounded_rect.rs
@@ -20,5 +20,5 @@ pub struct BlurredRoundedRectangle {
     ///
     /// When `true`, the paint is fully opaque outside the blurred rectangle and fades to
     /// transparent inside it. This is useful for implementing inset box shadows.
-    pub inverse: bool,
+    pub invert: bool,
 }

--- a/sparse_strips/vello_common/src/blurred_rounded_rect.rs
+++ b/sparse_strips/vello_common/src/blurred_rounded_rect.rs
@@ -16,4 +16,9 @@ pub struct BlurredRoundedRectangle {
     pub radius: f32,
     /// The standard deviation of the blur effect.
     pub std_dev: f32,
+    /// Whether to paint the inverse (`1 - alpha`) of the blur coverage.
+    ///
+    /// When `true`, the paint is fully opaque outside the blurred rectangle and fades to
+    /// transparent inside it. This is useful for implementing inset box shadows.
+    pub inverse: bool,
 }

--- a/sparse_strips/vello_common/src/encode.rs
+++ b/sparse_strips/vello_common/src/encode.rs
@@ -883,7 +883,7 @@ pub struct EncodedBlurredRoundedRectangle {
     ///
     /// When `true`, the paint is fully opaque outside the blurred rectangle and fades to
     /// transparent inside it. This is useful for implementing inset box shadows.
-    pub inverse: bool,
+    pub invert: bool,
     /// The base color for the blurred rectangle.
     pub color: PremulColor,
     /// A transform that needs to be applied to the position of the first processed pixel.
@@ -958,7 +958,7 @@ impl EncodeExt for BlurredRoundedRectangle {
             r1,
             std_dev_inv,
             min_edge,
-            inverse: self.inverse,
+            invert: self.invert,
             color: PremulColor::from_alpha_color(self.color),
             w,
             h,

--- a/sparse_strips/vello_common/src/encode.rs
+++ b/sparse_strips/vello_common/src/encode.rs
@@ -879,6 +879,11 @@ pub struct EncodedBlurredRoundedRectangle {
     pub height: f32,
     /// An component for computing the blur effect.
     pub r1: f32,
+    /// Whether to paint the inverse (`1 - alpha`) of the blur coverage.
+    ///
+    /// When `true`, the paint is fully opaque outside the blurred rectangle and fades to
+    /// transparent inside it. This is useful for implementing inset box shadows.
+    pub inverse: bool,
     /// The base color for the blurred rectangle.
     pub color: PremulColor,
     /// A transform that needs to be applied to the position of the first processed pixel.
@@ -953,6 +958,7 @@ impl EncodeExt for BlurredRoundedRectangle {
             r1,
             std_dev_inv,
             min_edge,
+            inverse: self.inverse,
             color: PremulColor::from_alpha_color(self.color),
             w,
             h,

--- a/sparse_strips/vello_cpu/src/fine/common/rounded_blurred_rect.rs
+++ b/sparse_strips/vello_cpu/src/fine/common/rounded_blurred_rect.rs
@@ -19,6 +19,7 @@ pub(crate) struct BlurredRoundedRectFiller<S: Simd> {
     g: f32x8<S>,
     b: f32x8<S>,
     a: f32x8<S>,
+    inverse: bool,
     alpha_calculator: AlphaCalculator<S>,
 }
 
@@ -53,6 +54,7 @@ impl<S: Simd> BlurredRoundedRectFiller<S> {
                     g,
                     b,
                     a,
+                    inverse: rect.inverse,
                 }
             },
         )
@@ -64,7 +66,10 @@ impl<S: Simd> Iterator for BlurredRoundedRectFiller<S> {
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
-        let next = self.alpha_calculator.next().unwrap();
+        let mut next = self.alpha_calculator.next().unwrap();
+        if self.inverse {
+            next = f32x8::splat(next.simd, 1.0) - next;
+        }
         let r = self.r * next;
         let g = self.g * next;
         let b = self.b * next;

--- a/sparse_strips/vello_cpu/src/fine/common/rounded_blurred_rect.rs
+++ b/sparse_strips/vello_cpu/src/fine/common/rounded_blurred_rect.rs
@@ -19,7 +19,7 @@ pub(crate) struct BlurredRoundedRectFiller<S: Simd> {
     g: f32x8<S>,
     b: f32x8<S>,
     a: f32x8<S>,
-    inverse: bool,
+    invert: bool,
     alpha_calculator: AlphaCalculator<S>,
 }
 
@@ -54,7 +54,7 @@ impl<S: Simd> BlurredRoundedRectFiller<S> {
                     g,
                     b,
                     a,
-                    inverse: rect.inverse,
+                    invert: rect.invert,
                 }
             },
         )
@@ -67,7 +67,7 @@ impl<S: Simd> Iterator for BlurredRoundedRectFiller<S> {
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
         let mut next = self.alpha_calculator.next().unwrap();
-        if self.inverse {
+        if self.invert {
             next = f32x8::splat(next.simd, 1.0) - next;
         }
         let r = self.r * next;

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -388,9 +388,19 @@ impl RenderContext {
 
     /// Fill a blurred rectangle with the given corner radius and standard deviation.
     ///
+    /// When `inverse` is `true`, the inverse (`1 - alpha`) of the blur coverage is painted: the
+    /// paint is fully opaque outside the blurred rectangle and fades to transparent inside it. This
+    /// can be used to implement inset box shadows.
+    ///
     /// Note that this only works properly if the current paint is set to a solid color.
     /// If not, it will fall back to using black as the fill color.
-    pub fn fill_blurred_rounded_rect(&mut self, rect: &Rect, radius: f32, std_dev: f32) {
+    pub fn fill_blurred_rounded_rect(
+        &mut self,
+        rect: &Rect,
+        radius: f32,
+        std_dev: f32,
+        inverse: bool,
+    ) {
         let rect = rect.abs();
         let color = match self.state.paint {
             PaintType::Solid(s) => s,
@@ -403,6 +413,7 @@ impl RenderContext {
             color,
             radius,
             std_dev,
+            inverse,
         };
 
         // The actual rectangle we paint needs to be larger so that the blurring effect

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -388,7 +388,7 @@ impl RenderContext {
 
     /// Fill a blurred rectangle with the given corner radius and standard deviation.
     ///
-    /// When `inverse` is `true`, the inverse (`1 - alpha`) of the blur coverage is painted: the
+    /// When `invert` is `true`, the inverse (`1 - alpha`) of the blur coverage is painted: the
     /// paint is fully opaque outside the blurred rectangle and fades to transparent inside it. This
     /// can be used to implement inset box shadows.
     ///
@@ -399,7 +399,7 @@ impl RenderContext {
         rect: &Rect,
         radius: f32,
         std_dev: f32,
-        inverse: bool,
+        invert: bool,
     ) {
         let rect = rect.abs();
         let color = match self.state.paint {
@@ -413,7 +413,7 @@ impl RenderContext {
             color,
             radius,
             std_dev,
-            inverse,
+            invert,
         };
 
         // The actual rectangle we paint needs to be larger so that the blurring effect

--- a/sparse_strips/vello_example_scenes/src/lib.rs
+++ b/sparse_strips/vello_example_scenes/src/lib.rs
@@ -279,7 +279,7 @@ impl RenderingContext for Scene {
     }
 
     fn fill_blurred_rounded_rect(&mut self, rect: &Rect, radius: f32, std_dev: f32) {
-        self.fill_blurred_rounded_rect(rect, radius, std_dev);
+        self.fill_blurred_rounded_rect(rect, radius, std_dev, false);
     }
 
     fn glyph_run<'a>(

--- a/sparse_strips/vello_example_scenes/src/lib.rs
+++ b/sparse_strips/vello_example_scenes/src/lib.rs
@@ -174,7 +174,7 @@ impl RenderingContext for RenderContext {
     }
 
     fn fill_blurred_rounded_rect(&mut self, rect: &Rect, radius: f32, std_dev: f32) {
-        self.fill_blurred_rounded_rect(rect, radius, std_dev);
+        self.fill_blurred_rounded_rect(rect, radius, std_dev, false);
     }
 
     fn glyph_run<'a>(

--- a/sparse_strips/vello_hybrid/src/render/common.rs
+++ b/sparse_strips/vello_hybrid/src/render/common.rs
@@ -236,7 +236,7 @@ pub(crate) struct GpuBlurredRoundedRect {
     /// Premultiplied color packed as RGBA8 unorm (`pack4x8unorm` layout).
     pub color: u32,
     /// Whether to paint the inverse (`1 - alpha`) of the blur coverage (`0` = normal, `1` = inverse).
-    pub inverse: u32,
+    pub invert: u32,
     /// Blur parameters: exponent, reciprocal exponent, scale, and inverse standard deviation.
     pub params0: [f32; 4],
     /// Blur parameters: minimum edge length, adjusted width, adjusted height, and outer radius.

--- a/sparse_strips/vello_hybrid/src/render/common.rs
+++ b/sparse_strips/vello_hybrid/src/render/common.rs
@@ -235,7 +235,7 @@ pub(crate) struct GpuBlurredRoundedRect {
     pub transform: [f32; 6],
     /// Premultiplied color packed as RGBA8 unorm (`pack4x8unorm` layout).
     pub color: u32,
-    /// Whether to paint the inverse (`1 - alpha`) of the blur coverage (`0` = normal, `1` = inverse).
+    /// Whether to paint the inverse (`1 - alpha`) of the blur coverage
     pub invert: u32,
     /// Blur parameters: exponent, reciprocal exponent, scale, and inverse standard deviation.
     pub params0: [f32; 4],

--- a/sparse_strips/vello_hybrid/src/render/common.rs
+++ b/sparse_strips/vello_hybrid/src/render/common.rs
@@ -235,8 +235,8 @@ pub(crate) struct GpuBlurredRoundedRect {
     pub transform: [f32; 6],
     /// Premultiplied color packed as RGBA8 unorm (`pack4x8unorm` layout).
     pub color: u32,
-    /// Padding for 16-byte alignment.
-    pub _padding0: u32,
+    /// Whether to paint the inverse (`1 - alpha`) of the blur coverage (`0` = normal, `1` = inverse).
+    pub inverse: u32,
     /// Blur parameters: exponent, reciprocal exponent, scale, and inverse standard deviation.
     pub params0: [f32; 4],
     /// Blur parameters: minimum edge length, adjusted width, adjusted height, and outer radius.

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -988,7 +988,7 @@ impl WebGlRenderer {
         GpuEncodedPaint::BlurredRoundedRect(GpuBlurredRoundedRect {
             transform: rect.transform.as_coeffs().map(|x| x as f32),
             color: rect.color.as_premul_rgba8().to_u32(),
-            inverse: u32::from(rect.inverse),
+            invert: u32::from(rect.invert),
             params0: [
                 rect.exponent,
                 rect.recip_exponent,

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -988,7 +988,7 @@ impl WebGlRenderer {
         GpuEncodedPaint::BlurredRoundedRect(GpuBlurredRoundedRect {
             transform: rect.transform.as_coeffs().map(|x| x as f32),
             color: rect.color.as_premul_rgba8().to_u32(),
-            _padding0: 0,
+            inverse: u32::from(rect.inverse),
             params0: [
                 rect.exponent,
                 rect.recip_exponent,

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -916,7 +916,7 @@ impl Renderer {
         GpuEncodedPaint::BlurredRoundedRect(GpuBlurredRoundedRect {
             transform: rect.transform.as_coeffs().map(|x| x as f32),
             color: rect.color.as_premul_rgba8().to_u32(),
-            _padding0: 0,
+            inverse: u32::from(rect.inverse),
             params0: [
                 rect.exponent,
                 rect.recip_exponent,

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -916,7 +916,7 @@ impl Renderer {
         GpuEncodedPaint::BlurredRoundedRect(GpuBlurredRoundedRect {
             transform: rect.transform.as_coeffs().map(|x| x as f32),
             color: rect.color.as_premul_rgba8().to_u32(),
-            inverse: u32::from(rect.inverse),
+            invert: u32::from(rect.invert),
             params0: [
                 rect.exponent,
                 rect.recip_exponent,

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -740,9 +740,19 @@ impl Scene {
 
     /// Fill a blurred rectangle with the given corner radius and standard deviation.
     ///
+    /// When `inverse` is `true`, the inverse (`1 - alpha`) of the blur coverage is painted: the
+    /// paint is fully opaque outside the blurred rectangle and fades to transparent inside it. This
+    /// can be used to implement inset box shadows.
+    ///
     /// This operation uses the current transform and paint transform. Like Vello CPU, it only
     /// uses solid paints; non-solid paints fall back to black.
-    pub fn fill_blurred_rounded_rect(&mut self, rect: &Rect, radius: f32, std_dev: f32) {
+    pub fn fill_blurred_rounded_rect(
+        &mut self,
+        rect: &Rect,
+        radius: f32,
+        std_dev: f32,
+        inverse: bool,
+    ) {
         if !self.paint_visible {
             return;
         }
@@ -758,7 +768,7 @@ impl Scene {
                 color,
                 radius,
                 std_dev,
-                inverse: false,
+                inverse,
             };
 
             let kernel_size = 2.5 * std_dev;

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -758,6 +758,7 @@ impl Scene {
                 color,
                 radius,
                 std_dev,
+                inverse: false,
             };
 
             let kernel_size = 2.5 * std_dev;

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -740,7 +740,7 @@ impl Scene {
 
     /// Fill a blurred rectangle with the given corner radius and standard deviation.
     ///
-    /// When `inverse` is `true`, the inverse (`1 - alpha`) of the blur coverage is painted: the
+    /// When `invert` is `true`, the inverse (`1 - alpha`) of the blur coverage is painted: the
     /// paint is fully opaque outside the blurred rectangle and fades to transparent inside it. This
     /// can be used to implement inset box shadows.
     ///
@@ -751,7 +751,7 @@ impl Scene {
         rect: &Rect,
         radius: f32,
         std_dev: f32,
-        inverse: bool,
+        invert: bool,
     ) {
         if !self.paint_visible {
             return;
@@ -768,7 +768,7 @@ impl Scene {
                 color,
                 radius,
                 std_dev,
-                inverse,
+                invert,
             };
 
             let kernel_size = 2.5 * std_dev;

--- a/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
@@ -1336,7 +1336,7 @@ fn get_blurred_rounded_rect_translate(texel1: vec4<u32>) -> vec2<f32> {
 fn get_blurred_rounded_rect_color(texel1: vec4<u32>) -> vec4<f32> { return unpack4x8unorm(texel1.z); }
 
 /// Whether to paint the inverse (`1 - alpha`) of the blur coverage (`0` = normal, `1` = inverse).
-fn get_blurred_rounded_rect_inverse(texel1: vec4<u32>) -> u32 { return texel1.w; }
+fn get_blurred_rounded_rect_invert(texel1: vec4<u32>) -> u32 { return texel1.w; }
 
 fn get_blurred_rounded_rect_exponent(texel2: vec4<u32>) -> f32 { return bitcast<f32>(texel2.x); }
 
@@ -1473,7 +1473,7 @@ fn calculate_blurred_rounded_rect(
     let transform = get_blurred_rounded_rect_transform(texel0);
     let translate = get_blurred_rounded_rect_translate(texel1);
     let color = get_blurred_rounded_rect_color(texel1);
-    let inverse = get_blurred_rounded_rect_inverse(texel1);
+    let invert = get_blurred_rounded_rect_invert(texel1);
     let exponent = get_blurred_rounded_rect_exponent(texel2);
     let recip_exponent = get_blurred_rounded_rect_recip_exponent(texel2);
     let scale = get_blurred_rounded_rect_scale(texel2);
@@ -1506,8 +1506,8 @@ fn calculate_blurred_rounded_rect(
         erf7(std_dev_inv * d)
     );
 
-    // Invert alpha when `inverse` flag is set
-    let blur_alpha = select(blur_coverage, 1.0 - blur_coverage, inverse != 0u);
+    // Invert alpha when `invert` flag is set
+    let blur_alpha = select(blur_coverage, 1.0 - blur_coverage, invert != 0u);
 
     return color * blur_alpha;
 }

--- a/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
@@ -1335,6 +1335,9 @@ fn get_blurred_rounded_rect_translate(texel1: vec4<u32>) -> vec2<f32> {
 /// Premultiplied rectangle color.
 fn get_blurred_rounded_rect_color(texel1: vec4<u32>) -> vec4<f32> { return unpack4x8unorm(texel1.z); }
 
+/// Whether to paint the inverse (`1 - alpha`) of the blur coverage (`0` = normal, `1` = inverse).
+fn get_blurred_rounded_rect_inverse(texel1: vec4<u32>) -> u32 { return texel1.w; }
+
 fn get_blurred_rounded_rect_exponent(texel2: vec4<u32>) -> f32 { return bitcast<f32>(texel2.x); }
 
 fn get_blurred_rounded_rect_recip_exponent(texel2: vec4<u32>) -> f32 { return bitcast<f32>(texel2.y); }
@@ -1470,6 +1473,7 @@ fn calculate_blurred_rounded_rect(
     let transform = get_blurred_rounded_rect_transform(texel0);
     let translate = get_blurred_rounded_rect_translate(texel1);
     let color = get_blurred_rounded_rect_color(texel1);
+    let inverse = get_blurred_rounded_rect_inverse(texel1);
     let exponent = get_blurred_rounded_rect_exponent(texel2);
     let recip_exponent = get_blurred_rounded_rect_recip_exponent(texel2);
     let scale = get_blurred_rounded_rect_scale(texel2);
@@ -1497,10 +1501,13 @@ fn calculate_blurred_rounded_rect(
     );
     let d_neg = min(max(x0, y0), 0.0);
     let d = d_pos + d_neg - r1;
-    let blur_alpha = scale * (
+    let blur_coverage = scale * (
         erf7(std_dev_inv * (min_edge + d)) -
         erf7(std_dev_inv * d)
     );
+
+    // Invert alpha when `inverse` flag is set
+    let blur_alpha = select(blur_coverage, 1.0 - blur_coverage, inverse != 0u);
 
     return color * blur_alpha;
 }

--- a/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
@@ -1335,7 +1335,7 @@ fn get_blurred_rounded_rect_translate(texel1: vec4<u32>) -> vec2<f32> {
 /// Premultiplied rectangle color.
 fn get_blurred_rounded_rect_color(texel1: vec4<u32>) -> vec4<f32> { return unpack4x8unorm(texel1.z); }
 
-/// Whether to paint the inverse (`1 - alpha`) of the blur coverage (`0` = normal, `1` = inverse).
+/// Whether to paint the inverse (`1 - alpha`) of the blur coverage.
 fn get_blurred_rounded_rect_invert(texel1: vec4<u32>) -> u32 { return texel1.w; }
 
 fn get_blurred_rounded_rect_exponent(texel2: vec4<u32>) -> f32 { return bitcast<f32>(texel2.x); }

--- a/sparse_strips/vello_sparse_tests/snapshots/inverse_blurred_rounded_rect_large_std_dev.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/inverse_blurred_rounded_rect_large_std_dev.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39dc3625e9becb4938f160929a4da6214d178eb7c4ce1f8a19fb3e1fc78e291c
+size 2768

--- a/sparse_strips/vello_sparse_tests/snapshots/inverse_blurred_rounded_rect_medium_std_dev.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/inverse_blurred_rounded_rect_medium_std_dev.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9718067808db55b31e6dca854017227ac90f59d9736a3119d8130466156bae9
+size 2107

--- a/sparse_strips/vello_sparse_tests/snapshots/inverse_blurred_rounded_rect_small_std_dev.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/inverse_blurred_rounded_rect_small_std_dev.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f3fc5bb82acb0dca175769051b2a2efa07accf9c6d60ef4660f7c50517e7767
+size 1127

--- a/sparse_strips/vello_sparse_tests/snapshots/inverse_blurred_rounded_rect_with_large_radius.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/inverse_blurred_rounded_rect_with_large_radius.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5693d47408d9f52222fc741ad141dd5cff58fc3a372ac50ac1db97ff0e0bd6c5
+size 2901

--- a/sparse_strips/vello_sparse_tests/snapshots/inverse_blurred_rounded_rect_with_radius.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/inverse_blurred_rounded_rect_with_radius.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ac1c99ed3e726e98fde017963c23cbb282f0989cc094591a84ec5e9eab109b0
+size 2290

--- a/sparse_strips/vello_sparse_tests/snapshots/inverse_blurred_rounded_rect_with_transform.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/inverse_blurred_rounded_rect_with_transform.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2aafba6053f21e82d7b90de95115f4bae9c02df886dac43ded61e191a8b25931
+size 2423

--- a/sparse_strips/vello_sparse_tests/tests/basic.rs
+++ b/sparse_strips/vello_sparse_tests/tests/basic.rs
@@ -355,7 +355,7 @@ fn blurred_rounded_rect_inverted(ctx: &mut impl Renderer) {
     let rect = Rect::new(80.0, 80.0, 20.0, 20.0);
 
     ctx.set_paint(REBECCA_PURPLE);
-    ctx.fill_blurred_rounded_rect(&rect, 10.0, 2.0);
+    ctx.fill_blurred_rounded_rect(&rect, 10.0, 2.0, false);
 }
 
 #[vello_test(width = 30, height = 30)]

--- a/sparse_strips/vello_sparse_tests/tests/blurred_rounded_rect.rs
+++ b/sparse_strips/vello_sparse_tests/tests/blurred_rounded_rect.rs
@@ -10,7 +10,7 @@ fn rect_with(ctx: &mut impl Renderer, radius: f32, std_dev: f32, affine: Affine)
     let rect = Rect::new(20.0, 20.0, 80.0, 80.0);
     ctx.set_paint(REBECCA_PURPLE);
     ctx.set_transform(affine);
-    ctx.fill_blurred_rounded_rect(&rect, radius, std_dev);
+    ctx.fill_blurred_rounded_rect(&rect, radius, std_dev, false);
 }
 
 #[vello_test]
@@ -56,6 +56,48 @@ fn blurred_rounded_rect_with_large_radius(ctx: &mut impl Renderer) {
 #[vello_test]
 fn blurred_rounded_rect_with_transform(ctx: &mut impl Renderer) {
     rect_with(
+        ctx,
+        10.0,
+        10.0,
+        Affine::rotate_about(45.0_f64.to_radians(), Point::new(50.0, 50.0)),
+    );
+}
+
+fn inverse_rect_with(ctx: &mut impl Renderer, radius: f32, std_dev: f32, affine: Affine) {
+    let rect = Rect::new(20.0, 20.0, 80.0, 80.0);
+    ctx.set_paint(REBECCA_PURPLE);
+    ctx.set_transform(affine);
+    ctx.fill_blurred_rounded_rect(&rect, radius, std_dev, true);
+}
+
+#[vello_test]
+fn inverse_blurred_rounded_rect_small_std_dev(ctx: &mut impl Renderer) {
+    inverse_rect_with(ctx, 0.0, 5.0, Affine::IDENTITY);
+}
+
+#[vello_test]
+fn inverse_blurred_rounded_rect_medium_std_dev(ctx: &mut impl Renderer) {
+    inverse_rect_with(ctx, 0.0, 10.0, Affine::IDENTITY);
+}
+
+#[vello_test]
+fn inverse_blurred_rounded_rect_large_std_dev(ctx: &mut impl Renderer) {
+    inverse_rect_with(ctx, 0.0, 20.0, Affine::IDENTITY);
+}
+
+#[vello_test]
+fn inverse_blurred_rounded_rect_with_radius(ctx: &mut impl Renderer) {
+    inverse_rect_with(ctx, 10.0, 10.0, Affine::IDENTITY);
+}
+
+#[vello_test]
+fn inverse_blurred_rounded_rect_with_large_radius(ctx: &mut impl Renderer) {
+    inverse_rect_with(ctx, 30.0, 10.0, Affine::IDENTITY);
+}
+
+#[vello_test]
+fn inverse_blurred_rounded_rect_with_transform(ctx: &mut impl Renderer) {
+    inverse_rect_with(
         ctx,
         10.0,
         10.0,

--- a/sparse_strips/vello_sparse_tests/tests/renderer.rs
+++ b/sparse_strips/vello_sparse_tests/tests/renderer.rs
@@ -36,7 +36,7 @@ pub(crate) trait Renderer: Sized {
     fn fill_path(&mut self, path: &BezPath);
     fn stroke_path(&mut self, path: &BezPath);
     fn fill_rect(&mut self, rect: &Rect);
-    fn fill_blurred_rounded_rect(&mut self, rect: &Rect, radius: f32, std_dev: f32, inverse: bool);
+    fn fill_blurred_rounded_rect(&mut self, rect: &Rect, radius: f32, std_dev: f32, invert: bool);
     fn stroke_rect(&mut self, rect: &Rect);
     fn glyph_run(
         &mut self,
@@ -136,9 +136,9 @@ impl Renderer for CpuRenderer {
         self.ctx.fill_rect(rect);
     }
 
-    fn fill_blurred_rounded_rect(&mut self, rect: &Rect, radius: f32, std_dev: f32, inverse: bool) {
+    fn fill_blurred_rounded_rect(&mut self, rect: &Rect, radius: f32, std_dev: f32, invert: bool) {
         self.ctx
-            .fill_blurred_rounded_rect(rect, radius, std_dev, inverse);
+            .fill_blurred_rounded_rect(rect, radius, std_dev, invert);
     }
 
     fn stroke_rect(&mut self, rect: &Rect) {
@@ -424,9 +424,9 @@ impl Renderer for HybridRenderer {
         self.scene.fill_rect(rect);
     }
 
-    fn fill_blurred_rounded_rect(&mut self, rect: &Rect, radius: f32, std_dev: f32, inverse: bool) {
+    fn fill_blurred_rounded_rect(&mut self, rect: &Rect, radius: f32, std_dev: f32, invert: bool) {
         self.scene
-            .fill_blurred_rounded_rect(rect, radius, std_dev, inverse);
+            .fill_blurred_rounded_rect(rect, radius, std_dev, invert);
     }
 
     fn stroke_rect(&mut self, rect: &Rect) {
@@ -801,9 +801,9 @@ impl Renderer for HybridRenderer {
         self.scene.fill_rect(rect);
     }
 
-    fn fill_blurred_rounded_rect(&mut self, rect: &Rect, radius: f32, std_dev: f32, inverse: bool) {
+    fn fill_blurred_rounded_rect(&mut self, rect: &Rect, radius: f32, std_dev: f32, invert: bool) {
         self.scene
-            .fill_blurred_rounded_rect(rect, radius, std_dev, inverse);
+            .fill_blurred_rounded_rect(rect, radius, std_dev, invert);
     }
 
     fn stroke_rect(&mut self, rect: &Rect) {

--- a/sparse_strips/vello_sparse_tests/tests/renderer.rs
+++ b/sparse_strips/vello_sparse_tests/tests/renderer.rs
@@ -36,7 +36,7 @@ pub(crate) trait Renderer: Sized {
     fn fill_path(&mut self, path: &BezPath);
     fn stroke_path(&mut self, path: &BezPath);
     fn fill_rect(&mut self, rect: &Rect);
-    fn fill_blurred_rounded_rect(&mut self, rect: &Rect, radius: f32, std_dev: f32);
+    fn fill_blurred_rounded_rect(&mut self, rect: &Rect, radius: f32, std_dev: f32, inverse: bool);
     fn stroke_rect(&mut self, rect: &Rect);
     fn glyph_run(
         &mut self,
@@ -136,8 +136,9 @@ impl Renderer for CpuRenderer {
         self.ctx.fill_rect(rect);
     }
 
-    fn fill_blurred_rounded_rect(&mut self, rect: &Rect, radius: f32, std_dev: f32) {
-        self.ctx.fill_blurred_rounded_rect(rect, radius, std_dev);
+    fn fill_blurred_rounded_rect(&mut self, rect: &Rect, radius: f32, std_dev: f32, inverse: bool) {
+        self.ctx
+            .fill_blurred_rounded_rect(rect, radius, std_dev, inverse);
     }
 
     fn stroke_rect(&mut self, rect: &Rect) {
@@ -423,8 +424,9 @@ impl Renderer for HybridRenderer {
         self.scene.fill_rect(rect);
     }
 
-    fn fill_blurred_rounded_rect(&mut self, rect: &Rect, radius: f32, std_dev: f32) {
-        self.scene.fill_blurred_rounded_rect(rect, radius, std_dev);
+    fn fill_blurred_rounded_rect(&mut self, rect: &Rect, radius: f32, std_dev: f32, inverse: bool) {
+        self.scene
+            .fill_blurred_rounded_rect(rect, radius, std_dev, inverse);
     }
 
     fn stroke_rect(&mut self, rect: &Rect) {
@@ -799,8 +801,9 @@ impl Renderer for HybridRenderer {
         self.scene.fill_rect(rect);
     }
 
-    fn fill_blurred_rounded_rect(&mut self, rect: &Rect, radius: f32, std_dev: f32) {
-        self.scene.fill_blurred_rounded_rect(rect, radius, std_dev);
+    fn fill_blurred_rounded_rect(&mut self, rect: &Rect, radius: f32, std_dev: f32, inverse: bool) {
+        self.scene
+            .fill_blurred_rounded_rect(rect, radius, std_dev, inverse);
     }
 
     fn stroke_rect(&mut self, rect: &Rect) {


### PR DESCRIPTION
Partially fixes #1374 (fixes it for Vello Hybrid and Vello CPU)

Adds an `inverse: bool` parameter to the `fill_blurred_rounded_rect` method on `vello_hybrid::Scene` and `vello_cpu::RenderContext`. When the `inverse` flag is set, the region that gets painted with by the blurred rounded rect fill is inverted. This can be used to implement inset box shadows.

Generated with Opus 4.8 High. Some manual review, but I don't claim to understand in particular the GPU code. The tests have been reviewed and look good to me.

Feedback on whether PRs like this are helpful is welcome.