### PR TITLE
vello_hybrid: Deallocate filter regions at the end of each frame instead of the start of next

### DIFF
--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -402,13 +402,6 @@ impl WebGlRenderer {
         clear: bool,
         root_output_target: RootRenderTarget,
     ) -> Result<(), RenderError> {
-        if !self.filter_context.filter_textures.is_empty() {
-            self.programs.clear_filter_atlas_textures(&self.gl);
-        }
-
-        self.filter_context
-            .deallocate_all_and_clear_context(image_cache);
-
         let mut encoded_paints = scene.encoded_paints.borrow_mut();
         let original_scene_paint_count = encoded_paints.len();
 
@@ -458,6 +451,10 @@ impl WebGlRenderer {
             &encoded_paints,
         )?;
 
+        // TODO: Most likely we will want to clean up even if rendering fails. The current assumption
+        // is that if something fails, the user will create a new renderer instead of trying
+        // to reuse the existing one. This should likely be changed in the future.
+
         // See: https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices#use_invalidateframebuffer
         // We want to indicate to the GPU driver that we won't read the depth buffer again
         // until the next clear. This enables the GPU to avoid storing depth tiles back to VRAM.
@@ -476,6 +473,12 @@ impl WebGlRenderer {
 
         encoded_paints.truncate(original_scene_paint_count);
         self.gradient_cache.maintain();
+
+        if !self.filter_context.filter_textures.is_empty() {
+            self.programs.clear_filter_atlas_textures(&self.gl);
+        }
+        self.filter_context
+            .deallocate_all_and_clear_context(image_cache);
 
         Ok(())
     }


### PR DESCRIPTION
Currently, the `probe` method piggybacks an existing `WebGlRenderer` and does some `mem::swap`s in an effort to not dirty the existing renderer state. Unfortunately, it turns out that this is not enough. Currently, filter handling is written in such a way that at the beginning of the render operation (i.e. when calling `render_scene`), we check the filter context and clear/deallocate image regions _from the last frame_. Obviously, this doesn't work well with probing: If we rendered a filter in the previous frame and are about to render the probe image next, it thinks it still needs to deallocate an image from the last frame, and if the image IDs happen to be the same it will instead deallocate the image that is needed by the probe itself. The fact that filter regions are currently deallocated this way is more than dubious, but I won't bother fixing this now since it will go away with the Vello Hybrid rewrite.

However, I also don't want to fix this issue with a bandaid fix by just trying to `mem::swap` the filter context and any other associated state that we missed, since this is still fragile. Therefore, we instead simply make `probe` create its own `WebGlRenderContext` and therefore leave any other existing contexts untouched. I initially didn't do this because I wanted to avoid having to allocate those additional buffers, but I now think that this is the best and cleanest way.

As a nice side effect, this also _seems_ to fix the CI flakiness, so we can run the probe in CI again.

I verified on a number of low-tier devices that this does not seem to regress the probe time itself.

This PR was done with assistance of GPT5.6-Sol.