### PR TITLE
sparse_strips: Introduce `Padding` type and streamline clip handling

### DIFF
--- a/sparse_strips/vello_common/src/clip.rs
+++ b/sparse_strips/vello_common/src/clip.rs
@@ -8,14 +8,12 @@ use crate::kurbo::{Affine, BezPath, PathEl};
 use crate::strip::Strip;
 use crate::strip_generator::{GenerationMode, StripGenerator, StripStorage};
 use crate::tile::Tile;
-use crate::util::{Clear, Pool, normalized_mul_u8x16};
+use crate::util::{Clear, Pool, normalized_mul_u8x16, strip_bbox};
 use alloc::vec;
 use alloc::vec::Vec;
 use core::ops::Range;
 use fearless_simd::{Level, Simd, SimdBase, dispatch, u8x16};
 use peniko::Fill;
-
-use crate::util;
 
 #[derive(Debug)]
 struct ClipData {
@@ -91,7 +89,7 @@ impl ClipContext {
     #[inline]
     pub fn push_clip(
         &mut self,
-        clip_path: impl IntoIterator<Item = PathEl> + Clone,
+        clip_path: impl IntoIterator<Item = PathEl>,
         strip_generator: &mut StripGenerator,
         fill_rule: Fill,
         transform: Affine,
@@ -101,31 +99,6 @@ impl ClipContext {
 
         let alpha_start = self.storage.alphas.len() as u32;
         let strip_start = self.storage.strips.len() as u32;
-
-        // Calculate a coarse bounding box of the path. If the path is empty, the bounding box is
-        // an infinite and inversed `kurbo::Rect`. This is harmless in practice: an empty path does
-        // not produce any strips.
-        //
-        // Note this iterates `clip_path`, which means we iterate it twice: once here, and once in
-        // flattening. If we ever take an iterator instead, or want to prevent iterating twice, we
-        // could move this calculation into flattening (perhaps with a const-generic as to not
-        // pessimize calls that don't require the bbox).
-        let mut bbox = util::control_point_bbox_u16(clip_path.clone(), transform);
-
-        // Intersect with the existing clip bounding box, or the viewport if this is the outermost
-        // clip.
-        if let Some(existing) = self.clip_stack.last() {
-            bbox = bbox.intersect(existing.bbox);
-        } else {
-            bbox.x1 = bbox.x1.min(strip_generator.width());
-            bbox.y1 = bbox.y1.min(strip_generator.height());
-        }
-
-        let clip_data = ClipData {
-            alpha_start,
-            strip_start,
-            bbox,
-        };
 
         let existing_clip = self
             .clip_stack
@@ -140,6 +113,13 @@ impl ClipContext {
             &mut self.temp_storage,
             existing_clip,
         );
+
+        let bbox = strip_bbox(&self.temp_storage.strips).unwrap_or(RectU16::ZERO);
+        let clip_data = ClipData {
+            alpha_start,
+            strip_start,
+            bbox,
+        };
 
         self.storage.extend(&self.temp_storage);
         self.clip_stack.push(clip_data);
@@ -338,8 +318,7 @@ pub struct PathDataRef<'a> {
     pub strips: &'a [Strip],
     /// The alpha buffer.
     pub alphas: &'a [u8],
-
-    /// A coarse bounding box of the clip path in pixel coordinates.
+    /// A tile-aligned coarse bounding box of the clip path in pixel coordinates.
     ///
     /// These bounds have already been intersected with the viewport.
     pub bbox: RectU16,

--- a/sparse_strips/vello_common/src/coarse.rs
+++ b/sparse_strips/vello_common/src/coarse.rs
@@ -285,10 +285,12 @@ impl WideTilesBbox {
         }
     }
 
-    /// Update this bounding box to include another bounding box (union in place).
+    /// Update this bounding box to include another bounding box.
     #[inline(always)]
     pub(crate) fn union(&mut self, other: Self) {
-        self.bbox.union(other.bbox);
+        if !other.is_empty() {
+            self.bbox.union(other.bbox);
+        }
     }
 
     /// Update the bbox to include the given tile coordinates.

--- a/sparse_strips/vello_common/src/filter/mod.rs
+++ b/sparse_strips/vello_common/src/filter/mod.rs
@@ -12,8 +12,9 @@ use crate::filter::flood::Flood;
 use crate::filter::gaussian_blur::{GaussianBlur, transform_blur_params};
 use crate::filter::offset::Offset;
 use crate::filter_effects::{Filter, FilterPrimitive};
-use crate::geometry::RectU16;
+use crate::geometry::{PaddingU16, RectU16};
 use crate::kurbo::{Affine, Rect, Vec2};
+use crate::tile::Tile;
 use crate::util::RectExt;
 
 pub mod drop_shadow;
@@ -169,35 +170,38 @@ pub struct FilterData {
     /// Padding that needs to be added for the area where the filter is applied.
     ///
     /// See [`Filter::filter_expansion`].
-    pub filter_padding: RectU16,
+    pub filter_padding: PaddingU16,
     /// Padding that needs to be added to the source region for correct filter application.
     ///
     /// See [`Filter::source_expansion`].
-    pub source_padding: RectU16,
+    pub source_padding: PaddingU16,
 }
 
 impl FilterData {
     /// Create precomputed data for a filter and transform.
     pub fn new(filter: Filter, transform: Affine) -> Self {
-        fn expansion_padding(expansion: Rect) -> RectU16 {
+        fn snapped_padding(expansion: Rect) -> PaddingU16 {
             // TODO: We technically shouldn't need to snap here. `source_padding` is only
             // used to shift the contents when rendering into the render context, and the
             // final pixmap bbox (which is derived from `filter_expansion` will be snapped
             // separately. However, not snapping here causes larger mismatches with Vello Hybrid
             // since the size of the final pixmap determines in which way we decimate for the
             // gaussian blur filter. Therefore, we keep this for compatibility.
-            let expansion = expansion.snap_to_tile_coordinates();
+            fn snap_up(value: f64, step: u16) -> u16 {
+                let step = f64::from(step);
+                ((value / step).ceil() * step) as u16
+            }
 
-            RectU16::new(
-                (-expansion.x0) as u16,
-                (-expansion.y0) as u16,
-                expansion.x1 as u16,
-                expansion.y1 as u16,
+            PaddingU16::new(
+                snap_up(-expansion.x0, Tile::WIDTH),
+                snap_up(-expansion.y0, Tile::HEIGHT),
+                snap_up(expansion.x1, Tile::WIDTH),
+                snap_up(expansion.y1, Tile::HEIGHT),
             )
         }
 
-        let source_padding = expansion_padding(filter.source_expansion(&transform));
-        let filter_padding = expansion_padding(filter.filter_expansion(&transform));
+        let source_padding = snapped_padding(filter.source_expansion(&transform));
+        let filter_padding = snapped_padding(filter.filter_expansion(&transform));
 
         Self {
             filter,
@@ -210,7 +214,7 @@ impl FilterData {
     /// By how much to shift all rendered contents to ensure that all rendered contents
     /// are visible in the viewport [0, 0, width, height].
     pub fn source_shift(&self) -> (u16, u16) {
-        (self.source_padding.x0, self.source_padding.y0)
+        (self.source_padding.left, self.source_padding.top)
     }
 }
 

--- a/sparse_strips/vello_common/src/filter/mod.rs
+++ b/sparse_strips/vello_common/src/filter/mod.rs
@@ -13,6 +13,8 @@ use crate::filter::gaussian_blur::{GaussianBlur, transform_blur_params};
 use crate::filter::offset::Offset;
 use crate::filter_effects::{Filter, FilterPrimitive};
 use crate::geometry::{PaddingU16, RectU16};
+#[cfg(not(feature = "std"))]
+use crate::kurbo::common::FloatFuncs as _;
 use crate::kurbo::{Affine, Rect, Vec2};
 use crate::tile::Tile;
 use crate::util::RectExt;
@@ -113,13 +115,17 @@ pub struct FilterLayerPlacement {
 
 impl FilterLayerPlacement {
     pub(crate) const EMPTY: Self = Self {
-        pixmap_bbox: RectU16::INVERTED,
-        dest_bbox: RectU16::INVERTED,
+        pixmap_bbox: RectU16::ZERO,
+        dest_bbox: RectU16::ZERO,
         src_x: 0,
         src_y: 0,
     };
 
     pub(crate) fn new(bbox: RectU16, filter_plan: &FilterData) -> Self {
+        if bbox.is_empty() {
+            return Self::EMPTY;
+        }
+
         // Some more detailed explanations of what's going on here since this
         // part is a bit confusing.
 

--- a/sparse_strips/vello_common/src/filter/mod.rs
+++ b/sparse_strips/vello_common/src/filter/mod.rs
@@ -186,6 +186,14 @@ impl FilterData {
     /// Create precomputed data for a filter and transform.
     pub fn new(filter: Filter, transform: Affine) -> Self {
         fn snapped_padding(expansion: Rect) -> PaddingU16 {
+            debug_assert!(
+                expansion.x0 <= 0.0
+                    && expansion.y0 <= 0.0
+                    && expansion.x1 >= 0.0
+                    && expansion.y1 >= 0.0,
+                "filter expansion must contain the origin"
+            );
+
             // TODO: We technically shouldn't need to snap here. `source_padding` is only
             // used to shift the contents when rendering into the render context, and the
             // final pixmap bbox (which is derived from `filter_expansion` will be snapped

--- a/sparse_strips/vello_common/src/filter/mod.rs
+++ b/sparse_strips/vello_common/src/filter/mod.rs
@@ -13,9 +13,8 @@ use crate::filter::gaussian_blur::{GaussianBlur, transform_blur_params};
 use crate::filter::offset::Offset;
 use crate::filter_effects::{Filter, FilterPrimitive};
 use crate::geometry::{PaddingU16, RectU16};
-#[cfg(not(feature = "std"))]
-use crate::kurbo::common::FloatFuncs as _;
 use crate::kurbo::{Affine, Rect, Vec2};
+use crate::math::snap_up;
 use crate::tile::Tile;
 use crate::util::RectExt;
 
@@ -193,16 +192,11 @@ impl FilterData {
             // separately. However, not snapping here causes larger mismatches with Vello Hybrid
             // since the size of the final pixmap determines in which way we decimate for the
             // gaussian blur filter. Therefore, we keep this for compatibility.
-            fn snap_up(value: f64, step: u16) -> u16 {
-                let step = f64::from(step);
-                ((value / step).ceil() * step) as u16
-            }
-
             PaddingU16::new(
-                snap_up(-expansion.x0, Tile::WIDTH),
-                snap_up(-expansion.y0, Tile::HEIGHT),
-                snap_up(expansion.x1, Tile::WIDTH),
-                snap_up(expansion.y1, Tile::HEIGHT),
+                snap_up(-expansion.x0, Tile::WIDTH) as u16,
+                snap_up(-expansion.y0, Tile::HEIGHT) as u16,
+                snap_up(expansion.x1, Tile::WIDTH) as u16,
+                snap_up(expansion.y1, Tile::HEIGHT) as u16,
             )
         }
 

--- a/sparse_strips/vello_common/src/geometry.rs
+++ b/sparse_strips/vello_common/src/geometry.rs
@@ -184,15 +184,15 @@ impl RectU16 {
 
     /// Compute the intersection of two rectangles.
     ///
-    /// The result may be empty if the rectangles do not overlap.
+    /// The result may have zero area if the rectangles do not overlap, but is never inverted.
     #[inline(always)]
     pub const fn intersect(self, other: Self) -> Self {
-        Self {
-            x0: const_max(self.x0, other.x0),
-            y0: const_max(self.y0, other.y0),
-            x1: const_min(self.x1, other.x1),
-            y1: const_min(self.y1, other.y1),
-        }
+        let x0 = const_max(self.x0, other.x0);
+        let y0 = const_max(self.y0, other.y0);
+        let x1 = const_min(self.x1, other.x1);
+        let y1 = const_min(self.y1, other.y1);
+
+        Self::new(x0, y0, const_max(x1, x0), const_max(y1, y0))
     }
 
     /// Expand this rectangle by the given left, top, right, and bottom padding.
@@ -456,5 +456,15 @@ mod tests {
         let rect = RectU16::new(10, 20, 30, 40);
 
         assert_eq!(rect.relative_to_origin((20, 35)), RectU16::new(0, 0, 10, 5));
+    }
+
+    #[test]
+    fn disjoint_intersection_is_empty_but_not_inverted() {
+        let intersection = RectU16::new(0, 0, 4, 4).intersect(RectU16::new(8, 1, 12, 3));
+
+        assert_eq!(intersection, RectU16::new(8, 1, 8, 3));
+        assert!(intersection.is_empty());
+        assert!(intersection.x0 <= intersection.x1);
+        assert!(intersection.y0 <= intersection.y1);
     }
 }

--- a/sparse_strips/vello_common/src/geometry.rs
+++ b/sparse_strips/vello_common/src/geometry.rs
@@ -85,6 +85,34 @@ impl Add<u16> for SizeU16 {
     }
 }
 
+/// Padding for the four sides of a region.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct PaddingU16 {
+    /// The left padding.
+    pub left: u16,
+    /// The top padding.
+    pub top: u16,
+    /// The right padding.
+    pub right: u16,
+    /// The bottom padding.
+    pub bottom: u16,
+}
+
+impl PaddingU16 {
+    /// Padding with all sides set to zero.
+    pub const ZERO: Self = Self::new(0, 0, 0, 0);
+
+    /// Create padding from its left, top, right, and bottom amounts.
+    pub const fn new(left: u16, top: u16, right: u16, bottom: u16) -> Self {
+        Self {
+            left,
+            top,
+            right,
+            bottom,
+        }
+    }
+}
+
 /// An axis-aligned rectangle with `u16` coordinates, stored as two corners `(x0, y0)` and
 /// `(x1, y1)`.
 ///
@@ -169,12 +197,12 @@ impl RectU16 {
 
     /// Expand this rectangle by the given left, top, right, and bottom padding.
     #[inline(always)]
-    pub const fn expand(self, padding: Self) -> Self {
+    pub const fn expand(self, padding: PaddingU16) -> Self {
         Self {
-            x0: self.x0.saturating_sub(padding.x0),
-            y0: self.y0.saturating_sub(padding.y0),
-            x1: self.x1.saturating_add(padding.x1),
-            y1: self.y1.saturating_add(padding.y1),
+            x0: self.x0.saturating_sub(padding.left),
+            y0: self.y0.saturating_sub(padding.top),
+            x1: self.x1.saturating_add(padding.right),
+            y1: self.y1.saturating_add(padding.bottom),
         }
     }
 

--- a/sparse_strips/vello_common/src/math.rs
+++ b/sparse_strips/vello_common/src/math.rs
@@ -7,6 +7,13 @@ use core::ops::Sub;
 #[cfg(not(feature = "std"))]
 use peniko::kurbo::common::FloatFuncs as _;
 
+/// Round `value` up to the next multiple of `step`.
+#[inline]
+pub(crate) fn snap_up(value: f64, step: u16) -> f64 {
+    let step = f64::from(step);
+    (value / step).ceil() * step
+}
+
 // See https://raphlinus.github.io/audio/2018/09/05/sigmoid.html for a little
 // explanation of this approximation to the erf function.
 /// Approximate the erf function.

--- a/sparse_strips/vello_common/src/record.rs
+++ b/sparse_strips/vello_common/src/record.rs
@@ -44,8 +44,9 @@ use smallvec::SmallVec;
 
 /// A drawable object that can report its bounding box.
 pub trait Drawable {
-    /// Return the bounding box of the given object.
-    fn bbox(&self, strips: &[Strip]) -> RectU16;
+    /// Return the **tile-aligned** bounding box of the given object, if it
+    /// has one.
+    fn bbox(&self, strips: &[Strip]) -> Option<RectU16>;
 }
 
 /// A node in the recorded render graph.
@@ -75,7 +76,7 @@ pub struct RecordedLayer {
     pub kind: RecordedLayerKind,
     /// Nesting depth of the layer.
     pub depth: usize,
-    /// Bounding box of the layer.
+    /// Tile-aligned bounding box of the layer.
     pub bbox: RectU16,
 }
 
@@ -99,7 +100,7 @@ pub struct LayerClip {
     pub strip_range: Range<usize>,
     /// Index of the thread-local strip storage containing the strips.
     pub thread_idx: u8,
-    /// Coarse bounds of the clip path.
+    /// Tile-aligned bounds of the clip path.
     pub bbox: RectU16,
 }
 
@@ -126,7 +127,7 @@ impl RecordedLayer {
             kind: RecordedLayerKind::Regular,
             depth,
             // Will be initialized once we call `pop_layer`.
-            bbox: RectU16::INVERTED,
+            bbox: RectU16::ZERO,
         }
     }
 
@@ -141,7 +142,7 @@ impl RecordedLayer {
             },
             depth,
             // Will be initialized once we call `pop_layer`.
-            bbox: RectU16::INVERTED,
+            bbox: RectU16::ZERO,
         }
     }
 }
@@ -294,15 +295,26 @@ impl<D> CommandRecorder<D> {
             let recorded_layer = &mut self.layers[id as usize];
             match &mut recorded_layer.kind {
                 RecordedLayerKind::Regular => {
-                    recorded_layer.bbox = layer.bbox;
+                    let mut bbox = layer.bbox;
 
-                    let layer_size = layer.bbox.into();
+                    // Turn the potentially still-inverted bbox into a zero-sized one.
+                    if bbox.is_empty() {
+                        bbox = RectU16::ZERO;
+                    }
+
+                    if let Some(clip_path) = &recorded_layer.props.clip_path {
+                        bbox = bbox.intersect(clip_path.bbox);
+                    }
+
+                    recorded_layer.bbox = bbox;
+
+                    let layer_size = bbox.into();
                     self.largest_layer_size = Some(
                         self.largest_layer_size
                             .map_or(layer_size, |current| current.max(layer_size)),
                     );
 
-                    (PoppedLayer::Regular, layer.bbox)
+                    (PoppedLayer::Regular, bbox)
                 }
                 RecordedLayerKind::Filter {
                     filter_data: filter_plan,
@@ -328,7 +340,7 @@ impl<D> CommandRecorder<D> {
 
         // Update the parent bbox as well.
         self.active_layer = layer.parent_layer;
-        self.record_bbox(|| bbox_in_parent);
+        self.record_bbox(|| Some(bbox_in_parent));
 
         popped_layer
     }
@@ -370,10 +382,16 @@ impl<D> CommandRecorder<D> {
         id
     }
 
-    fn record_bbox(&mut self, bbox: impl FnOnce() -> RectU16) {
-        if let Some(layer) = self.layer_stack.last_mut() {
-            layer.bbox.union(bbox());
-        }
+    fn record_bbox(&mut self, bbox: impl FnOnce() -> Option<RectU16>) {
+        let Some(layer) = self.layer_stack.last_mut() else {
+            return;
+        };
+
+        let Some(bbox) = bbox().and_then(|b| if b.is_empty() { None } else { Some(b) }) else {
+            return;
+        };
+
+        layer.bbox.union(bbox);
     }
 }
 
@@ -429,8 +447,17 @@ mod tests {
     struct TestDraw;
 
     impl Drawable for TestDraw {
-        fn bbox(&self, _strips: &[Strip]) -> RectU16 {
-            RectU16::new(0, 0, 64, 4)
+        fn bbox(&self, _strips: &[Strip]) -> Option<RectU16> {
+            Some(RectU16::new(0, 0, 64, 4))
+        }
+    }
+
+    #[derive(Debug)]
+    struct EmptyDraw;
+
+    impl Drawable for EmptyDraw {
+        fn bbox(&self, _strips: &[Strip]) -> Option<RectU16> {
+            None
         }
     }
 
@@ -592,6 +619,33 @@ mod tests {
         };
 
         assert_eq!(node.draws_in(&draws), &[1, 2]);
+    }
+
+    #[test]
+    fn empty_draws_do_not_affect_layer_bounds() {
+        let mut recorder = CommandRecorder::<EmptyDraw>::new(DEFAULT_SIZE, DEFAULT_SIZE);
+        recorder.push_layer(layer_props(), None);
+        recorder.push_draw(EmptyDraw, &[]);
+        recorder.pop_layer();
+
+        assert!(recorder.layers[0].bbox.is_empty());
+    }
+
+    #[test]
+    fn disjoint_layer_bounds_are_empty_but_not_inverted() {
+        let mut recorder = CommandRecorder::<TestDraw>::new(DEFAULT_SIZE, DEFAULT_SIZE);
+        let mut props = layer_props();
+        props.clip_path = Some(LayerClip {
+            strip_range: 0..0,
+            thread_idx: 0,
+            bbox: RectU16::new(8, 8, 12, 12),
+        });
+
+        recorder.push_layer(props, None);
+        recorder.push_draw(TestDraw, &[]);
+        recorder.pop_layer();
+
+        assert_eq!(recorder.layers[0].bbox, RectU16::new(8, 8, 12, 8));
     }
 
     #[test]

--- a/sparse_strips/vello_common/src/record.rs
+++ b/sparse_strips/vello_common/src/record.rs
@@ -418,6 +418,7 @@ pub enum PoppedLayer {
 mod tests {
     use super::*;
     use crate::filter_effects::{Filter, FilterPrimitive};
+    use crate::geometry::PaddingU16;
     use crate::kurbo::Affine;
     use crate::peniko::Mix;
     use crate::tile::Tile;
@@ -449,7 +450,7 @@ mod tests {
         }
     }
 
-    fn filter_data(filter_padding: RectU16, source_padding: RectU16) -> FilterData {
+    fn filter_data(filter_padding: PaddingU16, source_padding: PaddingU16) -> FilterData {
         FilterData {
             filter: Filter::from_primitive(FilterPrimitive::Offset { dx: 0.0, dy: 0.0 }),
             transform: Affine::IDENTITY,
@@ -490,7 +491,7 @@ mod tests {
     fn filter_placement_padding_expands_bbox() {
         let placement = FilterLayerPlacement::new(
             RectU16::new(8, 8, 16, 20),
-            &filter_data(RectU16::new(2, 4, 6, 8), RectU16::ZERO),
+            &filter_data(PaddingU16::new(2, 4, 6, 8), PaddingU16::ZERO),
         );
 
         // Since we are tile-aligned, values are expanded to a multiple of tile-size.
@@ -503,7 +504,7 @@ mod tests {
     fn filter_placement_with_source_shift() {
         let placement = FilterLayerPlacement::new(
             RectU16::new(8, 12, 20, 24),
-            &filter_data(RectU16::new(6, 2, 4, 6), RectU16::new(10, 16, 0, 0)),
+            &filter_data(PaddingU16::new(6, 2, 4, 6), PaddingU16::new(10, 16, 0, 0)),
         );
 
         // Bbox expanded with padding is [8 - 6, 12 - 2, 20 + 4, 24 + 6]
@@ -522,11 +523,11 @@ mod tests {
 
         recorder.push_layer(
             layer_props(),
-            Some(filter_data(RectU16::ZERO, RectU16::ZERO)),
+            Some(filter_data(PaddingU16::ZERO, PaddingU16::ZERO)),
         );
         recorder.push_layer(
             layer_props(),
-            Some(filter_data(RectU16::ZERO, RectU16::ZERO)),
+            Some(filter_data(PaddingU16::ZERO, PaddingU16::ZERO)),
         );
         recorder.push_layer(layer_props(), None);
 
@@ -618,7 +619,7 @@ mod tests {
         recorder.push_layer(blended_layer_props(), None);
         recorder.push_layer(
             layer_props(),
-            Some(filter_data(RectU16::ZERO, RectU16::ZERO)),
+            Some(filter_data(PaddingU16::ZERO, PaddingU16::ZERO)),
         );
         recorder.push_draw(TestDraw, &[]);
         recorder.pop_layer();

--- a/sparse_strips/vello_common/src/util.rs
+++ b/sparse_strips/vello_common/src/util.rs
@@ -4,7 +4,6 @@
 //! Utility functions.
 
 use crate::geometry::RectU16;
-use crate::kurbo::PathEl;
 use crate::math::FloatExt;
 use crate::strip::{Strip, visit_strip_fill_segments};
 use crate::tile::Tile;
@@ -140,9 +139,16 @@ pub trait RectExt {
 impl RectExt for Rect {
     #[inline]
     fn snap_to_tile_coordinates(self) -> Self {
+        let x0 = snap_down(self.x0, Tile::WIDTH);
+        let y0 = snap_down(self.y0, Tile::HEIGHT);
+
+        if self.is_zero_area() {
+            return Self::new(x0, y0, x0, y0);
+        }
+
         Self::new(
-            snap_down(self.x0, Tile::WIDTH),
-            snap_down(self.y0, Tile::HEIGHT),
+            x0,
+            y0,
             snap_up(self.x1, Tile::WIDTH),
             snap_up(self.y1, Tile::HEIGHT),
         )
@@ -152,15 +158,21 @@ impl RectExt for Rect {
 impl RectExt for RectU16 {
     #[inline]
     fn snap_to_tile_coordinates(self) -> Self {
+        // This method will panic if we have a viewport of size u16::MAX and draw
+        // at the very edge, but better than returning a wrong result.
+
+        let x0 = (self.x0 / Tile::WIDTH).checked_mul(Tile::WIDTH).unwrap();
+        let y0 = (self.y0 / Tile::HEIGHT).checked_mul(Tile::HEIGHT).unwrap();
+
+        if self.is_empty() {
+            return Self::new(x0, y0, x0, y0);
+        }
+
         Self::new(
-            (self.x0 / Tile::WIDTH) * Tile::WIDTH,
-            (self.y0 / Tile::HEIGHT) * Tile::HEIGHT,
-            self.x1
-                .checked_next_multiple_of(Tile::WIDTH)
-                .unwrap_or(u16::MAX),
-            self.y1
-                .checked_next_multiple_of(Tile::HEIGHT)
-                .unwrap_or(u16::MAX),
+            x0,
+            y0,
+            self.x1.checked_next_multiple_of(Tile::WIDTH).unwrap(),
+            self.y1.checked_next_multiple_of(Tile::HEIGHT).unwrap(),
         )
     }
 }
@@ -330,57 +342,8 @@ impl<T> IndexMut<usize> for RetainVec<T> {
     }
 }
 
-/// Compute a conservative bounding box for the transformed path by computing the bounding box of
-/// the transformed control points.
-///
-/// If `path` is empty, this returns an infinite, inversed [`Rect`] (`left` > `right` and `top` > `bottom`).
-pub fn control_point_bbox(path: impl IntoIterator<Item = PathEl>, transform: Affine) -> Rect {
-    // Start with an infinite, inversed rectangle. Adding the first point immediately collapses it
-    // without branching.
-    let mut bbox = Rect::new(
-        f64::INFINITY,
-        f64::INFINITY,
-        f64::NEG_INFINITY,
-        f64::NEG_INFINITY,
-    );
-    for el in path {
-        match el {
-            PathEl::MoveTo(p) | PathEl::LineTo(p) => {
-                bbox = bbox.union_pt(transform * p);
-            }
-            PathEl::QuadTo(p1, p2) => {
-                bbox = bbox.union_pt(transform * p1);
-                bbox = bbox.union_pt(transform * p2);
-            }
-            PathEl::CurveTo(p1, p2, p3) => {
-                bbox = bbox.union_pt(transform * p1);
-                bbox = bbox.union_pt(transform * p2);
-                bbox = bbox.union_pt(transform * p3);
-            }
-            PathEl::ClosePath => {}
-        }
-    }
-    bbox
-}
-
-/// Compute a conservative bounding box for the transformed path in pixel coordinates.
-///
-/// If `path` is empty, this returns an inverted [`RectU16`].
-pub fn control_point_bbox_u16(
-    path: impl IntoIterator<Item = PathEl>,
-    transform: Affine,
-) -> RectU16 {
-    let bbox = control_point_bbox(path, transform);
-    RectU16::new(
-        bbox.x0 as u16,
-        bbox.y0 as u16,
-        bbox.x1.ceil() as u16,
-        bbox.y1.ceil() as u16,
-    )
-}
-
 /// Calculate the bounding box of the strips.
-pub fn strip_bbox(strips: &[Strip]) -> RectU16 {
+pub fn strip_bbox(strips: &[Strip]) -> Option<RectU16> {
     // Fill and alpha fill segments internally store their coordinates in tile units,
     // in order to avoid multiplications in every invocation of the closure we calculate
     // the bbox in tile units first and then convert back to pixel units.
@@ -401,14 +364,14 @@ pub fn strip_bbox(strips: &[Strip]) -> RectU16 {
 
     // Convert to pixel units.
     if tile_bbox.is_empty() {
-        tile_bbox
+        None
     } else {
-        RectU16::new(
-            tile_bbox.x0.saturating_mul(Tile::WIDTH),
-            tile_bbox.y0.saturating_mul(Tile::HEIGHT),
-            tile_bbox.x1.saturating_mul(Tile::WIDTH),
-            tile_bbox.y1.saturating_mul(Tile::HEIGHT),
-        )
+        Some(RectU16::new(
+            tile_bbox.x0.checked_mul(Tile::WIDTH).unwrap(),
+            tile_bbox.y0.checked_mul(Tile::HEIGHT).unwrap(),
+            tile_bbox.x1.checked_mul(Tile::WIDTH).unwrap(),
+            tile_bbox.y1.checked_mul(Tile::HEIGHT).unwrap(),
+        ))
     }
 }
 
@@ -437,10 +400,22 @@ mod tests {
     }
 
     #[test]
+    fn snap_to_tile_coordinates_preserves_empty_rects() {
+        assert_eq!(
+            Rect::new(5.0, 3.0, 5.0, 7.0).snap_to_tile_coordinates(),
+            Rect::new(4.0, 0.0, 4.0, 0.0)
+        );
+        assert_eq!(
+            RectU16::new(5, 3, 9, 3).snap_to_tile_coordinates(),
+            RectU16::new(4, 0, 4, 0)
+        );
+    }
+
+    #[test]
     fn empty_strip_bbox() {
         let strips = [Strip::sentinel(0, 0)];
 
-        assert_eq!(strip_bbox(&strips), RectU16::INVERTED);
+        assert_eq!(strip_bbox(&strips), None);
     }
 
     #[test]
@@ -450,7 +425,7 @@ mod tests {
             sentinel(4, u32::from(Tile::HEIGHT) * 4),
         ];
 
-        assert_eq!(strip_bbox(&strips), RectU16::new(8, 4, 12, 8));
+        assert_eq!(strip_bbox(&strips), Some(RectU16::new(8, 4, 12, 8)));
     }
 
     #[test]
@@ -461,7 +436,7 @@ mod tests {
             sentinel(0, u32::from(Tile::HEIGHT) * 8),
         ];
 
-        assert_eq!(strip_bbox(&strips), RectU16::new(4, 0, 24, 4));
+        assert_eq!(strip_bbox(&strips), Some(RectU16::new(4, 0, 24, 4)));
     }
 
     #[test]
@@ -472,7 +447,7 @@ mod tests {
             sentinel(0, u32::from(Tile::HEIGHT) * 4),
         ];
 
-        assert_eq!(strip_bbox(&strips), RectU16::new(4, 0, 32, 4));
+        assert_eq!(strip_bbox(&strips), Some(RectU16::new(4, 0, 32, 4)));
     }
 
     #[test]
@@ -483,6 +458,6 @@ mod tests {
             sentinel(8, u32::from(Tile::HEIGHT) * 8),
         ];
 
-        assert_eq!(strip_bbox(&strips), RectU16::new(4, 0, 16, 12));
+        assert_eq!(strip_bbox(&strips), Some(RectU16::new(4, 0, 16, 12)));
     }
 }

--- a/sparse_strips/vello_common/src/util.rs
+++ b/sparse_strips/vello_common/src/util.rs
@@ -4,7 +4,7 @@
 //! Utility functions.
 
 use crate::geometry::RectU16;
-use crate::math::FloatExt;
+use crate::math::{FloatExt, snap_up};
 use crate::strip::{Strip, visit_strip_fill_segments};
 use crate::tile::Tile;
 use alloc::vec::Vec;
@@ -181,12 +181,6 @@ impl RectExt for RectU16 {
 fn snap_down(value: f64, step: u16) -> f64 {
     let step = f64::from(step);
     (value / step).floor() * step
-}
-
-#[inline]
-fn snap_up(value: f64, step: u16) -> f64 {
-    let step = f64::from(step);
-    (value / step).ceil() * step
 }
 
 /// A type that can be cleared.

--- a/sparse_strips/vello_common/src/viewport.rs
+++ b/sparse_strips/vello_common/src/viewport.rs
@@ -90,13 +90,13 @@ impl ViewportState {
         let width = self
             .strip_generator
             .width()
-            .saturating_add(padding.x0)
-            .saturating_add(padding.x1);
+            .saturating_add(padding.left)
+            .saturating_add(padding.right);
         let height = self
             .strip_generator
             .height()
-            .saturating_add(padding.y0)
-            .saturating_add(padding.y1);
+            .saturating_add(padding.top)
+            .saturating_add(padding.bottom);
         // TODO: Use a pool of strip generators.
         let filter_generator = StripGenerator::new(width, height, self.level);
         let parent_generator = core::mem::replace(&mut self.strip_generator, filter_generator);

--- a/sparse_strips/vello_cpu/src/coarse/bucketer.rs
+++ b/sparse_strips/vello_cpu/src/coarse/bucketer.rs
@@ -216,6 +216,7 @@ impl CommandBucketer {
     fn bbox_span(bbox: RectU16) -> Span {
         // Bbox might be empty vertically but not horizontally. In this case,
         // it should still be considered a zero-sized span, though.
+        // TODO: Discard empty layers in an earlier stage.
         if bbox.is_empty() {
             Span::new(bbox.x0, 0)
         } else {

--- a/sparse_strips/vello_cpu/src/coarse/bucketer.rs
+++ b/sparse_strips/vello_cpu/src/coarse/bucketer.rs
@@ -214,7 +214,13 @@ impl CommandBucketer {
     }
 
     fn bbox_span(bbox: RectU16) -> Span {
-        Span::new(bbox.x0, bbox.x1.saturating_sub(bbox.x0))
+        // Bbox might be empty vertically but not horizontally. In this case,
+        // it should still be considered a zero-sized span, though.
+        if bbox.is_empty() {
+            Span::new(bbox.x0, 0)
+        } else {
+            Span::new(bbox.x0, bbox.x1 - bbox.x0)
+        }
     }
 
     pub(crate) fn rows(&self) -> &[RowState] {
@@ -373,10 +379,6 @@ impl CommandBucketer {
             })
             .unwrap_or(parent_bbox);
 
-        // Once again, this need to be snapped because fine rasterization assumes tile-alignment.
-        // The bbox is used to clip fill commands, but if the bbox itself is not aligned we might
-        // end up making the fill commands unaligned as well.
-        let bbox = bbox.snap_to_tile_coordinates();
         if props.clip_path.is_some() {
             self.clip_bboxes.push(bbox);
         }
@@ -396,7 +398,7 @@ impl CommandBucketer {
         // If the blend mode is destructive, we need to eagerly push to all rows in the clip bbox,
         // since even areas where we didn't draw anything need to be blended with the destructive
         // blend mode.
-        if props.blend_mode.is_destructive() {
+        if props.blend_mode.is_destructive() && !bbox.is_empty() {
             let row_start = usize::from(bbox.y0 / Tile::HEIGHT);
             let row_end = usize::from(bbox.y1.div_ceil(Tile::HEIGHT)).min(self.rows.len());
             for row_idx in row_start..row_end {
@@ -636,9 +638,16 @@ impl CommandBucketer {
         }
 
         let clip_bbox = *self.clip_bboxes.last().unwrap();
+
+        // TODO: Don't emit layers with empty clip bboxes (and non-destructive blend modes)
+        // in the first place during recordings.
+        if clip_bbox.is_empty() {
+            return;
+        }
+
         // Note: Those will always be aligned to tile coordinates.
         let clip_x0 = clip_bbox.x0;
-        let clip_x1 = clip_bbox.x1.min(self.width());
+        let clip_x1 = clip_bbox.x1;
 
         debug_assert_tile_aligned((clip_x0, clip_bbox.y0), "clip start");
         debug_assert_tile_aligned((clip_x1, clip_bbox.y1), "clip end");
@@ -654,11 +663,10 @@ impl CommandBucketer {
         // mean that this method might be called with strips that do not lie within the viewport.
         // Therefore, we need to make sure to clip those appropriately.
 
-        let viewport_y1 = self.viewport.y1;
         let origin_tile_x = origin.0 / Tile::WIDTH;
         let origin_tile_y = origin.1 / Tile::HEIGHT;
-        let clip_scene_y0 = viewport_y1.min(origin.1.saturating_add(clip_bbox.y0));
-        let clip_scene_y1 = viewport_y1.min(origin.1.saturating_add(clip_bbox.y1));
+        let clip_scene_y0 = origin.1.saturating_add(clip_bbox.y0);
+        let clip_scene_y1 = origin.1.saturating_add(clip_bbox.y1);
         // Convert to scene coordinates.
         let clip_scene_x0 = origin.0.saturating_add(clip_x0);
         let clip_scene_x1 = origin.0.saturating_add(clip_x1);
@@ -766,7 +774,7 @@ mod tests {
     use vello_common::color::{AlphaColor, Srgb};
     use vello_common::geometry::RectU16;
     use vello_common::paint::{Paint, PremulColor};
-    use vello_common::peniko::BlendMode;
+    use vello_common::peniko::{BlendMode, Compose, Mix};
     use vello_common::record::LayerProps;
     use vello_common::strip::Strip;
     use vello_common::tile::Tile;
@@ -805,6 +813,13 @@ mod tests {
                 thread_idx: 0,
                 bbox,
             }),
+        }
+    }
+
+    fn destructive_clipped_layer_props(bbox: RectU16) -> LayerProps {
+        LayerProps {
+            blend_mode: BlendMode::new(Mix::Normal, Compose::Clear),
+            ..clipped_layer_props(bbox)
         }
     }
 
@@ -868,6 +883,28 @@ mod tests {
                     && cmd.span.pixel_width() == 4
                     && cmd.alpha_idx() == Some(u32::from(4 * Tile::HEIGHT))
         ));
+    }
+
+    #[test]
+    fn disjoint_nested_clip_bounds_do_not_emit_commands() {
+        let mut bucketer = CommandBucketer::from_wh(16, 4);
+        let strips = [Strip::new(0, 0, 0, false), Strip::new(16, 0, 0, true)];
+
+        bucketer.push_layer(&clipped_layer_props(RectU16::new(0, 0, 4, 4)));
+        bucketer.push_layer(&clipped_layer_props(RectU16::new(8, 0, 12, 4)));
+        bucketer.generate_fill(&strips, &fill_attrs(Paint::Solid(color(RED))), &[]);
+
+        assert!(bucketer.rows().iter().all(|row| row.render_cmds.is_empty()));
+    }
+
+    #[test]
+    fn empty_destructive_clip_does_not_push_rows() {
+        let mut bucketer = CommandBucketer::from_wh(16, 4);
+
+        bucketer.push_layer(&clipped_layer_props(RectU16::new(0, 0, 4, 4)));
+        bucketer.push_layer(&destructive_clipped_layer_props(RectU16::new(8, 0, 12, 4)));
+
+        assert!(bucketer.rows().iter().all(|row| row.render_cmds.is_empty()));
     }
 
     #[test]

--- a/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
@@ -36,7 +36,6 @@ use vello_common::pixmap::PixmapMut;
 use vello_common::record::{CommandRecorder, LayerClip, LayerProps, PoppedLayer};
 use vello_common::strip::Strip;
 use vello_common::strip_generator::{GenerationMode, StripGenerator, StripStorage};
-use vello_common::util::control_point_bbox_u16;
 
 mod cost;
 mod worker;
@@ -563,12 +562,8 @@ impl Dispatcher for MultiThreadedDispatcher {
             let start = self.allocation_group.path.len() as u32;
             self.allocation_group.path.extend(c);
             let end = self.allocation_group.path.len() as u32;
-            let mut bbox = control_point_bbox_u16(c.iter(), clip_transform);
-            if let Some(existing_clip) = self.clip_context.get() {
-                bbox = bbox.intersect(existing_clip.bbox);
-            }
 
-            (start..end, clip_transform, bbox)
+            (start..end, clip_transform)
         });
 
         self.register_task(RenderTaskType::PushLayer {
@@ -868,7 +863,7 @@ pub(crate) enum RenderTaskType {
         mask: Option<Mask>,
     },
     PushLayer {
-        clip_path: Option<(Range<u32>, Affine, RectU16)>,
+        clip_path: Option<(Range<u32>, Affine)>,
         blend_mode: BlendMode,
         opacity: f32,
         mask: Option<Mask>,

--- a/sparse_strips/vello_cpu/src/dispatch/multi_threaded/cost.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/multi_threaded/cost.rs
@@ -34,7 +34,7 @@ pub(crate) fn estimate_render_task_cost(task: &RenderTaskType, paths: &[PathEl])
             LAYER_COST
                 + clip_path
                     .as_ref()
-                    .map(|(path_range, transform, _)| {
+                    .map(|(path_range, transform)| {
                         let path = &paths[path_range.start as usize..path_range.end as usize];
                         estimate_path_cost(segments(path.iter().copied()), *transform, false)
                     })

--- a/sparse_strips/vello_cpu/src/dispatch/multi_threaded/worker.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/multi_threaded/worker.rs
@@ -7,7 +7,9 @@ use crate::dispatch::multi_threaded::{
 };
 use std::vec::Vec;
 use vello_common::clip::PathDataRef;
+use vello_common::geometry::RectU16;
 use vello_common::strip_generator::{GenerationMode, StripGenerator, StripStorage};
+use vello_common::util::strip_bbox;
 
 #[derive(Debug)]
 pub(crate) struct Worker {
@@ -142,7 +144,7 @@ impl Worker {
                     fill_rule,
                     aliasing_threshold,
                 } => {
-                    let (clip, clip_bbox) = if let Some((path_range, transform, bbox)) = clip_path {
+                    let (clip, clip_bbox) = if let Some((path_range, transform)) = clip_path {
                         let start = self.strip_storage.strips.len() as u32;
                         let path = &render_task.allocation_group.path
                             [path_range.start as usize..path_range.end as usize];
@@ -157,8 +159,13 @@ impl Worker {
                         );
 
                         let end = self.strip_storage.strips.len() as u32;
+                        let range = start..end;
+                        let bbox = strip_bbox(
+                            &self.strip_storage.strips[range.start as usize..range.end as usize],
+                        )
+                        .unwrap_or(RectU16::ZERO);
 
-                        (Some(start..end), Some(bbox))
+                        (Some(range), Some(bbox))
                     } else {
                         (None, None)
                     };

--- a/sparse_strips/vello_cpu/src/dispatch/single_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/single_threaded.rs
@@ -23,7 +23,7 @@ use vello_common::record::{
     CommandRecorder, LayerClip, LayerProps, Node, PoppedLayer, RecordedLayerKind,
 };
 use vello_common::strip_generator::{GenerationMode, StripStorage};
-use vello_common::util::control_point_bbox_u16;
+use vello_common::util::strip_bbox;
 use vello_common::viewport::ViewportState;
 
 /// Single-threaded implementation of the rendering dispatcher.
@@ -362,11 +362,6 @@ impl Dispatcher for SingleThreadedDispatcher {
             let strip_storage = &mut self.strip_storage;
             self.viewport
                 .with_generator_and_clip(|strip_generator, existing_clip| {
-                    let mut bbox = control_point_bbox_u16(clip_path.iter(), clip_transform);
-                    if let Some(existing_clip) = existing_clip {
-                        bbox = bbox.intersect(existing_clip.bbox);
-                    }
-
                     strip_generator.generate_filled_path(
                         clip_path,
                         fill_rule,
@@ -376,10 +371,12 @@ impl Dispatcher for SingleThreadedDispatcher {
                         existing_clip,
                     );
 
+                    let strip_range = strip_start..strip_storage.strips.len();
                     LayerClip {
-                        strip_range: strip_start..strip_storage.strips.len(),
+                        bbox: strip_bbox(&strip_storage.strips[strip_range.clone()])
+                            .unwrap_or(RectU16::ZERO),
+                        strip_range,
                         thread_idx: 0,
-                        bbox,
                     }
                 })
         });

--- a/sparse_strips/vello_cpu/src/record.rs
+++ b/sparse_strips/vello_cpu/src/record.rs
@@ -38,7 +38,7 @@ impl RecordedFill {
 }
 
 impl Drawable for RecordedFill {
-    fn bbox(&self, strips: &[Strip]) -> RectU16 {
+    fn bbox(&self, strips: &[Strip]) -> Option<RectU16> {
         strip_bbox(strips)
     }
 }

--- a/sparse_strips/vello_sparse_tests/snapshots/filter_offset_flipped.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/filter_offset_flipped.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae1df1b3300cc35244fb05df1725ea12d700f42fde6d29ef8f62f1ca86915ec3
+size 104

--- a/sparse_strips/vello_sparse_tests/snapshots/filter_offset_horizontal_only.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/filter_offset_horizontal_only.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae1df1b3300cc35244fb05df1725ea12d700f42fde6d29ef8f62f1ca86915ec3
+size 104

--- a/sparse_strips/vello_sparse_tests/snapshots/filter_offset_vertical_only.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/filter_offset_vertical_only.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae1df1b3300cc35244fb05df1725ea12d700f42fde6d29ef8f62f1ca86915ec3
+size 104

--- a/sparse_strips/vello_sparse_tests/tests/filter.rs
+++ b/sparse_strips/vello_sparse_tests/tests/filter.rs
@@ -64,6 +64,34 @@ fn filter_offset_simple(ctx: &mut impl Renderer) {
 }
 
 #[vello_test(skip_multithreaded)]
+fn filter_offset_vertical_only(ctx: &mut impl Renderer) {
+    let filter = Filter::from_primitive(FilterPrimitive::Offset { dx: 0.0, dy: 10.0 });
+    ctx.push_filter_layer(filter);
+    ctx.set_paint(RED);
+    ctx.fill_rect(&Rect::new(10.0, 0.0, 90.0, 80.0));
+    ctx.pop_layer();
+}
+
+#[vello_test(skip_multithreaded)]
+fn filter_offset_horizontal_only(ctx: &mut impl Renderer) {
+    let filter = Filter::from_primitive(FilterPrimitive::Offset { dx: 10.0, dy: 0.0 });
+    ctx.push_filter_layer(filter);
+    ctx.set_paint(RED);
+    ctx.fill_rect(&Rect::new(0.0, 10.0, 80.0, 90.0));
+    ctx.pop_layer();
+}
+
+#[vello_test(skip_multithreaded)]
+fn filter_offset_flipped(ctx: &mut impl Renderer) {
+    ctx.set_transform(Affine::translate((100.0, 100.0)) * Affine::scale(-1.0));
+    let filter = Filter::from_primitive(FilterPrimitive::Offset { dx: 0.0, dy: 10.0 });
+    ctx.push_filter_layer(filter);
+    ctx.set_paint(RED);
+    ctx.fill_rect(&Rect::new(10.0, 0.0, 90.0, 80.0));
+    ctx.pop_layer();
+}
+
+#[vello_test(skip_multithreaded)]
 fn filter_offset_no_offset(ctx: &mut impl Renderer) {
     let filter = Filter::from_primitive(FilterPrimitive::Offset { dx: 0.0, dy: 0.0 });
     ctx.push_filter_layer(filter);


### PR DESCRIPTION
This is part 4 in the prep commit series, based on top of #1746.

The first commit introduces a new `PaddingU16` type. On current main, we use kurbo `Rect` to represent the padding that is derived from  a filter. For example, a Rect of (-2, -2, 2, 2,) represents an outward padding of 2 into each direction. This makes somewhat sense, however, we use that same idea to represent a padding using `RectU16`. I think in the latter case, it doesn't make that much sense anymore. A RectU16 with dimensions (2, 2, 2, 2) represents the same idea as for `Rect`. But in reality, this is simply a zero-sized rectangle. It doesn't make a lot of sense to use `RectU16` to represent the idea of a filter padding. Therefore, this commit adds an explicit padding type so that the semantics are clearer. Methods like `intersect` and `union` that exist on `RectU16` don't really make much sense if the rectangle represents a padding, like it currently can. 

I think using `Rect` in the first place is also questionable, but at least left/top padding is represented as negative coordinates, so it makes a bit more sense. This change is necessary because the follow-up commit changes how zero-sized rectangles are handled, but for example for offset filters, it would be valid to have a padding in only one direction, while all other sides are 0.

The second commit introduces some changes to how we handle layer clips. To put it briefly, due to the fact that strips always have a fixed height of `Tile::HEIGHT` and a width with a multiple of `Tile::WIDTH`, we often need to ensure that bounding boxes are snapped to tile coordinates. Previously, this was done in various places at different times, so very inconsistently. For Vello CPU, we basically only needed this for filter layers, but for Vello Hybrid we will need to make sure that this is also the case for normal layers.

- First, we instead of computing the bbox of clips based on the control points, we simply compute it based on the strips instead. Admittedly, this is probably going to be more expensive for rectangular clips, but on the other hand it's good if we can unify this. But if desired, I can change this back and just snap the control point bbox to tile coordinates again.
- `RectU16::INVERTED` is now only used as an internal accumulator to represent "no bounding box yet". However, when returning it to the user we always return an empty rectangle instead. This way, we don't have to special case this everywhere.
- The definition of `RectU16::intersect` is changed such that it cannot produce negative rectangles anymore, also aligning with the kurbo implementation.
- `Drawable::bbox` must return tile-aligned bounding boxes.
- Some other small fixes, for example to ensure that `snap_to_tile_coorindates` preserved empty bboxes.

As a consequence, vello_cpu (and in the future vello_hybrid) do not need to do any snapping anymore. All of this is taken care of at the recorder level. There's some more optimizations we should do in the future to prevent zero-sized nodes from being emitted in the first place, but this change by itself is already large enough that I'm going to leave this as a TODO!

I've tested the combination of all 4 PRs against my PDF suite, and didn't see any regressions!

### PR train

1. #1744 — Move some code from `vello_cpu` to `vello_common`
2. #1745 — Add more new/refactored code into `vello_common`
3. #1746 — Generalize the command recorder abstraction and add more metadata
4. #1751 — Introduce `Padding` and streamline clip handling 👈