### PR TITLE
sparse_strips: Add a "DropShadowOnly" filter variant

### DIFF
--- a/sparse_strips/vello_common/src/filter/drop_shadow.rs
+++ b/sparse_strips/vello_common/src/filter/drop_shadow.rs
@@ -22,6 +22,8 @@ pub struct DropShadow {
     pub std_deviation: f32,
     /// Edge mode for blur sampling.
     pub edge_mode: EdgeMode,
+    /// Whether to composite the original input over the colored shadow.
+    pub composite_original: bool,
     /// Number of 2x2 decimation levels to use (0 means direct convolution).
     pub n_decimations: usize,
     /// Pre-computed Gaussian kernel weights for the reduced blur.
@@ -42,6 +44,28 @@ impl DropShadow {
         edge_mode: EdgeMode,
         color: AlphaColor<Srgb>,
     ) -> Self {
+        Self::new_impl(dx, dy, std_deviation, edge_mode, color, true)
+    }
+
+    /// Create a new shadow-only drop shadow with the specified parameters.
+    pub fn new_shadow_only(
+        dx: f32,
+        dy: f32,
+        std_deviation: f32,
+        edge_mode: EdgeMode,
+        color: AlphaColor<Srgb>,
+    ) -> Self {
+        Self::new_impl(dx, dy, std_deviation, edge_mode, color, false)
+    }
+
+    fn new_impl(
+        dx: f32,
+        dy: f32,
+        std_deviation: f32,
+        edge_mode: EdgeMode,
+        color: AlphaColor<Srgb>,
+        composite_original: bool,
+    ) -> Self {
         // Precompute blur plan (same logic as GaussianBlur::new)
         let (n_decimations, kernel, kernel_size) = plan_decimated_blur(std_deviation);
 
@@ -51,6 +75,7 @@ impl DropShadow {
             color,
             std_deviation,
             edge_mode,
+            composite_original,
             n_decimations,
             kernel,
             kernel_size,

--- a/sparse_strips/vello_common/src/filter/mod.rs
+++ b/sparse_strips/vello_common/src/filter/mod.rs
@@ -71,6 +71,25 @@ impl PreparedFilter {
 
                 Self::DropShadow(drop_shadow)
             }
+            FilterPrimitive::DropShadowOnly {
+                dx,
+                dy,
+                std_deviation,
+                color,
+                edge_mode,
+            } => {
+                let (scaled_dx, scaled_dy, scaled_std_dev) =
+                    transform_shadow_params(*dx, *dy, *std_deviation, transform);
+                let drop_shadow = DropShadow::new_shadow_only(
+                    scaled_dx,
+                    scaled_dy,
+                    scaled_std_dev,
+                    *edge_mode,
+                    *color,
+                );
+
+                Self::DropShadow(drop_shadow)
+            }
             FilterPrimitive::Offset { dx, dy } => {
                 let (scaled_dx, scaled_dy) = transform_offset_params(*dx, *dy, transform);
                 let offset = Offset::new(scaled_dx, scaled_dy);

--- a/sparse_strips/vello_common/src/filter_effects.rs
+++ b/sparse_strips/vello_common/src/filter_effects.rs
@@ -20,6 +20,7 @@
 //! - `Flood` - Solid color fill
 //! - `GaussianBlur` - Gaussian blur filter
 //! - `DropShadow` - Drop shadow effect (compound primitive)
+//! - `DropShadowOnly` - Drop shadow effect without the original input
 //! - `Offset` - Translation/shift (single primitive)
 //!
 //! **Note:** Currently only single primitive filters are supported. Filter graphs with
@@ -410,6 +411,21 @@ pub enum FilterPrimitive {
         /// Default is `EdgeMode::None` per SVG spec.
         edge_mode: EdgeMode,
     },
+    /// Same as [`FilterPrimitive::DropShadow`], but without compositing the original
+    /// layer on top of it.
+    DropShadowOnly {
+        /// Horizontal offset of the shadow in pixels. Positive values shift right.
+        dx: f32,
+        /// Vertical offset of the shadow in pixels. Positive values shift down.
+        dy: f32,
+        /// Blur standard deviation for the shadow. Larger values create softer shadows.
+        std_deviation: f32,
+        /// Color applied to the blurred, offset input alpha mask. The input's color
+        /// channels are ignored, and this color's alpha controls shadow opacity.
+        color: AlphaColor<Srgb>,
+        /// Edge mode for handling boundaries during blur operation.
+        edge_mode: EdgeMode,
+    },
     //
     // ============================================================
     // TODO: The following filter primitives are not yet implemented
@@ -577,9 +593,14 @@ impl FilterPrimitive {
                 dx,
                 dy,
                 ..
+            }
+            | Self::DropShadowOnly {
+                std_deviation,
+                dx,
+                dy,
+                ..
             } => {
-                // Drop shadow = blur + offset + composite with original
-                // The expansion rect encompasses both the blur and the offset
+                // The expansion rect encompasses both the blur and the offset.
                 let blur_radius = (*std_deviation * 3.0) as f64;
                 let dx = *dx as f64;
                 let dy = *dy as f64;
@@ -599,7 +620,9 @@ impl FilterPrimitive {
     /// The source expansion of the primitive, see [`Filter::source_expansion`].
     pub fn source_expansion(&self) -> Rect {
         match self {
-            Self::Offset { dx, dy } | Self::DropShadow { dx, dy, .. } => {
+            Self::Offset { dx, dy }
+            | Self::DropShadow { dx, dy, .. }
+            | Self::DropShadowOnly { dx, dy, .. } => {
                 self.filter_expansion() - Vec2::new(f64::from(*dx), f64::from(*dy))
             }
             _ => self.filter_expansion(),

--- a/sparse_strips/vello_cpu/src/filter/drop_shadow.rs
+++ b/sparse_strips/vello_cpu/src/filter/drop_shadow.rs
@@ -36,6 +36,7 @@ impl FilterEffect for DropShadow {
             &self.kernel[..usize::from(self.kernel_size)],
             self.color,
             self.edge_mode,
+            self.composite_original,
             filter_scratch,
         );
     }
@@ -52,7 +53,7 @@ impl FilterEffect for DropShadow {
 /// This is the main entry point that splits the drop shadow operation into well-defined steps:
 /// 1. Offset the shadow pixels
 /// 2. Blur the already-offset shadow
-/// 3. Apply shadow color and composite with original
+/// 3. Apply shadow color and optionally composite with original
 fn apply_drop_shadow(
     pixmap: &mut Pixmap,
     dx: f32,
@@ -62,6 +63,7 @@ fn apply_drop_shadow(
     kernel: &[f32],
     color: AlphaColor<Srgb>,
     edge_mode: EdgeMode,
+    composite_original: bool,
     filter_scratch: &mut ScratchBuffer,
 ) {
     // Clone pixmap to create shadow buffer
@@ -83,15 +85,21 @@ fn apply_drop_shadow(
         );
     }
 
-    // Step 3: Apply shadow color and composite with original
-    compose_shadow_direct(&shadow_pixmap, pixmap, color);
+    // Step 3: Apply shadow color and optionally composite with original
+    write_shadow_direct(&shadow_pixmap, pixmap, color, composite_original);
 }
 
-/// Apply shadow color and composite with original.
+/// Apply the shadow color and optionally composite with the original.
 ///
 /// The shadow has already been offset and blurred, so this simply applies
-/// the shadow color to the alpha channel and composites using source-over.
-fn compose_shadow_direct(shadow: &Pixmap, dst: &mut Pixmap, color: AlphaColor<Srgb>) {
+/// the shadow color to the alpha channel and, when requested, composites the
+/// original over it using source-over.
+fn write_shadow_direct(
+    shadow: &Pixmap,
+    dst: &mut Pixmap,
+    color: AlphaColor<Srgb>,
+    composite_original: bool,
+) {
     let width = dst.width();
     let height = dst.height();
 
@@ -120,9 +128,12 @@ fn compose_shadow_direct(shadow: &Pixmap, dst: &mut Pixmap, color: AlphaColor<Sr
                 a: final_alpha,
             };
 
-            // Read original and composite: original over shadow
-            let original_pixel = dst.sample(x, y);
-            let result = compose_src_over(original_pixel, colored_shadow);
+            let result = if composite_original {
+                // Read original and composite: original over shadow
+                compose_src_over(dst.sample(x, y), colored_shadow)
+            } else {
+                colored_shadow
+            };
 
             dst.set_pixel(x, y, result);
         }
@@ -277,7 +288,7 @@ mod tests {
         );
     }
 
-    /// Test `compose_shadow_direct` applies color correctly.
+    /// Test `write_shadow_direct` applies color correctly.
     #[test]
     fn test_compose_shadow_color() {
         let mut shadow_pixmap = Pixmap::new(2, 2);
@@ -300,7 +311,7 @@ mod tests {
             cs: std::marker::PhantomData::<Srgb>,
         };
 
-        compose_shadow_direct(&shadow_pixmap, &mut dst_pixmap, shadow_color);
+        write_shadow_direct(&shadow_pixmap, &mut dst_pixmap, shadow_color, true);
 
         // Shadow at (0,0) should be red
         let result = dst_pixmap.sample(0, 0);

--- a/sparse_strips/vello_cpu/src/filter/drop_shadow.rs
+++ b/sparse_strips/vello_cpu/src/filter/drop_shadow.rs
@@ -86,7 +86,7 @@ fn apply_drop_shadow(
     }
 
     // Step 3: Apply shadow color and optionally composite with original
-    write_shadow_direct(&shadow_pixmap, pixmap, color, composite_original);
+    write_colored_shadow(&shadow_pixmap, pixmap, color, composite_original);
 }
 
 /// Apply the shadow color and optionally composite with the original.
@@ -94,7 +94,7 @@ fn apply_drop_shadow(
 /// The shadow has already been offset and blurred, so this simply applies
 /// the shadow color to the alpha channel and, when requested, composites the
 /// original over it using source-over.
-fn write_shadow_direct(
+fn write_colored_shadow(
     shadow: &Pixmap,
     dst: &mut Pixmap,
     color: AlphaColor<Srgb>,
@@ -288,7 +288,7 @@ mod tests {
         );
     }
 
-    /// Test `write_shadow_direct` applies color correctly.
+    /// Test `write_colored_shadow` applies color correctly.
     #[test]
     fn test_compose_shadow_color() {
         let mut shadow_pixmap = Pixmap::new(2, 2);
@@ -311,7 +311,7 @@ mod tests {
             cs: std::marker::PhantomData::<Srgb>,
         };
 
-        write_shadow_direct(&shadow_pixmap, &mut dst_pixmap, shadow_color, true);
+        write_colored_shadow(&shadow_pixmap, &mut dst_pixmap, shadow_color, true);
 
         // Shadow at (0,0) should be red
         let result = dst_pixmap.sample(0, 0);

--- a/sparse_strips/vello_hybrid/src/filter.rs
+++ b/sparse_strips/vello_hybrid/src/filter.rs
@@ -33,6 +33,7 @@ pub(crate) const FILTER_ATLAS_PADDING: u16 = MAX_KERNEL_SIZE as u16 / 2;
 const BYTES_PER_TEXEL: usize = 16;
 const FILTER_SIZE_BYTES: usize = 48;
 const FILTER_SIZE_U32: usize = FILTER_SIZE_BYTES / 4;
+const COMPOSITE_ORIGINAL_SHIFT: u32 = 13;
 
 const _: () = assert!(
     size_of::<GpuFilterData>() == FILTER_SIZE_BYTES,
@@ -78,6 +79,7 @@ pub(crate) mod pass_kind {
     pub(crate) const BLUR_V: u32 = 5;
     pub(crate) const UPSCALE: u32 = 6;
     pub(crate) const COMPOSITE_DROP_SHADOW: u32 = 7;
+    pub(crate) const COLORIZE: u32 = 8;
 }
 
 pub(crate) fn edge_mode_to_gpu(mode: EdgeMode) -> u32 {
@@ -284,7 +286,7 @@ impl From<&DropShadow> for GpuDropShadow {
                 edge_mode_to_gpu(shadow.edge_mode),
                 shadow.n_decimations as u32,
                 lk.n_taps as u32,
-            ),
+            ) | (u32::from(shadow.composite_original) << COMPOSITE_ORIGINAL_SHIFT),
             center_weight: lk.center_weight,
             linear_weights: lk.weights,
             linear_offsets: lk.offsets,
@@ -318,10 +320,14 @@ impl GpuFilterData {
         ((self.data[0] >> 7) & 0xF) as usize
     }
 
+    pub(crate) fn composite_original(&self) -> bool {
+        (self.data[0] >> COMPOSITE_ORIGINAL_SHIFT) & 1 != 0
+    }
+
     pub(crate) fn needs_copy_pass(&self) -> bool {
         // For drop shadows, we need to retain the original rendered layer because in the end
         // we need to composite it _on top_ of the actual shadow.
-        self.filter_type() == filter_type::DROP_SHADOW
+        self.filter_type() == filter_type::DROP_SHADOW && self.composite_original()
     }
 }
 
@@ -429,7 +435,11 @@ impl FilterPassPlan {
                 filter_type::DROP_SHADOW => {
                     builder.emit(pass_kind::OFFSET);
                     builder.emit_blur_sequence(filter.gpu_filter.n_decimations());
-                    builder.emit(pass_kind::COMPOSITE_DROP_SHADOW);
+                    if filter.gpu_filter.composite_original() {
+                        builder.emit(pass_kind::COMPOSITE_DROP_SHADOW);
+                    } else {
+                        builder.emit(pass_kind::COLORIZE);
+                    }
                 }
                 _ => unreachable!("unsupported filter type was encoded"),
             }

--- a/sparse_strips/vello_hybrid/src/filter.rs
+++ b/sparse_strips/vello_hybrid/src/filter.rs
@@ -34,6 +34,7 @@ const BYTES_PER_TEXEL: usize = 16;
 const FILTER_SIZE_BYTES: usize = 48;
 const FILTER_SIZE_U32: usize = FILTER_SIZE_BYTES / 4;
 const COMPOSITE_ORIGINAL_SHIFT: u32 = 13;
+const COMPOSITE_ORIGINAL_MASK: u32 = 1 << COMPOSITE_ORIGINAL_SHIFT;
 
 const _: () = assert!(
     size_of::<GpuFilterData>() == FILTER_SIZE_BYTES,
@@ -97,7 +98,7 @@ fn pack_header(filter_type: u32) -> u32 {
     filter_type
 }
 
-fn pack_header_with_gaussian_params(
+const fn pack_header_with_gaussian_params(
     filter_type: u32,
     edge_mode: u32,
     n_decimations: u32,
@@ -110,6 +111,11 @@ fn pack_header_with_gaussian_params(
 
     filter_type | (edge_mode << 5) | (n_decimations << 7) | (n_linear_taps << 11)
 }
+
+const _: () = assert!(
+    pack_header_with_gaussian_params(31, 3, 15, 3) & COMPOSITE_ORIGINAL_MASK == 0,
+    "Gaussian filter parameters overlap the composite_original bit"
+);
 
 // To a large degree, the vello_hybrid implementation of gaussian blur follows the one in vello_cpu.
 // However, we apply a specific optimization, where instead of averaging and weighting each sample
@@ -280,13 +286,19 @@ impl From<&DropShadow> for GpuDropShadow {
     )]
     fn from(shadow: &DropShadow) -> Self {
         let lk = LinearKernel::new(&shadow.kernel, shadow.kernel_size);
+        let composite_original = if shadow.composite_original {
+            COMPOSITE_ORIGINAL_MASK
+        } else {
+            0
+        };
+
         Self {
             header: pack_header_with_gaussian_params(
                 filter_type::DROP_SHADOW,
                 edge_mode_to_gpu(shadow.edge_mode),
                 shadow.n_decimations as u32,
                 lk.n_taps as u32,
-            ) | (u32::from(shadow.composite_original) << COMPOSITE_ORIGINAL_SHIFT),
+            ) | composite_original,
             center_weight: lk.center_weight,
             linear_weights: lk.weights,
             linear_offsets: lk.offsets,
@@ -321,7 +333,7 @@ impl GpuFilterData {
     }
 
     pub(crate) fn composite_original(&self) -> bool {
-        (self.data[0] >> COMPOSITE_ORIGINAL_SHIFT) & 1 != 0
+        self.data[0] & COMPOSITE_ORIGINAL_MASK != 0
     }
 
     pub(crate) fn needs_copy_pass(&self) -> bool {

--- a/sparse_strips/vello_hybrid/src/schedule/schedule_tests.rs
+++ b/sparse_strips/vello_hybrid/src/schedule/schedule_tests.rs
@@ -5,11 +5,11 @@ use super::test_support::{SceneCase, ScheduledCase};
 use super::{IntermediateTextureAllocations, IntermediateTextureRequirements, ScheduleStorage};
 use crate::filter::FILTER_ATLAS_PADDING;
 use crate::target::{RootTarget, TextureParity};
-use vello_common::filter_effects::{Filter, FilterPrimitive};
+use vello_common::filter_effects::{EdgeMode, Filter, FilterPrimitive};
 use vello_common::geometry::SizeU16;
 use vello_common::kurbo::Rect;
 use vello_common::multi_atlas::AtlasError;
-use vello_common::peniko::{BlendMode, Compose, Mix};
+use vello_common::peniko::{BlendMode, Color, Compose, Mix};
 
 #[test]
 fn intermediate_texture_requirements_validate_limit() {
@@ -706,6 +706,28 @@ fn filter_layer() {
     assert_eq!(rounds_view[0].filter_passes, [0, 1]);
     assert!(rounds_view[0].root.has_child_layer);
     assert_eq!(scheduled.total_clears(), 2);
+}
+
+#[test]
+fn drop_shadow_only_uses_two_layer_textures() {
+    let mut case = SceneCase::new(32, 32);
+    let filter = Filter::from_primitive(FilterPrimitive::DropShadowOnly {
+        dx: 4.0,
+        dy: 4.0,
+        std_deviation: 2.0,
+        color: Color::BLACK,
+        edge_mode: EdgeMode::None,
+    });
+    case.layer_with(None, None, Some(filter), |case| {
+        case.draw(Rect::new(8.0, 8.0, 16.0, 16.0), 0.5);
+    });
+
+    let scheduled = case
+        .schedule(RootTarget::UserSurface, SizeU16::new(64), 2)
+        .unwrap();
+
+    assert_eq!(scheduled.page_counts(), [1, 1]);
+    assert!(!scheduled.scratch_texture());
 }
 
 #[test]

--- a/sparse_strips/vello_sparse_shaders/shaders/filter.wgsl
+++ b/sparse_strips/vello_sparse_shaders/shaders/filter.wgsl
@@ -30,6 +30,7 @@ const PASS_BLUR_H: u32 = 4u;
 const PASS_BLUR_V: u32 = 5u;
 const PASS_UPSCALE: u32 = 6u;
 const PASS_COMPOSITE_DROP_SHADOW: u32 = 7u;
+const PASS_COLORIZE: u32 = 8u;
 
 // Keep in sync with FILTER_ATLAS_PADDING in vello_hybrid/src/filter.rs.
 const FILTER_ATLAS_PADDING: u32 = 6u;
@@ -41,7 +42,8 @@ const MAX_TAPS_PER_SIDE: u32 = 3u;
 //   bits [5:6]   = edge_mode     (2 bits, only for blur filters), currently ignored.
 //   bits [7:10]  = n_decimations (4 bits, only for blur filters), only read on the CPU side.
 //   bits [11:12] = n_linear_taps (2 bits, only for blur filters)
-//   bits [13:32] = reserved for future use
+//   bit  [13]    = composite_original (only for drop shadows), only read on the CPU side.
+//   bits [14:32] = reserved for future use
 
 fn load_filter_texel(texel_offset: u32, texel_index: u32) -> vec4<u32> {
     let w = textureDimensions(filter_data).x;
@@ -388,6 +390,12 @@ fn fs_main(
 
             // Simple source-over compositing.
             return original + shadow_result * (1.0 - original.a);
+        }
+        case PASS_COLORIZE: {
+            let filter_texel2 = load_filter_texel(filter_data_offset, 2u);
+            let blurred = sample_source(source_origin, rel_coord);
+            let shadow_color = unpack4x8unorm(get_drop_shadow_color(filter_texel2));
+            return shadow_color * blurred.a;
         }
         // Shouldn't be reached.
         default: {

--- a/sparse_strips/vello_sparse_tests/snapshots/filter_drop_shadow_only_four_directions.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/filter_drop_shadow_only_four_directions.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b49a9e073c13dcd5d84106374d7423c7ca77149b6ccb042713b3d8b8c4e3e3a
+size 2416

--- a/sparse_strips/vello_sparse_tests/snapshots/filter_drop_shadow_only_simple.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/filter_drop_shadow_only_simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a046b022e6800a571937395ab4faa685785bbf76bb5323e935e0b5069d2c88f
+size 840

--- a/sparse_strips/vello_sparse_tests/snapshots/filter_drop_shadow_only_simple_with_opacity.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/filter_drop_shadow_only_simple_with_opacity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a68adb6219b7c8b1be8351905ed7487695fff4dea75281a955e7ad4685439e81
+size 729

--- a/sparse_strips/vello_sparse_tests/tests/filter.rs
+++ b/sparse_strips/vello_sparse_tests/tests/filter.rs
@@ -257,6 +257,65 @@ fn filter_drop_shadow(ctx: &mut impl Renderer) {
     ctx.pop_layer();
 }
 
+#[vello_test(skip_multithreaded, hybrid_tolerance = 1)]
+fn filter_drop_shadow_only_simple(ctx: &mut impl Renderer) {
+    let filter = Filter::from_primitive(FilterPrimitive::DropShadowOnly {
+        dx: 20.0,
+        dy: 20.0,
+        std_deviation: 3.0,
+        color: TOMATO,
+        edge_mode: EdgeMode::None,
+    });
+
+    ctx.push_filter_layer(filter);
+    ctx.set_paint(ROYAL_BLUE);
+    ctx.fill_rect(&Rect::new(20.0, 20.0, 60.0, 60.0));
+    ctx.pop_layer();
+}
+
+#[vello_test(skip_multithreaded, hybrid_tolerance = 1)]
+fn filter_drop_shadow_only_simple_with_opacity(ctx: &mut impl Renderer) {
+    let filter = Filter::from_primitive(FilterPrimitive::DropShadowOnly {
+        dx: 20.0,
+        dy: 20.0,
+        std_deviation: 3.0,
+        color: TOMATO,
+        edge_mode: EdgeMode::None,
+    });
+
+    ctx.push_filter_layer(filter);
+    ctx.set_paint(ROYAL_BLUE.with_alpha(0.5));
+    ctx.fill_rect(&Rect::new(20.0, 20.0, 60.0, 60.0));
+    ctx.pop_layer();
+}
+
+#[vello_test(skip_multithreaded, hybrid_tolerance = 2)]
+fn filter_drop_shadow_only_four_directions(ctx: &mut impl Renderer) {
+    let rect = Rect::new(35.0, 35.0, 65.0, 65.0);
+    let shadows = [
+        (-20.0, -20.0, RED),
+        (20.0, -20.0, GREEN),
+        (-20.0, 20.0, BLUE),
+        (20.0, 20.0, YELLOW),
+    ];
+
+    for (dx, dy, color) in shadows {
+        let filter = Filter::from_primitive(FilterPrimitive::DropShadowOnly {
+            dx,
+            dy,
+            std_deviation: 3.0,
+            color,
+            edge_mode: EdgeMode::None,
+        });
+
+        ctx.push_filter_layer(filter);
+        // Just to double-check that the existing color is ignored.
+        ctx.set_paint(BLUE);
+        ctx.fill_rect(&rect);
+        ctx.pop_layer();
+    }
+}
+
 // Make sure drop shadows are not cut off at the top/left.
 #[vello_test(skip_multithreaded, hybrid_tolerance = 1, width = 100, height = 100)]
 fn filter_drop_shadow_offscreen(ctx: &mut impl Renderer) {


### PR DESCRIPTION
This is based on top of #1759. It adds a variation of drop shadow that doesn't composite the original layer on top of the shadow. CC @angusj-canva

Skia has something similar: https://api.skia.org/classSkImageFilters.html#a91354167ad35b6a0d95b6f1fc23f3aea