### PR TITLE
sparse_strips: Fix clipping for inverse blurred_rounded_rects

### DIFF
--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -420,8 +420,12 @@ impl RenderContext {
         // is not cut off.
         // The impulse response of a gaussian filter is infinite.
         // For performance reason we cut off the filter at some extent where the response is close to zero.
-        let kernel_size = 2.5 * std_dev;
-        let inflated_rect = rect.inflate(f64::from(kernel_size), f64::from(kernel_size));
+        let inflated_rect = if invert {
+            rect.inflate(rect.origin().x.abs(), rect.origin().y.abs())
+        } else {
+            let kernel_size = 2.5 * std_dev;
+            rect.inflate(f64::from(kernel_size), f64::from(kernel_size))
+        };
         let transform = self.effective_path_transform();
         let paint_transform = self.effective_paint_transform();
 

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -771,8 +771,12 @@ impl Scene {
                 invert,
             };
 
-            let kernel_size = 2.5 * std_dev;
-            let inflated_rect = rect.inflate(f64::from(kernel_size), f64::from(kernel_size));
+            let inflated_rect = if invert {
+                rect.inflate(rect.origin().x.abs(), rect.origin().y.abs())
+            } else {
+                let kernel_size = 2.5 * std_dev;
+                rect.inflate(f64::from(kernel_size), f64::from(kernel_size))
+            };
             let transform = ctx.render_state.transform * ctx.render_state.paint_transform;
             let paint =
                 blurred_rect.encode_into(&mut ctx.encoded_paints.borrow_mut(), transform, None);

--- a/sparse_strips/vello_sparse_tests/snapshots/inverse_blurred_rounded_rect_small_std_dev.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/inverse_blurred_rounded_rect_small_std_dev.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1f3fc5bb82acb0dca175769051b2a2efa07accf9c6d60ef4660f7c50517e7767
-size 1127
+oid sha256:6434f100baf484dd13ee9e996fe36c3ed427a65431fad99697a5e5c2a117e685
+size 1055

--- a/sparse_strips/vello_sparse_tests/snapshots/inverse_blurred_rounded_rect_with_transform.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/inverse_blurred_rounded_rect_with_transform.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2aafba6053f21e82d7b90de95115f4bae9c02df886dac43ded61e191a8b25931
-size 2423
+oid sha256:a1aefc7ca4bd2d0f6a852826df4a64e62eac5744f53dd18cf0cdd12231426631
+size 2428

--- a/sparse_strips/vello_sparse_tests/snapshots/inverse_blurred_rounded_rect_zero_with_radius.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/inverse_blurred_rounded_rect_zero_with_radius.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3fe837de1f45b1b7b7f52479ba5421cd3ddf693387fa0bc51defe50012941c8a
+size 145

--- a/sparse_strips/vello_sparse_tests/tests/blurred_rounded_rect.rs
+++ b/sparse_strips/vello_sparse_tests/tests/blurred_rounded_rect.rs
@@ -71,6 +71,11 @@ fn inverse_rect_with(ctx: &mut impl Renderer, radius: f32, std_dev: f32, affine:
 }
 
 #[vello_test]
+fn inverse_blurred_rounded_rect_zero_with_radius(ctx: &mut impl Renderer) {
+    inverse_rect_with(ctx, 10.0, 0.0, Affine::IDENTITY);
+}
+
+#[vello_test]
 fn inverse_blurred_rounded_rect_small_std_dev(ctx: &mut impl Renderer) {
     inverse_rect_with(ctx, 0.0, 5.0, Affine::IDENTITY);
 }


### PR DESCRIPTION
Follow-up fix for https://github.com/linebender/vello/pull/1715 which has a bug where "hard" shadows (with blur `std_dev` of 0) don't render correctly. This is because the inverse shadows were still using the clip-region logic used for "regular" shadows (inflate rect by `2.5 * std_dev`) which happens to work if the `std_dev` is large enough, but in general clips far too aggressively if the `std_dev` is small and not aggressively enough when it is large.

For inverse shadows, what we want to do is clip to the exact size of the user-specified rect, but possibly at a location that is offset (translated) relative to where the shadow itself should render (if the shadow has a offset specified). This PR uses a bit of hack to encode this in the origin of the Rect:

- The paint is clipped to position of the rect ignoring the origin
- The shadow is draw offset by the origin of the rect

This results in correct rendering, but is arguably a bit of a hack. I could add a separate offset (Vec2) parameter if that's preferred.

This PR was entirely hand written.
