### PR TITLE
vello_common: Remove failing test

### DIFF
--- a/sparse_strips/vello_common/src/clip.rs
+++ b/sparse_strips/vello_common/src/clip.rs
@@ -846,28 +846,6 @@ mod tests {
         run_test(expected, path, cover);
     }
 
-    #[test]
-    fn row_iterator_zero_width_alpha_region() {
-        let mut path = StripStorage::default();
-        path.strips.push(Strip::new(8, 0, 0, false));
-        path.strips.push(Strip::new(16, 0, 0, true));
-        path.strips.push(Strip::sentinel(0, 0));
-        let path_ref = path_ref(&path);
-
-        let mut idx = 0;
-        let iter = RowIterator::new(path_ref, &mut idx, 0);
-
-        assert_eq!(iter.cur_strip_width(), 0);
-        let fill = iter.cur_strip_fill_area().unwrap();
-        assert_eq!(fill.start, 8);
-        assert_eq!(fill.width, 8);
-
-        let cover = StripBuilder::new().add_strip(0, 0, 20, false).finish();
-        let expected = StripBuilder::new().add_strip(8, 0, 16, false).finish();
-
-        run_test(expected, path, cover);
-    }
-
     fn run_test(expected: StripStorage, path_1: StripStorage, path_2: StripStorage) {
         let mut write_target = StripStorage::default();
 


### PR DESCRIPTION
This test fails since #1714, the reason is that since the PR we ensure that no zero-width strips can be emitted at places other than the row end. 

```
---- clip::tests::row_iterator_zero_width_alpha_region stdout ----

thread 'clip::tests::row_iterator_zero_width_alpha_region' (957770) panicked at sparse_strips/vello_common/src/clip.rs:549:17:
zero-width strips must only appear at the end of a row
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    clip::tests::row_iterator_zero_width_alpha_region
```

This is true for our current strip generation code, so the assertion is correct, but of course in a unit test it's still possible to manually construct such strip. The reason this wasn't caught in the PR is that we run tests in release mode now. :( We should probably consider running at least the `vello_common` (and maybe `vello_cpu`) unit tests in debug mode in CI.