### PR TITLE
Destroy image textures before dropping them

### DIFF
--- a/vello/src/wgpu_engine.rs
+++ b/vello/src/wgpu_engine.rs
@@ -768,8 +768,9 @@ impl WgpuEngine {
             }
         }
         for id in free_images {
-            if let Some((_texture, _view)) = self.bind_map.image_map.remove(&id) {
+            if let Some((texture, _view)) = self.bind_map.image_map.remove(&id) {
                 // TODO: have a pool to avoid needless re-allocation
+                texture.destroy();
             }
         }
         Ok(())


### PR DESCRIPTION
Running vello in Firefox, textures seem to never get freed (not 100% sure, but
it might be SpiderMonkey's GC never feeling GPU memory pressure). Chromium
behaves better, but still seems to have the same general issue of GCing
textures too late.

For our other wgpu textures in [Graphite](https://github.com/GraphiteEditor/Graphite) we manually call `destroy()` to free as fast as
possible.

That leaves the textures from vello as the remaining "leak" that we can't control.
This PR contains the minimal workaround that could be done in vello (works for us at least).

One could also address the TODO and implement a texture pool in the same PR.
I can do that if desired.