### PR TITLE
vello_cpu: Use a LUT for `powf` calculations for blurred rectangles

### DIFF
--- a/sparse_strips/vello_common/src/encode.rs
+++ b/sparse_strips/vello_common/src/encode.rs
@@ -841,6 +841,47 @@ impl BitEq for GradientCacheKey {
     }
 }
 
+const BLURRED_ROUNDED_RECT_P_NORM_LUT_SIZE: usize = 255;
+
+/// A lookup table for the normalized p-norm factor of blurred rounded rectangles.
+#[derive(Debug)]
+pub struct BlurredRoundedRectPNormLut {
+    lut: Vec<f32>,
+    scale: f32,
+}
+
+impl BlurredRoundedRectPNormLut {
+    fn new(exponent: f32, recip_exponent: f32) -> Self {
+        let scale = BLURRED_ROUNDED_RECT_P_NORM_LUT_SIZE as f32;
+        let mut lut = Vec::with_capacity(BLURRED_ROUNDED_RECT_P_NORM_LUT_SIZE + 1);
+        // During sampling we interpolate between i and i + 1, so make it one larger.
+        for idx in 0..(BLURRED_ROUNDED_RECT_P_NORM_LUT_SIZE + 1) {
+            let t = idx as f32 / scale;
+            lut.push((1.0 + t.powf(exponent)).powf(recip_exponent));
+        }
+
+        Self { lut, scale }
+    }
+
+    /// Get the sample value at a specific index.
+    #[inline(always)]
+    pub fn get(&self, idx: usize) -> f32 {
+        self.lut[idx]
+    }
+
+    /// Return the number of entries in the lookup table.
+    #[inline(always)]
+    pub fn width(&self) -> usize {
+        self.lut.len()
+    }
+
+    /// Get the scale factor by which to scale the normalized value.
+    #[inline(always)]
+    pub fn scale(&self) -> f32 {
+        self.scale
+    }
+}
+
 /// An encoded range between two color stops.
 #[derive(Debug, Clone)]
 pub struct GradientRange {
@@ -892,6 +933,15 @@ pub struct EncodedBlurredRoundedRectangle {
     pub x_advance: Vec2,
     /// How much to advance into the x/y direction for one step in the y direction.
     pub y_advance: Vec2,
+    p_norm_lut: OnceCell<BlurredRoundedRectPNormLut>,
+}
+
+impl EncodedBlurredRoundedRectangle {
+    /// Get the lookup table for the normalized Lp norm factor.
+    pub fn p_norm_lut(&self) -> &BlurredRoundedRectPNormLut {
+        self.p_norm_lut
+            .get_or_init(|| BlurredRoundedRectPNormLut::new(self.exponent, self.recip_exponent))
+    }
 }
 
 impl private::Sealed for BlurredRoundedRectangle {}
@@ -965,6 +1015,7 @@ impl EncodeExt for BlurredRoundedRectangle {
             transform,
             x_advance,
             y_advance,
+            p_norm_lut: OnceCell::new(),
         };
 
         let idx = paints.len();

--- a/sparse_strips/vello_cpu/src/fine/common/rounded_blurred_rect.rs
+++ b/sparse_strips/vello_cpu/src/fine/common/rounded_blurred_rect.rs
@@ -7,26 +7,26 @@
 
 use crate::fine::{NumericVec, PosExt, ShaderResultF32};
 use crate::kurbo::{Point, Vec2};
-use vello_common::encode::EncodedBlurredRoundedRectangle;
+use vello_common::encode::{BlurredRoundedRectPNormLut, EncodedBlurredRoundedRectangle};
 use vello_common::fearless_simd::{Simd, SimdBase, SimdFloat, f32x8, u8x16};
 
 #[cfg(not(feature = "std"))]
 use vello_common::kurbo::common::FloatFuncs as _;
 
 #[derive(Debug)]
-pub(crate) struct BlurredRoundedRectFiller<S: Simd> {
+pub(crate) struct BlurredRoundedRectFiller<'a, S: Simd> {
     r: f32x8<S>,
     g: f32x8<S>,
     b: f32x8<S>,
     a: f32x8<S>,
     invert: bool,
-    alpha_calculator: AlphaCalculator<S>,
+    alpha_calculator: AlphaCalculator<'a, S>,
 }
 
-impl<S: Simd> BlurredRoundedRectFiller<S> {
+impl<'a, S: Simd> BlurredRoundedRectFiller<'a, S> {
     pub(crate) fn new(
         simd: S,
-        rect: &EncodedBlurredRoundedRectangle,
+        rect: &'a EncodedBlurredRoundedRectangle,
         start_x: f64,
         start_y: f64,
     ) -> Self {
@@ -61,7 +61,7 @@ impl<S: Simd> BlurredRoundedRectFiller<S> {
     }
 }
 
-impl<S: Simd> Iterator for BlurredRoundedRectFiller<S> {
+impl<S: Simd> Iterator for BlurredRoundedRectFiller<'_, S> {
     type Item = ShaderResultF32<S>;
 
     #[inline(always)]
@@ -79,7 +79,7 @@ impl<S: Simd> Iterator for BlurredRoundedRectFiller<S> {
     }
 }
 
-impl<S: Simd> crate::fine::Painter for BlurredRoundedRectFiller<S> {
+impl<S: Simd> crate::fine::Painter for BlurredRoundedRectFiller<'_, S> {
     fn paint_u8(&mut self, buf: &mut [u8]) {
         self.a.simd.vectorize(
             #[inline(always)]
@@ -123,20 +123,20 @@ impl<S: Simd> crate::fine::Painter for BlurredRoundedRectFiller<S> {
 }
 
 #[derive(Debug)]
-struct AlphaCalculator<S: Simd> {
+struct AlphaCalculator<'a, S: Simd> {
     cur_pos: Point,
     x_advance: Vec2,
     y_advance: Vec2,
-    r: SimdRoundedBlurredRect<S>,
+    r: SimdRoundedBlurredRect<'a, S>,
     simd: S,
 }
 
-impl<S: Simd> AlphaCalculator<S> {
+impl<'a, S: Simd> AlphaCalculator<'a, S> {
     fn new(
         start_pos: Point,
         x_advance: Vec2,
         y_advance: Vec2,
-        r: SimdRoundedBlurredRect<S>,
+        r: SimdRoundedBlurredRect<'a, S>,
         simd: S,
     ) -> Self {
         Self {
@@ -149,7 +149,7 @@ impl<S: Simd> AlphaCalculator<S> {
     }
 }
 
-impl<S: Simd> Iterator for AlphaCalculator<S> {
+impl<S: Simd> Iterator for AlphaCalculator<'_, S> {
     type Item = f32x8<S>;
 
     #[inline(always)]
@@ -177,7 +177,7 @@ impl<S: Simd> Iterator for AlphaCalculator<S> {
         // Equivalent to r.r1 + x.abs() - (r.w * r.v1)
         let x0 = r.r1 - r.w.mul_sub(r.v1, x.abs());
         let x1 = x0.max(r.v0);
-        let d_pos = p_norm_distance(self.simd, x1, y1, r.exponent, r.recip_exponent);
+        let d_pos = p_norm_distance(self.simd, x1, y1, r.p_norm_lut, r.p_norm_lut_scale);
         let d_neg = x0.max(y0).min(r.v0);
         let d = d_pos + d_neg - r.r1;
         let z = r.scale
@@ -191,9 +191,9 @@ impl<S: Simd> Iterator for AlphaCalculator<S> {
 }
 
 #[derive(Debug)]
-struct SimdRoundedBlurredRect<S: Simd> {
-    pub exponent: f32,
-    pub recip_exponent: f32,
+struct SimdRoundedBlurredRect<'a, S: Simd> {
+    pub p_norm_lut: &'a BlurredRoundedRectPNormLut,
+    pub p_norm_lut_scale: f32x8<S>,
     pub scale: f32x8<S>,
     pub std_dev_inv: f32x8<S>,
     pub min_edge: f32x8<S>,
@@ -206,18 +206,18 @@ struct SimdRoundedBlurredRect<S: Simd> {
     pub v1: f32x8<S>,
 }
 
-impl<S: Simd> SimdRoundedBlurredRect<S> {
-    fn new(encoded: &EncodedBlurredRoundedRectangle, s: S) -> Self {
+impl<'a, S: Simd> SimdRoundedBlurredRect<'a, S> {
+    fn new(encoded: &'a EncodedBlurredRoundedRectangle, s: S) -> Self {
         s.vectorize(
             #[inline(always)]
             || {
+                let p_norm_lut = encoded.p_norm_lut();
+                let p_norm_lut_scale = f32x8::splat(s, p_norm_lut.width() as f32 - 1.0);
                 let h = f32x8::splat(s, encoded.h);
                 let w = f32x8::splat(s, encoded.w);
                 let width = f32x8::splat(s, encoded.width);
                 let height = f32x8::splat(s, encoded.height);
                 let r1 = f32x8::splat(s, encoded.r1);
-                let exponent = encoded.exponent;
-                let recip_exponent = encoded.recip_exponent;
                 let scale = f32x8::splat(s, encoded.scale);
                 let min_edge = f32x8::splat(s, encoded.min_edge);
                 let std_dev_inv = f32x8::splat(s, encoded.std_dev_inv);
@@ -225,8 +225,8 @@ impl<S: Simd> SimdRoundedBlurredRect<S> {
                 let v1 = f32x8::splat(s, 0.5);
 
                 Self {
-                    exponent,
-                    recip_exponent,
+                    p_norm_lut,
+                    p_norm_lut_scale,
                     scale,
                     std_dev_inv,
                     min_edge,
@@ -248,8 +248,8 @@ fn p_norm_distance<S: Simd>(
     simd: S,
     x: f32x8<S>,
     y: f32x8<S>,
-    exponent: f32,
-    recip_exponent: f32,
+    lut: &BlurredRoundedRectPNormLut,
+    lut_scale: f32x8<S>,
 ) -> f32x8<S> {
     // Note: In our case, x and y are always >= 0.
 
@@ -267,8 +267,24 @@ fn p_norm_distance<S: Simd>(
         f32x8::splat(simd, 0.0),
         min_fact / max_fact,
     );
+    let lookup = {
+        let scaled = t * lut_scale;
+        
+        f32x8::from_fn(simd, |i| {
+            let scaled = scaled[i];
+            // t can range from [0.0, 1.0] (_inclusive_ 1.0!),
+            // since we access `idx` and `idx + 1`, we need to
+            // clamp to width - 2 instead of just - 1.
+            let idx = (scaled as usize).min(lut.width() - 2);
+            let fract = scaled - idx as f32;
+            let a = lut.get(idx);
+            let b = lut.get(idx + 1);
 
-    max_fact * (f32x8::splat(simd, 1.0) + t.powf(exponent)).powf(recip_exponent)
+            fract.mul_add(b - a, a)
+        })
+    };
+
+    max_fact * lookup
 }
 
 trait FloatExt<S: Simd> {
@@ -276,7 +292,6 @@ trait FloatExt<S: Simd> {
     // explanation of this approximation to the erf function.
     /// Approximate the erf function.
     fn compute_erf7(simd: S, x: Self) -> Self;
-    fn powf(self, x: f32) -> Self;
 }
 
 impl<S: Simd> FloatExt<S> for f32x8<S> {
@@ -294,20 +309,5 @@ impl<S: Simd> FloatExt<S> for f32x8<S> {
         let x = p2.mul_add(p3, x);
         let denom = x.mul_add(x, Self::splat(simd, 1.0)).sqrt();
         x / denom
-    }
-
-    #[inline]
-    fn powf(mut self, x: f32) -> Self {
-        // TODO: SIMD
-        self[0] = self[0].powf(x);
-        self[1] = self[1].powf(x);
-        self[2] = self[2].powf(x);
-        self[3] = self[3].powf(x);
-        self[4] = self[4].powf(x);
-        self[5] = self[5].powf(x);
-        self[6] = self[6].powf(x);
-        self[7] = self[7].powf(x);
-
-        self
     }
 }

--- a/sparse_strips/vello_cpu/src/fine/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/mod.rs
@@ -374,12 +374,12 @@ pub trait FineKernel<S: Simd>: Send + Sync + 'static {
     ///
     /// Efficiently renders rounded rectangles with gaussian blur applied,
     /// computing the blur analytically rather than as a post-process.
-    fn blurred_rounded_rectangle_painter(
+    fn blurred_rounded_rectangle_painter<'a>(
         simd: S,
-        rect: &EncodedBlurredRoundedRectangle,
+        rect: &'a EncodedBlurredRoundedRectangle,
         start_x: f64,
         start_y: f64,
-    ) -> impl Painter {
+    ) -> impl Painter + 'a {
         simd.vectorize(
             #[inline(always)]
             || BlurredRoundedRectFiller::new(simd, rect, start_x, start_y),

--- a/sparse_strips/vello_sparse_tests/snapshots/blurred_rounded_rect_medium_std_dev.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/blurred_rounded_rect_medium_std_dev.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2539415149075108e719617bcb1b6e7118842af24804be5183e76b0b70e6e7b8
-size 2091
+oid sha256:85c24a0a05ebe5bcf992158e4c9eea308d04ce80bc4bdf41b8592a4c2bb39ea2
+size 2088

--- a/sparse_strips/vello_sparse_tests/snapshots/inverse_blurred_rounded_rect_medium_std_dev.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/inverse_blurred_rounded_rect_medium_std_dev.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eeb7a44b0dc603fa3958ae4eee47919e98937aac99afc6d069a79df445c4e874
-size 2111
+oid sha256:b9718067808db55b31e6dca854017227ac90f59d9736a3119d8130466156bae9
+size 2107


### PR DESCRIPTION
Builds on top of #1724. Now that we have rewritten the calculation to operate on a normalized `t` value between 0.0 and 1.0, instead of doing two `powf` calls for each pixel we can instead precompute a lookup table which will give us a reasonable enough approximation for the whole expression. This is possible because the exponent itself is constant across all pixels, only the underlying x/y position (represented by `t`) changes.

Compared to main, together with #1724 this now gives a 4x speed boost:

```
fine/rounded_blurred_rect/no_transform_u8_neon
                        time:   [3.7443 µs 3.7517 µs 3.7595 µs]
                        change: [-72.664% -72.582% -72.500%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
```

And you need to consider that this benchmark only paints over a 256x4 wide tile, meaning that the computation for the lookup table will still take up a significant chunk of the time. The great thing is that the work for computing the lookup table stays constant regardless of whether you are drawing a 20x20 blurred rectangle or a 2000x2000 one!