### PR TITLE
fix: don't allocate filter atlas textures for scenes without filters

### DIFF
--- a/sparse_strips/vello_hybrid/examples/wgpu_webgl/src/lib.rs
+++ b/sparse_strips/vello_hybrid/examples/wgpu_webgl/src/lib.rs
@@ -98,7 +98,7 @@ impl RendererWrapper {
             },
             RenderSettings {
                 level: Level::try_detect().unwrap_or(Level::baseline()),
-                atlas_config: AtlasConfig {
+                image_atlas_config: AtlasConfig {
                     atlas_size: (max_texture_dimension_2d, max_texture_dimension_2d),
                     ..AtlasConfig::default()
                 },

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -205,12 +205,12 @@ impl WebGlRenderer {
             max_texture_array_layers,
             1,
         );
-        // Filter scratch textures are individual 2D textures (not a D2Array), so they can start
-        // at zero and only be allocated on demand when a scene actually uses filters.
         normalize_atlas_config(
             &mut settings.filter_atlas_config,
             max_texture_dimension_2d,
             max_texture_array_layers,
+            // Filter scratch textures are individual 2D textures (not a D2Array), so they can
+            // start at zero and only be allocated on demand when a scene actually uses filters.
             0,
         );
         let total_slots: usize = (max_texture_dimension_2d / u32::from(Tile::HEIGHT)) as usize;

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -198,11 +198,20 @@ impl WebGlRenderer {
 
         let mut settings = settings;
         let max_texture_dimension_2d = get_max_texture_dimension_2d(&gl);
+        let max_texture_array_layers = get_max_texture_array_layers(&gl);
         normalize_atlas_config(
-            &mut settings.atlas_config,
+            &mut settings.image_atlas_config,
             max_texture_dimension_2d,
-            get_max_texture_array_layers(&gl),
+            max_texture_array_layers,
             1,
+        );
+        // Filter scratch textures are individual 2D textures (not a D2Array), so they can start
+        // at zero and only be allocated on demand when a scene actually uses filters.
+        normalize_atlas_config(
+            &mut settings.filter_atlas_config,
+            max_texture_dimension_2d,
+            max_texture_array_layers,
+            0,
         );
         let total_slots: usize = (max_texture_dimension_2d / u32::from(Tile::HEIGHT)) as usize;
         assert!(
@@ -213,13 +222,13 @@ impl WebGlRenderer {
                 >= 24.0,
             "Depth buffer must be at least 24 bits"
         );
-        let image_cache = ImageCache::new_with_config(settings.atlas_config);
+        let image_cache = ImageCache::new_with_config(settings.image_atlas_config);
         // Estimate the maximum number of gradient cache entries based on the max texture dimension
         // and the maximum gradient LUT size - worst case scenario.
         let max_gradient_cache_size =
             max_texture_dimension_2d * max_texture_dimension_2d / MAX_GRADIENT_LUT_SIZE as u32;
         let gradient_cache = GradientRampCache::new(max_gradient_cache_size, settings.level);
-        let filter_context = FilterContext::new(settings.atlas_config);
+        let filter_context = FilterContext::new(settings.filter_atlas_config);
 
         Self {
             programs: WebGlPrograms::new(gl.clone(), &image_cache, &filter_context, total_slots),

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -196,21 +196,31 @@ impl Renderer {
         let min_initial_atlas_count = 2;
         #[cfg(not(target_arch = "wasm32"))]
         let min_initial_atlas_count = 1;
+        let max_texture_array_layers = device.limits().max_texture_array_layers;
         normalize_atlas_config(
-            &mut settings.atlas_config,
+            &mut settings.image_atlas_config,
             max_texture_dimension_2d,
-            device.limits().max_texture_array_layers,
+            max_texture_array_layers,
             min_initial_atlas_count,
         );
+        // Filter scratch textures are individual 2D textures (see `FilterAtlasState`), not a
+        // D2Array, so the GLES D2/D2Array workaround above does not apply. They can start at zero
+        // and only be allocated on demand when a scene actually uses filters.
+        normalize_atlas_config(
+            &mut settings.filter_atlas_config,
+            max_texture_dimension_2d,
+            max_texture_array_layers,
+            0,
+        );
         let total_slots = (max_texture_dimension_2d / u32::from(Tile::HEIGHT)) as usize;
-        let image_cache = ImageCache::new_with_config(settings.atlas_config);
+        let image_cache = ImageCache::new_with_config(settings.image_atlas_config);
         // Estimate the maximum number of gradient cache entries based on the max texture dimension
         // and the maximum gradient LUT size - worst case scenario.
         let max_gradient_cache_size =
             max_texture_dimension_2d * max_texture_dimension_2d / MAX_GRADIENT_LUT_SIZE as u32;
         let gradient_cache = GradientRampCache::new(max_gradient_cache_size, settings.level);
 
-        let filter_context = FilterContext::new(settings.atlas_config);
+        let filter_context = FilterContext::new(settings.filter_atlas_config);
         Self {
             programs: Programs::new(
                 device,

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -168,10 +168,10 @@ impl SceneConstraints {
 pub struct RenderSettings {
     /// The SIMD level that should be used for rendering operations.
     pub level: Level,
-    /// The configuration for the texture atlas.
+    /// The configuration for the image/glyph texture atlas.
     ///
-    /// This controls how images are managed in GPU memory through texture atlases.
-    /// The atlas system packs multiple images into larger textures to reduce the
+    /// This controls how uploaded images and glyphs are managed in GPU memory through texture
+    /// atlases. The atlas system packs multiple images into larger textures to reduce the
     /// number of GPU texture bindings. This config allows customizing atlas parameters such as:
     /// - The number and size of atlases
     /// - How images are allocated across multiple atlases
@@ -179,7 +179,12 @@ pub struct RenderSettings {
     ///
     /// Adjusting these settings can affect memory usage and rendering performance
     /// depending on your application's image usage patterns.
-    pub atlas_config: AtlasConfig,
+    pub image_atlas_config: AtlasConfig,
+    /// The configuration for the filter scratch texture atlas.
+    ///
+    /// Filters (e.g. blurs) render intermediate results into their own set of scratch atlas
+    /// textures, independent from the image/glyph atlas.
+    pub filter_atlas_config: AtlasConfig,
     /// Constraints on the scene that the renderer can exploit for optimisation.
     pub constraints: SceneConstraints,
 }
@@ -188,7 +193,13 @@ impl Default for RenderSettings {
     fn default() -> Self {
         Self {
             level: Level::try_detect().unwrap_or(Level::baseline()),
-            atlas_config: AtlasConfig::default(),
+            image_atlas_config: AtlasConfig::default(),
+            filter_atlas_config: AtlasConfig {
+                // Filter scratch textures are only needed when a scene actually uses filters,
+                // so start with none and let `auto_grow` allocate them on demand.
+                initial_atlas_count: 0,
+                ..AtlasConfig::default()
+            },
             constraints: SceneConstraints::new(),
         }
     }

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -183,7 +183,7 @@ pub struct RenderSettings {
     /// The configuration for the filter scratch texture atlas.
     ///
     /// Filters (e.g. blurs) render intermediate results into their own set of scratch atlas
-    /// textures, independent from the image/glyph atlas.
+    /// textures, separate from the image/glyph atlas.
     pub filter_atlas_config: AtlasConfig,
     /// Constraints on the scene that the renderer can exploit for optimisation.
     pub constraints: SceneConstraints,


### PR DESCRIPTION
### Problem
On the vello_hybrid backends (webgl2 and wgpu), a renderer allocated filter scratch atlas texture(s) on its first frame even when the scene contained no filters — 64 MiB per texture at the default 4096² config, and 128 MiB on the wasm/wgpu path where the initial atlas count is forced to 2.

### Root Cause
`RenderSettings` exposed a single `atlas_config` shared by both the image/glyph atlas and the filter atlas. The number of filter scratch textures created (`maybe_resize_filter_atlas_textures` on webgl, `FilterAtlasState::ensure_count` on wgpu) is driven by the filter cache's `atlas_count()`, which equals `initial_atlas_count`. Because the shared config defaulted to `initial_atlas_count = 1` (and 2 on wasm for the GLES D2/D2Array workaround), the filter atlas always started with at least one atlas and materialized full-size scratch textures on the first render, regardless of whether any filter ran.

### Solution
Split `atlas_config` into two independent configs on `RenderSettings`: `image_atlas_config` (defaults unchanged) and `filter_atlas_config` (defaults to `initial_atlas_count = 0`). Each backend normalizes them separately — the image config keeps its `min_initial_atlas_count` (1, or 2 on wasm), while the filter config uses 0, since filter scratch textures are individual 2D textures and are not subject to the `D2Array` workaround. With `auto_grow`, filter atlases are now created lazily on the first actual filter pass, so filterless scenes allocate zero filter textures on both backends.

Created with assistance from Claude Opus 4.8 High.