### PR TITLE
fix: pin WESL dependencies to Rust-compatible versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4582,6 +4582,9 @@ version = "0.0.9"
 dependencies = [
  "naga",
  "wesl",
+ "wesl-macros",
+ "wgsl-parse",
+ "wgsl-types",
 ]
 
 [[package]]

--- a/sparse_strips/vello_sparse_shaders/Cargo.toml
+++ b/sparse_strips/vello_sparse_shaders/Cargo.toml
@@ -21,7 +21,13 @@ naga = { workspace = true, features = ["wgsl-in", "glsl-out"], optional = true }
 
 [build-dependencies]
 naga = { workspace = true, features = ["wgsl-in", "glsl-out"], optional = true }
-wesl = "0.4.0"
+# Pinned exactly: the 0.4.1 releases of wesl and its wgsl-* crates require rustc 1.96,
+# newer than our toolchain. The wgsl-*/wesl-macros pins force wesl's own `^0.4`
+# transitive requirements to resolve to 0.4.0 as well.
+wesl = "=0.4.0"
+wesl-macros = "=0.4.0"
+wgsl-parse = "=0.4.0"
+wgsl-types = "=0.4.0"
 
 [features]
 glsl = ["dep:naga"]


### PR DESCRIPTION
Pin WESL and related build dependencies to version 0.4.0 because version 0.4.1 requires Rust 1.96, newer than Vello’s supported toolchain.