### PR TITLE
vello_cpu: Flush `MultiThreadedDispatcher` before resetting

### DIFF
--- a/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
@@ -587,6 +587,10 @@ impl Dispatcher for MultiThreadedDispatcher {
     }
 
     fn reset(&mut self, width: u16, height: u16) {
+        if self.task_sender.is_some() {
+            self.flush();
+        }
+
         // Bucketer will be reset lazily during rasterization with the active viewport.
         self.clip_context.reset();
         self.recorder.reset();

--- a/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
@@ -587,9 +587,7 @@ impl Dispatcher for MultiThreadedDispatcher {
     }
 
     fn reset(&mut self, width: u16, height: u16) {
-        if self.task_sender.is_some() {
-            self.flush();
-        }
+        self.flush();
 
         // Bucketer will be reset lazily during rasterization with the active viewport.
         self.clip_context.reset();

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -1240,7 +1240,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        
+
         // Note: This test only works if we draw enough rectangles
         // to trigger a batch send.
         for _ in 0..300 {

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -1227,6 +1227,29 @@ mod tests {
         ctx.render_with(&mut pixmap, &mut resources, rasterizer_settings);
     }
 
+    #[cfg(feature = "multithreading")]
+    #[test]
+    fn multithreaded_reset_with_pending_tasks() {
+        use crate::RenderSettings;
+
+        let mut ctx = RenderContext::new_with(
+            100,
+            100,
+            RenderSettings {
+                num_threads: 4,
+                ..Default::default()
+            },
+        );
+        
+        // Note: This test only works if we draw enough rectangles
+        // to trigger a batch send.
+        for _ in 0..300 {
+            ctx.fill_rect(&Rect::new(0.0, 0.0, 100., 100.0));
+        }
+
+        ctx.reset();
+    }
+
     #[cfg(feature = "text")]
     #[test]
     fn glyph_atlas_resources_are_lazy() {


### PR DESCRIPTION
Right now, `reset()` drops `task_sender` and `recorded_command_receiver` without
waiting for in-flight workers to finish: https://github.com/linebender/vello/blob/cd852dc06bc0f9011385fc63a4852b0fc853f4b1/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs#L599-L600

This would panic if a worker is still sending.

Fixes: https://github.com/linebender/vello/issues/1731
Testing: Run the example in https://github.com/linebender/vello/issues/1731 for 10 minutes without panic.