### PR TITLE
vello_hybrid: Atlas texture lifecycle fixes and external-render accessors

### DIFF
--- a/sparse_strips/vello_hybrid/CHANGELOG.md
+++ b/sparse_strips/vello_hybrid/CHANGELOG.md
@@ -19,11 +19,11 @@ This release has an [MSRV][] of 1.88.
 
 ### Changed
 
-- `Renderer::destroy_image` no longer takes an `encoder`; it clears the freed atlas slot through the `queue`. ([#1739][] by [@AdrianEddy][])
+- `Renderer::destroy_image` no longer takes an `encoder` or `queue`, and takes `&Resources`; the destruction is deferred to the start of the next `render` call. ([#1739][] by [@AdrianEddy][])
 
 ### Fixed
 
-- `Renderer::destroy_image` now clears the freed atlas slot via `queue.write_texture`, so a slot reused within the same frame is no longer wiped by the freshly-uploaded image. ([#1739][] by [@AdrianEddy][])
+- `Renderer::destroy_image` now defers retiring the slot until the start of the next `render` call, where the freed region is cleared via `queue.write_texture`. This keeps an already-encoded (but not yet submitted) render sampling the image intact, and orders the clear before any re-upload into the reused region. ([#1739][] by [@AdrianEddy][])
 
 ## [0.2.0][] - 2026-08-07
 

--- a/sparse_strips/vello_hybrid/CHANGELOG.md
+++ b/sparse_strips/vello_hybrid/CHANGELOG.md
@@ -19,11 +19,11 @@ This release has an [MSRV][] of 1.88.
 
 ### Changed
 
-- `Renderer::destroy_image` no longer takes an `encoder`; it clears the freed atlas slot through the `queue`. ([#1739][] by [@AdrianEddy][])
+- `Renderer::destroy_image` no longer takes an `encoder` or `queue`, and takes `&Resources`; the destruction is deferred to the start of the next `render` call. ([#1739][] by [@AdrianEddy][])
 
 ### Fixed
 
-- `Renderer::destroy_image` now clears the freed atlas slot via `queue.write_texture`, so a slot reused within the same frame is no longer wiped by the freshly-uploaded image. ([#1739][] by [@AdrianEddy][])
+- `Renderer::destroy_image` now defers retiring the slot until the start of the next `render` call, where the freed region is cleared via `queue.write_texture`. This keeps an already-encoded (but not yet submitted) render sampling the image intact, and orders the clear before any re-upload into the reused region. ([#1739][] by [@AdrianEddy][])
 
 ## [0.1.0][] - 2026-07-29
 

--- a/sparse_strips/vello_hybrid/CHANGELOG.md
+++ b/sparse_strips/vello_hybrid/CHANGELOG.md
@@ -12,6 +12,19 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 This release has an [MSRV][] of 1.88.
 
+### Added
+
+- `Resources::image_cache`/`image_cache_mut` and `Scene::transform` accessors for driving `render_to_atlas` from external code. ([#1739][] by [@AdrianEddy][])
+- `Renderer::render_to_atlas` takes a `clear_rect: Option<RectU16>` that clears the destination slot to transparent before compositing (for reused slots whose stale pixels would otherwise show through source-over), recorded after the atlas grows and before the scene render. ([#1739][] by [@AdrianEddy][])
+
+### Changed
+
+- `Renderer::destroy_image` no longer takes an `encoder`; it clears the freed atlas slot through the `queue`. ([#1739][] by [@AdrianEddy][])
+
+### Fixed
+
+- `Renderer::destroy_image` now clears the freed atlas slot via `queue.write_texture`, so a slot reused within the same frame is no longer wiped by the freshly-uploaded image. ([#1739][] by [@AdrianEddy][])
+
 ## [0.2.0][] - 2026-08-07
 
 This release has an [MSRV][] of 1.88.
@@ -201,6 +214,7 @@ This is the initial release. No changelog was kept for this release.
 
 See also the [vello_cpu 0.0.4](../vello_cpu/CHANGELOG.md#004---2025-10-17) and [vello_common 0.0.4](../vello_common/CHANGELOG.md#004---2025-10-17) releases.
 
+[@AdrianEddy]: https://github.com/AdrianEddy
 [@DJMcNab]: https://github.com/DJMcNab
 [@b0nes164]: https://github.com/b0nes164
 [@dipeshbabu]: https://github.com/dipeshbabu
@@ -287,6 +301,7 @@ See also the [vello_cpu 0.0.4](../vello_cpu/CHANGELOG.md#004---2025-10-17) and [
 [#1726]: https://github.com/linebender/vello/pull/1726
 [#1734]: https://github.com/linebender/vello/pull/1734
 [#1735]: https://github.com/linebender/vello/pull/1735
+[#1739]: https://github.com/linebender/vello/pull/1739
 [#1747]: https://github.com/linebender/vello/pull/1747
 [#1750]: https://github.com/linebender/vello/pull/1750
 [#1757]: https://github.com/linebender/vello/pull/1757

--- a/sparse_strips/vello_hybrid/CHANGELOG.md
+++ b/sparse_strips/vello_hybrid/CHANGELOG.md
@@ -12,6 +12,19 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 This release has an [MSRV][] of 1.88.
 
+### Added
+
+- `Renderer::reset_atlas_textures` to rebuild the atlas texture array (e.g. after a memory-pressure resource rebuild), plus `Resources::image_cache`/`image_cache_mut` and `Scene::transform` accessors for driving `render_to_atlas` from external code. ([#1739][] by [@AdrianEddy][])
+- `Renderer::render_to_atlas` takes a `clear_rect: Option<RectU16>` that clears the destination slot to transparent before compositing (for reused slots whose stale pixels would otherwise show through source-over), recorded after the atlas grows and before the scene render. ([#1739][] by [@AdrianEddy][])
+
+### Changed
+
+- `Renderer::destroy_image` no longer takes an `encoder`; it clears the freed atlas slot through the `queue`. ([#1739][] by [@AdrianEddy][])
+
+### Fixed
+
+- `Renderer::destroy_image` now clears the freed atlas slot via `queue.write_texture`, so a slot reused within the same frame is no longer wiped by the freshly-uploaded image. ([#1739][] by [@AdrianEddy][])
+
 ## [0.1.0][] - 2026-07-29
 
 This release has an [MSRV][] of 1.88.
@@ -175,6 +188,7 @@ This is the initial release. No changelog was kept for this release.
 
 See also the [vello_cpu 0.0.4](../vello_cpu/CHANGELOG.md#004---2025-10-17) and [vello_common 0.0.4](../vello_common/CHANGELOG.md#004---2025-10-17) releases.
 
+[@AdrianEddy]: https://github.com/AdrianEddy
 [@DJMcNab]: https://github.com/DJMcNab
 [@b0nes164]: https://github.com/b0nes164
 [@dipeshbabu]: https://github.com/dipeshbabu
@@ -261,6 +275,7 @@ See also the [vello_cpu 0.0.4](../vello_cpu/CHANGELOG.md#004---2025-10-17) and [
 [#1726]: https://github.com/linebender/vello/pull/1726
 [#1734]: https://github.com/linebender/vello/pull/1734
 [#1735]: https://github.com/linebender/vello/pull/1735
+[#1739]: https://github.com/linebender/vello/pull/1739
 [#1747]: https://github.com/linebender/vello/pull/1747
 [#1750]: https://github.com/linebender/vello/pull/1750
 [#1757]: https://github.com/linebender/vello/pull/1757

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -164,6 +164,11 @@ pub struct Renderer {
     schedule_storage: ScheduleStorage,
     scratch_buffers: ScratchBuffers,
     layers_config: LayersConfig,
+    /// Images destroyed via [`destroy_image`](Self::destroy_image), awaiting the
+    /// next [`render`](Self::render) call. Their cache slots and atlas regions stay
+    /// allocated (so nothing can reuse them) and the GPU clear is not enqueued
+    /// until then; see `flush_pending_image_destroys` for the ordering argument.
+    pending_image_destroys: Vec<vello_common::paint::ImageId>,
     #[cfg(feature = "text")]
     atlas_clear_scratch: Vec<u8>,
 }
@@ -207,6 +212,7 @@ impl Renderer {
             schedule_storage: ScheduleStorage::default(),
             scratch_buffers: ScratchBuffers::default(),
             layers_config: layer_config,
+            pending_image_destroys: Vec::new(),
             #[cfg(feature = "text")]
             atlas_clear_scratch: Vec::new(),
         }
@@ -230,6 +236,11 @@ impl Renderer {
         view: &TextureView,
         texture_bindings: &TextureBindings,
     ) -> Result<(), RenderError> {
+        // Retire images destroyed since the previous render call, before glyph
+        // maintenance below so freed regions are reusable by this frame's
+        // glyph allocations.
+        self.flush_pending_image_destroys(resources, queue);
+
         #[cfg(feature = "text")]
         {
             resources.before_render(
@@ -614,31 +625,60 @@ impl Renderer {
         );
     }
 
-    /// Destroy an image from the cache and clear the allocated slot in the atlas.
-    pub fn destroy_image(
-        &mut self,
-        resources: &mut Resources,
-        queue: &Queue,
-        image_id: vello_common::paint::ImageId,
-    ) {
-        if let Some(image_resource) = resources.image_cache.deallocate(image_id) {
-            let padding = image_resource.padding as u32;
+    /// Destroy an image: its cache slot and atlas region are retired at the start
+    /// of the next [`render`](Self::render) call, where the freed region is also
+    /// cleared to transparent.
+    ///
+    /// The destruction is deferred, not immediate, to stay correct on both GPU
+    /// orderings involved:
+    ///
+    /// * A clear issued here via `queue.write_texture` would execute before *all*
+    ///   command buffers in the next submit, including a render that was already
+    ///   encoded (but not yet submitted) and still samples this image.
+    /// * A clear recorded on an encoder would execute after *all* queued texture
+    ///   writes in its submit, including a later re-upload into the reused region,
+    ///   wiping it.
+    ///
+    /// Deferring until the next `render` call resolves both: every submit that
+    /// could reference the old content has been made by then (command buffers must
+    /// be submitted before the next `render` call, the same cadence
+    /// [`render_to_atlas`](Self::render_to_atlas) documents), and the region is
+    /// only returned to the allocator at that point, so any re-upload's
+    /// `write_texture` is enqueued after the clear's and stays ordered with it.
+    ///
+    /// `image_id` must belong to the `Resources` that will be passed to that next
+    /// `render` call, and the caller must not reference the image in scenes
+    /// rendered after this call.
+    pub fn destroy_image(&mut self, resources: &Resources, image_id: vello_common::paint::ImageId) {
+        if resources.image_cache.get(image_id).is_some() {
+            self.pending_image_destroys.push(image_id);
+        }
+    }
 
-            // Clear via `queue.write_texture` rather than an encoder pass: wgpu
-            // runs all queued texture writes before any command buffers in a
-            // submit, so an encoder-based clear would land AFTER a same-frame
-            // re-upload into this slot and wipe it. Queue writes stay in call
-            // order.
-            self.clear_atlas_region_via_queue(
-                queue,
-                image_resource.atlas_id,
-                [
-                    image_resource.offset[0] as u32 - padding,
-                    image_resource.offset[1] as u32 - padding,
-                ],
-                image_resource.width as u32 + padding * 2,
-                image_resource.height as u32 + padding * 2,
-            );
+    /// Retire images destroyed since the previous render call: return their slots
+    /// to the image cache and zero the freed atlas regions.
+    ///
+    /// Called at the start of [`render`](Self::render). At that point every
+    /// command buffer that could sample the old content has been submitted, so the
+    /// `write_texture` clears enqueued here execute after those reads (queue
+    /// writes run at the head of the *next* submit). Regions become reusable only
+    /// now, so any subsequent re-upload is enqueued after the clear and queue-write
+    /// call order keeps the pair correct.
+    fn flush_pending_image_destroys(&mut self, resources: &mut Resources, queue: &Queue) {
+        while let Some(image_id) = self.pending_image_destroys.pop() {
+            if let Some(image_resource) = resources.image_cache.deallocate(image_id) {
+                let padding = u32::from(image_resource.padding);
+                self.clear_atlas_region_via_queue(
+                    queue,
+                    image_resource.atlas_id,
+                    [
+                        u32::from(image_resource.offset[0]) - padding,
+                        u32::from(image_resource.offset[1]) - padding,
+                    ],
+                    u32::from(image_resource.width) + padding * 2,
+                    u32::from(image_resource.height) + padding * 2,
+                );
+            }
         }
     }
 
@@ -653,7 +693,12 @@ impl Renderer {
     /// placeholder is zero-initialised, and the next frame grows it back as
     /// needed via `maybe_resize_atlas_texture_array` (which skips the
     /// stale-layer copy while promoting the placeholder).
+    ///
+    /// Destroys still pending from [`destroy_image`](Self::destroy_image) are
+    /// dropped: their `ImageId`s belong to the discarded allocator, and the
+    /// recreated texture has no stale content to clear.
     pub fn reset_atlas_textures(&mut self, device: &Device) {
+        self.pending_image_destroys.clear();
         let (texture, view) = Programs::create_atlas_texture_array(device, 1, 1, 1);
         self.programs.resources.atlas_bind_group = Programs::create_paint_source_bind_group(
             device,

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -243,6 +243,7 @@ impl Renderer {
                             device,
                             queue,
                             atlas_id,
+                            None,
                             texture_bindings,
                         )
                         .expect("Failed to render glyphs to atlas");
@@ -300,6 +301,14 @@ impl Renderer {
     /// `texture_bindings` provides [externally bound textures](`TextureBindings`)
     /// referenced by the scene. Pass `&TextureBindings::new()` if the scene does
     /// not use any.
+    ///
+    /// The scene is composited into the layer with source-over, so a slot that
+    /// is being reused may retain stale pixels underneath the new content. Pass
+    /// `clear_rect` (a region in atlas-layer pixel coordinates) to clear exactly
+    /// that region to transparent first, leaving the rest of the layer intact.
+    /// The clear is recorded on the same encoder, after the atlas is grown to
+    /// fit `atlas_count` and before the scene is composited, so callers do not
+    /// need to size or pre-clear the atlas themselves.
     #[doc(hidden)]
     pub fn render_to_atlas(
         &mut self,
@@ -309,6 +318,7 @@ impl Renderer {
         device: &Device,
         queue: &Queue,
         atlas_id: AtlasId,
+        clear_rect: Option<RectU16>,
         texture_bindings: &TextureBindings,
     ) -> Result<(), RenderError> {
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
@@ -322,6 +332,20 @@ impl Renderer {
             &self.programs.atlas_bind_group_layout,
             atlas_count,
         );
+
+        // Clear the destination slot to transparent before compositing, if
+        // requested. This is recorded after the resize above (so it targets a
+        // correctly sized layer) and before the scene render pass below, and it
+        // leaves the rest of the layer untouched.
+        if let Some(clear_rect) = clear_rect {
+            self.clear_atlas_region(
+                &mut encoder,
+                atlas_id,
+                [u32::from(clear_rect.x0), u32::from(clear_rect.y0)],
+                u32::from(clear_rect.width()),
+                u32::from(clear_rect.height()),
+            );
+        }
 
         let (atlas_width, atlas_height) = atlas_config.atlas_size;
         let atlas_render_size = RenderSize {
@@ -594,14 +618,19 @@ impl Renderer {
     pub fn destroy_image(
         &mut self,
         resources: &mut Resources,
-        encoder: &mut CommandEncoder,
+        queue: &Queue,
         image_id: vello_common::paint::ImageId,
     ) {
         if let Some(image_resource) = resources.image_cache.deallocate(image_id) {
             let padding = image_resource.padding as u32;
 
-            self.clear_atlas_region(
-                encoder,
+            // Clear via `queue.write_texture` rather than an encoder pass: wgpu
+            // runs all queued texture writes before any command buffers in a
+            // submit, so an encoder-based clear would land AFTER a same-frame
+            // re-upload into this slot and wipe it. Queue writes stay in call
+            // order.
+            self.clear_atlas_region_via_queue(
+                queue,
                 image_resource.atlas_id,
                 [
                     image_resource.offset[0] as u32 - padding,
@@ -613,6 +642,68 @@ impl Renderer {
         }
     }
 
+    /// Drop the atlas texture array and recreate it fresh at the placeholder
+    /// (unallocated) state.
+    ///
+    /// Call this whenever the CPU-side [`Resources`] are rebuilt (e.g. on
+    /// memory pressure): the GPU texture array only ever grows and would keep
+    /// the dropped allocator's pixels. Content is composited into the atlas
+    /// with `SrcOver` assuming a freshly allocated slot is transparent, so
+    /// stale pixels would double-blend anti-aliased edges. The recreated
+    /// placeholder is zero-initialised, and the next frame grows it back as
+    /// needed via `maybe_resize_atlas_texture_array` (which skips the
+    /// stale-layer copy while promoting the placeholder).
+    pub fn reset_atlas_textures(&mut self, device: &Device) {
+        let (texture, view) = Programs::create_atlas_texture_array(device, 1, 1, 1);
+        self.programs.resources.atlas_bind_group = Programs::create_paint_source_bind_group(
+            device,
+            &self.programs.atlas_bind_group_layout,
+            &view,
+            &self.programs.resources.placeholder_external_texture_view,
+        );
+        self.programs.resources.atlas_texture_array = texture;
+        self.programs.resources.atlas_texture_array_view = view;
+        self.programs.resources.atlas_layer_count = 0;
+    }
+
+    /// Zero a region of the atlas via `queue.write_texture`, staying ordered
+    /// with `write_texture`-based uploads within a submit (unlike
+    /// [`Self::clear_atlas_region`], which records a render pass).
+    fn clear_atlas_region_via_queue(
+        &self,
+        queue: &Queue,
+        atlas_id: AtlasId,
+        offset: [u32; 2],
+        width: u32,
+        height: u32,
+    ) {
+        let byte_count = width as usize * height as usize * 4;
+        let zeros = vec![0_u8; byte_count];
+        queue.write_texture(
+            wgpu::TexelCopyTextureInfo {
+                texture: &self.programs.resources.atlas_texture_array,
+                mip_level: 0,
+                origin: wgpu::Origin3d {
+                    x: offset[0],
+                    y: offset[1],
+                    z: atlas_id.as_u32(),
+                },
+                aspect: wgpu::TextureAspect::All,
+            },
+            &zeros,
+            wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(width * 4),
+                rows_per_image: Some(height),
+            },
+            Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+        );
+    }
+
     /// Returns a reference to the underlying atlas texture array.
     ///
     /// This is a 2D array texture (`TextureViewDimension::D2Array`) containing all
@@ -622,8 +713,12 @@ impl Renderer {
         &self.programs.resources.atlas_texture_array
     }
 
-    /// Clear a specific region of the atlas texture.
-    fn clear_atlas_region(
+    /// Clear a specific region of the atlas texture by recording a render pass.
+    ///
+    /// For clears that must stay ordered with same-submit `queue.write_texture`
+    /// uploads (e.g. freeing a slot that may be reused the same frame), use
+    /// `clear_atlas_region_via_queue` instead.
+    pub fn clear_atlas_region(
         &mut self,
         encoder: &mut CommandEncoder,
         atlas_id: AtlasId,

--- a/sparse_strips/vello_hybrid/src/render/wgpu/mod.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu/mod.rs
@@ -284,6 +284,7 @@ impl Renderer {
                             device,
                             queue,
                             atlas_id,
+                            None,
                             texture_bindings,
                         )
                         .expect("Failed to render glyphs to atlas");
@@ -342,6 +343,14 @@ impl Renderer {
     /// `texture_bindings` provides [externally bound textures](`TextureBindings`)
     /// referenced by the scene. Pass `&TextureBindings::new()` if the scene does
     /// not use any.
+    ///
+    /// The scene is composited into the layer with source-over, so a slot that
+    /// is being reused may retain stale pixels underneath the new content. Pass
+    /// `clear_rect` (a region in atlas-layer pixel coordinates) to clear exactly
+    /// that region to transparent first, leaving the rest of the layer intact.
+    /// The clear is recorded on the same encoder, after the atlas is grown to
+    /// fit `atlas_count` and before the scene is composited, so callers do not
+    /// need to size or pre-clear the atlas themselves.
     #[doc(hidden)]
     pub fn render_to_atlas(
         &mut self,
@@ -351,6 +360,7 @@ impl Renderer {
         device: &Device,
         queue: &Queue,
         atlas_id: AtlasId,
+        clear_rect: Option<RectU16>,
         texture_bindings: &TextureBindings,
     ) -> Result<(), RenderError> {
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
@@ -364,6 +374,20 @@ impl Renderer {
             &self.programs.atlas_bind_group_layout,
             atlas_count,
         );
+
+        // Clear the destination slot to transparent before compositing, if
+        // requested. This is recorded after the resize above (so it targets a
+        // correctly sized layer) and before the scene render pass below, and it
+        // leaves the rest of the layer untouched.
+        if let Some(clear_rect) = clear_rect {
+            self.clear_atlas_region(
+                &mut encoder,
+                atlas_id,
+                [u32::from(clear_rect.x0), u32::from(clear_rect.y0)],
+                u32::from(clear_rect.width()),
+                u32::from(clear_rect.height()),
+            );
+        }
 
         let (atlas_width, atlas_height) = atlas_config.atlas_size;
         let atlas_render_size = RenderSize {
@@ -640,14 +664,19 @@ impl Renderer {
     pub fn destroy_image(
         &mut self,
         resources: &mut Resources,
-        encoder: &mut CommandEncoder,
+        queue: &Queue,
         image_id: vello_common::paint::ImageId,
     ) {
         if let Some(image_resource) = resources.image_cache.deallocate(image_id) {
             let padding = image_resource.padding as u32;
 
-            self.clear_atlas_region(
-                encoder,
+            // Clear via `queue.write_texture` rather than an encoder pass: wgpu
+            // runs all queued texture writes before any command buffers in a
+            // submit, so an encoder-based clear would land AFTER a same-frame
+            // re-upload into this slot and wipe it. Queue writes stay in call
+            // order.
+            self.clear_atlas_region_via_queue(
+                queue,
                 image_resource.atlas_id,
                 [
                     image_resource.offset[0] as u32 - padding,
@@ -659,6 +688,44 @@ impl Renderer {
         }
     }
 
+    /// Zero a region of the atlas via `queue.write_texture`, staying ordered
+    /// with `write_texture`-based uploads within a submit (unlike
+    /// [`Self::clear_atlas_region`], which records a render pass).
+    fn clear_atlas_region_via_queue(
+        &self,
+        queue: &Queue,
+        atlas_id: AtlasId,
+        offset: [u32; 2],
+        width: u32,
+        height: u32,
+    ) {
+        let byte_count = width as usize * height as usize * 4;
+        let zeros = vec![0_u8; byte_count];
+        queue.write_texture(
+            wgpu::TexelCopyTextureInfo {
+                texture: &self.programs.resources.atlas_texture_array,
+                mip_level: 0,
+                origin: wgpu::Origin3d {
+                    x: offset[0],
+                    y: offset[1],
+                    z: atlas_id.as_u32(),
+                },
+                aspect: wgpu::TextureAspect::All,
+            },
+            &zeros,
+            wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(width * 4),
+                rows_per_image: Some(height),
+            },
+            Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+        );
+    }
+
     /// Returns a reference to the underlying atlas texture array.
     ///
     /// This is a 2D array texture (`TextureViewDimension::D2Array`) containing all
@@ -668,8 +735,12 @@ impl Renderer {
         &self.programs.resources.atlas_texture_array
     }
 
-    /// Clear a specific region of the atlas texture.
-    fn clear_atlas_region(
+    /// Clear a specific region of the atlas texture by recording a render pass.
+    ///
+    /// For clears that must stay ordered with same-submit `queue.write_texture`
+    /// uploads (e.g. freeing a slot that may be reused the same frame), use
+    /// `clear_atlas_region_via_queue` instead.
+    pub fn clear_atlas_region(
         &mut self,
         encoder: &mut CommandEncoder,
         atlas_id: AtlasId,

--- a/sparse_strips/vello_hybrid/src/render/wgpu/mod.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu/mod.rs
@@ -162,6 +162,11 @@ pub struct Renderer {
     schedule_storage: ScheduleStorage,
     scratch_buffers: ScratchBuffers,
     layers_config: LayersConfig,
+    /// Images destroyed via [`destroy_image`](Self::destroy_image), awaiting the
+    /// next [`render`](Self::render) call. Their cache slots and atlas regions stay
+    /// allocated (so nothing can reuse them) and the GPU clear is not enqueued
+    /// until then; see `flush_pending_image_destroys` for the ordering argument.
+    pending_image_destroys: Vec<vello_common::paint::ImageId>,
     #[cfg(feature = "text")]
     atlas_clear_scratch: Vec<u8>,
 }
@@ -210,6 +215,7 @@ impl Renderer {
             schedule_storage: ScheduleStorage::default(),
             scratch_buffers: ScratchBuffers::default(),
             layers_config: layer_config,
+            pending_image_destroys: Vec::new(),
             #[cfg(feature = "text")]
             atlas_clear_scratch: Vec::new(),
         };
@@ -271,6 +277,11 @@ impl Renderer {
         depth_view: Option<&TextureView>,
         texture_bindings: &TextureBindings,
     ) -> Result<(), RenderError> {
+        // Retire images destroyed since the previous render call, before glyph
+        // maintenance below so freed regions are reusable by this frame's
+        // glyph allocations.
+        self.flush_pending_image_destroys(resources, queue);
+
         #[cfg(feature = "text")]
         {
             resources.before_render(
@@ -660,31 +671,60 @@ impl Renderer {
         );
     }
 
-    /// Destroy an image from the cache and clear the allocated slot in the atlas.
-    pub fn destroy_image(
-        &mut self,
-        resources: &mut Resources,
-        queue: &Queue,
-        image_id: vello_common::paint::ImageId,
-    ) {
-        if let Some(image_resource) = resources.image_cache.deallocate(image_id) {
-            let padding = image_resource.padding as u32;
+    /// Destroy an image: its cache slot and atlas region are retired at the start
+    /// of the next [`render`](Self::render) call, where the freed region is also
+    /// cleared to transparent.
+    ///
+    /// The destruction is deferred, not immediate, to stay correct on both GPU
+    /// orderings involved:
+    ///
+    /// * A clear issued here via `queue.write_texture` would execute before *all*
+    ///   command buffers in the next submit, including a render that was already
+    ///   encoded (but not yet submitted) and still samples this image.
+    /// * A clear recorded on an encoder would execute after *all* queued texture
+    ///   writes in its submit, including a later re-upload into the reused region,
+    ///   wiping it.
+    ///
+    /// Deferring until the next `render` call resolves both: every submit that
+    /// could reference the old content has been made by then (command buffers must
+    /// be submitted before the next `render` call, the same cadence
+    /// [`render_to_atlas`](Self::render_to_atlas) documents), and the region is
+    /// only returned to the allocator at that point, so any re-upload's
+    /// `write_texture` is enqueued after the clear's and stays ordered with it.
+    ///
+    /// `image_id` must belong to the `Resources` that will be passed to that next
+    /// `render` call, and the caller must not reference the image in scenes
+    /// rendered after this call.
+    pub fn destroy_image(&mut self, resources: &Resources, image_id: vello_common::paint::ImageId) {
+        if resources.image_cache.get(image_id).is_some() {
+            self.pending_image_destroys.push(image_id);
+        }
+    }
 
-            // Clear via `queue.write_texture` rather than an encoder pass: wgpu
-            // runs all queued texture writes before any command buffers in a
-            // submit, so an encoder-based clear would land AFTER a same-frame
-            // re-upload into this slot and wipe it. Queue writes stay in call
-            // order.
-            self.clear_atlas_region_via_queue(
-                queue,
-                image_resource.atlas_id,
-                [
-                    image_resource.offset[0] as u32 - padding,
-                    image_resource.offset[1] as u32 - padding,
-                ],
-                image_resource.width as u32 + padding * 2,
-                image_resource.height as u32 + padding * 2,
-            );
+    /// Retire images destroyed since the previous render call: return their slots
+    /// to the image cache and zero the freed atlas regions.
+    ///
+    /// Called at the start of [`render`](Self::render). At that point every
+    /// command buffer that could sample the old content has been submitted, so the
+    /// `write_texture` clears enqueued here execute after those reads (queue
+    /// writes run at the head of the *next* submit). Regions become reusable only
+    /// now, so any subsequent re-upload is enqueued after the clear and queue-write
+    /// call order keeps the pair correct.
+    fn flush_pending_image_destroys(&mut self, resources: &mut Resources, queue: &Queue) {
+        while let Some(image_id) = self.pending_image_destroys.pop() {
+            if let Some(image_resource) = resources.image_cache.deallocate(image_id) {
+                let padding = u32::from(image_resource.padding);
+                self.clear_atlas_region_via_queue(
+                    queue,
+                    image_resource.atlas_id,
+                    [
+                        u32::from(image_resource.offset[0]) - padding,
+                        u32::from(image_resource.offset[1]) - padding,
+                    ],
+                    u32::from(image_resource.width) + padding * 2,
+                    u32::from(image_resource.height) + padding * 2,
+                );
+            }
         }
     }
 

--- a/sparse_strips/vello_hybrid/src/resources.rs
+++ b/sparse_strips/vello_hybrid/src/resources.rs
@@ -33,4 +33,19 @@ impl Resources {
             glyph_resources: None,
         }
     }
+
+    /// Shared access to the image atlas cache.
+    pub fn image_cache(&self) -> &ImageCache {
+        &self.image_cache
+    }
+
+    /// Exclusive access to the image atlas cache.
+    ///
+    /// Deallocating directly through this handle frees the CPU-side slot
+    /// without clearing the freed region on the GPU; prefer
+    /// [`Renderer::destroy_image`](crate::Renderer::destroy_image) unless you
+    /// clear the region yourself.
+    pub fn image_cache_mut(&mut self) -> &mut ImageCache {
+        &mut self.image_cache
+    }
 }

--- a/sparse_strips/vello_hybrid/src/resources.rs
+++ b/sparse_strips/vello_hybrid/src/resources.rs
@@ -47,6 +47,21 @@ impl Resources {
             glyph_resources: None,
         }
     }
+
+    /// Shared access to the image atlas cache.
+    pub fn image_cache(&self) -> &ImageCache {
+        &self.image_cache
+    }
+
+    /// Exclusive access to the image atlas cache.
+    ///
+    /// Deallocating directly through this handle frees the CPU-side slot
+    /// without clearing the freed region on the GPU; prefer
+    /// [`Renderer::destroy_image`](crate::Renderer::destroy_image) unless you
+    /// clear the region yourself.
+    pub fn image_cache_mut(&mut self) -> &mut ImageCache {
+        &mut self.image_cache
+    }
 }
 
 impl Default for Resources {

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -854,6 +854,11 @@ impl Scene {
         self.render_state.fill_rule = fill_rule;
     }
 
+    /// The transform currently applied to subsequent rendering operations.
+    pub fn transform(&self) -> Affine {
+        *self.transforms().transform()
+    }
+
     /// Set the transform for subsequent rendering operations.
     pub fn set_transform(&mut self, transform: Affine) {
         self.transforms_mut().set_transform(transform);

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -904,6 +904,11 @@ impl Scene {
         self.render_state.fill_rule = fill_rule;
     }
 
+    /// The transform currently applied to subsequent rendering operations.
+    pub fn transform(&self) -> Affine {
+        *self.transforms().transform()
+    }
+
     /// Set the transform for subsequent rendering operations.
     pub fn set_transform(&mut self, transform: Affine) {
         self.transforms_mut().set_transform(transform);

--- a/sparse_strips/vello_sparse_tests/tests/renderer.rs
+++ b/sparse_strips/vello_sparse_tests/tests/renderer.rs
@@ -962,3 +962,65 @@ impl Renderer for HybridRenderer {
         self.upload_image(&pixmap)
     }
 }
+
+/// An atlas slot that is freed and immediately reused by a new image must
+/// render the *new* image. Regression test for `destroy_image` clearing the
+/// freed slot via an encoder pass, which wgpu orders after all queued texture
+/// writes in a submit and so wiped the re-uploaded pixels.
+#[cfg(not(all(target_arch = "wasm32", feature = "webgl")))]
+#[test]
+fn atlas_slot_reuse_survives_same_frame_destroy() {
+    use vello_common::color::palette::css::{GREEN, RED};
+    use vello_common::color::{AlphaColor, Srgb};
+    use vello_common::paint::Image;
+    use vello_common::peniko::ImageSampler;
+
+    fn solid(color: AlphaColor<Srgb>) -> Arc<Pixmap> {
+        let mut pixmap = Pixmap::new(4, 4);
+        pixmap.data_mut().fill(color.premultiply().to_rgba8());
+        Arc::new(pixmap)
+    }
+
+    let mut h = HybridRenderer::new_with_settings(16, 16, HybridRenderSettings::default());
+
+    let red_id = h.upload_image_with_resources(&solid(RED), "red");
+    let red_slot = {
+        let r = h.resources.image_cache().get(red_id).expect("red uploaded");
+        (r.atlas_id.as_u32(), r.offset)
+    };
+
+    h.renderer.destroy_image(&mut h.resources, &h.queue, red_id);
+
+    let green_id = h.upload_image_with_resources(&solid(GREEN), "green");
+    let green_slot = {
+        let g = h
+            .resources
+            .image_cache()
+            .get(green_id)
+            .expect("green uploaded");
+        (g.atlas_id.as_u32(), g.offset)
+    };
+    assert_eq!(
+        red_slot, green_slot,
+        "green must reuse red's freed atlas slot to exercise the reuse hazard"
+    );
+
+    h.scene.set_paint(Image {
+        image: ImageSource::opaque_id_with_transparency_hint(green_id, false),
+        sampler: ImageSampler::default(),
+    });
+    h.scene.fill_rect(&Rect::new(0.0, 0.0, 16.0, 16.0));
+
+    let mut out = Pixmap::new(16, 16);
+    h.render_to_pixmap(&mut out);
+
+    let center = out.sample(8, 8);
+    assert_eq!(
+        center.a, 255,
+        "reused slot must render opaque, got {center:?}"
+    );
+    assert!(
+        center.g > center.r && center.g > center.b,
+        "reused slot must render the green image, got {center:?}"
+    );
+}

--- a/sparse_strips/vello_sparse_tests/tests/renderer.rs
+++ b/sparse_strips/vello_sparse_tests/tests/renderer.rs
@@ -1045,10 +1045,11 @@ impl Renderer for HybridRenderer {
     }
 }
 
-/// An atlas slot that is freed and immediately reused by a new image must
-/// render the *new* image. Regression test for `destroy_image` clearing the
-/// freed slot via an encoder pass, which wgpu orders after all queued texture
-/// writes in a submit and so wiped the re-uploaded pixels.
+/// An atlas slot that is freed and reused by a new image must render the
+/// *new* image. Regression test for `destroy_image` clearing the freed slot
+/// via an encoder pass, which wgpu orders after all queued texture writes in
+/// a submit and so wiped the re-uploaded pixels; with deferred destruction
+/// this pins that the flush's clear stays ordered before the re-upload.
 #[cfg(not(all(target_arch = "wasm32", feature = "webgl")))]
 #[test]
 fn atlas_slot_reuse_survives_same_frame_destroy() {
@@ -1071,7 +1072,12 @@ fn atlas_slot_reuse_survives_same_frame_destroy() {
         (r.atlas_id.as_u32(), r.offset)
     };
 
-    h.renderer.destroy_image(&mut h.resources, &h.queue, red_id);
+    h.renderer.destroy_image(&h.resources, red_id);
+
+    // The destroy is deferred to the next render call; drive one (empty)
+    // render so the slot is cleared and returned to the allocator.
+    let mut flush_out = Pixmap::new(16, 16);
+    h.render_to_pixmap(&mut flush_out);
 
     let green_id = h.upload_image_with_resources(&solid(GREEN), "green");
     let green_slot = {
@@ -1104,5 +1110,111 @@ fn atlas_slot_reuse_survives_same_frame_destroy() {
     assert!(
         center.g > center.r && center.g > center.b,
         "reused slot must render the green image, got {center:?}"
+    );
+}
+
+/// An image destroyed after a render referencing it has been *encoded*, but
+/// before that encoder is *submitted*, must still render intact. Regression
+/// test for `destroy_image` clearing the slot eagerly through
+/// `queue.write_texture`, which wgpu executes before all command buffers of
+/// the next submit — including the already-encoded render.
+#[cfg(not(all(target_arch = "wasm32", feature = "webgl")))]
+#[test]
+fn destroyed_image_survives_already_encoded_render() {
+    use vello_common::color::palette::css::RED;
+    use vello_common::paint::Image;
+    use vello_common::peniko::ImageSampler;
+
+    const SIZE: u16 = 16;
+
+    let mut h =
+        HybridRenderer::new_with_settings(SIZE, SIZE, HybridRenderSettings::default(), true);
+
+    let mut pixmap = Pixmap::new(4, 4);
+    pixmap.data_mut().fill(RED.premultiply().to_rgba8());
+    let red_id = h.upload_image_with_resources(&Arc::new(pixmap), "red");
+
+    h.scene.set_paint(Image {
+        image: ImageSource::opaque_id_with_transparency_hint(red_id, false),
+        sampler: ImageSampler::default(),
+    });
+    h.scene
+        .fill_rect(&Rect::new(0.0, 0.0, f64::from(SIZE), f64::from(SIZE)));
+
+    let render_size = vello_hybrid::RenderSize {
+        width: SIZE.into(),
+        height: SIZE.into(),
+    };
+    let mut encoder = h
+        .device
+        .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("render before destroy"),
+        });
+    h.renderer
+        .render(
+            &h.scene,
+            &mut h.resources,
+            &h.device,
+            &h.queue,
+            &mut encoder,
+            &render_size,
+            &h.texture_view,
+            h.depth_texture_view.as_ref(),
+            &vello_hybrid::TextureBindings::new(),
+        )
+        .unwrap();
+
+    // Destroy after encoding and before submitting: the encoded render must
+    // still sample the red image when it executes.
+    h.renderer.destroy_image(&h.resources, red_id);
+
+    let bytes_per_row = (u32::from(SIZE) * 4).next_multiple_of(256);
+    let readback = h.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("readback"),
+        size: u64::from(bytes_per_row) * u64::from(SIZE),
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+    encoder.copy_texture_to_buffer(
+        wgpu::TexelCopyTextureInfo {
+            texture: &h.texture,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::TexelCopyBufferInfo {
+            buffer: &readback,
+            layout: wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(bytes_per_row),
+                rows_per_image: None,
+            },
+        },
+        wgpu::Extent3d {
+            width: SIZE.into(),
+            height: SIZE.into(),
+            depth_or_array_layers: 1,
+        },
+    );
+    h.queue.submit([encoder.finish()]);
+
+    readback
+        .slice(..)
+        .map_async(wgpu::MapMode::Read, move |result| {
+            if result.is_err() {
+                panic!("Failed to map texture for reading");
+            }
+        });
+    h.device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
+
+    let data = readback.slice(..).get_mapped_range();
+    let px = &data[8 * bytes_per_row as usize + 8 * 4..][..4];
+    assert_eq!(
+        px[3], 255,
+        "already-encoded render must stay opaque, got {px:?}"
+    );
+    assert!(
+        px[0] > px[1] && px[0] > px[2],
+        "already-encoded render must still sample the red image, got {px:?}"
     );
 }

--- a/sparse_strips/vello_sparse_tests/tests/renderer.rs
+++ b/sparse_strips/vello_sparse_tests/tests/renderer.rs
@@ -963,10 +963,11 @@ impl Renderer for HybridRenderer {
     }
 }
 
-/// An atlas slot that is freed and immediately reused by a new image must
-/// render the *new* image. Regression test for `destroy_image` clearing the
-/// freed slot via an encoder pass, which wgpu orders after all queued texture
-/// writes in a submit and so wiped the re-uploaded pixels.
+/// An atlas slot that is freed and reused by a new image must render the
+/// *new* image. Regression test for `destroy_image` clearing the freed slot
+/// via an encoder pass, which wgpu orders after all queued texture writes in
+/// a submit and so wiped the re-uploaded pixels; with deferred destruction
+/// this pins that the flush's clear stays ordered before the re-upload.
 #[cfg(not(all(target_arch = "wasm32", feature = "webgl")))]
 #[test]
 fn atlas_slot_reuse_survives_same_frame_destroy() {
@@ -989,7 +990,12 @@ fn atlas_slot_reuse_survives_same_frame_destroy() {
         (r.atlas_id.as_u32(), r.offset)
     };
 
-    h.renderer.destroy_image(&mut h.resources, &h.queue, red_id);
+    h.renderer.destroy_image(&h.resources, red_id);
+
+    // The destroy is deferred to the next render call; drive one (empty)
+    // render so the slot is cleared and returned to the allocator.
+    let mut flush_out = Pixmap::new(16, 16);
+    h.render_to_pixmap(&mut flush_out);
 
     let green_id = h.upload_image_with_resources(&solid(GREEN), "green");
     let green_slot = {
@@ -1022,5 +1028,109 @@ fn atlas_slot_reuse_survives_same_frame_destroy() {
     assert!(
         center.g > center.r && center.g > center.b,
         "reused slot must render the green image, got {center:?}"
+    );
+}
+
+/// An image destroyed after a render referencing it has been *encoded*, but
+/// before that encoder is *submitted*, must still render intact. Regression
+/// test for `destroy_image` clearing the slot eagerly through
+/// `queue.write_texture`, which wgpu executes before all command buffers of
+/// the next submit — including the already-encoded render.
+#[cfg(not(all(target_arch = "wasm32", feature = "webgl")))]
+#[test]
+fn destroyed_image_survives_already_encoded_render() {
+    use vello_common::color::palette::css::RED;
+    use vello_common::paint::Image;
+    use vello_common::peniko::ImageSampler;
+
+    const SIZE: u16 = 16;
+
+    let mut h = HybridRenderer::new_with_settings(SIZE, SIZE, HybridRenderSettings::default());
+
+    let mut pixmap = Pixmap::new(4, 4);
+    pixmap.data_mut().fill(RED.premultiply().to_rgba8());
+    let red_id = h.upload_image_with_resources(&Arc::new(pixmap), "red");
+
+    h.scene.set_paint(Image {
+        image: ImageSource::opaque_id_with_transparency_hint(red_id, false),
+        sampler: ImageSampler::default(),
+    });
+    h.scene
+        .fill_rect(&Rect::new(0.0, 0.0, f64::from(SIZE), f64::from(SIZE)));
+
+    let render_size = vello_hybrid::RenderSize {
+        width: SIZE.into(),
+        height: SIZE.into(),
+    };
+    let mut encoder = h
+        .device
+        .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("render before destroy"),
+        });
+    h.renderer
+        .render(
+            &h.scene,
+            &mut h.resources,
+            &h.device,
+            &h.queue,
+            &mut encoder,
+            &render_size,
+            &h.texture_view,
+            &vello_hybrid::TextureBindings::new(),
+        )
+        .unwrap();
+
+    // Destroy after encoding and before submitting: the encoded render must
+    // still sample the red image when it executes.
+    h.renderer.destroy_image(&h.resources, red_id);
+
+    let bytes_per_row = (u32::from(SIZE) * 4).next_multiple_of(256);
+    let readback = h.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("readback"),
+        size: u64::from(bytes_per_row) * u64::from(SIZE),
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+    encoder.copy_texture_to_buffer(
+        wgpu::TexelCopyTextureInfo {
+            texture: &h.texture,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::TexelCopyBufferInfo {
+            buffer: &readback,
+            layout: wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(bytes_per_row),
+                rows_per_image: None,
+            },
+        },
+        wgpu::Extent3d {
+            width: SIZE.into(),
+            height: SIZE.into(),
+            depth_or_array_layers: 1,
+        },
+    );
+    h.queue.submit([encoder.finish()]);
+
+    readback
+        .slice(..)
+        .map_async(wgpu::MapMode::Read, move |result| {
+            if result.is_err() {
+                panic!("Failed to map texture for reading");
+            }
+        });
+    h.device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
+
+    let data = readback.slice(..).get_mapped_range();
+    let px = &data[8 * bytes_per_row as usize + 8 * 4..][..4];
+    assert_eq!(
+        px[3], 255,
+        "already-encoded render must stay opaque, got {px:?}"
+    );
+    assert!(
+        px[0] > px[1] && px[0] > px[2],
+        "already-encoded render must still sample the red image, got {px:?}"
     );
 }

--- a/sparse_strips/vello_sparse_tests/tests/renderer.rs
+++ b/sparse_strips/vello_sparse_tests/tests/renderer.rs
@@ -1044,3 +1044,65 @@ impl Renderer for HybridRenderer {
         self.upload_image(&pixmap)
     }
 }
+
+/// An atlas slot that is freed and immediately reused by a new image must
+/// render the *new* image. Regression test for `destroy_image` clearing the
+/// freed slot via an encoder pass, which wgpu orders after all queued texture
+/// writes in a submit and so wiped the re-uploaded pixels.
+#[cfg(not(all(target_arch = "wasm32", feature = "webgl")))]
+#[test]
+fn atlas_slot_reuse_survives_same_frame_destroy() {
+    use vello_common::color::palette::css::{GREEN, RED};
+    use vello_common::color::{AlphaColor, Srgb};
+    use vello_common::paint::Image;
+    use vello_common::peniko::ImageSampler;
+
+    fn solid(color: AlphaColor<Srgb>) -> Arc<Pixmap> {
+        let mut pixmap = Pixmap::new(4, 4);
+        pixmap.data_mut().fill(color.premultiply().to_rgba8());
+        Arc::new(pixmap)
+    }
+
+    let mut h = HybridRenderer::new_with_settings(16, 16, HybridRenderSettings::default(), true);
+
+    let red_id = h.upload_image_with_resources(&solid(RED), "red");
+    let red_slot = {
+        let r = h.resources.image_cache().get(red_id).expect("red uploaded");
+        (r.atlas_id.as_u32(), r.offset)
+    };
+
+    h.renderer.destroy_image(&mut h.resources, &h.queue, red_id);
+
+    let green_id = h.upload_image_with_resources(&solid(GREEN), "green");
+    let green_slot = {
+        let g = h
+            .resources
+            .image_cache()
+            .get(green_id)
+            .expect("green uploaded");
+        (g.atlas_id.as_u32(), g.offset)
+    };
+    assert_eq!(
+        red_slot, green_slot,
+        "green must reuse red's freed atlas slot to exercise the reuse hazard"
+    );
+
+    h.scene.set_paint(Image {
+        image: ImageSource::opaque_id_with_transparency_hint(green_id, false),
+        sampler: ImageSampler::default(),
+    });
+    h.scene.fill_rect(&Rect::new(0.0, 0.0, 16.0, 16.0));
+
+    let mut out = Pixmap::new(16, 16);
+    h.render_to_pixmap(&mut out);
+
+    let center = out.sample(8, 8);
+    assert_eq!(
+        center.a, 255,
+        "reused slot must render opaque, got {center:?}"
+    );
+    assert!(
+        center.g > center.r && center.g > center.b,
+        "reused slot must render the green image, got {center:?}"
+    );
+}


### PR DESCRIPTION
Two related atlas lifecycle fixes for hosts that manage image/glyph atlases and rasterize vector content into atlas layers, plus the accessors external atlas driving needs:

- **`destroy_image` ordering fix** — destruction is now deferred to the start of the next `render` call, where the freed slot is zeroed via `queue.write_texture` and returned to the allocator. This solves both orderings: an already-encoded (but not yet submitted) render still samples the image intact (queued texture writes run before the command buffers of the *next* submit), and a slot reused within the same frame is no longer wiped after its fresh upload (queue writes run in call order).
- **`render_to_atlas` slot clearing** — a new `clear_rect: Option<RectU16>` clears the destination slot to transparent before compositing (recorded after the atlas grows, before the scene render), so content rendered into a *reused* slot doesn't blend over stale pixels — the atlas is composited with `SrcOver` under the freshly-allocated-slots-are-transparent invariant.
- **External-render accessors** — `Resources::image_cache`/`image_cache_mut` and `Scene::transform`, so external code can drive `render_to_atlas`.

**API note (breaking):** `Renderer::destroy_image` now takes `&Resources` and an `ImageId`; the `encoder` parameter is gone and `resources` is no longer `&mut` (the actual deallocation happens inside the next `render`).

**Tests:** two GPU regression tests — `atlas_slot_reuse_survives_same_frame_destroy` (destroy → reuse → render must show the new image) and `destroyed_image_survives_already_encoded_render` (destroy after encoding but before submitting — the encoded render must still sample the image).

<sub>This PR was generated by Claude.</sub>
