### PR TITLE
sparse_strips: Add `ColorMatrix` filter

### DIFF
--- a/sparse_strips/vello_common/src/filter/color_matrix.rs
+++ b/sparse_strips/vello_common/src/filter/color_matrix.rs
@@ -1,0 +1,21 @@
+// Copyright 2026 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! The color matrix filter.
+
+/// Matrix-based color transformation filter.
+///
+/// The matrix is stored as four rows of five values. Each row computes one output
+/// channel (`R`, `G`, `B`, `A`) from the four input channels plus a constant offset.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ColorMatrix {
+    /// The 4x5 color transformation matrix in row-major order.
+    pub matrix: [f32; 20],
+}
+
+impl ColorMatrix {
+    /// Create a new color matrix filter.
+    pub fn new(matrix: [f32; 20]) -> Self {
+        Self { matrix }
+    }
+}

--- a/sparse_strips/vello_common/src/filter/mod.rs
+++ b/sparse_strips/vello_common/src/filter/mod.rs
@@ -7,6 +7,7 @@
 //! represent a special representation of each filter to be used as the basis for rendering in
 //! `vello_hybrid` and `vello_cpu`.
 
+use crate::filter::color_matrix::ColorMatrix;
 use crate::filter::drop_shadow::{DropShadow, transform_shadow_params};
 use crate::filter::flood::Flood;
 use crate::filter::gaussian_blur::{GaussianBlur, transform_blur_params};
@@ -18,6 +19,7 @@ use crate::math::snap_up;
 use crate::tile::Tile;
 use crate::util::RectExt;
 
+pub mod color_matrix;
 pub mod drop_shadow;
 pub mod flood;
 pub mod gaussian_blur;
