### PR TITLE
vello_hybrid: Make scenes resizable

### DIFF
--- a/sparse_strips/vello_hybrid/examples/native_webgl/src/lib.rs
+++ b/sparse_strips/vello_hybrid/examples/native_webgl/src/lib.rs
@@ -139,7 +139,7 @@ impl AppState {
         self.width = width;
         self.height = height;
 
-        self.scene = Scene::new(width as u16, height as u16);
+        self.scene.reset_and_resize(width as u16, height as u16);
 
         self.need_render = true;
     }

--- a/sparse_strips/vello_hybrid/examples/wgpu_webgl/src/lib.rs
+++ b/sparse_strips/vello_hybrid/examples/wgpu_webgl/src/lib.rs
@@ -241,7 +241,7 @@ impl AppState {
         self.width = width;
         self.height = height;
 
-        self.scene = Scene::new(width as u16, height as u16);
+        self.scene.reset_and_resize(width as u16, height as u16);
         self.renderer_wrapper.resize(width, height);
 
         self.need_render = true;

--- a/sparse_strips/vello_hybrid/examples/winit/src/main.rs
+++ b/sparse_strips/vello_hybrid/examples/winit/src/main.rs
@@ -201,7 +201,7 @@ impl ApplicationHandler for App<'_> {
             WindowEvent::Resized(size) => {
                 self.context
                     .resize_surface(surface, size.width, size.height);
-                self.scene = Scene::new(
+                self.scene.reset_and_resize(
                     u16::try_from(size.width).unwrap(),
                     u16::try_from(size.height).unwrap(),
                 );

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -934,6 +934,14 @@ impl Scene {
         }
     }
 
+    /// Reset the scene and update its size.
+    pub fn reset_and_resize(&mut self, width: u16, height: u16) {
+        self.width = width;
+        self.height = height;
+
+        self.reset();
+    }
+
     /// Reset scene to default values.
     pub fn reset(&mut self) {
         self.viewport_state.reset(self.width, self.height);
@@ -1020,6 +1028,25 @@ mod tests {
         scene.fill_rect(&Rect::new(0.0, 0.0, 10.0, 10.0));
 
         assert_eq!(scene.recorder.draws.len(), 1);
+    }
+
+    #[test]
+    fn reset_and_resize_updates_scene_size() {
+        let mut scene = Scene::new(8, 4);
+
+        scene.reset_and_resize(4, 8);
+        assert_eq!(scene.width(), 4);
+        assert_eq!(scene.height(), 8);
+        assert_eq!(scene.recorder.scene_size.width(), 4);
+        assert_eq!(scene.recorder.scene_size.height(), 8);
+
+        scene.set_paint(BLUE);
+        scene.fill_rect(&Rect::new(0.0, 0.0, 8.0, 8.0));
+
+        let RecordedDraw::Rect(rect) = &scene.recorder.draws[0] else {
+            panic!("expected a recorded rectangle");
+        };
+        assert_eq!(rect.rect, Rect::new(0.0, 0.0, 4.0, 8.0));
     }
 
     #[test]


### PR DESCRIPTION
We already have this for `vello_cpu`, and now with the rewrite done we can also have this in Vello Hybrid! Tested this manually with the winit and WebGL examples.