### PR TITLE
feat: improve atlas allocation diagnostics

### DIFF
--- a/sparse_strips/vello_common/src/multi_atlas.rs
+++ b/sparse_strips/vello_common/src/multi_atlas.rs
@@ -139,7 +139,10 @@ impl MultiAtlasManager {
     /// Create a new atlas and return its ID.
     pub fn create_atlas(&mut self) -> Result<AtlasId, AtlasError> {
         if self.atlases.len() >= self.config.max_atlases {
-            return Err(AtlasError::AtlasLimitReached);
+            return Err(AtlasError::AtlasLimitReached {
+                max_atlases: self.config.max_atlases,
+                diagnostics: AtlasSpaceDiagnostics::Unavailable,
+            });
         }
 
         let atlas_id = AtlasId::new(self.next_atlas_id());
@@ -170,7 +173,12 @@ impl MultiAtlasManager {
     ) -> Result<AtlasAllocation, AtlasError> {
         // Check if the image is too large for any atlas
         if width > self.config.atlas_size.0 || height > self.config.atlas_size.1 {
-            return Err(AtlasError::TextureTooLarge { width, height });
+            return Err(AtlasError::TextureTooLarge {
+                width,
+                height,
+                max_width: self.config.atlas_size.0,
+                max_height: self.config.atlas_size.1,
+            });
         }
 
         // Try allocation based on strategy
@@ -185,6 +193,79 @@ impl MultiAtlasManager {
             AllocationStrategy::RoundRobin => {
                 self.allocate_round_robin(width, height, exclude_atlas_id)
             }
+        }
+    }
+
+    fn space_diagnostics(
+        &self,
+        width: u32,
+        height: u32,
+        exclude_atlas_id: Option<AtlasId>,
+    ) -> AtlasSpaceDiagnostics {
+        let mut atlases = Vec::new();
+
+        for atlas in &self.atlases {
+            if Some(atlas.id) == exclude_atlas_id {
+                continue;
+            }
+
+            let mut free_area = 0_u64;
+            let mut free_rectangle_count = 0;
+            let mut largest_free_width = 0;
+            let mut largest_free_height = 0;
+            let mut largest_free_area = 0_u64;
+            atlas.allocator.for_each_free_rectangle(|rect| {
+                let rect_width = rect.width() as u32;
+                let rect_height = rect.height() as u32;
+                let rect_area = u64::from(rect_width) * u64::from(rect_height);
+                free_area += rect_area;
+                free_rectangle_count += 1;
+
+                if rect_area > largest_free_area {
+                    largest_free_area = rect_area;
+                    largest_free_width = rect_width;
+                    largest_free_height = rect_height;
+                }
+            });
+
+            atlases.push(AtlasLayerDiagnostics {
+                atlas_id: atlas.id,
+                total_area: u64::from(atlas.stats.total_area),
+                free_area,
+                free_rectangle_count,
+                largest_free_width,
+                largest_free_height,
+            });
+        }
+
+        AtlasSpaceDiagnostics::Allocation {
+            width,
+            height,
+            atlas_width: self.config.atlas_size.0,
+            atlas_height: self.config.atlas_size.1,
+            max_atlases: self.config.max_atlases,
+            atlases,
+        }
+    }
+
+    fn no_space_available(
+        &self,
+        width: u32,
+        height: u32,
+        exclude_atlas_id: Option<AtlasId>,
+    ) -> AtlasError {
+        AtlasError::NoSpaceAvailable(self.space_diagnostics(width, height, exclude_atlas_id))
+    }
+
+    fn atlas_limit_reached(
+        &self,
+        width: u32,
+        height: u32,
+        exclude_atlas_id: Option<AtlasId>,
+    ) -> AtlasError {
+        AtlasError::AtlasLimitReached {
+            max_atlases: self.config.max_atlases,
+            diagnostics: self.space_diagnostics(width, height, exclude_atlas_id),
         }
     }
 
@@ -210,6 +291,9 @@ impl MultiAtlasManager {
 
         // Try creating a new atlas if auto-grow is enabled
         if self.config.auto_grow {
+            if self.atlases.len() >= self.config.max_atlases {
+                return Err(self.atlas_limit_reached(width, height, exclude_atlas_id));
+            }
             let atlas_id = self.create_atlas()?;
             let atlas = self.atlases.last_mut().unwrap();
             if let Some(allocation) = atlas.allocate(width, height) {
@@ -220,7 +304,7 @@ impl MultiAtlasManager {
             }
         }
 
-        Err(AtlasError::NoSpaceAvailable)
+        Err(self.no_space_available(width, height, exclude_atlas_id))
     }
 
     /// Allocate using best-fit strategy: choose the atlas with the smallest remaining space that
@@ -333,6 +417,9 @@ impl MultiAtlasManager {
 
         // Try creating a new atlas if auto-grow is enabled
         if self.config.auto_grow {
+            if self.atlases.len() >= self.config.max_atlases {
+                return Err(self.atlas_limit_reached(width, height, exclude_atlas_id));
+            }
             let atlas_id = self.create_atlas()?;
             let atlas = self.atlases.last_mut().unwrap();
             if let Some(allocation) = atlas.allocate(width, height) {
@@ -344,7 +431,7 @@ impl MultiAtlasManager {
             }
         }
 
-        Err(AtlasError::NoSpaceAvailable)
+        Err(self.no_space_available(width, height, exclude_atlas_id))
     }
 
     /// Deallocate space in the specified atlas.
@@ -395,22 +482,181 @@ impl core::fmt::Debug for MultiAtlasManager {
 #[derive(Debug, Clone, Error)]
 pub enum AtlasError {
     /// No space available in any atlas.
-    #[error("No space available in any atlas")]
-    NoSpaceAvailable,
+    #[error("No space available in any atlas{0}")]
+    NoSpaceAvailable(AtlasSpaceDiagnostics),
     /// Maximum number of atlases reached.
-    #[error("Maximum number of atlases reached")]
-    AtlasLimitReached,
+    #[error("Maximum atlas count reached ({max_atlases}){diagnostics}")]
+    AtlasLimitReached {
+        /// The configured maximum number of atlases.
+        max_atlases: usize,
+        /// Details about the failed allocation, when available.
+        diagnostics: AtlasSpaceDiagnostics,
+    },
     /// The requested texture size is too large for any atlas.
-    #[error("Texture too large ({width}x{height}) for atlas")]
+    #[error("Texture too large ({width}x{height}) for atlas (maximum {max_width}x{max_height})")]
     TextureTooLarge {
         /// The width of the requested texture.
         width: u32,
         /// The height of the requested texture.
         height: u32,
+        /// The maximum texture width supported by the atlas.
+        max_width: u32,
+        /// The maximum texture height supported by the atlas.
+        max_height: u32,
     },
     /// The specified atlas was not found.
     #[error("Atlas with Id {0:?} not found")]
     AtlasNotFound(AtlasId),
+}
+
+/// Free-space details collected after an atlas allocation fails.
+#[derive(Clone)]
+pub enum AtlasSpaceDiagnostics {
+    /// No allocation context is available.
+    Unavailable,
+    /// Details about the requested allocation and available atlas space.
+    Allocation {
+        /// The requested allocation width.
+        width: u32,
+        /// The requested allocation height.
+        height: u32,
+        /// The width shared by all atlas layers.
+        atlas_width: u32,
+        /// The height shared by all atlas layers.
+        atlas_height: u32,
+        /// The configured maximum number of atlas layers.
+        max_atlases: usize,
+        /// Per-layer details for each atlas considered for the allocation.
+        atlases: Vec<AtlasLayerDiagnostics>,
+    },
+}
+
+impl core::fmt::Debug for AtlasSpaceDiagnostics {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let Self::Allocation {
+            width,
+            height,
+            atlas_width,
+            atlas_height,
+            max_atlases,
+            atlases,
+        } = self
+        else {
+            return f.write_str("Unavailable");
+        };
+
+        f.debug_struct("Allocation")
+            .field("requested", &Dimensions(*width, *height))
+            .field("layer_size", &Dimensions(*atlas_width, *atlas_height))
+            .field("max_atlases", max_atlases)
+            .field("atlas_layers", atlases)
+            .finish()
+    }
+}
+
+impl core::fmt::Display for AtlasSpaceDiagnostics {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let Self::Allocation {
+            width,
+            height,
+            atlas_width: _,
+            atlas_height: _,
+            max_atlases,
+            atlases,
+        } = self
+        else {
+            return Ok(());
+        };
+
+        let total_area = atlases.iter().map(|atlas| atlas.total_area).sum::<u64>();
+        let free_area = atlases.iter().map(|atlas| atlas.free_area).sum::<u64>();
+        let used_percentage = if total_area == 0 {
+            0.0
+        } else {
+            (1.0 - free_area as f64 / total_area as f64) * 100.0
+        };
+        write!(
+            f,
+            ": failed to allocate {width}x{height} across {} atlas layers \
+             (maximum {max_atlases}; {used_percentage:.1}% used)",
+            atlases.len(),
+        )
+    }
+}
+
+/// Free-space details for one atlas texture-array layer.
+#[derive(Clone)]
+pub struct AtlasLayerDiagnostics {
+    /// The atlas represented by this layer.
+    pub atlas_id: AtlasId,
+    /// The total layer area, in texels.
+    pub total_area: u64,
+    /// The total free layer area, in texels.
+    pub free_area: u64,
+    /// The number of disjoint free rectangles in the layer.
+    pub free_rectangle_count: usize,
+    /// The width of the largest free rectangle by area.
+    pub largest_free_width: u32,
+    /// The height of the largest free rectangle by area.
+    pub largest_free_height: u32,
+}
+
+impl AtlasLayerDiagnostics {
+    /// Calculate layer utilization as a percentage from 0 to 100.
+    pub fn utilization_percentage(&self) -> f64 {
+        if self.total_area == 0 {
+            0.0
+        } else {
+            (1.0 - self.free_area as f64 / self.total_area as f64) * 100.0
+        }
+    }
+
+    /// Calculate layer fragmentation as a percentage from 0 to 100.
+    pub fn fragmentation_percentage(&self) -> f64 {
+        if self.free_area == 0 {
+            0.0
+        } else {
+            let largest_free_area =
+                u64::from(self.largest_free_width) * u64::from(self.largest_free_height);
+            (1.0 - largest_free_area as f64 / self.free_area as f64) * 100.0
+        }
+    }
+}
+
+impl core::fmt::Debug for AtlasLayerDiagnostics {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Layer")
+            .field("atlas_id", &self.atlas_id)
+            .field("utilization", &Percentage(self.utilization_percentage()))
+            .field("capacity", &self.total_area)
+            .field("free", &self.free_area)
+            .field(
+                "largest_free_rectangle",
+                &Dimensions(self.largest_free_width, self.largest_free_height),
+            )
+            .field("free_rectangles", &self.free_rectangle_count)
+            .field(
+                "fragmentation",
+                &Percentage(self.fragmentation_percentage()),
+            )
+            .finish()
+    }
+}
+
+struct Dimensions(u32, u32);
+
+impl core::fmt::Debug for Dimensions {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}x{}", self.0, self.1)
+    }
+}
+
+struct Percentage(f64);
+
+impl core::fmt::Debug for Percentage {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:.1}%", self.0)
+    }
 }
 
 /// Unique identifier for an atlas.