@@ -34,6 +36,8 @@ pub enum PreparedFilter {
     Offset(Offset),
     /// A drop shadow filter.
     DropShadow(DropShadow),
+    /// A color matrix filter.
+    ColorMatrix(ColorMatrix),
 }
 
 impl PreparedFilter {
@@ -96,8 +100,9 @@ impl PreparedFilter {
 
                 Self::Offset(offset)
             }
+            FilterPrimitive::ColorMatrix { matrix } => Self::ColorMatrix(ColorMatrix::new(*matrix)),
             _ => {
-                // Other primitives like Blend, ColorMatrix, ComponentTransfer, etc.
+                // Other primitives like Blend, ComponentTransfer, etc.
                 // are not yet implemented
                 unimplemented!("Other filter primitives not yet implemented");
             }
@@ -254,4 +259,24 @@ fn transform_offset_params(dx: f32, dy: f32, transform: &Affine) -> (f32, f32) {
     let [a, b, c, d, _, _] = transform.as_coeffs();
     let transformed_offset = Vec2::new(a * offset.x + c * offset.y, b * offset.x + d * offset.y);
     (transformed_offset.x as f32, transformed_offset.y as f32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::filter_effects::matrices;
+
+    #[test]
+    fn prepares_color_matrix_filter() {
+        let filter = Filter::from_primitive(FilterPrimitive::ColorMatrix {
+            matrix: matrices::SEPIA,
+        });
+        let prepared = PreparedFilter::new(&filter, &Affine::IDENTITY);
+
+        let PreparedFilter::ColorMatrix(color_matrix) = prepared else {
+            panic!("expected color matrix filter");
+        };
+
+        assert_eq!(color_matrix.matrix, matrices::SEPIA);
+    }
 }

--- a/sparse_strips/vello_common/src/filter_effects.rs
+++ b/sparse_strips/vello_common/src/filter_effects.rs
@@ -426,11 +426,6 @@ pub enum FilterPrimitive {
         /// Edge mode for handling boundaries during blur operation.
         edge_mode: EdgeMode,
     },
-    //
-    // ============================================================
-    // TODO: The following filter primitives are not yet implemented
-    // ============================================================
-    //
     /// Matrix-based color transformation.
     ///
     /// Applies a 4x5 matrix transformation to colors, allowing arbitrary
@@ -451,6 +446,11 @@ pub enum FilterPrimitive {
         dy: f32,
     },
 
+    //
+    // ============================================================
+    // TODO: The following filter primitives are not yet implemented
+    // ============================================================
+    //
     /// Composite two inputs using Porter-Duff compositing operations.
     ///
     /// Combines two input images using standard compositing operators

--- a/sparse_strips/vello_cpu/src/filter/color_matrix.rs
+++ b/sparse_strips/vello_cpu/src/filter/color_matrix.rs
@@ -1,0 +1,331 @@
+// Copyright 2026 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Color matrix filter implementation.
+
+use super::FilterEffect;
+use super::context::ScratchBuffer;
+use super::pixel::{
+    clamp_unit, norm_to_u8, premul_rgba8_to_straight_f32, straight_f32_to_premul_rgba8, u8_to_norm,
+};
+use vello_common::filter::color_matrix::ColorMatrix;
+use vello_common::filter_effects::matrices;
+use vello_common::peniko::color::PremulRgba8;
+use vello_common::pixmap::Pixmap;
+
+impl FilterEffect for ColorMatrix {
+    fn execute_lowp(&self, pixmap: &mut Pixmap, _filter_scratch: &mut ScratchBuffer) {
+        apply_color_matrix(pixmap, &self.matrix);
+    }
+
+    fn execute_highp(&self, pixmap: &mut Pixmap, _filter_scratch: &mut ScratchBuffer) {
+        apply_color_matrix(pixmap, &self.matrix);
+    }
+}
+
+// TODO: This walks every pixel scalar-by-scalar and is a strong candidate for
+// SIMD; filters are not yet wired up for SIMD in vello_cpu. Additionally, color
+// matrix is a purely per-pixel (non-spatial) filter, so it could bypass the
+// spatial filter path (which allocates a scratch pixmap) and run directly in
+// `vello_cpu` fine, like `Flood`. Both are worthwhile performance follow-ups.
+fn apply_color_matrix(pixmap: &mut Pixmap, matrix: &[f32; 20]) {
+    if matrix == &matrices::IDENTITY {
+        return;
+    }
+
+    let mut may_have_transparency = false;
+    if is_premul_compatible_matrix(matrix) {
+        // For RGB-only, alpha-preserving matrices, applying the RGB matrix to
+        // premultiplied channels is equivalent to unpremultiply -> matrix ->
+        // premultiply. This avoids the per-pixel alpha division.
+        for pixel in pixmap.data_mut() {
+            let transformed = apply_premul_color_matrix_to_pixel(*pixel, matrix);
+            may_have_transparency |= transformed.a != 255;
+            *pixel = transformed;
+        }
+    } else {
+        for pixel in pixmap.data_mut() {
+            let transformed = apply_color_matrix_to_pixel(*pixel, matrix);
+            may_have_transparency |= transformed.a != 255;
+            *pixel = transformed;
+        }
+    }
+
+    pixmap.set_may_have_transparency(may_have_transparency);
+}
+
+#[inline]
+fn apply_color_matrix_to_pixel(pixel: PremulRgba8, matrix: &[f32; 20]) -> PremulRgba8 {
+    let [r, g, b, a] = premul_rgba8_to_straight_f32(pixel);
+
+    let out_r = apply_row(matrix, 0, r, g, b, a);
+    let out_g = apply_row(matrix, 5, r, g, b, a);
+    let out_b = apply_row(matrix, 10, r, g, b, a);
+    let out_a = apply_row(matrix, 15, r, g, b, a);
+
+    straight_f32_to_premul_rgba8(out_r, out_g, out_b, out_a)
+}
+
+#[inline]
+fn apply_premul_color_matrix_to_pixel(pixel: PremulRgba8, matrix: &[f32; 20]) -> PremulRgba8 {
+    let r = u8_to_norm(pixel.r);
+    let g = u8_to_norm(pixel.g);
+    let b = u8_to_norm(pixel.b);
+    let a = u8_to_norm(pixel.a);
+
+    let out_r = matrix[0] * r + matrix[1] * g + matrix[2] * b;
+    let out_g = matrix[5] * r + matrix[6] * g + matrix[7] * b;
+    let out_b = matrix[10] * r + matrix[11] * g + matrix[12] * b;
+
+    PremulRgba8 {
+        // Straight-alpha clamping before re-premultiplication becomes
+        // clamping to [0, alpha] in premultiplied space.
+        r: norm_to_u8(out_r.clamp(0.0, a)),
+        g: norm_to_u8(out_g.clamp(0.0, a)),
+        b: norm_to_u8(out_b.clamp(0.0, a)),
+        a: pixel.a,
+    }
+}
+
+#[inline]
+fn apply_row(matrix: &[f32; 20], offset: usize, r: f32, g: f32, b: f32, a: f32) -> f32 {
+    clamp_unit(
+        matrix[offset] * r
+            + matrix[offset + 1] * g
+            + matrix[offset + 2] * b
+            + matrix[offset + 3] * a
+            + matrix[offset + 4],
+    )
+}
+
+#[inline]
+fn is_premul_compatible_matrix(matrix: &[f32; 20]) -> bool {
+    let row_r = &matrix[0..5];
+    let row_g = &matrix[5..10];
+    let row_b = &matrix[10..15];
+    let row_a = &matrix[15..20];
+    // RGB rows must not depend on alpha (col 3) or carry a constant offset (col 4):
+    // applying the matrix directly to premultiplied channels then yields the same
+    // result as unpremultiply -> matrix -> premultiply.
+    let rgb_alpha_independent = row_r[3] == 0.0
+        && row_r[4] == 0.0
+        && row_g[3] == 0.0
+        && row_g[4] == 0.0
+        && row_b[3] == 0.0
+        && row_b[4] == 0.0;
+    // And alpha must be preserved exactly.
+    let alpha_preserved =
+        row_a[0] == 0.0 && row_a[1] == 0.0 && row_a[2] == 0.0 && row_a[3] == 1.0 && row_a[4] == 0.0;
+    rgb_alpha_independent && alpha_preserved
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identity_preserves_premultiplied_pixel() {
+        let pixel = PremulRgba8 {
+            r: 128,
+            g: 64,
+            b: 32,
+            a: 128,
+        };
+
+        assert_eq!(
+            apply_color_matrix_to_pixel(pixel, &matrices::IDENTITY),
+            pixel
+        );
+    }
+
+    #[test]
+    fn identity_matrix_leaves_pixmap_unchanged() {
+        let mut pixmap = Pixmap::from_parts_with_opacity(
+            alloc::vec![
+                PremulRgba8 {
+                    r: 255,
+                    g: 0,
+                    b: 0,
+                    a: 255,
+                },
+                PremulRgba8 {
+                    r: 128,
+                    g: 64,
+                    b: 32,
+                    a: 128,
+                },
+            ],
+            2,
+            1,
+            true,
+        );
+        let before = [pixmap.sample(0, 0), pixmap.sample(1, 0)];
+
+        apply_color_matrix(&mut pixmap, &matrices::IDENTITY);
+
+        assert_eq!([pixmap.sample(0, 0), pixmap.sample(1, 0)], before);
+        assert!(pixmap.may_have_transparency());
+    }
+
+    #[test]
+    fn grayscale_uses_unpremultiplied_color_channels() {
+        let pixel = PremulRgba8 {
+            r: 128,
+            g: 0,
+            b: 0,
+            a: 128,
+        };
+
+        assert_eq!(
+            apply_color_matrix_to_pixel(pixel, &matrices::GRAYSCALE),
+            PremulRgba8 {
+                r: 27,
+                g: 27,
+                b: 27,
+                a: 128,
+            }
+        );
+    }
+
+    #[test]
+    fn premul_compatible_matrices_skip_straight_alpha_conversion() {
+        assert!(is_premul_compatible_matrix(&matrices::GRAYSCALE));
+        assert!(is_premul_compatible_matrix(&matrices::SEPIA));
+        assert!(!is_premul_compatible_matrix(&matrices::ALPHA_TO_BLACK));
+    }
+
+    #[test]
+    fn premul_compatible_path_matches_straight_alpha_path() {
+        let pixel = PremulRgba8 {
+            r: 80,
+            g: 32,
+            b: 16,
+            a: 128,
+        };
+
+        let premul = apply_premul_color_matrix_to_pixel(pixel, &matrices::SEPIA);
+        let straight = apply_color_matrix_to_pixel(pixel, &matrices::SEPIA);
+
+        assert_eq!(premul, straight);
+    }
+
+    #[test]
+    fn premul_compatible_path_clamps_rgb_to_alpha() {
+        let pixel = PremulRgba8 {
+            r: 128,
+            g: 0,
+            b: 0,
+            a: 128,
+        };
+        let matrix = [
+            2.0, 0.0, 0.0, 0.0, 0.0, //
+            0.0, 1.0, 0.0, 0.0, 0.0, //
+            0.0, 0.0, 1.0, 0.0, 0.0, //
+            0.0, 0.0, 0.0, 1.0, 0.0,
+        ];
+
+        let premul = apply_premul_color_matrix_to_pixel(pixel, &matrix);
+        let straight = apply_color_matrix_to_pixel(pixel, &matrix);
+
+        assert_eq!(premul, straight);
+        assert_eq!(
+            premul,
+            PremulRgba8 {
+                r: 128,
+                g: 0,
+                b: 0,
+                a: 128,
+            }
+        );
+    }
+
+    #[test]
+    fn matrix_offsets_can_create_color_from_transparent_black() {
+        let matrix = [
+            0.0, 0.0, 0.0, 0.0, 0.5, //
+            0.0, 0.0, 0.0, 0.0, 0.25, //
+            0.0, 0.0, 0.0, 0.0, 0.0, //
+            0.0, 0.0, 0.0, 0.0, 0.5,
+        ];
+
+        assert_eq!(
+            apply_color_matrix_to_pixel(PremulRgba8::from_u32(0), &matrix),
+            PremulRgba8 {
+                r: 64,
+                g: 32,
+                b: 0,
+                a: 128,
+            }
+        );
+    }
+
+    #[test]
+    fn execution_updates_pixmap_transparency_flag() {
+        let mut pixmap = Pixmap::from_parts_with_opacity(
+            alloc::vec![PremulRgba8 {
+                r: 255,
+                g: 0,
+                b: 0,
+                a: 255,
+            }],
+            1,
+            1,
+            false,
+        );
+        let mut filter_scratch = ScratchBuffer::new();
+        let matrix = [
+            1.0, 0.0, 0.0, 0.0, 0.0, //
+            0.0, 1.0, 0.0, 0.0, 0.0, //
+            0.0, 0.0, 1.0, 0.0, 0.0, //
+            0.0, 0.0, 0.0, 0.0, 0.5,
+        ];
+        let filter = ColorMatrix::new(matrix);
+
+        filter.execute_lowp(&mut pixmap, &mut filter_scratch);
+
+        assert!(pixmap.may_have_transparency());
+        assert_eq!(
+            pixmap.sample(0, 0),
+            PremulRgba8 {
+                r: 128,
+                g: 0,
+                b: 0,
+                a: 128,
+            }
+        );
+    }
+
+    #[test]
+    fn execution_updates_transparency_flag_for_opaque_output() {
+        let mut pixmap = Pixmap::from_parts_with_opacity(
+            alloc::vec![PremulRgba8 {
+                r: 128,
+                g: 0,
+                b: 0,
+                a: 128,
+            }],
+            1,
+            1,
+            true,
+        );
+        let matrix = [
+            1.0, 0.0, 0.0, 0.0, 0.0, //
+            0.0, 1.0, 0.0, 0.0, 0.0, //
+            0.0, 0.0, 1.0, 0.0, 0.0, //
+            0.0, 0.0, 0.0, 0.0, 1.0,
+        ];
+
+        apply_color_matrix(&mut pixmap, &matrix);
+
+        assert!(!pixmap.may_have_transparency());
+        assert_eq!(
+            pixmap.sample(0, 0),
+            PremulRgba8 {
+                r: 255,
+                g: 0,
+                b: 0,
+                a: 255,
+            }
+        );
+    }
+}

--- a/sparse_strips/vello_cpu/src/filter/mod.rs
+++ b/sparse_strips/vello_cpu/src/filter/mod.rs
@@ -8,11 +8,13 @@
 //! Filters are applied to rendered layer pixmaps and may use scratch storage for
 //! intermediate buffers.
 
+mod color_matrix;
 pub(crate) mod context;
 mod drop_shadow;
 mod flood;
 mod gaussian_blur;
 mod offset;
+mod pixel;
 mod shift;
 
 use context::ScratchBuffer;
@@ -79,6 +81,9 @@ pub(crate) fn filter_lowp(
         PreparedFilter::DropShadow(drop_shadow) => {
             drop_shadow.execute_lowp(pixmap, filter_scratch);
         }
+        PreparedFilter::ColorMatrix(color_matrix) => {
+            color_matrix.execute_lowp(pixmap, filter_scratch);
+        }
     }
 }
 
@@ -116,6 +121,9 @@ pub(crate) fn filter_highp(
         }
         PreparedFilter::DropShadow(drop_shadow) => {
             drop_shadow.execute_highp(pixmap, filter_scratch);
+        }
+        PreparedFilter::ColorMatrix(color_matrix) => {
+            color_matrix.execute_highp(pixmap, filter_scratch);
         }
     }
 }

