### PR TITLE
vello_hybrid: Get specific WebGL error in probe

### DIFF
--- a/sparse_strips/vello_hybrid/src/render/probe.rs
+++ b/sparse_strips/vello_hybrid/src/render/probe.rs
@@ -9,7 +9,7 @@ use crate::render::webgl::{
 };
 use crate::schedule::RootRenderTarget;
 use crate::{RenderError, RenderSize, Scene, WebGlRenderer};
-use alloc::{format, string::String, sync::Arc};
+use alloc::{borrow::Cow, format, sync::Arc};
 use core::ops::Deref;
 use thiserror::Error;
 use vello_common::filter_effects::Filter;
@@ -232,7 +232,7 @@ impl WebGlPendingProbe {
     }
 }
 
-fn webgl_error_name(error: u32) -> String {
+fn webgl_error_name(error: u32) -> Cow<'static, str> {
     let name = match error {
         WebGl2RenderingContext::NO_ERROR => "NO_ERROR",
         WebGl2RenderingContext::INVALID_ENUM => "INVALID_ENUM",
@@ -241,9 +241,10 @@ fn webgl_error_name(error: u32) -> String {
         WebGl2RenderingContext::INVALID_FRAMEBUFFER_OPERATION => "INVALID_FRAMEBUFFER_OPERATION",
         WebGl2RenderingContext::OUT_OF_MEMORY => "OUT_OF_MEMORY",
         WebGl2RenderingContext::CONTEXT_LOST_WEBGL => "CONTEXT_LOST_WEBGL",
-        _ => return format!("UNKNOWN_WEBGL_ERROR ({error:#06x})"),
+        _ => return Cow::Owned(format!("UNKNOWN_WEBGL_ERROR ({error:#06x})")),
     };
-    String::from(name)
+    
+    Cow::Borrowed(name)
 }
 
 impl Drop for WebGlPendingProbe {

--- a/sparse_strips/vello_hybrid/src/render/probe.rs
+++ b/sparse_strips/vello_hybrid/src/render/probe.rs
@@ -243,7 +243,6 @@ fn webgl_error_name(error: u32) -> String {
         WebGl2RenderingContext::CONTEXT_LOST_WEBGL => "CONTEXT_LOST_WEBGL",
         _ => return format!("UNKNOWN_WEBGL_ERROR ({error:#06x})"),
     };
-
     String::from(name)
 }
 

--- a/sparse_strips/vello_hybrid/src/render/probe.rs
+++ b/sparse_strips/vello_hybrid/src/render/probe.rs
@@ -9,7 +9,7 @@ use crate::render::webgl::{
 };
 use crate::schedule::RootRenderTarget;
 use crate::{RenderError, RenderSize, Scene, WebGlRenderer};
-use alloc::sync::Arc;
+use alloc::{format, string::String, sync::Arc};
 use core::ops::Deref;
 use thiserror::Error;
 use vello_common::filter_effects::Filter;
@@ -38,9 +38,9 @@ pub enum WebGlProbeError {
     /// Rendering the probe scene failed.
     #[error("probe render failed: {0}")]
     Render(RenderError),
-    /// Probe readback failed.
-    #[error("probe readback failed")]
-    ReadbackFailed,
+    /// Finishing the probe failed.
+    #[error("probe failed to finish: {}", webgl_error_name(*.0))]
+    FinishFailed(u32),
 }
 
 /// Result of polling the WebGL probe.
@@ -227,9 +227,24 @@ impl WebGlPendingProbe {
         Probe::from_actual(pixmap)
     }
 
-    fn finish_failure(&mut self) -> WebGlProbeError {
-        WebGlProbeError::ReadbackFailed
+    fn finish_failure(&self) -> WebGlProbeError {
+        WebGlProbeError::FinishFailed(self.gl.get_error())
     }
+}
+
+fn webgl_error_name(error: u32) -> String {
+    let name = match error {
+        WebGl2RenderingContext::NO_ERROR => "NO_ERROR",
+        WebGl2RenderingContext::INVALID_ENUM => "INVALID_ENUM",
+        WebGl2RenderingContext::INVALID_VALUE => "INVALID_VALUE",
+        WebGl2RenderingContext::INVALID_OPERATION => "INVALID_OPERATION",
+        WebGl2RenderingContext::INVALID_FRAMEBUFFER_OPERATION => "INVALID_FRAMEBUFFER_OPERATION",
+        WebGl2RenderingContext::OUT_OF_MEMORY => "OUT_OF_MEMORY",
+        WebGl2RenderingContext::CONTEXT_LOST_WEBGL => "CONTEXT_LOST_WEBGL",
+        _ => return format!("UNKNOWN_WEBGL_ERROR ({error:#06x})"),
+    };
+
+    String::from(name)
 }
 
 impl Drop for WebGlPendingProbe {

--- a/sparse_strips/vello_hybrid/src/render/probe.rs
+++ b/sparse_strips/vello_hybrid/src/render/probe.rs
@@ -243,7 +243,7 @@ fn webgl_error_name(error: u32) -> Cow<'static, str> {
         WebGl2RenderingContext::CONTEXT_LOST_WEBGL => "CONTEXT_LOST_WEBGL",
         _ => return Cow::Owned(format!("UNKNOWN_WEBGL_ERROR ({error:#06x})")),
     };
-    
+
     Cow::Borrowed(name)
 }
 


### PR DESCRIPTION
Instead of just returning a generic error, get the specific WebGL error code and return it.