### PR TITLE
vello_hybrid: Check WebGL errors before returning

### DIFF
--- a/sparse_strips/vello_hybrid/src/lib.rs
+++ b/sparse_strips/vello_hybrid/src/lib.rs
@@ -93,6 +93,10 @@ pub enum RenderError {
     /// A draw referenced a [`TextureId`] that was not provided at render time.
     #[error("Missing texture binding for {0:?}")]
     MissingTextureBinding(TextureId),
+    /// WebGL reported an error after rendering completed.
+    #[cfg(feature = "webgl")]
+    #[error("WebGL error: {}", render::webgl_error_name(*.0))]
+    WebGlError(u32),
     // TODO: Consider expanding `RenderError` to replace some `.unwrap` and `.expect`.
 }
 

--- a/sparse_strips/vello_hybrid/src/render/mod.rs
+++ b/sparse_strips/vello_hybrid/src/render/mod.rs
@@ -23,6 +23,8 @@ pub use probe::{WebGlPendingProbe, WebGlProbeError, WebGlProbeStatus};
 #[cfg(all(feature = "webgl", feature = "probe"))]
 pub use vello_common::probe::{Probe, ProbeResult};
 #[cfg(feature = "webgl")]
+pub(crate) use webgl::webgl_error_name;
+#[cfg(feature = "webgl")]
 pub use webgl::{AtlasTextureInfo, WebGlAtlasWriter, WebGlRenderer, WebGlTextureWithDimensions};
 #[cfg(feature = "wgpu")]
 pub use wgpu::{AtlasWriter, RenderTargetConfig, Renderer, TextureBindings};

--- a/sparse_strips/vello_hybrid/src/render/probe.rs
+++ b/sparse_strips/vello_hybrid/src/render/probe.rs
@@ -5,11 +5,11 @@ use crate::render::common::IMAGE_PADDING;
 use crate::render::webgl::resource::Framebuffer;
 use crate::render::webgl::{
     WebGlStateConfig, WebGlStateGuard, create_atlas_texture_array, create_framebuffer_for_texture,
-    create_texture,
+    create_texture, webgl_error_name,
 };
 use crate::target::RootTarget;
 use crate::{RenderError, RenderSize, Scene, WebGlRenderer};
-use alloc::{borrow::Cow, format, sync::Arc};
+use alloc::sync::Arc;
 use core::ops::Deref;
 use thiserror::Error;
 use vello_common::filter_effects::Filter;
@@ -252,21 +252,6 @@ impl WebGlPendingProbe {
     fn finish_failure(&self) -> WebGlProbeError {
         WebGlProbeError::FinishFailed(self.gl.get_error())
     }
-}
-
-fn webgl_error_name(error: u32) -> Cow<'static, str> {
-    let name = match error {
-        WebGl2RenderingContext::NO_ERROR => "NO_ERROR",
-        WebGl2RenderingContext::INVALID_ENUM => "INVALID_ENUM",
-        WebGl2RenderingContext::INVALID_VALUE => "INVALID_VALUE",
-        WebGl2RenderingContext::INVALID_OPERATION => "INVALID_OPERATION",
-        WebGl2RenderingContext::INVALID_FRAMEBUFFER_OPERATION => "INVALID_FRAMEBUFFER_OPERATION",
-        WebGl2RenderingContext::OUT_OF_MEMORY => "OUT_OF_MEMORY",
-        WebGl2RenderingContext::CONTEXT_LOST_WEBGL => "CONTEXT_LOST_WEBGL",
-        _ => return Cow::Owned(format!("UNKNOWN_WEBGL_ERROR ({error:#06x})")),
-    };
-
-    Cow::Borrowed(name)
 }
 
 impl Drop for WebGlPendingProbe {

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -50,9 +50,7 @@ use crate::{
         RootTarget, TextureParity,
     },
 };
-use alloc::sync::Arc;
-use alloc::vec;
-use alloc::vec::Vec;
+use alloc::{borrow::Cow, format, sync::Arc, vec, vec::Vec};
 use core::fmt::Debug;
 #[cfg(feature = "text")]
 use glifo::{GLYPH_PADDING, PendingClearRect};