@@ -560,7 +806,102 @@ mod tests {
             auto_grow: false,
         });
 
-        assert!(manager.create_atlas().is_err());
+        assert!(matches!(
+            manager.create_atlas(),
+            Err(AtlasError::AtlasLimitReached {
+                max_atlases: 1,
+                diagnostics: AtlasSpaceDiagnostics::Unavailable,
+            })
+        ));
+    }
+
+    #[test]
+    fn test_no_space_diagnostics() {
+        let mut manager = MultiAtlasManager::new(AtlasConfig {
+            initial_atlas_count: 1,
+            max_atlases: 1,
+            atlas_size: (256, 256),
+            auto_grow: false,
+            ..Default::default()
+        });
+        manager.try_allocate(128, 256).unwrap();
+
+        let Err(AtlasError::NoSpaceAvailable(AtlasSpaceDiagnostics::Allocation {
+            width: 129,
+            height: 256,
+            atlas_width: 256,
+            atlas_height: 256,
+            max_atlases: 1,
+            atlases,
+        })) = manager.try_allocate(129, 256)
+        else {
+            panic!("expected no-space diagnostics");
+        };
+        assert_eq!(atlases.len(), 1);
+        let atlas = &atlases[0];
+        assert_eq!(atlas.atlas_id, AtlasId::new(0));
+        assert_eq!(atlas.total_area, 65_536);
+        assert_eq!(atlas.free_area, 32_768);
+        assert_eq!(atlas.free_rectangle_count, 1);
+        assert_eq!(
+            (atlas.largest_free_width, atlas.largest_free_height),
+            (128, 256)
+        );
+        assert_eq!(atlas.fragmentation_percentage(), 0.0);
+    }
+
+    #[test]
+    fn test_atlas_limit_diagnostics() {
+        let mut manager = MultiAtlasManager::new(AtlasConfig {
+            initial_atlas_count: 1,
+            max_atlases: 1,
+            atlas_size: (256, 256),
+            auto_grow: true,
+            ..Default::default()
+        });
+        manager.try_allocate(128, 256).unwrap();
+
+        let Err(AtlasError::AtlasLimitReached {
+            max_atlases: 1,
+            diagnostics:
+                AtlasSpaceDiagnostics::Allocation {
+                    width: 129,
+                    height: 256,
+                    atlas_width: 256,
+                    atlas_height: 256,
+                    max_atlases: 1,
+                    atlases,
+                },
+        }) = manager.try_allocate(129, 256)
+        else {
+            panic!("expected atlas-limit diagnostics");
+        };
+        assert_eq!(atlases.len(), 1);
+    }
+
+    #[test]
+    fn test_fragmentation_per_atlas_layer() {
+        let atlases = [
+            AtlasLayerDiagnostics {
+                atlas_id: AtlasId::new(0),
+                total_area: 100,
+                free_area: 100,
+                free_rectangle_count: 1,
+                largest_free_width: 10,
+                largest_free_height: 10,
+            },
+            AtlasLayerDiagnostics {
+                atlas_id: AtlasId::new(1),
+                total_area: 100,
+                free_area: 100,
+                free_rectangle_count: 2,
+                largest_free_width: 5,
+                largest_free_height: 10,
+            },
+        ];
+
+        assert_eq!(atlases[0].fragmentation_percentage(), 0.0);
+        assert_eq!(atlases[1].fragmentation_percentage(), 50.0);
     }
 
     #[test]
