### PR TITLE
feat: lazily allocate image atlas textures

### DIFF
--- a/sparse_strips/vello_common/src/multi_atlas.rs
+++ b/sparse_strips/vello_common/src/multi_atlas.rs
@@ -469,6 +469,8 @@ pub struct AtlasAllocation {
 #[derive(Debug, Clone, Copy)]
 pub struct AtlasConfig {
     /// Initial number of atlases to create.
+    ///
+    /// Set this to zero to allocate the first atlas lazily.
     pub initial_atlas_count: usize,
     /// Maximum number of atlases to create.
     pub max_atlases: usize,
@@ -484,7 +486,7 @@ pub struct AtlasConfig {
 impl Default for AtlasConfig {
     fn default() -> Self {
         Self {
-            initial_atlas_count: 1,
+            initial_atlas_count: 0,
             max_atlases: 8,
             atlas_size: (4096, 4096),
             auto_grow: true,
@@ -520,6 +522,16 @@ mod tests {
 
         let atlas_id = manager.create_atlas().unwrap();
         assert_eq!(atlas_id.as_u32(), 0);
+        assert_eq!(manager.atlas_count(), 1);
+    }
+
+    #[test]
+    fn test_default_lazily_creates_first_atlas() {
+        let mut manager = MultiAtlasManager::new(AtlasConfig::default());
+        assert_eq!(manager.atlas_count(), 0);
+
+        let allocation = manager.try_allocate(100, 100).unwrap();
+        assert_eq!(allocation.atlas_id.as_u32(), 0);
         assert_eq!(manager.atlas_count(), 1);
     }
 

--- a/sparse_strips/vello_hybrid/examples/wgpu_webgl/src/lib.rs
+++ b/sparse_strips/vello_hybrid/examples/wgpu_webgl/src/lib.rs
@@ -17,7 +17,7 @@ use vello_common::{
     paint::{ImageId, ImageSource},
 };
 use vello_example_scenes::{AnyScene, image::ImageScene};
-use vello_hybrid::{AtlasConfig, Pixmap, RenderSettings, RenderTargetConfig, Renderer, Scene};
+use vello_hybrid::{Pixmap, RenderSettings, RenderTargetConfig, Renderer, Scene};
 use wasm_bindgen::prelude::*;
 use web_sys::{Event, HtmlCanvasElement, KeyboardEvent, MouseEvent, WheelEvent};
 use wgpu::{
@@ -88,7 +88,6 @@ impl RendererWrapper {
         };
         surface.configure(&device, &surface_config);
 
-        let max_texture_dimension_2d = device.limits().max_texture_dimension_2d;
         let renderer = Renderer::new_with(
             &device,
             &RenderTargetConfig {
@@ -98,10 +97,6 @@ impl RendererWrapper {
             },
             RenderSettings {
                 level: Level::try_detect().unwrap_or(Level::baseline()),
-                image_atlas_config: AtlasConfig {
-                    atlas_size: (max_texture_dimension_2d, max_texture_dimension_2d),
-                    ..AtlasConfig::default()
-                },
                 ..Default::default()
             },
         );

--- a/sparse_strips/vello_hybrid/src/lib.rs
+++ b/sparse_strips/vello_hybrid/src/lib.rs
@@ -58,13 +58,13 @@ mod text;
 
 pub mod util;
 
+#[cfg(feature = "webgl")]
+pub use render::{AtlasTextureInfo, WebGlAtlasWriter, WebGlRenderer, WebGlTextureWithDimensions};
 #[cfg(feature = "wgpu")]
 pub use render::{AtlasWriter, RenderTargetConfig, Renderer, TextureBindings};
 pub use render::{Config, GpuStrip, RenderSize};
 #[cfg(all(feature = "webgl", feature = "probe"))]
 pub use render::{Probe, ProbeResult};
-#[cfg(feature = "webgl")]
-pub use render::{WebGlAtlasWriter, WebGlRenderer, WebGlTextureWithDimensions};
 #[cfg(all(feature = "webgl", feature = "probe"))]
 pub use render::{WebGlPendingProbe, WebGlProbeError, WebGlProbeStatus};
 pub use resources::Resources;

--- a/sparse_strips/vello_hybrid/src/render/common.rs
+++ b/sparse_strips/vello_hybrid/src/render/common.rs
@@ -79,6 +79,19 @@ mod tests {
         assert_eq!(config.max_atlases, 2);
         assert_eq!(config.atlas_size, (1, 1));
     }
+
+    #[test]
+    fn normalize_atlas_config_allows_lazy_initial_allocation() {
+        let mut config = AtlasConfig {
+            initial_atlas_count: 0,
+            ..Default::default()
+        };
+
+        normalize_atlas_config(&mut config, 4096, 8, 0);
+
+        assert_eq!(config.initial_atlas_count, 0);
+        assert_eq!(config.max_atlases, 8);
+    }
 }
 
 /// Dimensions of the rendering target.

--- a/sparse_strips/vello_hybrid/src/render/common.rs
+++ b/sparse_strips/vello_hybrid/src/render/common.rs
@@ -29,18 +29,12 @@ pub(crate) fn normalize_atlas_config(
     config: &mut AtlasConfig,
     max_texture_dimension_2d: u32,
     max_texture_array_layers: u32,
-    min_initial_atlas_count: usize,
 ) {
     config.atlas_size.0 = config.atlas_size.0.clamp(1, max_texture_dimension_2d);
     config.atlas_size.1 = config.atlas_size.1.clamp(1, max_texture_dimension_2d);
 
-    let supported_max_atlases = (max_texture_array_layers as usize).max(min_initial_atlas_count);
-    config.max_atlases = config
-        .max_atlases
-        .clamp(min_initial_atlas_count, supported_max_atlases);
-    config.initial_atlas_count = config
-        .initial_atlas_count
-        .clamp(min_initial_atlas_count, config.max_atlases);
+    config.max_atlases = config.max_atlases.min(max_texture_array_layers as usize);
+    config.initial_atlas_count = config.initial_atlas_count.min(config.max_atlases);
 }
 
 #[cfg(test)]
@@ -57,27 +51,11 @@ mod tests {
             ..Default::default()
         };
 
-        normalize_atlas_config(&mut config, 4096, 4, 1);
+        normalize_atlas_config(&mut config, 4096, 4);
 
         assert_eq!(config.initial_atlas_count, 4);
         assert_eq!(config.max_atlases, 4);
         assert_eq!(config.atlas_size, (4096, 2048));
-    }
-
-    #[test]
-    fn normalize_atlas_config_enforces_minimum_initial_count() {
-        let mut config = AtlasConfig {
-            initial_atlas_count: 0,
-            max_atlases: 1,
-            atlas_size: (0, 0),
-            ..Default::default()
-        };
-
-        normalize_atlas_config(&mut config, 4096, 8, 2);
-
-        assert_eq!(config.initial_atlas_count, 2);
-        assert_eq!(config.max_atlases, 2);
-        assert_eq!(config.atlas_size, (1, 1));
     }
 
     #[test]
@@ -87,7 +65,7 @@ mod tests {
             ..Default::default()
         };
 
-        normalize_atlas_config(&mut config, 4096, 8, 0);
+        normalize_atlas_config(&mut config, 4096, 8);
 
         assert_eq!(config.initial_atlas_count, 0);
         assert_eq!(config.max_atlases, 8);

--- a/sparse_strips/vello_hybrid/src/render/mod.rs
+++ b/sparse_strips/vello_hybrid/src/render/mod.rs
@@ -23,6 +23,6 @@ pub use probe::{WebGlPendingProbe, WebGlProbeError, WebGlProbeStatus};
 #[cfg(all(feature = "webgl", feature = "probe"))]
 pub use vello_common::probe::{Probe, ProbeResult};
 #[cfg(feature = "webgl")]
-pub use webgl::{WebGlAtlasWriter, WebGlRenderer, WebGlTextureWithDimensions};
+pub use webgl::{AtlasTextureInfo, WebGlAtlasWriter, WebGlRenderer, WebGlTextureWithDimensions};
 #[cfg(feature = "wgpu")]
 pub use wgpu::{AtlasWriter, RenderTargetConfig, Renderer, TextureBindings};

--- a/sparse_strips/vello_hybrid/src/render/probe.rs
+++ b/sparse_strips/vello_hybrid/src/render/probe.rs
@@ -123,9 +123,19 @@ impl WebGlRenderer {
         let mut probe_image_cache = ImageCache::new_with_config(atlas_config);
         let mut probe_atlas_texture_array =
             create_atlas_texture_array(&self.gl, atlas_width, atlas_height, 1);
+        let mut probe_atlas_size = (atlas_width, atlas_height);
+        let mut probe_atlas_layer_count = 1;
         core::mem::swap(
             &mut self.programs.resources.atlas_texture_array,
             &mut probe_atlas_texture_array,
+        );
+        core::mem::swap(
+            &mut self.programs.resources.atlas_size,
+            &mut probe_atlas_size,
+        );
+        core::mem::swap(
+            &mut self.programs.resources.atlas_layer_count,
+            &mut probe_atlas_layer_count,
         );
 
         let probe_image = Arc::new(vello_common::probe::probe_image_pixmap());
@@ -165,6 +175,14 @@ impl WebGlRenderer {
         core::mem::swap(
             &mut self.programs.resources.atlas_texture_array,
             &mut probe_atlas_texture_array,
+        );
+        core::mem::swap(
+            &mut self.programs.resources.atlas_size,
+            &mut probe_atlas_size,
+        );
+        core::mem::swap(
+            &mut self.programs.resources.atlas_layer_count,
+            &mut probe_atlas_layer_count,
         );
 
         // We do this here instead of above such that in case the render result is not

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -214,15 +214,13 @@ impl WebGlRenderer {
             &mut settings.image_atlas_config,
             max_texture_dimension_2d,
             max_texture_array_layers,
-            0,
         );
+        // Filter scratch textures are individual 2D textures (not a D2Array), so they can
+        // start at zero and only be allocated on demand when a scene actually uses filters.
         normalize_atlas_config(
             &mut settings.filter_atlas_config,
             max_texture_dimension_2d,
             max_texture_array_layers,
-            // Filter scratch textures are individual 2D textures (not a D2Array), so they can
-            // start at zero and only be allocated on demand when a scene actually uses filters.
-            0,
         );
         let total_slots: usize = (max_texture_dimension_2d / u32::from(Tile::HEIGHT)) as usize;
         assert!(

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -116,6 +116,17 @@ pub struct WebGlRenderer {
     dummy_image_cache: Option<ImageCache>,
 }
 
+/// Current allocation state of the WebGL image/glyph atlas texture.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AtlasTextureInfo {
+    /// Width of the currently bound texture array.
+    pub width: u32,
+    /// Height of the currently bound texture array.
+    pub height: u32,
+    /// Number of real atlas layers available to the image cache.
+    pub layer_count: u32,
+}
+
 impl WebGlRenderer {
     /// Creates a new WebGL2 renderer
     pub fn new(canvas: &HtmlCanvasElement) -> Self {
@@ -203,7 +214,7 @@ impl WebGlRenderer {
             &mut settings.image_atlas_config,
             max_texture_dimension_2d,
             max_texture_array_layers,
-            1,
+            0,
         );
         normalize_atlas_config(
             &mut settings.filter_atlas_config,
@@ -571,9 +582,20 @@ impl WebGlRenderer {
     ///
     /// This is a 2D array texture (`TextureViewDimension::D2Array`) containing all
     /// atlas layers used by the image cache. Each layer holds cached image data
-    /// (e.g., rasterised glyphs) that the renderer samples during draw calls.
+    /// (e.g., rasterised glyphs) that the renderer samples during draw calls. Before the first
+    /// layer is allocated, this returns the 1x1 placeholder texture.
     pub fn atlas_texture(&self) -> &WebGlTexture {
         &self.programs.resources.atlas_texture_array.texture
+    }
+
+    /// Returns the current allocation state of the image/glyph atlas texture.
+    pub fn atlas_info(&self) -> AtlasTextureInfo {
+        let resources = &self.programs.resources;
+        AtlasTextureInfo {
+            width: resources.atlas_texture_array.size.width,
+            height: resources.atlas_texture_array.size.height,
+            layer_count: resources.atlas_layer_count,
+        }
     }
 
     /// Clear a specific region of the atlas texture array.
@@ -872,6 +894,10 @@ pub(crate) struct WebGlResources {
     alpha_texture_height: u32,
     /// Texture array for atlas data (multiple atlases supported)
     pub(crate) atlas_texture_array: WebGlTextureArray,
+    /// Configured dimensions used when promoting the placeholder to a real atlas.
+    pub(crate) atlas_size: (u32, u32),
+    /// Number of real atlas layers currently allocated.
+    pub(crate) atlas_layer_count: u32,
     /// Encoded paints texture for image metadata.
     encoded_paints_texture: Texture,
     /// Height of encoded paints texture.
@@ -1048,12 +1074,9 @@ impl WebGlPrograms {
         gl: &WebGl2RenderingContext,
         required_atlas_count: u32,
     ) {
-        let WebGlTextureSize {
-            width,
-            height,
-            depth_or_array_layers: current_atlas_count,
-        } = self.resources.atlas_texture_array.size();
+        let current_atlas_count = self.resources.atlas_layer_count;
         if required_atlas_count > current_atlas_count {
+            let (width, height) = self.resources.atlas_size;
             // Create new texture array with more layers
             let new_atlas_texture_array =
                 create_atlas_texture_array(gl, width, height, required_atlas_count);
@@ -1063,6 +1086,7 @@ impl WebGlPrograms {
 
             // Replace the old resources
             self.resources.atlas_texture_array = new_atlas_texture_array;
+            self.resources.atlas_layer_count = required_atlas_count;
             // Cached FBOs were attached to the old texture; drop them so we recreate on next use.
             self.resources.atlas_render_framebuffer = None;
             self.resources.filter_main_atlas_framebuffer = None;
@@ -2061,8 +2085,15 @@ fn create_webgl_resources(
         initial_atlas_count,
         ..
     } = image_cache.atlas_manager().config();
-    let atlas_texture_array =
-        create_atlas_texture_array(gl, *atlas_width, *atlas_height, *initial_atlas_count as u32);
+    let atlas_size = (*atlas_width, *atlas_height);
+    let atlas_layer_count = *initial_atlas_count as u32;
+    let atlas_texture_array = if atlas_layer_count == 0 {
+        // Texture arrays cannot have zero layers. Keep a tiny bindable placeholder until the image
+        // cache makes its first real allocation.
+        create_atlas_texture_array(gl, 1, 1, 1)
+    } else {
+        create_atlas_texture_array(gl, *atlas_width, *atlas_height, atlas_layer_count)
+    };
 
     // Create a 1x1 stub atlas texture array for use during render_to_atlas.
     // This avoids binding the real atlas as a shader input while it is the render target.
@@ -2102,6 +2133,8 @@ fn create_webgl_resources(
         alphas_texture,
         alpha_texture_height: 0,
         atlas_texture_array,
+        atlas_size,
+        atlas_layer_count,
         encoded_paints_texture,
         encoded_paints_texture_height: 0,
         gradient_texture,
@@ -2143,6 +2176,10 @@ pub(crate) fn create_atlas_texture_array(
     height: u32,
     layer_count: u32,
 ) -> WebGlTextureArray {
+    debug_assert!(
+        layer_count > 0,
+        "atlas texture arrays must have at least one physical layer"
+    );
     let atlas_texture = create_texture_array(gl);
 
     // Initialize with empty texture array data
@@ -2160,7 +2197,7 @@ pub(crate) fn create_atlas_texture_array(
     )
     .unwrap();
 
-    WebGlTextureArray::new(atlas_texture, width, height, layer_count)
+    WebGlTextureArray::new(atlas_texture, width, height)
 }
 
 /// Create a texture for slot rendering.
@@ -2962,14 +2999,10 @@ pub(crate) struct WebGlTextureArray {
 
 impl WebGlTextureArray {
     /// Create a new WebGL texture array wrapper.
-    fn new(texture: Texture, width: u32, height: u32, depth_or_array_layers: u32) -> Self {
+    fn new(texture: Texture, width: u32, height: u32) -> Self {
         Self {
             texture,
-            size: WebGlTextureSize {
-                width,
-                height,
-                depth_or_array_layers,
-            },
+            size: WebGlTextureSize { width, height },
         }
     }
 
@@ -2986,8 +3019,6 @@ struct WebGlTextureSize {
     width: u32,
     /// The height of the texture.
     height: u32,
-    /// The number of layers in the texture array.
-    depth_or_array_layers: u32,
 }
 
 /// Helper function to copy from a source texture/framebuffer to a destination texture array layer.

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -182,30 +182,15 @@ impl Renderer {
 
         let mut settings = settings;
         let max_texture_dimension_2d = device.limits().max_texture_dimension_2d;
-        // When targeting wasm32 with a WebGL/GLES backend, we need to set
-        // `initial_atlas_count` to 2. In WGPU's GLES backend, heuristics are used to decide
-        // whether a texture should be treated as D2 or D2Array. However, this can cause a
-        // mismatch: when depth_or_array_layers == 1, the backend assumes the texture is D2,
-        // even if it was actually created as a D2Array. This issue only occurs with the GLES
-        // backend.
-        //
-        // @see https://github.com/gfx-rs/wgpu/blob/61e5124eb9530d3b3865556a7da4fd320d03ddc5/wgpu-hal/src/gles/mod.rs#L470-L517
-        // TODO: Can we somehow dynamically detect whether the WebGL backend was chosen, so that the
-        // wgpu backend isn't affected by this?
-        #[cfg(target_arch = "wasm32")]
-        let min_initial_atlas_count = 2;
-        #[cfg(not(target_arch = "wasm32"))]
-        let min_initial_atlas_count = 1;
         let max_texture_array_layers = device.limits().max_texture_array_layers;
         normalize_atlas_config(
             &mut settings.image_atlas_config,
             max_texture_dimension_2d,
             max_texture_array_layers,
-            min_initial_atlas_count,
+            0,
         );
-        // Filter scratch textures are individual 2D textures (see `FilterAtlasState`), not a
-        // D2Array, so the GLES D2/D2Array workaround above does not apply. They can start at zero
-        // and only be allocated on demand when a scene actually uses filters.
+        // Filter scratch textures are individual 2D textures (see `FilterAtlasState`). They can
+        // start at zero and only be allocated on demand when a scene actually uses filters.
         normalize_atlas_config(
             &mut settings.filter_atlas_config,
             max_texture_dimension_2d,
@@ -1104,6 +1089,10 @@ struct GpuResources {
     atlas_texture_array: Texture,
     /// View for atlas texture array
     atlas_texture_array_view: TextureView,
+    /// Configured dimensions used when promoting the placeholder to a real atlas.
+    atlas_size: (u32, u32),
+    /// Number of real atlas layers currently exposed by the texture view.
+    atlas_layer_count: u32,
     /// Bind group for paint sources: an atlas textures as texture array plus an external texture.
     atlas_bind_group: BindGroup,
     /// Transparent 1x1 placeholder texture in case no external texture is bound by the user.
@@ -1641,12 +1630,15 @@ impl Programs {
             initial_atlas_count,
             ..
         } = image_cache.atlas_manager().config();
-        let (atlas_texture_array, atlas_texture_array_view) = Self::create_atlas_texture_array(
-            device,
-            *atlas_width,
-            *atlas_height,
-            *initial_atlas_count as u32,
-        );
+        let atlas_size = (*atlas_width, *atlas_height);
+        let atlas_layer_count = *initial_atlas_count as u32;
+        let (atlas_texture_array, atlas_texture_array_view) = if atlas_layer_count == 0 {
+            // Texture arrays cannot have zero layers. Keep a tiny bindable placeholder until the
+            // image cache makes its first real allocation.
+            Self::create_atlas_texture_array(device, 1, 1, 1)
+        } else {
+            Self::create_atlas_texture_array(device, *atlas_width, *atlas_height, atlas_layer_count)
+        };
         let placeholder_external_texture_view = Self::create_placeholder_external_texture(device);
         let atlas_bind_group = Self::create_paint_source_bind_group(
             device,
@@ -1742,6 +1734,8 @@ impl Programs {
             alphas_texture,
             atlas_texture_array,
             atlas_texture_array_view,
+            atlas_size,
+            atlas_layer_count,
             atlas_bind_group,
             placeholder_external_texture_view,
             filter_atlas,
@@ -1877,8 +1871,14 @@ impl Programs {
         height: u32,
         atlas_count: u32,
     ) -> (Texture, TextureView) {
-        // See the comment in `Renderer::new_with`. On WASM, we need to set this to at
-        // least 2 so it works with the wgpu WebGL backend.
+        debug_assert!(
+            atlas_count > 0,
+            "atlas texture arrays must have at least one physical layer"
+        );
+        // In WGPU's GLES backend, heuristics classify a one-layer texture as D2 even when it was
+        // created as D2Array. Allocate at least two physical layers on WASM to keep the backend's
+        // classification consistent with the D2Array view.
+        // See https://github.com/gfx-rs/wgpu/blob/61e5124eb9530d3b3865556a7da4fd320d03ddc5/wgpu-hal/src/gles/mod.rs#L470-L517.
         #[cfg(target_arch = "wasm32")]
         let depth_or_array_layers = atlas_count.max(2);
         #[cfg(not(target_arch = "wasm32"))]
@@ -1902,7 +1902,17 @@ impl Programs {
             view_formats: &[],
         });
 
-        let atlas_texture_array_view = atlas_texture_array.create_view(&TextureViewDescriptor {
+        let atlas_texture_array_view =
+            Self::create_atlas_texture_array_view(&atlas_texture_array, atlas_count);
+
+        (atlas_texture_array, atlas_texture_array_view)
+    }
+
+    fn create_atlas_texture_array_view(
+        atlas_texture_array: &Texture,
+        atlas_count: u32,
+    ) -> TextureView {
+        atlas_texture_array.create_view(&TextureViewDescriptor {
             label: Some("Atlas Texture Array View"),
             format: None,
             dimension: Some(wgpu::TextureViewDimension::D2Array),
@@ -1912,9 +1922,7 @@ impl Programs {
             base_array_layer: 0,
             array_layer_count: Some(atlas_count),
             usage: None,
-        });
-
-        (atlas_texture_array, atlas_texture_array_view)
+        })
     }
 
     fn create_filter_data_texture(device: &Device, width: u32, height: u32) -> Texture {
@@ -2351,25 +2359,48 @@ impl Programs {
         atlas_bind_group_layout: &BindGroupLayout,
         required_atlas_count: u32,
     ) {
-        let Extent3d {
-            width,
-            height,
-            depth_or_array_layers: current_atlas_count,
-        } = resources.atlas_texture_array.size();
+        let current_atlas_count = resources.atlas_layer_count;
         if required_atlas_count > current_atlas_count {
+            let (width, height) = resources.atlas_size;
+            let physical_layer_count = resources.atlas_texture_array.size().depth_or_array_layers;
+
+            // WGPU's WebGL backend allocates at least two physical layers to keep the texture
+            // classified as D2Array. Expose an already-allocated layer without replacing the
+            // texture when that spare capacity is available.
+            if current_atlas_count > 0 && required_atlas_count <= physical_layer_count {
+                let new_atlas_texture_array_view = Self::create_atlas_texture_array_view(
+                    &resources.atlas_texture_array,
+                    required_atlas_count,
+                );
+                let new_atlas_bind_group = Self::create_paint_source_bind_group(
+                    device,
+                    atlas_bind_group_layout,
+                    &new_atlas_texture_array_view,
+                    &resources.placeholder_external_texture_view,
+                );
+                resources.atlas_texture_array_view = new_atlas_texture_array_view;
+                resources.atlas_bind_group = new_atlas_bind_group;
+                resources.atlas_layer_count = required_atlas_count;
+                return;
+            }
+
             // Create new texture array with more layers
             let (new_atlas_texture_array, new_atlas_texture_array_view) =
                 Self::create_atlas_texture_array(device, width, height, required_atlas_count);
 
-            // Copy existing atlas data from old texture array to new one
-            Self::copy_atlas_texture_data(
-                encoder,
-                &resources.atlas_texture_array,
-                &new_atlas_texture_array,
-                current_atlas_count,
-                width,
-                height,
-            );
+            if current_atlas_count > 0 {
+                // Copy existing atlas data from old texture array to new one. A zero-depth copy is
+                // still validated against the placeholder's 1x1 extent by WGPU, so skip it when
+                // promoting the placeholder.
+                Self::copy_atlas_texture_data(
+                    encoder,
+                    &resources.atlas_texture_array,
+                    &new_atlas_texture_array,
+                    current_atlas_count,
+                    width,
+                    height,
+                );
+            }
 
             // Update the bind group with the new texture array view
             let new_atlas_bind_group = Self::create_paint_source_bind_group(
@@ -2383,6 +2414,7 @@ impl Programs {
             resources.atlas_texture_array = new_atlas_texture_array;
             resources.atlas_texture_array_view = new_atlas_texture_array_view;
             resources.atlas_bind_group = new_atlas_bind_group;
+            resources.atlas_layer_count = required_atlas_count;
         }
     }
 

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -187,7 +187,6 @@ impl Renderer {
             &mut settings.image_atlas_config,
             max_texture_dimension_2d,
             max_texture_array_layers,
-            0,
         );
         // Filter scratch textures are individual 2D textures (see `FilterAtlasState`). They can
         // start at zero and only be allocated on demand when a scene actually uses filters.
@@ -195,7 +194,6 @@ impl Renderer {
             &mut settings.filter_atlas_config,
             max_texture_dimension_2d,
             max_texture_array_layers,
-            0,
         );
         let total_slots = (max_texture_dimension_2d / u32::from(Tile::HEIGHT)) as usize;
         let image_cache = ImageCache::new_with_config(settings.image_atlas_config);

--- a/sparse_strips/vello_sparse_tests/tests/image_atlas.rs
+++ b/sparse_strips/vello_sparse_tests/tests/image_atlas.rs
@@ -4,10 +4,66 @@
 //! Tests for the image/glyph atlas configuration of the WebGL renderer.
 
 use vello_common::pixmap::Pixmap;
-use vello_hybrid::{AtlasConfig, RenderSettings, Resources, WebGlRenderer};
+use vello_hybrid::{AtlasConfig, AtlasTextureInfo, RenderSettings, Resources, WebGlRenderer};
 use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
-use web_sys::HtmlCanvasElement;
+use web_sys::{HtmlCanvasElement, WebGl2RenderingContext};
+
+#[wasm_bindgen_test]
+fn image_atlas_placeholder_is_promoted_on_first_upload() {
+    let document = web_sys::window().unwrap().document().unwrap();
+    let canvas = document
+        .create_element("canvas")
+        .unwrap()
+        .dyn_into::<HtmlCanvasElement>()
+        .unwrap();
+    canvas.set_width(100);
+    canvas.set_height(100);
+
+    let atlas_config = AtlasConfig {
+        initial_atlas_count: 0,
+        atlas_size: (10, 10),
+        ..AtlasConfig::default()
+    };
+    let settings = RenderSettings {
+        image_atlas_config: atlas_config,
+        ..RenderSettings::default()
+    };
+    let mut renderer = WebGlRenderer::new_with(&canvas, settings);
+    let mut resources = Resources::new_with_config(atlas_config);
+
+    assert_eq!(
+        renderer.atlas_info(),
+        AtlasTextureInfo {
+            width: 1,
+            height: 1,
+            layer_count: 0,
+        },
+        "renderer should start with only the 1x1 placeholder atlas texture"
+    );
+    assert_eq!(
+        renderer.gl_context().get_error(),
+        WebGl2RenderingContext::NO_ERROR,
+        "renderer initialization should not produce a WebGL error"
+    );
+
+    renderer.upload_image(&mut resources, &Pixmap::new(2, 2));
+
+    assert_eq!(
+        renderer.atlas_info(),
+        AtlasTextureInfo {
+            width: 10,
+            height: 10,
+            layer_count: 1,
+        },
+        "first upload should promote the placeholder to the configured atlas"
+    );
+    assert_eq!(
+        renderer.gl_context().get_error(),
+        WebGl2RenderingContext::NO_ERROR,
+        "first atlas upload should not produce a WebGL error"
+    );
+}
 
 /// Uploading an image that is larger than the configured atlas must fail with
 /// `AtlasError::TextureTooLarge`.


### PR DESCRIPTION
Make image atlas allocation lazy by default. WebGL and WGPU now use tiny placeholder textures until the first upload, then promote and grow them while preserving existing layers and WGPU GLES compatibility.

Created with assistance from GPT-5.6 Sol.