### PR TITLE
Add a variation of the into_png function exposing the encoder via callback

### DIFF
--- a/sparse_strips/vello_common/src/pixmap.rs
+++ b/sparse_strips/vello_common/src/pixmap.rs
@@ -322,8 +322,18 @@ impl Pixmap {
     /// Return the current content of the pixmap as a PNG.
     #[cfg(feature = "png")]
     pub fn into_png(self) -> Result<Vec<u8>, png::EncodingError> {
+        self.into_png_with_callback(|_| {})
+    }
+
+    /// Return the current content of the pixmap as a PNG.
+    #[cfg(feature = "png")]
+    pub fn into_png_with_callback(
+        self,
+        callback: fn(&mut png::Encoder<'_, &mut Vec<u8>>),
+    ) -> Result<Vec<u8>, png::EncodingError> {
         let mut data = Vec::new();
         let mut encoder = png::Encoder::new(&mut data, self.width as u32, self.height as u32);
+        callback(&mut encoder);
         encoder.set_color(png::ColorType::Rgba);
         encoder.set_depth(png::BitDepth::Eight);
         let mut writer = encoder.write_header()?;


### PR DESCRIPTION
I wanted to modify some stuff in the png header, like setting pixel dimensions. This seemed like the simplest fix,
because it doesn't require us to make an abstraction layer for every knob in the png encoder someone might want to twist. If we hate this approach, then not a lot of time wasted.