@@ -571,7 +912,15 @@ mod tests {
         });
 
         let result = manager.try_allocate(300, 300);
-        assert!(matches!(result, Err(AtlasError::TextureTooLarge { .. })));
+        assert!(matches!(
+            result,
+            Err(AtlasError::TextureTooLarge {
+                width: 300,
+                height: 300,
+                max_width: 256,
+                max_height: 256,
+            })
+        ));
     }
 
     #[test]

--- a/sparse_strips/vello_common/src/multi_atlas.rs
+++ b/sparse_strips/vello_common/src/multi_atlas.rs
@@ -196,19 +196,10 @@ impl MultiAtlasManager {
         }
     }
 
-    fn space_diagnostics(
-        &self,
-        width: u32,
-        height: u32,
-        exclude_atlas_id: Option<AtlasId>,
-    ) -> AtlasSpaceDiagnostics {
+    fn space_diagnostics(&self, width: u32, height: u32) -> AtlasSpaceDiagnostics {
         let mut atlases = Vec::new();
 
         for atlas in &self.atlases {
-            if Some(atlas.id) == exclude_atlas_id {
-                continue;
-            }
-
             let mut free_area = 0_u64;
             let mut free_rectangle_count = 0;
             let mut largest_free_width = 0;
@@ -248,24 +239,14 @@ impl MultiAtlasManager {
         }
     }
 
-    fn no_space_available(
-        &self,
-        width: u32,
-        height: u32,
-        exclude_atlas_id: Option<AtlasId>,
-    ) -> AtlasError {
-        AtlasError::NoSpaceAvailable(self.space_diagnostics(width, height, exclude_atlas_id))
+    fn no_space_available(&self, width: u32, height: u32) -> AtlasError {
+        AtlasError::NoSpaceAvailable(self.space_diagnostics(width, height))
     }
 
-    fn atlas_limit_reached(
-        &self,
-        width: u32,
-        height: u32,
-        exclude_atlas_id: Option<AtlasId>,
-    ) -> AtlasError {
+    fn atlas_limit_reached(&self, width: u32, height: u32) -> AtlasError {
         AtlasError::AtlasLimitReached {
             max_atlases: self.config.max_atlases,
-            diagnostics: self.space_diagnostics(width, height, exclude_atlas_id),
+            diagnostics: self.space_diagnostics(width, height),
         }
     }
 
@@ -291,10 +272,9 @@ impl MultiAtlasManager {
 
         // Try creating a new atlas if auto-grow is enabled
         if self.config.auto_grow {
-            if self.atlases.len() >= self.config.max_atlases {
-                return Err(self.atlas_limit_reached(width, height, exclude_atlas_id));
-            }
-            let atlas_id = self.create_atlas()?;
+            let atlas_id = self
+                .create_atlas()
+                .map_err(|_| self.atlas_limit_reached(width, height))?;
             let atlas = self.atlases.last_mut().unwrap();
             if let Some(allocation) = atlas.allocate(width, height) {
                 return Ok(AtlasAllocation {
@@ -304,7 +284,7 @@ impl MultiAtlasManager {
             }
         }
 
-        Err(self.no_space_available(width, height, exclude_atlas_id))
+        Err(self.no_space_available(width, height))
     }
 
     /// Allocate using best-fit strategy: choose the atlas with the smallest remaining space that
@@ -417,10 +397,9 @@ impl MultiAtlasManager {
 
         // Try creating a new atlas if auto-grow is enabled
         if self.config.auto_grow {
-            if self.atlases.len() >= self.config.max_atlases {
-                return Err(self.atlas_limit_reached(width, height, exclude_atlas_id));
-            }
-            let atlas_id = self.create_atlas()?;
+            let atlas_id = self
+                .create_atlas()
+                .map_err(|_| self.atlas_limit_reached(width, height))?;
             let atlas = self.atlases.last_mut().unwrap();
             if let Some(allocation) = atlas.allocate(width, height) {
                 self.round_robin_counter = self.atlases.len() - 1;
@@ -431,7 +410,7 @@ impl MultiAtlasManager {
             }
         }
 
-        Err(self.no_space_available(width, height, exclude_atlas_id))
+        Err(self.no_space_available(width, height))
     }
 
     /// Deallocate space in the specified atlas.

--- a/sparse_strips/vello_hybrid/src/lib.rs
+++ b/sparse_strips/vello_hybrid/src/lib.rs
@@ -119,6 +119,30 @@ pub enum RenderError {
     /// A draw referenced a [`TextureId`] that was not provided at render time.
     #[error("Missing texture binding for {0:?}")]
     MissingTextureBinding(TextureId),
+    /// An intermediate texture allocation exceeds the configured texture dimensions.
+    #[error(
+        "Intermediate texture allocation {width}x{height} exceeds maximum {max_width}x{max_height}"
+    )]
+    IntermediateTextureTooLarge {
+        /// The requested allocation width.
+        width: u32,
+        /// The requested allocation height.
+        height: u32,
+        /// The maximum intermediate texture width.
+        max_width: u32,
+        /// The maximum intermediate texture height.
+        max_height: u32,
+    },
+    /// A render requires more intermediate textures than configured.
+    #[error(
+        "Render requires {required} intermediate textures, exceeding the configured maximum of {max}"
+    )]
+    IntermediateTextureLimitReached {
+        /// The number of intermediate textures required by the render.
+        required: usize,
+        /// The configured maximum number of intermediate textures.
+        max: usize,
+    },
     // TODO: Consider expanding `RenderError` to replace some `.unwrap` and `.expect`.
 }
 

--- a/sparse_strips/vello_hybrid/src/lib.rs
+++ b/sparse_strips/vello_hybrid/src/lib.rs
@@ -113,17 +113,26 @@ use thiserror::Error;
 /// Errors that can occur during rendering.
 #[derive(Error, Debug, Clone)]
 pub enum RenderError {
-    /// An atlas allocation failed.
+    /// An image atlas allocation failed.
     #[error("Atlas allocation failed: {0}")]
     AtlasError(#[from] vello_common::multi_atlas::AtlasError),
     /// A draw referenced a [`TextureId`] that was not provided at render time.
     #[error("Missing texture binding for {0:?}")]
     MissingTextureBinding(TextureId),
+    /// An intermediate texture allocation failed.
+    #[error(transparent)]
+    IntermediateTexture(#[from] IntermediateTextureError),
+    // TODO: Consider expanding `RenderError` to replace some `.unwrap` and `.expect`.
+}
+
+/// Errors that can occur while allocating intermediate textures.
+#[derive(Error, Debug, Clone)]
+pub enum IntermediateTextureError {
     /// An intermediate texture allocation exceeds the configured texture dimensions.
     #[error(
         "Intermediate texture allocation {width}x{height} exceeds maximum {max_width}x{max_height}"
     )]
-    IntermediateTextureTooLarge {
+    TooLarge {
         /// The requested allocation width.
         width: u32,
         /// The requested allocation height.
@@ -137,13 +146,12 @@ pub enum RenderError {
     #[error(
         "Render requires {required} intermediate textures, exceeding the configured maximum of {max}"
     )]
-    IntermediateTextureLimitReached {
+    LimitReached {
         /// The number of intermediate textures required by the render.
         required: usize,
         /// The configured maximum number of intermediate textures.
         max: usize,
     },
-    // TODO: Consider expanding `RenderError` to replace some `.unwrap` and `.expect`.
 }
 
 #[cfg(test)]

--- a/sparse_strips/vello_hybrid/src/render/common.rs
+++ b/sparse_strips/vello_hybrid/src/render/common.rs
@@ -8,6 +8,7 @@
     reason = "GPU paint structures have small, fixed sizes that fit in u32"
 )]
 
+use crate::IntermediateTextureError;
 use crate::blend::GpuBlendInstance;
 use crate::copy::GpuCopyInstance;
 use crate::filter::FILTER_ATLAS_PADDING;
@@ -15,7 +16,6 @@ use crate::scene::{LayersConfig, MemorySettings, RecordedDraw};
 use alloc::vec::Vec;
 use bytemuck::{Pod, Zeroable};
 use vello_common::geometry::{SizeU16, SizeU32};
-use vello_common::multi_atlas::AtlasError;
 use vello_common::record::CommandRecorder;
 
 // GPU paint structure sizes in texels (1 texel = 16 bytes for RGBA32Uint texture format).
@@ -130,7 +130,7 @@ impl LayersConfig {
     pub(crate) fn required_intermediate_texture_size(
         self,
         recorder: &CommandRecorder<RecordedDraw>,
-    ) -> Result<SizeU16, AtlasError> {
+    ) -> Result<SizeU16, IntermediateTextureError> {
         let min_size = self.min_texture_size;
         let max_size = self.max_texture_size;
 
@@ -138,7 +138,7 @@ impl LayersConfig {
             if size.width() > u32::from(max_size.width())
                 || size.height() > u32::from(max_size.height())
             {
-                return Err(AtlasError::TextureTooLarge {
+                return Err(IntermediateTextureError::TooLarge {
                     width: size.width(),
                     height: size.height(),
                     max_width: u32::from(max_size.width()),
@@ -174,8 +174,8 @@ impl LayersConfig {
 mod tests {
     use super::DeviceLimits;
     use crate::scene::RecordedDraw;
-    use crate::{LayersConfig, MemorySettings, SizeU16};
-    use vello_common::multi_atlas::{AtlasConfig, AtlasError};
+    use crate::{IntermediateTextureError, LayersConfig, MemorySettings, SizeU16};
+    use vello_common::multi_atlas::AtlasConfig;
     use vello_common::record::CommandRecorder;
 
     fn device_limits(max_texture_dimension_2d: u32, max_texture_array_layers: u32) -> DeviceLimits {
@@ -297,7 +297,7 @@ mod tests {
 
         assert!(matches!(
             config.required_intermediate_texture_size(&recorder),
-            Err(AtlasError::TextureTooLarge {
+            Err(IntermediateTextureError::TooLarge {
                 width: 513,
                 height: 10,
                 max_width: 512,

--- a/sparse_strips/vello_hybrid/src/render/common.rs
+++ b/sparse_strips/vello_hybrid/src/render/common.rs
@@ -141,6 +141,8 @@ impl LayersConfig {
                 return Err(AtlasError::TextureTooLarge {
                     width: size.width(),
                     height: size.height(),
+                    max_width: u32::from(max_size.width()),
+                    max_height: u32::from(max_size.height()),
                 });
             }
 
@@ -297,7 +299,9 @@ mod tests {
             config.required_intermediate_texture_size(&recorder),
             Err(AtlasError::TextureTooLarge {
                 width: 513,
-                height: 10
+                height: 10,
+                max_width: 512,
+                max_height: 512,
             })
         ));
     }

--- a/sparse_strips/vello_hybrid/src/schedule/allocate.rs
+++ b/sparse_strips/vello_hybrid/src/schedule/allocate.rs
@@ -134,7 +134,7 @@ impl LayerAllocationRequest {
     }
 
     pub(super) fn allocation_size(self) -> SizeU32 {
-        SizeU32::from(self.region.size) + u32::from(self.region.padding) * 2
+        self.region.allocation_size()
     }
 }
 
@@ -145,6 +145,13 @@ struct RegionProps {
     size: SizeU16,
     /// Transparent padding reserved around the usable region.
     padding: u16,
+}
+
+impl RegionProps {
+    /// Size of the atlas allocation needed to hold the region and its padding.
+    fn allocation_size(self) -> SizeU32 {
+        SizeU32::from(self.size) + u32::from(self.padding) * 2
+    }
 }
 
 /// Texture region and allocator metadata needed to release it.
@@ -201,7 +208,7 @@ impl AtlasExt for Atlas {
         let padding = u32::from(props.padding);
         let width = props.size.width();
         let height = props.size.height();
-        let allocation_size = SizeU32::from(props.size) + padding * 2;
+        let allocation_size = props.allocation_size();
         let allocation = self.allocate(allocation_size.width(), allocation_size.height())?;
         let x = u16::try_from(allocation.x + padding).unwrap();
         let y = u16::try_from(allocation.y + padding).unwrap();

--- a/sparse_strips/vello_hybrid/src/schedule/allocate.rs
+++ b/sparse_strips/vello_hybrid/src/schedule/allocate.rs
@@ -43,6 +43,10 @@ impl Atlases {
         self.scratch_texture
     }
 
+    pub(super) fn texture_size(&self) -> SizeU16 {
+        self.texture_size
+    }
+
     pub(super) fn allocate_layer(
         &mut self,
         request: &LayerAllocationRequest,
@@ -127,6 +131,10 @@ impl LayerAllocationRequest {
             texture_parity,
             region,
         }
+    }
+
+    pub(super) fn allocation_size(self) -> SizeU32 {
+        SizeU32::from(self.region.size) + u32::from(self.region.padding) * 2
     }
 }
 

--- a/sparse_strips/vello_hybrid/src/schedule/cursor.rs
+++ b/sparse_strips/vello_hybrid/src/schedule/cursor.rs
@@ -8,10 +8,10 @@
 //! preferring to advance the base round count in case a requested allocation doesn't fit
 //! into the current round, and only resorting to adding more textures as a last resort.
 
-use crate::RenderError;
 use crate::schedule::allocate::{
     AllocatedTextureRegion, Allocation, Atlases, LayerAllocationRequest,
 };
+use crate::{IntermediateTextureError, RenderError};
 use alloc::vec::Vec;
 
 /// The round cursor.
@@ -75,7 +75,7 @@ impl Cursor {
             .allocate_layer(&request)
             // If we successfully added a new texture but allocation still fails, it means the layer
             // itself is larger than the maximum texture size, so it cannot possibly fit.
-            .ok_or(RenderError::IntermediateTextureTooLarge {
+            .ok_or(IntermediateTextureError::TooLarge {
                 width: requested_size.width(),
                 height: requested_size.height(),
                 max_width: u32::from(texture_size.width()),
@@ -139,9 +139,9 @@ impl Cursor {
 #[cfg(test)]
 mod tests {
     use super::Cursor;
-    use crate::RenderError;
     use crate::schedule::allocate::{Atlases, LayerAllocationRequest};
     use crate::target::{LayerTextureId, TextureParity};
+    use crate::{IntermediateTextureError, RenderError};
     use vello_common::geometry::{RectU16, SizeU16};
     use vello_common::record::RecordedLayerKind;
 
@@ -212,12 +212,14 @@ mod tests {
 
         assert!(matches!(
             cursor.allocate_layer(request(TextureParity::Even, SizeU16::from_wh(9, 8),)),
-            Err(RenderError::IntermediateTextureTooLarge {
-                width: 9,
-                height: 8,
-                max_width: 8,
-                max_height: 8,
-            })
+            Err(RenderError::IntermediateTexture(
+                IntermediateTextureError::TooLarge {
+                    width: 9,
+                    height: 8,
+                    max_width: 8,
+                    max_height: 8,
+                }
+            ))
         ));
     }
 

--- a/sparse_strips/vello_hybrid/src/schedule/cursor.rs
+++ b/sparse_strips/vello_hybrid/src/schedule/cursor.rs
@@ -8,11 +8,11 @@
 //! preferring to advance the base round count in case a requested allocation doesn't fit
 //! into the current round, and only resorting to adding more textures as a last resort.
 
+use crate::RenderError;
 use crate::schedule::allocate::{
     AllocatedTextureRegion, Allocation, Atlases, LayerAllocationRequest,
 };
 use alloc::vec::Vec;
-use vello_common::multi_atlas::AtlasError;
 
 /// The round cursor.
 #[derive(Debug)]
@@ -51,7 +51,7 @@ impl Cursor {
     pub(super) fn allocate_layer(
         &mut self,
         request: LayerAllocationRequest,
-    ) -> Result<Allocation, AtlasError> {
+    ) -> Result<Allocation, RenderError> {
         // TODO: This can be optimized further. Currently, we try go through all pending releases
         // until we have enough space or are forced to create a new texture. However, we don't
         // consider the parity of the texture request. In case we are requesting an even
@@ -68,12 +68,19 @@ impl Cursor {
         // Therefore, we need to attempt to create a new one.
         self.atlases.add_layer_atlas(request.texture_parity);
 
+        let requested_size = request.allocation_size();
+        let texture_size = self.atlases.texture_size();
         let allocation = self
             .atlases
             .allocate_layer(&request)
             // If we successfully added a new texture but allocation still fails, it means the layer
             // itself is larger than the maximum texture size, so it cannot possibly fit.
-            .ok_or(AtlasError::NoSpaceAvailable)?;
+            .ok_or(RenderError::IntermediateTextureTooLarge {
+                width: requested_size.width(),
+                height: requested_size.height(),
+                max_width: u32::from(texture_size.width()),
+                max_height: u32::from(texture_size.height()),
+            })?;
 
         Ok(Allocation {
             allocation,
@@ -132,6 +139,7 @@ impl Cursor {
 #[cfg(test)]
 mod tests {
     use super::Cursor;
+    use crate::RenderError;
     use crate::schedule::allocate::{Atlases, LayerAllocationRequest};
     use crate::target::{LayerTextureId, TextureParity};
     use vello_common::geometry::{RectU16, SizeU16};
@@ -196,6 +204,21 @@ mod tests {
             grown.allocation.region.target,
             LayerTextureId::new(TextureParity::Even, 1)
         );
+    }
+
+    #[test]
+    fn oversized_layer_reports_texture_dimensions() {
+        let mut cursor = cursor();
+
+        assert!(matches!(
+            cursor.allocate_layer(request(TextureParity::Even, SizeU16::from_wh(9, 8),)),
+            Err(RenderError::IntermediateTextureTooLarge {
+                width: 9,
+                height: 8,
+                max_width: 8,
+                max_height: 8,
+            })
+        ));
     }
 
     #[test]

--- a/sparse_strips/vello_hybrid/src/schedule/mod.rs
+++ b/sparse_strips/vello_hybrid/src/schedule/mod.rs
@@ -141,7 +141,7 @@ use crate::schedule::allocate::AllocatedTextureRegion;
 use crate::target::{
     DrawTarget, LayerTextureRegion, RootTarget, RoundBindings, TextureParity, TextureRegion,
 };
-use crate::{RenderError, Scene, blend::BlendStrip};
+use crate::{IntermediateTextureError, RenderError, Scene, blend::BlendStrip};
 use alloc::vec::Vec;
 use vello_common::filter::FilterLayerPlacement;
 use vello_common::geometry::{RectU16, SizeU16};
@@ -250,13 +250,13 @@ impl IntermediateTextureRequirements {
         self,
         existing: IntermediateTextureAllocations,
         max_textures: Option<usize>,
-    ) -> Result<(), RenderError> {
+    ) -> Result<(), IntermediateTextureError> {
         let retained_textures = self.allocations.combine(existing).texture_count();
 
         if let Some(max) = max_textures
             && retained_textures > max
         {
-            return Err(RenderError::IntermediateTextureLimitReached {
+            return Err(IntermediateTextureError::LimitReached {
                 required: retained_textures,
                 max,
             });

--- a/sparse_strips/vello_hybrid/src/schedule/mod.rs
+++ b/sparse_strips/vello_hybrid/src/schedule/mod.rs
@@ -145,7 +145,6 @@ use crate::{RenderError, Scene, blend::BlendStrip};
 use alloc::vec::Vec;
 use vello_common::filter::FilterLayerPlacement;
 use vello_common::geometry::{RectU16, SizeU16};
-use vello_common::multi_atlas::AtlasError;
 use vello_common::peniko::BlendMode;
 use vello_common::record::{CommandRecorder, LayerProps, Node, RecordedLayer, RecordedLayerKind};
 use vello_common::strip::visit_strip_fill_segments;
@@ -251,11 +250,16 @@ impl IntermediateTextureRequirements {
         self,
         existing: IntermediateTextureAllocations,
         max_textures: Option<usize>,
-    ) -> Result<(), AtlasError> {
+    ) -> Result<(), RenderError> {
         let retained_textures = self.allocations.combine(existing).texture_count();
 
-        if max_textures.is_some_and(|limit| retained_textures > limit) {
-            return Err(AtlasError::NoSpaceAvailable);
+        if let Some(max) = max_textures
+            && retained_textures > max
+        {
+            return Err(RenderError::IntermediateTextureLimitReached {
+                required: retained_textures,
+                max,
+            });
         }
 
         Ok(())

--- a/sparse_strips/vello_hybrid/src/schedule/schedule_tests.rs
+++ b/sparse_strips/vello_hybrid/src/schedule/schedule_tests.rs
@@ -3,9 +3,9 @@
 
 use super::test_support::{SceneCase, ScheduledCase};
 use super::{IntermediateTextureAllocations, IntermediateTextureRequirements, ScheduleStorage};
-use crate::RenderError;
 use crate::filter::FILTER_ATLAS_PADDING;
 use crate::target::{RootTarget, TextureParity};
+use crate::{IntermediateTextureError, RenderError};
 use vello_common::filter_effects::{EdgeMode, Filter, FilterPrimitive};
 use vello_common::geometry::SizeU16;
 use vello_common::kurbo::Rect;
@@ -36,28 +36,28 @@ fn intermediate_texture_requirements_validate_limit() {
     assert!(base.validate(allocations([0, 3], false), Some(4)).is_err());
     assert!(matches!(
         base.validate(allocations([2, 0], false), Some(3)),
-        Err(RenderError::IntermediateTextureLimitReached {
+        Err(IntermediateTextureError::LimitReached {
             required: 4,
             max: 3,
         })
     ));
     assert!(matches!(
         base.validate(allocations([1, 0], true), Some(2)),
-        Err(RenderError::IntermediateTextureLimitReached {
+        Err(IntermediateTextureError::LimitReached {
             required: 3,
             max: 2,
         })
     ));
     assert!(matches!(
         base.validate(allocations([0, 2], false), Some(3)),
-        Err(RenderError::IntermediateTextureLimitReached {
+        Err(IntermediateTextureError::LimitReached {
             required: 4,
             max: 3,
         })
     ));
     assert!(matches!(
         base.validate(allocations([2, 2], false), Some(4)),
-        Err(RenderError::IntermediateTextureLimitReached {
+        Err(IntermediateTextureError::LimitReached {
             required: 5,
             max: 4,
         })
@@ -370,10 +370,12 @@ fn root_blend_budget() {
     );
     assert!(matches!(
         case.schedule(RootTarget::UserSurface, SizeU16::new(16), 2,),
-        Err(RenderError::IntermediateTextureLimitReached {
-            required: 3,
-            max: 2,
-        })
+        Err(RenderError::IntermediateTexture(
+            IntermediateTextureError::LimitReached {
+                required: 3,
+                max: 2,
+            }
+        ))
     ));
 }
 

--- a/sparse_strips/vello_hybrid/src/schedule/schedule_tests.rs
+++ b/sparse_strips/vello_hybrid/src/schedule/schedule_tests.rs
@@ -3,12 +3,12 @@
 
 use super::test_support::{SceneCase, ScheduledCase};
 use super::{IntermediateTextureAllocations, IntermediateTextureRequirements, ScheduleStorage};
+use crate::RenderError;
 use crate::filter::FILTER_ATLAS_PADDING;
 use crate::target::{RootTarget, TextureParity};
 use vello_common::filter_effects::{EdgeMode, Filter, FilterPrimitive};
 use vello_common::geometry::SizeU16;
 use vello_common::kurbo::Rect;
-use vello_common::multi_atlas::AtlasError;
 use vello_common::peniko::{BlendMode, Color, Compose, Mix};
 
 #[test]
@@ -36,19 +36,31 @@ fn intermediate_texture_requirements_validate_limit() {
     assert!(base.validate(allocations([0, 3], false), Some(4)).is_err());
     assert!(matches!(
         base.validate(allocations([2, 0], false), Some(3)),
-        Err(AtlasError::NoSpaceAvailable)
+        Err(RenderError::IntermediateTextureLimitReached {
+            required: 4,
+            max: 3,
+        })
     ));
     assert!(matches!(
         base.validate(allocations([1, 0], true), Some(2)),
-        Err(AtlasError::NoSpaceAvailable)
+        Err(RenderError::IntermediateTextureLimitReached {
+            required: 3,
+            max: 2,
+        })
     ));
     assert!(matches!(
         base.validate(allocations([0, 2], false), Some(3)),
-        Err(AtlasError::NoSpaceAvailable)
+        Err(RenderError::IntermediateTextureLimitReached {
+            required: 4,
+            max: 3,
+        })
     ));
     assert!(matches!(
         base.validate(allocations([2, 2], false), Some(4)),
-        Err(AtlasError::NoSpaceAvailable)
+        Err(RenderError::IntermediateTextureLimitReached {
+            required: 5,
+            max: 4,
+        })
     ));
 }
 
@@ -358,7 +370,10 @@ fn root_blend_budget() {
     );
     assert!(matches!(
         case.schedule(RootTarget::UserSurface, SizeU16::new(16), 2,),
-        Err(crate::RenderError::AtlasError(_))
+        Err(RenderError::IntermediateTextureLimitReached {
+            required: 3,
+            max: 2,
+        })
     ));
 }
 


### PR DESCRIPTION
Improve atlas allocation diagnostics by reporting configured limits, requested and maximum sizes, available space, per-layer utilization, free rectangles, and fragmentation. Introduce dedicated intermediate-texture errors for oversized allocations and texture-count limits instead of reusing generic atlas errors with different semantics.

Created with assistance from GPT-5.6 Sol.