### PR TITLE
Bump skrifa

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,7 +1192,7 @@ dependencies = [
  "objc2-core-text",
  "objc2-foundation 0.3.2",
  "parlance",
- "read-fonts",
+ "read-fonts 0.40.2",
  "roxmltree 0.21.1",
  "smallvec",
  "windows",
@@ -1362,7 +1362,7 @@ dependencies = [
  "log",
  "peniko",
  "png",
- "skrifa",
+ "skrifa 0.44.0",
  "smallvec",
  "vello_common",
 ]
@@ -1452,7 +1452,7 @@ checksum = "f0589ddd0d2935dd2845827ac606b4081c266225d613b268ed2910f832889cab"
 dependencies = [
  "bitflags 2.11.1",
  "bytemuck",
- "read-fonts",
+ "read-fonts 0.40.2",
  "smallvec",
 ]
 
@@ -3027,7 +3027,7 @@ dependencies = [
  "linebender_resource_handle",
  "parlance",
  "parley_data",
- "skrifa",
+ "skrifa 0.43.2",
 ]
 
 [[package]]
@@ -3377,6 +3377,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "487889119a5f19ff7c0a20637196bdc76b9f54ebec17e3588b5d75e4999f8773"
 dependencies = [
  "bytemuck",
+ "font-types",
+ "once_cell",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046a7d674daf459825b32f5062056d6882db0d2f5a479fbd76ccfc870ac18709"
+dependencies = [
+ "bytemuck",
  "core_maths",
  "font-types",
  "once_cell",
@@ -3578,7 +3589,7 @@ dependencies = [
  "image",
  "rand",
  "roxmltree 0.20.0",
- "skrifa",
+ "skrifa 0.44.0",
  "vello",
  "web-time",
 ]
@@ -3795,8 +3806,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbe997d0f2480442d727488fbe2150779114cbe480ecdbadef58b33e0318ffb"
 dependencies = [
  "bytemuck",
+ "read-fonts 0.40.2",
+]
+
+[[package]]
+name = "skrifa"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819ab7d62b1d3e72d9d9dea5650bac30424f9111364bb94928dbf5ecad1baa68"
+dependencies = [
+ "bytemuck",
  "core_maths",
- "read-fonts",
+ "read-fonts 0.41.0",
 ]
 
 [[package]]
@@ -4430,7 +4451,7 @@ dependencies = [
  "log",
  "peniko",
  "png",
- "skrifa",
+ "skrifa 0.44.0",
  "static_assertions",
  "thiserror 2.0.18",
  "vello_encoding",
@@ -4512,7 +4533,7 @@ dependencies = [
  "bytemuck",
  "guillotiere",
  "peniko",
- "skrifa",
+ "skrifa 0.44.0",
  "smallvec",
 ]
 
@@ -4527,7 +4548,7 @@ dependencies = [
  "image",
  "log",
  "parley",
- "skrifa",
+ "skrifa 0.44.0",
  "smallvec",
  "vello_common",
  "vello_cpu",
@@ -4596,7 +4617,7 @@ dependencies = [
  "pollster",
  "serde",
  "serde_json",
- "skrifa",
+ "skrifa 0.44.0",
  "smallvec",
  "vello_common",
  "vello_cpu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ vello = { version = "0.9.0", path = "vello" }
 vello_encoding = { version = "0.9.0", path = "vello_encoding" }
 vello_shaders = { version = "0.9.0", path = "vello_shaders" }
 bytemuck = { version = "1.25.0", features = ["derive"] }
-skrifa = { version = "0.43.2", default-features = false, features = ["autohint_shaping"] }
+skrifa = { version = "0.44.0", default-features = false, features = ["autohint_shaping"] }
 # The version of kurbo used below should be kept in sync
 # with the version of kurbo used by peniko.
 peniko = { version = "0.6.1", default-features = false }


### PR DESCRIPTION
Lock file makes it look like we have two versions of harfrust/read-fonts now, but this is only because we are pulling in parley in vello_bench and vello_examples_scenes.

skrifa 0.45 exists in theory, but harfrust hasn't been bumped to it yet, so we stick to the version that uses read-fonts 0.41 instead.