### PR TITLE
sparse_strips: Reduce `powf` calls for rounded blurred rects

### DIFF
--- a/sparse_strips/vello_cpu/src/fine/common/rounded_blurred_rect.rs
+++ b/sparse_strips/vello_cpu/src/fine/common/rounded_blurred_rect.rs
@@ -177,7 +177,7 @@ impl<S: Simd> Iterator for AlphaCalculator<S> {
         // Equivalent to r.r1 + x.abs() - (r.w * r.v1)
         let x0 = r.r1 - r.w.mul_sub(r.v1, x.abs());
         let x1 = x0.max(r.v0);
-        let d_pos = (x1.powf(r.exponent) + y1.powf(r.exponent)).powf(r.recip_exponent);
+        let d_pos = p_norm_distance(self.simd, x1, y1, r.exponent, r.recip_exponent);
         let d_neg = x0.max(y0).min(r.v0);
         let d = d_pos + d_neg - r.r1;
         let z = r.scale
@@ -241,6 +241,34 @@ impl<S: Simd> SimdRoundedBlurredRect<S> {
             },
         )
     }
+}
+
+#[inline(always)]
+fn p_norm_distance<S: Simd>(
+    simd: S,
+    x: f32x8<S>,
+    y: f32x8<S>,
+    exponent: f32,
+    recip_exponent: f32,
+) -> f32x8<S> {
+    // Note: In our case, x and y are always >= 0.
+
+    let max_fact = x.max(y);
+    let min_fact = x.min(y);
+
+    // This is the 2D p-norm, normalized by the larger component:
+    //
+    //   d = (x^p + y^p)^(1/p)
+    //     = (max_fact^p + min_fact^p)^(1/p)
+    //     = (max_fact^p * (1 + (min_fact / max_fact)^p))^(1/p)
+    //     = max_fact * (1 + t^p)^(1/p), where t = min_fact / max_fact.
+    let t = simd.select_f32x8(
+        max_fact.simd_eq(f32x8::splat(simd, 0.0)),
+        f32x8::splat(simd, 0.0),
+        min_fact / max_fact,
+    );
+
+    max_fact * (f32x8::splat(simd, 1.0) + t.powf(exponent)).powf(recip_exponent)
 }
 
 trait FloatExt<S: Simd> {

--- a/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render_strips.wgsl
@@ -1495,10 +1495,10 @@ fn calculate_blurred_rounded_rect(
     let x0 = r1 + abs(x) - 0.5 * w;
     let x1 = max(x0, 0.0);
 
-    let d_pos = pow(
-        pow(x1, exponent) + pow(y1, exponent),
-        recip_exponent,
-    );
+    let max_fact = max(x1, y1);
+    let min_fact = min(x1, y1);
+    let t = select(min_fact / max_fact, 0.0, max_fact == 0.0);
+    let d_pos = max_fact * pow(1.0 + pow(t, exponent), recip_exponent);
     let d_neg = min(max(x0, y0), 0.0);
     let d = d_pos + d_neg - r1;
     let blur_coverage = scale * (

--- a/sparse_strips/vello_sparse_tests/snapshots/blurred_rounded_rect_medium_std_dev.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/blurred_rounded_rect_medium_std_dev.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:85c24a0a05ebe5bcf992158e4c9eea308d04ce80bc4bdf41b8592a4c2bb39ea2
-size 2088
+oid sha256:2539415149075108e719617bcb1b6e7118842af24804be5183e76b0b70e6e7b8
+size 2091

--- a/sparse_strips/vello_sparse_tests/snapshots/inverse_blurred_rounded_rect_medium_std_dev.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/inverse_blurred_rounded_rect_medium_std_dev.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b9718067808db55b31e6dca854017227ac90f59d9736a3119d8130466156bae9
-size 2107
+oid sha256:eeb7a44b0dc603fa3958ae4eee47919e98937aac99afc6d069a79df445c4e874
+size 2111


### PR DESCRIPTION
Someone with better math skills should double check this, but it makes sense to me.

```
lstampfl@MacBookPro vello_bench % cargo bench --bench main -- rounded --baseline main
fine/rounded_blurred_rect/with_transform_u8_neon
                        time:   [6.0929 µs 6.1034 µs 6.1149 µs]
                        change: [-55.059% -54.952% -54.849%] (p = 0.00 < 0.05)
                        Performance has improved.
```

For GPU, it doesn't seem to have much of an effect, but for consistency I still ported it over.

Done with assistance of GPT 5.5, high.