### PR TITLE
vello_cpu: Don't unset flushed status in `MultiThreadedDispatcher.reset`

### DIFF
--- a/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
@@ -596,7 +596,6 @@ impl Dispatcher for MultiThreadedDispatcher {
         self.allocation_group.clear();
         self.batch_cost = 0.0;
         self.task_idx = 0;
-        self.flushed = false;
         self.layer_depth = 0;
         self.task_sender = None;
         self.recorded_command_receiver = None;


### PR DESCRIPTION
Follow up to #1732

This adds additional workload and would introduce some extra flush when task queue is empty.
cc @xiaochengh