### PR TITLE
vello_cpu: Make `paint_*` methods consume `self`

### DIFF
--- a/sparse_strips/vello_cpu/src/fine/common/gradient/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/common/gradient/mod.rs
@@ -96,7 +96,7 @@ impl<S: Simd> Iterator for GradientPainter<'_, S> {
 }
 
 impl<S: Simd> crate::fine::Painter for GradientPainter<'_, S> {
-    fn paint_u8(&mut self, buf: &mut [u8]) {
+    fn paint_u8(mut self, buf: &mut [u8]) {
         let max_index = self.lut.width() as u32 - 1;
         let mut masked_iter = self.has_undefined.then_some(self.clone());
 
@@ -170,7 +170,7 @@ impl<S: Simd> crate::fine::Painter for GradientPainter<'_, S> {
         }
     }
 
-    fn paint_f32(&mut self, buf: &mut [f32]) {
+    fn paint_f32(mut self, buf: &mut [f32]) {
         let mut masked_iter = self.has_undefined.then_some(self.clone());
 
         self.simd.vectorize(

--- a/sparse_strips/vello_cpu/src/fine/common/rounded_blurred_rect.rs
+++ b/sparse_strips/vello_cpu/src/fine/common/rounded_blurred_rect.rs
@@ -80,7 +80,7 @@ impl<S: Simd> Iterator for BlurredRoundedRectFiller<S> {
 }
 
 impl<S: Simd> crate::fine::Painter for BlurredRoundedRectFiller<S> {
-    fn paint_u8(&mut self, buf: &mut [u8]) {
+    fn paint_u8(mut self, buf: &mut [u8]) {
         self.a.simd.vectorize(
             #[inline(always)]
             || {
@@ -106,7 +106,7 @@ impl<S: Simd> crate::fine::Painter for BlurredRoundedRectFiller<S> {
         );
     }
 
-    fn paint_f32(&mut self, buf: &mut [f32]) {
+    fn paint_f32(mut self, buf: &mut [f32]) {
         self.a.simd.vectorize(
             #[inline(always)]
             || {

--- a/sparse_strips/vello_cpu/src/fine/highp/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/highp/mod.rs
@@ -103,7 +103,7 @@ impl<S: Simd> FineKernel<S> for F32Kernel {
     ///
     /// Delegates to the painter's f32-specific implementation.
     #[inline(always)]
-    fn apply_painter<'a>(_: S, dest: &mut [Self::Numeric], mut painter: impl Painter + 'a) {
+    fn apply_painter<'a>(_: S, dest: &mut [Self::Numeric], painter: impl Painter + 'a) {
         painter.paint_f32(dest);
     }
 

--- a/sparse_strips/vello_cpu/src/fine/lowp/gradient.rs
+++ b/sparse_strips/vello_cpu/src/fine/lowp/gradient.rs
@@ -58,7 +58,7 @@ impl<S: Simd> Iterator for GradientPainter<'_, S> {
 }
 
 impl<S: Simd> crate::fine::Painter for GradientPainter<'_, S> {
-    fn paint_u8(&mut self, buf: &mut [u8]) {
+    fn paint_u8(mut self, buf: &mut [u8]) {
         self.simd.vectorize(
             #[inline(always)]
             || {
@@ -69,7 +69,7 @@ impl<S: Simd> crate::fine::Painter for GradientPainter<'_, S> {
         );
     }
 
-    fn paint_f32(&mut self, _: &mut [f32]) {
+    fn paint_f32(self, _: &mut [f32]) {
         unimplemented!()
     }
 }

--- a/sparse_strips/vello_cpu/src/fine/lowp/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/lowp/mod.rs
@@ -152,7 +152,7 @@ impl<S: Simd> FineKernel<S> for U8Kernel {
     ///
     /// Delegates to the painter's u8-specific implementation.
     #[inline(always)]
-    fn apply_painter<'a>(_: S, dest: &mut [Self::Numeric], mut painter: impl Painter + 'a) {
+    fn apply_painter<'a>(_: S, dest: &mut [Self::Numeric], painter: impl Painter + 'a) {
         painter.paint_u8(dest);
     }
 

--- a/sparse_strips/vello_cpu/src/fine/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/mod.rs
@@ -1108,7 +1108,7 @@ pub(crate) struct FineRenderParams {
 /// may convert between types as needed.
 pub trait Painter: Sized {
     /// Paint pixel data into a u8 buffer (values in 0-255 range).
-    fn paint_u8(self, buf: &mut [u8]);
+    fn paint_u8(mut self, buf: &mut [u8]);
 
     /// Paint pixel data into an f32 buffer (values in 0.0-1.0 range).
     fn paint_f32(self, buf: &mut [f32]);

--- a/sparse_strips/vello_cpu/src/fine/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/mod.rs
@@ -1108,7 +1108,7 @@ pub(crate) struct FineRenderParams {
 /// may convert between types as needed.
 pub trait Painter: Sized {
     /// Paint pixel data into a u8 buffer (values in 0-255 range).
-    fn paint_u8(mut self, buf: &mut [u8]);
+    fn paint_u8(self, buf: &mut [u8]);
 
     /// Paint pixel data into an f32 buffer (values in 0.0-1.0 range).
     fn paint_f32(self, buf: &mut [f32]);

--- a/sparse_strips/vello_cpu/src/fine/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/mod.rs
@@ -1106,12 +1106,12 @@ pub(crate) struct FineRenderParams {
 ///
 /// Note: Some painters may only efficiently support one numeric type. The implementation
 /// may convert between types as needed.
-pub trait Painter {
+pub trait Painter: Sized {
     /// Paint pixel data into a u8 buffer (values in 0-255 range).
-    fn paint_u8(&mut self, buf: &mut [u8]);
+    fn paint_u8(self, buf: &mut [u8]);
 
     /// Paint pixel data into an f32 buffer (values in 0.0-1.0 range).
-    fn paint_f32(&mut self, buf: &mut [f32]);
+    fn paint_f32(self, buf: &mut [f32]);
 }
 
 /// Extension trait for creating position vectors for gradient and image sampling.
@@ -1196,7 +1196,7 @@ mod macros {
     macro_rules! f32x16_painter {
         ($($type_path:tt)+) => {
             impl<S: Simd> crate::fine::Painter for $($type_path)+ {
-                fn paint_u8(&mut self, buf: &mut [u8]) {
+                fn paint_u8(mut self, buf: &mut [u8]) {
                     use vello_common::fearless_simd::*;
                     use crate::fine::NumericVec;
 
@@ -1209,7 +1209,7 @@ mod macros {
                     })
                 }
 
-                fn paint_f32(&mut self, buf: &mut [f32]) {
+                fn paint_f32(mut self, buf: &mut [f32]) {
                     self.simd.vectorize(#[inline(always)] || {
                         for chunk in buf.chunks_exact_mut(16) {
                             let next = self.next().unwrap();
@@ -1228,7 +1228,7 @@ mod macros {
     macro_rules! u8x16_painter {
         ($($type_path:tt)+) => {
             impl<S: Simd> crate::fine::Painter for $($type_path)+ {
-                fn paint_u8(&mut self, buf: &mut [u8]) {
+                fn paint_u8(mut self, buf: &mut [u8]) {
                     self.simd.vectorize(#[inline(always)] || {
                         for chunk in buf.chunks_exact_mut(16) {
                             let next = self.next().unwrap();
@@ -1237,7 +1237,7 @@ mod macros {
                     })
                 }
 
-                fn paint_f32(&mut self, buf: &mut [f32]) {
+                fn paint_f32(mut self, buf: &mut [f32]) {
                     use vello_common::fearless_simd::*;
                     use crate::fine::NumericVec;
 


### PR DESCRIPTION
~~Based on top of #1728.~~

A painter is supposed to be initialized and then only used once, since each time we change the location we need to reinitialize it. This PR changes the signature so this intention is properly encoded in the `paint_*` methods.

This PR was done with assistance of GPT 5.6-Sol.