--- a/sparse_strips/vello_cpu/src/filter/pixel.rs
+++ b/sparse_strips/vello_cpu/src/filter/pixel.rs
@@ -1,0 +1,110 @@
+// Copyright 2026 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Pixel helpers for CPU filter effects.
+
+use vello_common::peniko::color::PremulRgba8;
+#[cfg(not(feature = "std"))]
+use vello_common::peniko::kurbo::common::FloatFuncs as _;
+
+const INV_255: f32 = 1.0 / 255.0;
+
+/// Convert a u8 color component to normalized f32.
+#[inline]
+pub(super) fn u8_to_norm(value: u8) -> f32 {
+    f32::from(value) * INV_255
+}
+
+/// Convert a normalized f32 color component to u8.
+#[inline]
+pub(super) fn norm_to_u8(value: f32) -> u8 {
+    (clamp_unit(value) * 255.0).round() as u8
+}
+
+/// Convert a premultiplied RGBA8 pixel to normalized straight-alpha components.
+#[inline]
+pub(super) fn premul_rgba8_to_straight_f32(pixel: PremulRgba8) -> [f32; 4] {
+    let a = u8_to_norm(pixel.a);
+
+    match pixel.a {
+        0 => [0.0, 0.0, 0.0, 0.0],
+        255 => [
+            u8_to_norm(pixel.r),
+            u8_to_norm(pixel.g),
+            u8_to_norm(pixel.b),
+            1.0,
+        ],
+        _ => {
+            let inv_alpha = 1.0 / a;
+            [
+                u8_to_norm(pixel.r) * inv_alpha,
+                u8_to_norm(pixel.g) * inv_alpha,
+                u8_to_norm(pixel.b) * inv_alpha,
+                a,
+            ]
+        }
+    }
+}
+
+/// Convert normalized straight-alpha components to a premultiplied RGBA8 pixel.
+#[inline]
+pub(super) fn straight_f32_to_premul_rgba8(r: f32, g: f32, b: f32, a: f32) -> PremulRgba8 {
+    let a = clamp_unit(a);
+
+    PremulRgba8 {
+        r: norm_to_u8(r * a),
+        g: norm_to_u8(g * a),
+        b: norm_to_u8(b * a),
+        a: norm_to_u8(a),
+    }
+}
+
+#[inline]
+pub(super) fn clamp_unit(value: f32) -> f32 {
+    value.clamp(0.0, 1.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn u8_to_norm_converts_endpoints() {
+        assert_eq!(u8_to_norm(0), 0.0);
+        assert!((u8_to_norm(255) - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn norm_to_u8_rounds_to_nearest() {
+        assert_eq!(norm_to_u8(0.0), 0);
+        assert_eq!(norm_to_u8(1.0), 255);
+        assert_eq!(norm_to_u8(0.5), 128);
+    }
+
+    #[test]
+    fn norm_to_u8_clamps() {
+        assert_eq!(norm_to_u8(-1.0), 0);
+        assert_eq!(norm_to_u8(2.0), 255);
+    }
+
+    #[test]
+    fn premul_to_straight_handles_transparent_black() {
+        assert_eq!(
+            premul_rgba8_to_straight_f32(PremulRgba8::from_u32(0)),
+            [0.0, 0.0, 0.0, 0.0]
+        );
+    }
+
+    #[test]
+    fn straight_to_premul_premultiplies_rgb() {
+        assert_eq!(
+            straight_f32_to_premul_rgba8(1.0, 0.5, 0.0, 0.5),
+            PremulRgba8 {
+                r: 128,
+                g: 64,
+                b: 0,
+                a: 128,
+            }
+        );
+    }
+}

--- a/sparse_strips/vello_hybrid/src/filter.rs
+++ b/sparse_strips/vello_hybrid/src/filter.rs
@@ -8,6 +8,7 @@ use crate::schedule::round::FilterOp;
 use crate::util::pack_u16_pair;
 use alloc::vec::Vec;
 use bytemuck::{Pod, Zeroable};
+use vello_common::filter::color_matrix::ColorMatrix;
 use vello_common::filter::drop_shadow::DropShadow;
 use vello_common::filter::flood::Flood;
 use vello_common::filter::gaussian_blur::{DecimationSizer, GaussianBlur, MAX_KERNEL_SIZE};
@@ -31,30 +32,31 @@ pub(crate) const FILTER_ATLAS_PADDING: u16 = MAX_KERNEL_SIZE as u16 / 2;
 
 // Since we store in RGBA32 texture.
 const BYTES_PER_TEXEL: usize = 16;
-const FILTER_SIZE_BYTES: usize = 48;
-const FILTER_SIZE_U32: usize = FILTER_SIZE_BYTES / 4;
 const COMPOSITE_ORIGINAL_SHIFT: u32 = 13;
 const COMPOSITE_ORIGINAL_MASK: u32 = 1 << COMPOSITE_ORIGINAL_SHIFT;
 
+// Each filter is packed into a whole number of 16-byte texels; the shader
+// indexes fields by texel within a filter's span, so these sizes must stay in
+// sync with `filter.wgsl`.
 const _: () = assert!(
-    size_of::<GpuFilterData>() == FILTER_SIZE_BYTES,
-    "memory size of filters need to match"
+    size_of::<GpuOffset>() == BYTES_PER_TEXEL,
+    "GpuOffset must be one texel"
 );
 const _: () = assert!(
-    size_of::<GpuOffset>() == FILTER_SIZE_BYTES,
-    "memory size of filters need to match"
+    size_of::<GpuFlood>() == BYTES_PER_TEXEL,
+    "GpuFlood must be one texel"
 );
 const _: () = assert!(
-    size_of::<GpuFlood>() == FILTER_SIZE_BYTES,
-    "memory size of filters need to match"
+    size_of::<GpuGaussianBlur>() == 2 * BYTES_PER_TEXEL,
+    "GpuGaussianBlur must be two texels"
 );
 const _: () = assert!(
-    size_of::<GpuDropShadow>() == FILTER_SIZE_BYTES,
-    "memory size of filters need to match"
+    size_of::<GpuDropShadow>() == 3 * BYTES_PER_TEXEL,
+    "GpuDropShadow must be three texels"
 );
 const _: () = assert!(
-    size_of::<GpuGaussianBlur>() == FILTER_SIZE_BYTES,
-    "memory size of filters need to match"
+    size_of::<GpuColorMatrix>() == 6 * BYTES_PER_TEXEL,
+    "GpuColorMatrix must be six texels"
 );
 
 pub(crate) mod filter_type {
@@ -62,6 +64,7 @@ pub(crate) mod filter_type {
     pub(crate) const FLOOD: u32 = 1;
     pub(crate) const GAUSSIAN_BLUR: u32 = 2;
     pub(crate) const DROP_SHADOW: u32 = 3;
+    pub(crate) const COLOR_MATRIX: u32 = 4;
 }
 
 pub(crate) mod edge_mode {
@@ -81,6 +84,7 @@ pub(crate) mod pass_kind {
     pub(crate) const UPSCALE: u32 = 6;
     pub(crate) const COMPOSITE_DROP_SHADOW: u32 = 7;
     pub(crate) const COLORIZE: u32 = 8;
+    pub(crate) const COLOR_MATRIX: u32 = 9;
 }
 
 pub(crate) fn edge_mode_to_gpu(mode: EdgeMode) -> u32 {
@@ -186,10 +190,22 @@ impl LinearKernel {
     }
 }
 
-// Currently, we assume that each filter struct has the same size so we can cast them into
-// the type-erased type and assume uniform offsets. It might be worth exploring variable offsets
-// (as is done for encoded paints) in the future, but it doesn't seem to be worth it for filters
-// specifically since it's uncommon to have more than a few dozen filters in a single scene.
+// Filters are packed back-to-back into the filter-data texture with per-filter
+// texel offsets (see `FilterInstanceData::filter_data_offset`), so each filter
+// occupies only as many 16-byte texels as its parameters need — the same
+// variable-stride scheme used for encoded paints. Each `Gpu*` struct is
+// `#[repr(C, align(16))]` and explicitly padded to a whole number of texels
+// (bytemuck's `Pod` forbids implicit trailing padding), and the shader reads
+// each filter's fields by texel index within that struct's span.
+
+/// Number of 16-byte texels a filter struct occupies in the filter-data texture.
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "filter struct sizes are small constants"
+)]
+const fn filter_size_texels<T>() -> u32 {
+    (size_of::<T>() / BYTES_PER_TEXEL) as u32
+}
 
 #[repr(C, align(16))]
 #[derive(Debug, Clone, Copy, PartialEq, Zeroable, Pod)]
@@ -197,7 +213,7 @@ pub(crate) struct GpuOffset {
     pub header: u32,
     pub dx: f32,
     pub dy: f32,
-    pub _padding: [u32; 9],
+    pub _padding: [u32; 1],
 }
 
 impl From<&Offset> for GpuOffset {
@@ -206,7 +222,7 @@ impl From<&Offset> for GpuOffset {
             header: pack_header(filter_type::OFFSET),
             dx: offset.dx,
             dy: offset.dy,
-            _padding: [0; 9],
+            _padding: [0; 1],
         }
     }
 }
@@ -216,7 +232,7 @@ impl From<&Offset> for GpuOffset {
 pub(crate) struct GpuFlood {
     pub header: u32,
     pub color: u32,
-    pub _padding: [u32; 10],
+    pub _padding: [u32; 2],
 }
 
 impl From<&Flood> for GpuFlood {
@@ -224,7 +240,7 @@ impl From<&Flood> for GpuFlood {
         Self {
             header: pack_header(filter_type::FLOOD),
             color: flood.color.premultiply().to_rgba8().to_u32(),
-            _padding: [0; 10],
+            _padding: [0; 2],
         }
     }
 }
@@ -236,8 +252,6 @@ pub(crate) struct GpuGaussianBlur {
     pub center_weight: f32,
     pub linear_weights: [f32; MAX_TAPS_PER_SIDE],
     pub linear_offsets: [f32; MAX_TAPS_PER_SIDE],
-    // Needed since drop shadow has a bigger footprint.
-    pub _padding: [u32; 4],
 }
 
 impl From<&GaussianBlur> for GpuGaussianBlur {
@@ -261,7 +275,6 @@ impl From<&GaussianBlur> for GpuGaussianBlur {
             center_weight: lk.center_weight,
             linear_weights: lk.weights,
             linear_offsets: lk.offsets,
-            _padding: [0; 4],
         }
     }
 }
@@ -311,29 +324,44 @@ impl From<&DropShadow> for GpuDropShadow {
 }
 
 #[repr(C, align(16))]
+#[derive(Debug, Clone, Copy, PartialEq, Zeroable, Pod)]
+pub(crate) struct GpuColorMatrix {
+    pub header: u32,
+    pub matrix: [f32; 20],
+    pub _padding: [u32; 3],
+}
+
+impl From<&ColorMatrix> for GpuColorMatrix {
+    fn from(color_matrix: &ColorMatrix) -> Self {
+        Self {
+            header: pack_header(filter_type::COLOR_MATRIX),
+            matrix: color_matrix.matrix,
+            _padding: [0; 3],
+        }
+    }
+}
+
+/// The packed filter header. Carries the metadata the scheduler reads (filter
+/// type, decimation count, `composite_original`); the full per-filter
+/// parameters are serialized separately through [`GpuFilter`].
+#[repr(C)]
 #[derive(Debug, Clone, Copy, Zeroable, Pod)]
 pub(crate) struct GpuFilterData {
-    data: [u32; FILTER_SIZE_U32],
+    header: u32,
 }
 
 impl GpuFilterData {
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "filter size is a small constant"
-    )]
-    pub(crate) const SIZE_TEXELS: u32 = size_of::<Self>().div_ceil(BYTES_PER_TEXEL) as u32;
-
     pub(crate) fn filter_type(&self) -> u32 {
-        self.data[0] & 0x1F
+        self.header & 0x1F
     }
 
     /// Returns the number of decimation levels encoded in the header.
     pub(crate) fn n_decimations(&self) -> usize {
-        ((self.data[0] >> 7) & 0xF) as usize
+        ((self.header >> 7) & 0xF) as usize
     }
 
     pub(crate) fn composite_original(&self) -> bool {
-        self.data[0] & COMPOSITE_ORIGINAL_MASK != 0
+        self.header & COMPOSITE_ORIGINAL_MASK != 0
     }
 
     pub(crate) fn needs_copy_pass(&self) -> bool {
@@ -343,26 +371,61 @@ impl GpuFilterData {
     }
 }
 
-trait CastToFilterData: Pod {}
+/// A filter's full GPU parameters, sized to its own texel span.
+#[derive(Debug, Clone, Copy)]
+enum GpuFilter {
+    Offset(GpuOffset),
+    Flood(GpuFlood),
+    GaussianBlur(GpuGaussianBlur),
+    DropShadow(GpuDropShadow),
+    ColorMatrix(GpuColorMatrix),
+}
 
-impl CastToFilterData for GpuOffset {}
-impl CastToFilterData for GpuFlood {}
-impl CastToFilterData for GpuGaussianBlur {}
-impl CastToFilterData for GpuDropShadow {}
+impl GpuFilter {
+    /// Number of 16-byte texels this filter occupies in the filter-data texture.
+    fn size_texels(&self) -> u32 {
+        match self {
+            Self::Offset(_) => filter_size_texels::<GpuOffset>(),
+            Self::Flood(_) => filter_size_texels::<GpuFlood>(),
+            Self::GaussianBlur(_) => filter_size_texels::<GpuGaussianBlur>(),
+            Self::DropShadow(_) => filter_size_texels::<GpuDropShadow>(),
+            Self::ColorMatrix(_) => filter_size_texels::<GpuColorMatrix>(),
+        }
+    }
 
-impl<T: CastToFilterData> From<T> for GpuFilterData {
-    fn from(filter: T) -> Self {
-        bytemuck::cast(filter)
+    /// The packed header carrying the scheduler metadata.
+    fn header(&self) -> GpuFilterData {
+        let header = match self {
+            Self::Offset(f) => f.header,
+            Self::Flood(f) => f.header,
+            Self::GaussianBlur(f) => f.header,
+            Self::DropShadow(f) => f.header,
+            Self::ColorMatrix(f) => f.header,
+        };
+        GpuFilterData { header }
+    }
+
+    /// Serialize this filter's bytes into `out`, which must be exactly
+    /// `size_texels() * 16` bytes long.
+    fn write_bytes(&self, out: &mut [u8]) {
+        match self {
+            Self::Offset(f) => out.copy_from_slice(bytemuck::bytes_of(f)),
+            Self::Flood(f) => out.copy_from_slice(bytemuck::bytes_of(f)),
+            Self::GaussianBlur(f) => out.copy_from_slice(bytemuck::bytes_of(f)),
+            Self::DropShadow(f) => out.copy_from_slice(bytemuck::bytes_of(f)),
+            Self::ColorMatrix(f) => out.copy_from_slice(bytemuck::bytes_of(f)),
+        }
     }
 }
 
-impl From<&PreparedFilter> for GpuFilterData {
+impl From<&PreparedFilter> for GpuFilter {
     fn from(filter: &PreparedFilter) -> Self {
         match filter {
-            PreparedFilter::Offset(f) => GpuOffset::from(f).into(),
-            PreparedFilter::Flood(f) => GpuFlood::from(f).into(),
-            PreparedFilter::GaussianBlur(f) => GpuGaussianBlur::from(f).into(),
-            PreparedFilter::DropShadow(f) => GpuDropShadow::from(f).into(),
+            PreparedFilter::Offset(f) => Self::Offset(f.into()),
+            PreparedFilter::Flood(f) => Self::Flood(f.into()),
+            PreparedFilter::GaussianBlur(f) => Self::GaussianBlur(f.into()),
+            PreparedFilter::DropShadow(f) => Self::DropShadow(f.into()),
+            PreparedFilter::ColorMatrix(f) => Self::ColorMatrix(f.into()),
         }
     }
 }
@@ -396,7 +459,7 @@ pub(crate) struct FilterInstanceData {
 pub(crate) struct FilterContext {
     /// The encoded data for each filter used in the current scene that will be uploaded to the
     /// filter data texture.
-    filters: Vec<GpuFilterData>,
+    filters: Vec<GpuFilter>,
 }
 
 /// Offset and encoded parameters for one filter recorded in [`FilterContext`].
@@ -440,6 +503,9 @@ impl FilterPassPlan {
                 }
                 filter_type::FLOOD => {
                     builder.emit(pass_kind::FLOOD);
+                }
+                filter_type::COLOR_MATRIX => {
+                    builder.emit(pass_kind::COLOR_MATRIX);
                 }
                 filter_type::GAUSSIAN_BLUR => {
                     builder.emit_blur_sequence(filter.gpu_filter.n_decimations());
@@ -625,8 +691,9 @@ impl FilterContext {
     pub(crate) fn push(&mut self, filter_data: &FilterData) -> PreparedGpuFilter {
         let data_offset = self.total_texels();
         let prepared = PreparedFilter::new(&filter_data.filter, &filter_data.transform);
-        let data = GpuFilterData::from(&prepared);
-        self.filters.push(data);
+        let filter = GpuFilter::from(&prepared);
+        let data = filter.header();
+        self.filters.push(filter);
 
         PreparedGpuFilter { data_offset, data }
     }
@@ -635,23 +702,23 @@ impl FilterContext {
         self.filters.is_empty()
     }
 
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "filter count won't exceed u32"
-    )]
     pub(crate) fn total_texels(&self) -> u32 {
-        self.filters.len() as u32 * GpuFilterData::SIZE_TEXELS
+        self.filters.iter().map(GpuFilter::size_texels).sum()
     }
 
     pub(crate) fn serialize_to_buffer(&self, buffer: &mut [u8]) {
-        let src = bytemuck::cast_slice::<GpuFilterData, u8>(&self.filters);
-        debug_assert!(
-            buffer.len() >= src.len(),
-            "filter data buffer too small: {} < {}",
-            buffer.len(),
-            src.len()
-        );
-        buffer[..src.len()].copy_from_slice(src);
+        let mut offset = 0;
+        for filter in &self.filters {
+            let len = filter.size_texels() as usize * BYTES_PER_TEXEL;
+            debug_assert!(
+                buffer.len() >= offset + len,
+                "filter data buffer too small: {} < {}",
+                buffer.len(),
+                offset + len
+            );
+            filter.write_bytes(&mut buffer[offset..offset + len]);
+            offset += len;
+        }
     }
 
     /// Calculate the required height for the filter data texture.
@@ -679,6 +746,7 @@ mod tests {
     use crate::target::{LayerTextureId, TextureParity, TextureRegion};
     use vello_common::color::AlphaColor;
     use vello_common::filter::gaussian_blur::{compute_gaussian_kernel, plan_decimated_blur};
+    use vello_common::filter_effects::matrices;
 
     fn region(parity: TextureParity) -> TextureRegion {
         TextureRegion {
@@ -699,26 +767,33 @@ mod tests {
     }
 
     fn gpu_offset() -> GpuFilterData {
-        GpuOffset::from(&Offset::new(1.0, 2.0)).into()
+        GpuFilter::Offset(GpuOffset::from(&Offset::new(1.0, 2.0))).header()
     }
 
     fn gpu_flood() -> GpuFilterData {
-        GpuFlood::from(&Flood::new(AlphaColor::new([0.2, 0.4, 0.6, 0.8]))).into()
+        GpuFilter::Flood(GpuFlood::from(&Flood::new(AlphaColor::new([
+            0.2, 0.4, 0.6, 0.8,
+        ]))))
+        .header()
     }
 
     fn gpu_blur(std_deviation: f32) -> GpuFilterData {
-        GpuGaussianBlur::from(&GaussianBlur::new(std_deviation, EdgeMode::None)).into()
+        GpuFilter::GaussianBlur(GpuGaussianBlur::from(&GaussianBlur::new(
+            std_deviation,
+            EdgeMode::None,
+        )))
+        .header()
     }
 
     fn gpu_shadow() -> GpuFilterData {
-        GpuDropShadow::from(&DropShadow::new(
+        GpuFilter::DropShadow(GpuDropShadow::from(&DropShadow::new(
             3.0,
             -4.0,
             8.0,
             EdgeMode::None,
             AlphaColor::new([0.0, 0.0, 0.0, 1.0]),
-        ))
-        .into()
+        )))
+        .header()
     }
 
     fn step_layout(plan: &FilterPassPlan) -> Vec<Vec<(u32, u32)>> {
@@ -816,47 +891,69 @@ mod tests {
         assert_eq!(gpu_offset.dy, -20.3);
     }
 
-    fn check_round_trip<T>(gpu: T, expected_type: u32)
-    where
-        T: Into<GpuFilterData> + Copy + PartialEq + core::fmt::Debug + Pod,
-    {
-        let erased: GpuFilterData = gpu.into();
-        assert_eq!(erased.filter_type(), expected_type);
-        assert_eq!(bytemuck::cast::<_, T>(erased), gpu);
+    /// A filter's header must carry the expected type, and it must serialize
+    /// into exactly its advertised texel span.
+    fn check_round_trip(filter: GpuFilter, expected_type: u32, expected_texels: u32) {
+        assert_eq!(filter.header().filter_type(), expected_type);
+        assert_eq!(filter.size_texels(), expected_texels);
+        let mut buffer = alloc::vec![0_u8; expected_texels as usize * BYTES_PER_TEXEL];
+        // Panics if `size_texels` disagrees with the serialized length.
+        filter.write_bytes(&mut buffer);
     }
 
     #[test]
     fn test_offset_round_trip() {
-        check_round_trip(GpuOffset::from(&Offset::new(1.0, 2.0)), filter_type::OFFSET);
+        check_round_trip(
+            GpuFilter::Offset(GpuOffset::from(&Offset::new(1.0, 2.0))),
+            filter_type::OFFSET,
+            1,
+        );
     }
 
     #[test]
     fn test_flood_round_trip() {
         check_round_trip(
-            GpuFlood::from(&Flood::new(AlphaColor::new([0.2, 0.4, 0.6, 0.8]))),
+            GpuFilter::Flood(GpuFlood::from(&Flood::new(AlphaColor::new([
+                0.2, 0.4, 0.6, 0.8,
+            ])))),
             filter_type::FLOOD,
+            1,
+        );
+    }
+
+    #[test]
+    fn test_color_matrix_round_trip() {
+        check_round_trip(
+            GpuFilter::ColorMatrix(GpuColorMatrix::from(&ColorMatrix::new(matrices::SEPIA))),
+            filter_type::COLOR_MATRIX,
+            6,
         );
     }
 
     #[test]
     fn test_gaussian_blur_round_trip() {
         check_round_trip(
-            GpuGaussianBlur::from(&GaussianBlur::new(2.0, EdgeMode::None)),
+            GpuFilter::GaussianBlur(GpuGaussianBlur::from(&GaussianBlur::new(
+                2.0,
+                EdgeMode::None,
+            ))),
             filter_type::GAUSSIAN_BLUR,
+            2,
         );
     }
 
     #[test]
     fn test_drop_shadow_round_trip() {
         check_round_trip(
-            GpuDropShadow::from(&DropShadow::new(
+            GpuFilter::DropShadow(GpuDropShadow::from(&DropShadow::new(
                 3.0,
                 -4.0,
                 1.5,
                 EdgeMode::Duplicate,
                 AlphaColor::new([0.0, 0.0, 0.0, 1.0]),
-            )),
+            ))),
             filter_type::DROP_SHADOW,
+            3,
         );
     }
 

--- a/sparse_strips/vello_sparse_shaders/shaders/filter.wesl
+++ b/sparse_strips/vello_sparse_shaders/shaders/filter.wesl
@@ -13,14 +13,14 @@
 
 // Keep these variables and layouts in sync with the ones in `filter.rs`!
 
-const FILTER_SIZE_BYTES: u32 = 48;
-const FILTER_SIZE_U32: u32 = FILTER_SIZE_BYTES / 4;
-const TEXELS_PER_FILTER: u32 = FILTER_SIZE_U32 / 4u;
+// Filters are packed with variable stride: each filter occupies only as many
+// 16-byte texels as its parameters need, addressed via `filter_data_offset`.
 
 const FILTER_TYPE_OFFSET: u32 = 0u;
 const FILTER_TYPE_FLOOD: u32 = 1u;
 const FILTER_TYPE_GAUSSIAN_BLUR: u32 = 2u;
 const FILTER_TYPE_DROP_SHADOW: u32 = 3u;
+const FILTER_TYPE_COLOR_MATRIX: u32 = 4u;
 
 const PASS_COPY: u32 = 0u;
 const PASS_FLOOD: u32 = 1u;
@@ -31,6 +31,7 @@ const PASS_BLUR_V: u32 = 5u;
 const PASS_UPSCALE: u32 = 6u;
 const PASS_COMPOSITE_DROP_SHADOW: u32 = 7u;
 const PASS_COLORIZE: u32 = 8u;
+const PASS_COLOR_MATRIX: u32 = 9u;
 
 // Keep in sync with FILTER_ATLAS_PADDING in vello_hybrid/src/filter.rs.
 const FILTER_ATLAS_PADDING: u32 = 6u;
@@ -308,6 +309,44 @@ fn convolve(
 const HORIZONTAL: vec2<f32> = vec2<f32>(1.0, 0.0);
 const VERTICAL: vec2<f32> = vec2<f32>(0.0, 1.0);
 
+// One output channel of the 4x5 color matrix: the five packed coefficients
+// (RGBA weights + constant offset) applied to a straight-alpha color, clamped.
+fn color_matrix_row(m0: u32, m1: u32, m2: u32, m3: u32, m4: u32, color: vec4<f32>) -> f32 {
+    return clamp(
+        bitcast<f32>(m0) * color.r +
+        bitcast<f32>(m1) * color.g +
+        bitcast<f32>(m2) * color.b +
+        bitcast<f32>(m3) * color.a +
+        bitcast<f32>(m4),
+        0.0,
+        1.0,
+    );
+}
+
+// The `matrix[0..20]` values are packed after the `header` u32, so `matrix[i]`
+// lives at u32 index `i + 1`: texels 0-5 hold header, matrix[0..20], padding.
+fn apply_color_matrix(filter_data_offset: u32, pixel: vec4<f32>) -> vec4<f32> {
+    let t0 = load_filter_texel(filter_data_offset, 0u);
+    let t1 = load_filter_texel(filter_data_offset, 1u);
+    let t2 = load_filter_texel(filter_data_offset, 2u);
+    let t3 = load_filter_texel(filter_data_offset, 3u);
+    let t4 = load_filter_texel(filter_data_offset, 4u);
+    let t5 = load_filter_texel(filter_data_offset, 5u);
+
+    var rgb = vec3<f32>(0.0);
+    if pixel.a > 0.0 {
+        rgb = pixel.rgb / pixel.a;
+    }
+    let c = vec4<f32>(rgb, pixel.a);
+
+    let out_r = color_matrix_row(t0.y, t0.z, t0.w, t1.x, t1.y, c);
+    let out_g = color_matrix_row(t1.z, t1.w, t2.x, t2.y, t2.z, c);
+    let out_b = color_matrix_row(t2.w, t3.x, t3.y, t3.z, t3.w, c);
+    let out_a = color_matrix_row(t4.x, t4.y, t4.z, t4.w, t5.x, c);
+
+    return vec4<f32>(vec3<f32>(out_r, out_g, out_b) * out_a, out_a);
+}
+
 @fragment
 fn fs_main(
     @location(0) @interpolate(flat) filter_data_offset: u32,
@@ -396,6 +435,9 @@ fn fs_main(
             let blurred = sample_source(source_origin, rel_coord);
             let shadow_color = unpack4x8unorm(get_drop_shadow_color(filter_texel2));
             return shadow_color * blurred.a;
+        }
+        case PASS_COLOR_MATRIX: {
+            return apply_color_matrix(filter_data_offset, sample_source(source_origin, rel_coord));
         }
         // Shouldn't be reached.
         default: {

--- a/sparse_strips/vello_sparse_shaders/shaders/filter.wesl
+++ b/sparse_strips/vello_sparse_shaders/shaders/filter.wesl
@@ -24,14 +24,14 @@ import package::helpers::util::unpack_u16_pair;
 
 // Keep these variables and layouts in sync with the ones in `filter.rs`!
 
-const FILTER_SIZE_BYTES: u32 = 48;
-const FILTER_SIZE_U32: u32 = FILTER_SIZE_BYTES / 4;
-const TEXELS_PER_FILTER: u32 = FILTER_SIZE_U32 / 4u;
+// Filters are packed with variable stride: each filter occupies only as many
+// 16-byte texels as its parameters need, addressed via `filter_data_offset`.
 
 const FILTER_TYPE_OFFSET: u32 = 0u;
 const FILTER_TYPE_FLOOD: u32 = 1u;
 const FILTER_TYPE_GAUSSIAN_BLUR: u32 = 2u;
 const FILTER_TYPE_DROP_SHADOW: u32 = 3u;
+const FILTER_TYPE_COLOR_MATRIX: u32 = 4u;
 
 const PASS_COPY: u32 = 0u;
 const PASS_FLOOD: u32 = 1u;
@@ -42,6 +42,7 @@ const PASS_BLUR_V: u32 = 5u;
 const PASS_UPSCALE: u32 = 6u;
 const PASS_COMPOSITE_DROP_SHADOW: u32 = 7u;
 const PASS_COLORIZE: u32 = 8u;
+const PASS_COLOR_MATRIX: u32 = 9u;
 
 // Keep in sync with FILTER_ATLAS_PADDING in vello_hybrid/src/filter.rs.
 const FILTER_ATLAS_PADDING: u32 = 6u;
@@ -166,6 +167,44 @@ fn sample_source_checked(
     return sample_source(source_origin, rel_coord);
 }
 
+// One output channel of the 4x5 color matrix: the five packed coefficients
+// (RGBA weights + constant offset) applied to a straight-alpha color, clamped.
+fn color_matrix_row(m0: u32, m1: u32, m2: u32, m3: u32, m4: u32, color: vec4<f32>) -> f32 {
+    return clamp(
+        bitcast<f32>(m0) * color.r +
+        bitcast<f32>(m1) * color.g +
+        bitcast<f32>(m2) * color.b +
+        bitcast<f32>(m3) * color.a +
+        bitcast<f32>(m4),
+        0.0,
+        1.0,
+    );
+}
+
+// The `matrix[0..20]` values are packed after the `header` u32, so `matrix[i]`
+// lives at u32 index `i + 1`: texels 0-5 hold header, matrix[0..20], padding.
+fn apply_color_matrix(filter_data_offset: u32, pixel: vec4<f32>) -> vec4<f32> {
+    let t0 = load_filter_texel(filter_data_offset, 0u);
+    let t1 = load_filter_texel(filter_data_offset, 1u);
+    let t2 = load_filter_texel(filter_data_offset, 2u);
+    let t3 = load_filter_texel(filter_data_offset, 3u);
+    let t4 = load_filter_texel(filter_data_offset, 4u);
+    let t5 = load_filter_texel(filter_data_offset, 5u);
+
+    var rgb = vec3<f32>(0.0);
+    if pixel.a > 0.0 {
+        rgb = pixel.rgb / pixel.a;
+    }
+    let c = vec4<f32>(rgb, pixel.a);
+
+    let out_r = color_matrix_row(t0.y, t0.z, t0.w, t1.x, t1.y, c);
+    let out_g = color_matrix_row(t1.z, t1.w, t2.x, t2.y, t2.z, c);
+    let out_b = color_matrix_row(t2.w, t3.x, t3.y, t3.z, t3.w, c);
+    let out_a = color_matrix_row(t4.x, t4.y, t4.z, t4.w, t5.x, c);
+
+    return vec4<f32>(vec3<f32>(out_r, out_g, out_b) * out_a, out_a);
+}
+
 @fragment
 fn fs_main(
     @location(0) @interpolate(flat)filter_data_offset: u32,
@@ -269,6 +308,9 @@ fn fs_main(
                 rel_coord,
                 filter_texel2,
             );
+        }
+        case PASS_COLOR_MATRIX: {
+            return apply_color_matrix(filter_data_offset, sample_source(source_origin, rel_coord));
         }
         // Shouldn't be reached.
         default: {

--- a/sparse_strips/vello_sparse_tests/snapshots/filter_color_matrix_alpha_to_black.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/filter_color_matrix_alpha_to_black.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:977bb524a907bfc82718ecc3b2b705a37a29c37f588044c621dc9aa8f600515c
+size 101

--- a/sparse_strips/vello_sparse_tests/snapshots/filter_color_matrix_full_sepia.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/filter_color_matrix_full_sepia.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e894206089d727bc79c5330f6834a11d2fa623b66ec2d2a43effadc0b040c34
+size 151

--- a/sparse_strips/vello_sparse_tests/tests/filter.rs
+++ b/sparse_strips/vello_sparse_tests/tests/filter.rs
@@ -10,7 +10,7 @@ use vello_common::color::AlphaColor;
 use vello_common::color::palette::css::{
     BLACK, LIME, PURPLE, REBECCA_PURPLE, ROYAL_BLUE, SEA_GREEN, TOMATO, VIOLET,
 };
-use vello_common::filter_effects::{EdgeMode, Filter, FilterPrimitive};
+use vello_common::filter_effects::{EdgeMode, Filter, FilterPrimitive, matrices};
 use vello_common::kurbo::{Affine, BezPath, Circle, Point, Rect, Shape, Stroke};
 use vello_common::paint::Image;
 use vello_common::peniko::{
@@ -154,6 +154,44 @@ fn filter_offset_nested(ctx: &mut impl Renderer) {
     ctx.set_paint(RED);
     ctx.fill_rect(&Rect::new(5.0, 5.0, 55.0, 55.0));
     ctx.pop_layer();
+    ctx.pop_layer();
+}
+
+#[vello_test(skip_multithreaded, width = 120, height = 80, hybrid_tolerance = 1)]
+fn filter_color_matrix_full_sepia(ctx: &mut impl Renderer) {
+    let filter = Filter::from_primitive(FilterPrimitive::ColorMatrix {
+        matrix: matrices::SEPIA,
+    });
+
+    ctx.push_filter_layer(filter);
+    ctx.set_paint(RED);
+    ctx.fill_rect(&Rect::new(10.0, 10.0, 55.0, 35.0));
+    ctx.set_paint(GREEN);
+    ctx.fill_rect(&Rect::new(65.0, 10.0, 110.0, 35.0));
+    ctx.set_paint(BLUE);
+    ctx.fill_rect(&Rect::new(10.0, 45.0, 55.0, 70.0));
+    ctx.set_paint(AlphaColor::from_rgba8(60, 120, 240, 128));
+    ctx.fill_rect(&Rect::new(65.0, 45.0, 110.0, 70.0));
+    ctx.pop_layer();
+}
+
+/// Exercises the straight-alpha (non-premultiply-compatible) path with an
+/// alpha-modifying matrix and a non-zero constant offset.
+#[vello_test(skip_multithreaded, width = 120, height = 80, hybrid_tolerance = 1)]
+fn filter_color_matrix_alpha_to_black(ctx: &mut impl Renderer) {
+    let filter = Filter::from_primitive(FilterPrimitive::ColorMatrix {
+        matrix: matrices::ALPHA_TO_BLACK,
+    });
+
+    ctx.push_filter_layer(filter);
+    ctx.set_paint(RED);
+    ctx.fill_rect(&Rect::new(10.0, 10.0, 55.0, 35.0));
+    ctx.set_paint(GREEN);
+    ctx.fill_rect(&Rect::new(65.0, 10.0, 110.0, 35.0));
+    ctx.set_paint(BLUE);
+    ctx.fill_rect(&Rect::new(10.0, 45.0, 55.0, 70.0));
+    ctx.set_paint(AlphaColor::from_rgba8(60, 120, 240, 128));
+    ctx.fill_rect(&Rect::new(65.0, 45.0, 110.0, 70.0));
     ctx.pop_layer();
 }
 


### PR DESCRIPTION
Adds a `ColorMatrix` image filter — a 4x5 color matrix (SVG `feColorMatrix` style) where each output channel (R, G, B, A) is a linear combination of the straight-alpha input channels plus a constant offset.

This builds on and supersedes #1623 by @waywardmonkeys, which was written before the `vello_hybrid` core rewrite (#1759). It ports that work onto the new filter architecture and addresses the review feedback from there; @waywardmonkeys is credited as a co-author on the commit.

### What's included
- **`vello_common`**: a `ColorMatrix` prepared filter and `FilterPrimitive::ColorMatrix` handling.
- **`vello_cpu`**: a per-pixel implementation, with a fast path for RGB-only, alpha-preserving matrices that applies the matrix directly to the premultiplied channels (skipping the unpremultiply/premultiply round trip).
- **`vello_hybrid`** and the filter shader: the GPU color-matrix pass, written in the struct-free per-texel shader style (#1619, #1620).
- Snapshot tests for a premultiply-compatible matrix (sepia) and an alpha-affecting matrix with a non-zero offset.

### Variable-stride filter data
Following the review discussion on #1623, filter data is now packed with a **variable per-filter texel stride** (the same scheme as encoded paints) instead of a single fixed size. A color matrix needs six 16-byte texels; with the previous fixed size that would have widened *every* filter to six texels. Now offset and flood stay at one texel, gaussian blur at two, drop shadow at three, and color matrix at six.

### Review feedback from #1623 addressed
- Row-based `is_premul_compatible_matrix`.
- `#[inline]` on the per-pixel helpers.
- An additional snapshot test for an alpha-affecting matrix.
- Variable-stride filter data (the per-filter memory overhead).
- `TODO`s recording the SIMD and non-spatial fast-path opportunities.
