### PR TITLE
Update selected dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,9 +447,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -573,15 +573,14 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.11"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -965,9 +964,9 @@ dependencies = [
 
 [[package]]
 name = "fearless_simd"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76258897e51fd156ee03b6246ea53f3e0eb395d0b327e9961c4fc4c8b2fa151a"
+checksum = "b97b65636e5b9ef369943878ac74335ba1c55c1cb6adbf1e2c293c624248d693"
 dependencies = [
  "libm",
 ]
@@ -979,16 +978,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1fc6a637b6dc58414714eddd9170ff187ecb0933d4c7024d1abbd23a3cc26e9"
 dependencies = [
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "filetime"
-version = "0.2.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
-dependencies = [
- "cfg-if",
- "libc",
 ]
 
 [[package]]
@@ -1027,9 +1016,9 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "font-types"
-version = "0.11.3"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
+checksum = "81bf886368962a7d8456f136073ed33ed1b0770c690d2063731bb6a776e99f33"
 dependencies = [
  "bytemuck",
 ]
@@ -1059,9 +1048,9 @@ dependencies = [
 
 [[package]]
 name = "fontique"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "274fa4f0f0a926ae182c7c076c078cce8a38471d15e61a102a02cac984be9813"
+checksum = "1e04c4750a17111ebd77c3e0aea00476ce33f59235bc4d9e7f0aded5033ad3fc"
 dependencies = [
  "hashbrown 0.17.1",
  "linebender_resource_handle",
@@ -1315,9 +1304,9 @@ dependencies = [
 
 [[package]]
 name = "harfrust"
-version = "0.8.4"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d12c7c642d4ce8c2e784b4751a6634bd89583912265add4a679a8882d123fbcd"
+checksum = "f0589ddd0d2935dd2845827ac606b4081c266225d613b268ed2910f832889cab"
 dependencies = [
  "bitflags 2.11.1",
  "bytemuck",
@@ -1391,9 +1380,9 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -1445,9 +1434,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1655,9 +1644,9 @@ dependencies = [
 
 [[package]]
 name = "imagesize"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
+checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
 
 [[package]]
 name = "indexmap"
@@ -1674,14 +1663,14 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console",
- "number_prefix",
  "portable-atomic",
  "unicode-width",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -1861,20 +1850,22 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 [[package]]
 name = "kompari"
 version = "0.1.0"
-source = "git+https://github.com/linebender/kompari.git?rev=4b851413e1b17307064aa48c50e59d7e29656543#4b851413e1b17307064aa48c50e59d7e29656543"
+source = "git+https://github.com/linebender/kompari.git?rev=2643680d3e54a34b354a2dac5c62765c49d86176#2643680d3e54a34b354a2dac5c62765c49d86176"
 dependencies = [
- "image",
+ "bytemuck",
+ "color",
  "log",
- "oxipng 9.1.5",
+ "oxipng",
+ "png",
  "rayon",
  "thiserror 2.0.18",
  "walkdir",
 ]
 
 [[package]]
-name = "kompari-html"
+name = "kompari_html"
 version = "0.1.0"
-source = "git+https://github.com/linebender/kompari.git?rev=4b851413e1b17307064aa48c50e59d7e29656543#4b851413e1b17307064aa48c50e59d7e29656543"
+source = "git+https://github.com/linebender/kompari.git?rev=2643680d3e54a34b354a2dac5c62765c49d86176#2643680d3e54a34b354a2dac5c62765c49d86176"
 dependencies = [
  "axum",
  "base64",
@@ -1888,15 +1879,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "kompari-tasks"
+name = "kompari_tasks"
 version = "0.1.0"
-source = "git+https://github.com/linebender/kompari.git?rev=4b851413e1b17307064aa48c50e59d7e29656543#4b851413e1b17307064aa48c50e59d7e29656543"
+source = "git+https://github.com/linebender/kompari.git?rev=2643680d3e54a34b354a2dac5c62765c49d86176#2643680d3e54a34b354a2dac5c62765c49d86176"
 dependencies = [
  "clap",
  "humansize",
  "indicatif",
  "kompari",
- "kompari-html",
+ "kompari_html",
  "rayon",
  "termcolor",
 ]
@@ -1919,17 +1910,6 @@ checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
  "bitflags 2.11.1",
  "libc",
-]
-
-[[package]]
-name = "kurbo"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
-dependencies = [
- "arrayvec",
- "euclid",
- "smallvec",
 ]
 
 [[package]]
@@ -2313,12 +2293,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
 name = "nv-flip"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2686,24 +2660,6 @@ dependencies = [
 
 [[package]]
 name = "oxipng"
-version = "9.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c613f0f566526a647c7473f6a8556dbce22c91b13485ee4b4ec7ab648e4973"
-dependencies = [
- "bitvec",
- "crossbeam-channel",
- "filetime",
- "indexmap",
- "libdeflater",
- "log",
- "rayon",
- "rgb",
- "rustc-hash 2.1.2",
- "zopfli",
-]
-
-[[package]]
-name = "oxipng"
 version = "10.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eaaaa67c73558edaf5270e28abdf8d0663d88e8e7570cf894eff25305f4ed2"
@@ -2715,6 +2671,7 @@ dependencies = [
  "rayon",
  "rgb",
  "rustc-hash 2.1.2",
+ "zopfli",
 ]
 
 [[package]]
@@ -2748,9 +2705,9 @@ checksum = "4b6937eda350acc1a5d05872c3cbf99fe78619c269096e2be3d4a350058639d5"
 
 [[package]]
 name = "parley"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1cfcf399c774719fb1fa51bc6b91e86bdf003b03202a0902f1827ba6750746"
+checksum = "e0478b47dd9885a5e0a4f1c0782ffc42bf6ee8c41dea0917d7a9bcee3e6585fc"
 dependencies = [
  "fontique",
  "harfrust",
@@ -2766,9 +2723,9 @@ dependencies = [
 
 [[package]]
 name = "parley_data"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1d3755e2cc12c0625b0cd2f2773c6a37dd11d1531940c945ade4aeb78f2b145"
+checksum = "a649e01a1acc917247ee147b56b8a1fa91824acf7117bd003b4204306d601255"
 dependencies = [
  "icu_properties",
 ]
@@ -2781,7 +2738,7 @@ checksum = "839c8299360d2e998bdb106dc0a6cd71dcc5f4df51df1b620361bf50e283cca6"
 dependencies = [
  "bytemuck",
  "color",
- "kurbo 0.13.1",
+ "kurbo",
  "linebender_resource_handle",
  "smallvec",
 ]
@@ -3081,13 +3038,14 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.39.2"
+version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
+checksum = "487889119a5f19ff7c0a20637196bdc76b9f54ebec17e3588b5d75e4999f8773"
 dependencies = [
  "bytemuck",
  "core_maths",
  "font-types",
+ "once_cell",
 ]
 
 [[package]]
@@ -3285,7 +3243,7 @@ dependencies = [
  "getrandom",
  "image",
  "rand",
- "roxmltree 0.20.0",
+ "roxmltree 0.21.1",
  "skrifa",
  "vello",
  "web-time",
@@ -3488,9 +3446,9 @@ checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "skrifa"
-version = "0.42.1"
+version = "0.43.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c34617370ae968efb7161bb2beb517d9084659aae19e24b89e3db25b46e4564"
+checksum = "4cbe997d0f2480442d727488fbe2150779114cbe480ecdbadef58b33e0318ffb"
 dependencies = [
  "bytemuck",
  "core_maths",
@@ -3554,9 +3512,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -3644,11 +3602,11 @@ checksum = "0193cc4331cfd2f3d2011ef287590868599a2f33c3e69bc22c1a3d3acf9e02fb"
 
 [[package]]
 name = "svgtypes"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
+checksum = "695b5790b3131dafa99b3bbfd25a216edb3d216dad9ca208d4657bfb8f2abc3d"
 dependencies = [
- "kurbo 0.11.3",
+ "kurbo",
  "siphasher",
 ]
 
@@ -3755,7 +3713,7 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "log",
- "tiny-skia-path",
+ "tiny-skia-path 0.11.4",
 ]
 
 [[package]]
@@ -3763,6 +3721,17 @@ name = "tiny-skia-path"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca365c3faccca67d06593c5980fa6c57687de727a03131735bb85f01fdeeb9"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -4024,26 +3993,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "usvg"
-version = "0.45.1"
+name = "unit-prefix"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80be9b06fbae3b8b303400ab20778c80bbaf338f563afe567cf3c9eea17b47ef"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "usvg"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d46cf96c5f498d36b7a9693bc6a7075c0bb9303189d61b2249b0dc3d309c07de"
 dependencies = [
  "base64",
  "data-url",
  "flate2",
  "fontdb",
  "imagesize",
- "kurbo 0.11.3",
+ "kurbo",
  "log",
  "pico-args",
- "roxmltree 0.20.0",
+ "roxmltree 0.21.1",
  "rustybuzz",
  "simplecss",
  "siphasher",
  "strict-num",
  "svgtypes",
- "tiny-skia-path",
+ "tiny-skia-path 0.12.0",
+ "ttf-parser",
  "unicode-bidi",
  "unicode-script",
  "unicode-vo",
@@ -4113,7 +4089,7 @@ dependencies = [
  "log",
  "peniko",
  "png",
- "roxmltree 0.20.0",
+ "roxmltree 0.21.1",
  "smallvec",
  "thiserror 2.0.18",
 ]
@@ -4193,7 +4169,7 @@ dependencies = [
  "log",
  "png",
  "pollster",
- "roxmltree 0.20.0",
+ "roxmltree 0.21.1",
  "thiserror 2.0.18",
  "vello_common",
  "vello_sparse_shaders",
@@ -4239,7 +4215,7 @@ dependencies = [
  "fearless_simd",
  "glifo",
  "image",
- "oxipng 10.1.1",
+ "oxipng",
  "pollster",
  "serde",
  "serde_json",
@@ -4265,7 +4241,7 @@ dependencies = [
  "futures-intrusive",
  "image",
  "nv-flip",
- "oxipng 10.1.1",
+ "oxipng",
  "png",
  "pollster",
  "scenes",
@@ -5211,7 +5187,7 @@ dependencies = [
  "env_logger",
  "getrandom",
  "jni",
- "kurbo 0.13.1",
+ "kurbo",
  "log",
  "notify-debouncer-full",
  "pollster",
@@ -5320,7 +5296,7 @@ version = "0.0.0"
 dependencies = [
  "clap",
  "kompari",
- "kompari-tasks",
+ "kompari_tasks",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,7 @@ dependencies = [
  "android-properties",
  "bitflags 2.11.1",
  "cc",
- "jni 0.22.4",
+ "jni",
  "libc",
  "log",
  "ndk",
@@ -432,12 +432,6 @@ dependencies = [
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -1065,9 +1059,9 @@ dependencies = [
 
 [[package]]
 name = "fontique"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c20b425addb8661e97fe1d51c4d8bcec3ec29ed6ad0db983976a7521276b8f7"
+checksum = "274fa4f0f0a926ae182c7c076c078cce8a38471d15e61a102a02cac984be9813"
 dependencies = [
  "hashbrown 0.17.1",
  "linebender_resource_handle",
@@ -1321,13 +1315,12 @@ dependencies = [
 
 [[package]]
 name = "harfrust"
-version = "0.6.0"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ce5e848d21ba97a324266e41c70e0eb5e2577a610c1fbd546e15096f2e8e37"
+checksum = "d12c7c642d4ce8c2e784b4751a6634bd89583912265add4a679a8882d123fbcd"
 dependencies = [
  "bitflags 2.11.1",
  "bytemuck",
- "core_maths",
  "read-fonts",
  "smallvec",
 ]
@@ -1766,22 +1759,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "jni"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
-dependencies = [
- "cesu8",
- "cfg-if",
- "combine",
- "jni-sys 0.3.1",
- "log",
- "thiserror 1.0.69",
- "walkdir",
- "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2771,9 +2748,9 @@ checksum = "4b6937eda350acc1a5d05872c3cbf99fe78619c269096e2be3d4a350058639d5"
 
 [[package]]
 name = "parley"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fad031076f48f0d4d85ce1aea9b94b4e715a4d636a030a123038f8f5b5e4343"
+checksum = "6b1cfcf399c774719fb1fa51bc6b91e86bdf003b03202a0902f1827ba6750746"
 dependencies = [
  "fontique",
  "harfrust",
@@ -2789,9 +2766,9 @@ dependencies = [
 
 [[package]]
 name = "parley_data"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ab9ace3fad1b9ed603ddac5b595e69931fc50263d7e04e4055015b77b02da5"
+checksum = "d1d3755e2cc12c0625b0cd2f2773c6a37dd11d1531940c945ade4aeb78f2b145"
 dependencies = [
  "icu_properties",
 ]
@@ -4983,15 +4960,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5024,21 +4992,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -5085,12 +5038,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5103,12 +5050,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5118,12 +5059,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5151,12 +5086,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5166,12 +5095,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5187,12 +5110,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5202,12 +5119,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5299,7 +5210,7 @@ dependencies = [
  "console_log",
  "env_logger",
  "getrandom",
- "jni 0.21.1",
+ "jni",
  "kurbo 0.13.1",
  "log",
  "notify-debouncer-full",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ vello = { version = "0.9.0", path = "vello" }
 vello_encoding = { version = "0.9.0", path = "vello_encoding" }
 vello_shaders = { version = "0.9.0", path = "vello_shaders" }
 bytemuck = { version = "1.25.0", features = ["derive"] }
-skrifa = { version = "0.42.1", default-features = false, features = ["autohint_shaping"] }
+skrifa = { version = "0.43.2", default-features = false, features = ["autohint_shaping"] }
 # The version of kurbo used below should be kept in sync
 # with the version of kurbo used by peniko.
 peniko = { version = "0.6.1", default-features = false }
@@ -147,7 +147,7 @@ scenes = { path = "examples/scenes" }
 svg = "0.18.0"
 criterion = { version = "0.5.1", default-features = false }
 rand = { version = "0.9.4", default-features = false, features = ["std_rng"] }
-usvg = { version = "0.45.1" }
+usvg = { version = "0.47" }
 once_cell = "1.21.4"
 console_error_panic_hook = "0.1.7"
 console_log = "1.0"

--- a/examples/scenes/Cargo.toml
+++ b/examples/scenes/Cargo.toml
@@ -18,7 +18,7 @@ image = { workspace = true, features = ["jpeg"] }
 rand = { workspace = true, features = ["thread_rng"] }
 
 # for pico_svg
-roxmltree = "0.20.0"
+roxmltree = "0.21.1"
 bytemuck.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -68,7 +68,7 @@ tracing-subscriber = { version = "0.3.23", default-features = false, features = 
 profiling = { version = "1.0.18", features = ["profile-with-tracing"] }
 
 # For caching
-jni = "0.21.1"
+jni = "0.22"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = { workspace = true }

--- a/examples/with_winit/src/minimal_pipeline_cache.rs
+++ b/examples/with_winit/src/minimal_pipeline_cache.rs
@@ -19,28 +19,44 @@ fn get_cache_directory_android<T>(event_loop: &EventLoop<T>) -> anyhow::Result<P
     use winit::platform::android::EventLoopExtAndroid;
 
     let app = event_loop.android_app();
-    let app_jobject = unsafe { jni::objects::JObject::from_raw(app.activity_as_ptr().cast()) };
     // If we got a null VM, we can't pass up
-    let jvm = unsafe { jni::JavaVM::from_raw(app.vm_as_ptr().cast()).context("Making VM")? };
-    let mut env = jvm.attach_current_thread().context("Attaching to thread")?;
-    let res = env
-        .call_method(app_jobject, "getCacheDir", "()Ljava/io/File;", &[])
-        .context("Calling GetCacheDir")?;
-    let file = res.l().context("Converting to JObject")?;
-    let directory_path = env
-        .call_method(file, "getAbsolutePath", "()Ljava/lang/String;", &[])
-        .context("Calling `getAbsolutePath`")?;
-    let string = directory_path.l().context("Converting to a string")?.into();
-    let string = env
-        .get_string(&string)
-        .context("Converting into a Rust string")?;
-    let string: String = string.into();
-    let dir = PathBuf::from(string).join("vello");
-    if !dir.exists() {
-        std::fs::create_dir(&dir).context("Creating pipeline cache directory")?;
-    }
-    // TODO: Also get the quota. This appears to be more involved, requiring a worker thread and being asynchronous
-    Ok(dir)
+    let jvm = unsafe { jni::JavaVM::from_raw(app.vm_as_ptr().cast()) };
+    jvm.attach_current_thread(|env| -> anyhow::Result<PathBuf> {
+        let app_jobject =
+            unsafe { jni::objects::JObject::from_raw(env, app.activity_as_ptr().cast()) };
+        let res = env
+            .call_method(
+                app_jobject,
+                jni::jni_str!("getCacheDir"),
+                jni::jni_sig!("()Ljava/io/File;"),
+                &[],
+            )
+            .context("Calling GetCacheDir")?;
+        let file = res.l().context("Converting to JObject")?;
+        let directory_path = env
+            .call_method(
+                file,
+                jni::jni_str!("getAbsolutePath"),
+                jni::jni_sig!("()Ljava/lang/String;"),
+                &[],
+            )
+            .context("Calling `getAbsolutePath`")?;
+        let string = env
+            .cast_local::<jni::objects::JString<'_>>(
+                directory_path.l().context("Converting to a string")?,
+            )
+            .context("Casting to JString")?;
+        let string: String = string
+            .try_to_string(env)
+            .context("Converting into a Rust string")?;
+        let dir = PathBuf::from(string).join("vello");
+        if !dir.exists() {
+            std::fs::create_dir(&dir).context("Creating pipeline cache directory")?;
+        }
+        // TODO: Also get the quota. This appears to be more involved, requiring a worker thread and being asynchronous
+        Ok(dir)
+    })
+    .context("Attaching to thread")
 }
 
 pub(crate) fn get_cache_directory<T>(

--- a/sparse_strips/vello_bench/Cargo.toml
+++ b/sparse_strips/vello_bench/Cargo.toml
@@ -15,7 +15,7 @@ vello_cpu = { workspace = true }
 vello_dev_macros = { workspace = true }
 criterion = { workspace = true }
 image = { workspace = true, features = ["jpeg"] }
-parley = { version = "0.9.0", default-features = true }
+parley = { version = "0.10.0", default-features = true }
 rand = { workspace = true, features = ["small_rng"] }
 smallvec = { workspace = true }
 usvg = { workspace = true }

--- a/sparse_strips/vello_bench/Cargo.toml
+++ b/sparse_strips/vello_bench/Cargo.toml
@@ -15,7 +15,7 @@ vello_cpu = { workspace = true }
 vello_dev_macros = { workspace = true }
 criterion = { workspace = true }
 image = { workspace = true, features = ["jpeg"] }
-parley = { version = "0.10.0", default-features = true }
+parley = { version = "0.11.0", default-features = true }
 rand = { workspace = true, features = ["small_rng"] }
 smallvec = { workspace = true }
 usvg = { workspace = true }

--- a/sparse_strips/vello_common/Cargo.toml
+++ b/sparse_strips/vello_common/Cargo.toml
@@ -22,7 +22,7 @@ peniko = { workspace = true, features = ["bytemuck"] }
 fearless_simd = { workspace = true }
 hashbrown = { workspace = true, features = ["raw-entry"] }
 png = { workspace = true, optional = true }
-roxmltree = { version = "0.20.0", optional = true }
+roxmltree = { version = "0.21.1", optional = true }
 smallvec = { workspace = true }
 thiserror = { workspace = true, default-features = false }
 guillotiere = { workspace = true }

--- a/sparse_strips/vello_example_scenes/Cargo.toml
+++ b/sparse_strips/vello_example_scenes/Cargo.toml
@@ -27,7 +27,7 @@ console_log = { workspace = true }
 log = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-parley = { version = "0.10.0", default-features = false, features = ["std"] }
+parley = { version = "0.11.0", default-features = false, features = ["std"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-parley = { version = "0.10.0", default-features = true }
+parley = { version = "0.11.0", default-features = true }

--- a/sparse_strips/vello_example_scenes/Cargo.toml
+++ b/sparse_strips/vello_example_scenes/Cargo.toml
@@ -27,7 +27,7 @@ console_log = { workspace = true }
 log = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-parley = { version = "0.9.0", default-features = false, features = ["std"] }
+parley = { version = "0.10.0", default-features = false, features = ["std"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-parley = { version = "0.9.0", default-features = true }
+parley = { version = "0.10.0", default-features = true }

--- a/sparse_strips/vello_hybrid/Cargo.toml
+++ b/sparse_strips/vello_hybrid/Cargo.toml
@@ -44,7 +44,7 @@ web-sys = { version = "0.3.98", features = [
 png = { workspace = true }
 pollster = { workspace = true }
 vello_common = { workspace = true, features = ["pico_svg"] }
-roxmltree = "0.20.0"
+roxmltree = "0.21.1"
 
 [features]
 default = ["wgpu", "wgpu_default", "text"]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -11,8 +11,8 @@ categories = ["testing", "graphics"]
 
 
 [dependencies]
-kompari = { git = "https://github.com/linebender/kompari.git", rev = "4b851413e1b17307064aa48c50e59d7e29656543" }
-kompari-tasks = { git = "https://github.com/linebender/kompari.git", rev = "4b851413e1b17307064aa48c50e59d7e29656543" }
+kompari = { git = "https://github.com/linebender/kompari.git", rev = "2643680d3e54a34b354a2dac5c62765c49d86176" }
+kompari_tasks = { git = "https://github.com/linebender/kompari.git", rev = "2643680d3e54a34b354a2dac5c62765c49d86176" }
 clap = { workspace = true, features = ["derive"] }
 
 [lints]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -10,6 +10,7 @@ use kompari_tasks::{Actions, Args, Task};
 use std::path::Path;
 use std::process::Command;
 
+#[derive(Debug)]
 struct ActionsImpl();
 
 #[derive(Parser, Debug)]


### PR DESCRIPTION
First commit: update jni to remove lots of transitive (and old) dependencies. Plus a few others.
Second commit: a few more, new duplicate versions, but also got rid of some and fewer (lines) in total. Separate since there may be more doubts here, but feel free to squash.

(Motivation: be able to update some of these in egui.)

The rewrite of with_winit to work with jni 0.22 was done in collaboration with AI.