### PR TITLE
vello_cpu: Add Drop impl to `MultiThreadedDispatcher` to fix race panic

### DIFF
--- a/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
@@ -733,6 +733,12 @@ impl Debug for MultiThreadedDispatcher {
     }
 }
 
+impl Drop for MultiThreadedDispatcher {
+    fn drop(&mut self) {
+        self.flush();
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct OwnedClip {
     strips: Box<[Strip]>,

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -1250,6 +1250,32 @@ mod tests {
         ctx.reset();
     }
 
+    #[cfg(feature = "multithreading")]
+    #[test]
+    fn multithreaded_drop_with_pending_tasks() {
+        use crate::RenderSettings;
+
+        for _ in 0..100 {
+            let mut ctx = RenderContext::new_with(
+                100,
+                100,
+                RenderSettings {
+                    num_threads: 4,
+                    ..Default::default()
+                },
+            );
+            
+            // Note: This test only works if we draw enough rectangles
+            // to trigger a batch send.
+            for _ in 0..300 {
+                ctx.fill_rect(&Rect::new(0.0, 0.0, 100., 100.0));
+            }
+
+            drop(ctx);
+        }
+    }
+
+
     #[cfg(feature = "text")]
     #[test]
     fn glyph_atlas_resources_are_lazy() {

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -1255,7 +1255,7 @@ mod tests {
     fn multithreaded_drop_with_pending_tasks() {
         use crate::RenderSettings;
 
-        for _ in 0..100 {
+        for _ in 0..10 {
             let mut ctx = RenderContext::new_with(
                 100,
                 100,

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -1264,7 +1264,7 @@ mod tests {
                     ..Default::default()
                 },
             );
-            
+
             // Note: This test only works if we draw enough rectangles
             // to trigger a batch send.
             for _ in 0..300 {
@@ -1274,7 +1274,6 @@ mod tests {
             drop(ctx);
         }
     }
-
 
     #[cfg(feature = "text")]
     #[test]


### PR DESCRIPTION
When MultiThreadedDispatcher is dropped and causes https://github.com/linebender/vello/blob/8ecea46dc79bbb10315c101f9dbd0955c627dab8/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs#L83 to drop, worker threads may still be mid-send.

This stably causes panic in https://github.com/servo/servo/issues/46580#issuecomment-5018546939.

We now flush in `Drop` so that any field does exist.

Fixes: https://github.com/servo/servo/issues/46580
Testing: Added a unit test that panics stably, similar to #1732

cc @xiaochengh