### PR TITLE
vello_hybrid: Reject unsupported and unknown images

### DIFF
--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -651,14 +651,14 @@ impl WebGlRenderer {
             self.paint_idxs[encoded_paint_idx] = current_idx;
             match paint {
                 EncodedPaint::Image(img) => {
-                    if let ImageSource::OpaqueId { id: image_id, .. } = img.source {
-                        let image_resource: Option<&ImageResource> = image_cache.get(image_id);
-                        if let Some(image_resource) = image_resource {
-                            let gpu_image = self.encode_image_paint(img, image_resource);
-                            self.encoded_paints[encoded_paint_idx] = gpu_image;
-                            current_idx += GPU_ENCODED_IMAGE_SIZE_TEXELS;
-                        }
-                    }
+                    let ImageSource::OpaqueId { id: image_id, .. } = img.source else {
+                        panic!("pixmap image sources are not supported by Vello Hybrid");
+                    };
+                    
+                    let image_resource = image_cache.get(image_id).unwrap();
+                    let gpu_image = self.encode_image_paint(img, image_resource);
+                    self.encoded_paints[encoded_paint_idx] = gpu_image;
+                    current_idx += GPU_ENCODED_IMAGE_SIZE_TEXELS;
                 }
                 EncodedPaint::Gradient(gradient) => {
                     let (gradient_start, gradient_width) =

--- a/sparse_strips/vello_hybrid/src/render/webgl.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl.rs
@@ -654,7 +654,7 @@ impl WebGlRenderer {
                     let ImageSource::OpaqueId { id: image_id, .. } = img.source else {
                         panic!("pixmap image sources are not supported by Vello Hybrid");
                     };
-                    
+
                     let image_resource = image_cache.get(image_id).unwrap();
                     let gpu_image = self.encode_image_paint(img, image_resource);
                     self.encoded_paints[encoded_paint_idx] = gpu_image;

--- a/sparse_strips/vello_hybrid/src/render/wgpu.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu.rs
@@ -690,14 +690,14 @@ impl Renderer {
             self.paint_idxs[encoded_paint_idx] = current_idx;
             match paint {
                 EncodedPaint::Image(img) => {
-                    if let ImageSource::OpaqueId { id: image_id, .. } = img.source {
-                        let image_resource: Option<&ImageResource> = image_cache.get(image_id);
-                        if let Some(image_resource) = image_resource {
-                            let image_paint = self.encode_image_paint(img, image_resource);
-                            self.encoded_paints[encoded_paint_idx] = image_paint;
-                            current_idx += GPU_ENCODED_IMAGE_SIZE_TEXELS;
-                        }
-                    }
+                    let ImageSource::OpaqueId { id: image_id, .. } = img.source else {
+                        panic!("pixmap image sources are not supported by Vello Hybrid");
+                    };
+
+                    let image_resource = image_cache.get(image_id).unwrap();
+                    let image_paint = self.encode_image_paint(img, image_resource);
+                    self.encoded_paints[encoded_paint_idx] = image_paint;
+                    current_idx += GPU_ENCODED_IMAGE_SIZE_TEXELS;
                 }
                 EncodedPaint::ExternalTexture(img) => {
                     if texture_bindings.get(img.texture_id).is_none() {


### PR DESCRIPTION
Instead of silently failing, panic in case:
- A pixmap source is used, which is not supported by us.
- The image does not existing in the image cache, which means the user supplied an invalid image ID.

In the future, these will all be turned into errors instead.