@@ -76,6 +74,21 @@ use web_sys::{
     HtmlCanvasElement, WebGl2RenderingContext, WebGlBuffer, WebGlFramebuffer, WebGlProgram,
     WebGlShader, WebGlTexture, WebGlUniformLocation, WebGlVertexArrayObject,
 };
+
+pub(crate) fn webgl_error_name(error: u32) -> Cow<'static, str> {
+    let name = match error {
+        WebGl2RenderingContext::NO_ERROR => "NO_ERROR",
+        WebGl2RenderingContext::INVALID_ENUM => "INVALID_ENUM",
+        WebGl2RenderingContext::INVALID_VALUE => "INVALID_VALUE",
+        WebGl2RenderingContext::INVALID_OPERATION => "INVALID_OPERATION",
+        WebGl2RenderingContext::INVALID_FRAMEBUFFER_OPERATION => "INVALID_FRAMEBUFFER_OPERATION",
+        WebGl2RenderingContext::OUT_OF_MEMORY => "OUT_OF_MEMORY",
+        WebGl2RenderingContext::CONTEXT_LOST_WEBGL => "CONTEXT_LOST_WEBGL",
+        _ => return Cow::Owned(format!("UNKNOWN_WEBGL_ERROR ({error:#06x})")),
+    };
+
+    Cow::Borrowed(name)
+}
 
 /// Placeholder value for uninitialized GPU encoded paints.
 const GPU_PAINT_PLACEHOLDER: GpuEncodedPaint = GpuEncodedPaint::LinearGradient(GpuLinearGradient {
@@ -297,6 +310,14 @@ impl WebGlRenderer {
             resources.after_render(self, |renderer, rect| {
                 clear_atlas_region(renderer, rect);
             });
+        }
+
+        // Note that this might yield errors that existed before Vello started
+        // rendering, but still better to err on the side of caution and return
+        // an error if there is one.
+        let webgl_error = self.gl.get_error();
+        if webgl_error != WebGl2RenderingContext::NO_ERROR {
+            return Err(RenderError::WebGlError(webgl_error));
         }
 
         Ok(())

--- a/sparse_strips/vello_sparse_tests/tests/image_atlas.rs
+++ b/sparse_strips/vello_sparse_tests/tests/image_atlas.rs
@@ -5,7 +5,8 @@
 
 use vello_common::pixmap::Pixmap;
 use vello_hybrid::{
-    AtlasConfig, AtlasTextureInfo, MemorySettings, RenderSettings, Resources, WebGlRenderer,
+    AtlasConfig, AtlasTextureInfo, MemorySettings, RenderError, RenderSettings, RenderSize,
+    Resources, Scene, WebGlRenderer,
 };
 use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
@@ -68,6 +69,36 @@ fn image_atlas_placeholder_is_promoted_on_first_upload() {
         WebGl2RenderingContext::NO_ERROR,
         "first atlas upload should not produce a WebGL error"
     );
+}
+
+#[wasm_bindgen_test]
+fn render_returns_queued_webgl_error() {
+    let document = web_sys::window().unwrap().document().unwrap();
+    let canvas = document
+        .create_element("canvas")
+        .unwrap()
+        .dyn_into::<HtmlCanvasElement>()
+        .unwrap();
+    canvas.set_width(100);
+    canvas.set_height(100);
+
+    let mut renderer = WebGlRenderer::new(&canvas);
+    let mut resources = Resources::new();
+    let scene = Scene::new(100, 100);
+    let render_size = RenderSize {
+        width: 100,
+        height: 100,
+    };
+
+    renderer.gl_context().enable(u32::MAX);
+
+    let error = renderer
+        .render(&scene, &mut resources, &render_size)
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        RenderError::WebGlError(WebGl2RenderingContext::INVALID_ENUM)
+    ));
 }
 
 /// Uploading an image that is larger than the configured atlas must fail with


### PR DESCRIPTION
I think this is a good thing to do for additional safety. I'm not sure whether the same should be added to `render_to_atlas`, but since it's only intended to be called internally right now for glyph caching I haven't done this here now, but open to changing this.