### PR TITLE
vello_cpu: Fix horizontal extend mode for filtered images

### DIFF
--- a/sparse_strips/vello_cpu/src/fine/common/image.rs
+++ b/sparse_strips/vello_cpu/src/fine/common/image.rs
@@ -221,7 +221,7 @@ impl<S: Simd, const QUALITY: u8> Iterator for FilteredImagePainter<'_, S, QUALIT
                 extend(
                     self.simd,
                     x_positions + $offsets[$idx],
-                    self.data.image.sampler.y_extend,
+                    self.data.image.sampler.x_extend,
                     self.data.width,
                     self.data.width_inv,
                 )
@@ -564,7 +564,61 @@ const fn cubic_resampler(b: f32, c: f32) -> [[f32; 4]; 4] {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::sync::Arc;
+    use alloc::vec;
+    use vello_common::color::PremulRgba8;
     use vello_common::fearless_simd::Fallback;
+    use vello_common::kurbo::{Affine, Vec2};
+    use vello_common::paint::ImageSource;
+    use vello_common::peniko::{Extend, ImageQuality, ImageSampler};
+
+    #[test]
+    fn filtered_image_uses_x_extend_for_horizontal_samples() {
+        let simd = Fallback::new();
+        let pixmap = Arc::new(Pixmap::from_parts(
+            vec![
+                PremulRgba8 {
+                    r: 255,
+                    g: 0,
+                    b: 0,
+                    a: 255,
+                },
+                PremulRgba8 {
+                    r: 0,
+                    g: 0,
+                    b: 255,
+                    a: 255,
+                },
+            ],
+            2,
+            1,
+        ));
+        let image = EncodedImage {
+            source: ImageSource::Pixmap(Arc::clone(&pixmap)),
+            sampler: ImageSampler {
+                x_extend: Extend::Repeat,
+                y_extend: Extend::Pad,
+                quality: ImageQuality::Medium,
+                alpha: 1.0,
+            },
+            may_have_transparency: false,
+            transform: Affine::IDENTITY,
+            x_advance: Vec2::new(1.0, 0.0),
+            y_advance: Vec2::new(0.0, 1.0),
+            tint: None,
+        };
+
+        let mut painter = FilteredImagePainter::<_, 1>::new(simd, &image, &pixmap, 2.0, 0.0);
+        let mut samples = [0.0; 16];
+        painter.next().unwrap().store_slice(&mut samples);
+
+        for pixel in samples.chunks_exact(4) {
+            assert!((pixel[0] - 0.5).abs() < 1e-6);
+            assert_eq!(pixel[1], 0.0);
+            assert!((pixel[2] - 0.5).abs() < 1e-6);
+            assert_eq!(pixel[3], 1.0);
+        }
+    }
 
     #[test]
     fn extend_overflow() {
@@ -573,7 +627,7 @@ mod tests {
         let max_inv = 1.0 / max;
 
         let num = f32x4::splat(simd, 127.00001);
-        let res = extend(simd, num, crate::peniko::Extend::Repeat, max, max_inv);
+        let res = extend(simd, num, Extend::Repeat, max, max_inv);
 
         assert!(res[0] <= 127.0);
     }


### PR DESCRIPTION
## Summary

- use the X-axis extend mode for horizontal filtered-image taps
- cover differing X/Y extend modes with a focused SIMD regression test

## Root cause

The `ImageSampler` migration wired the horizontal helper to `y_extend`. As a result, bilinear and bicubic CPU sampling used the Y mode on both axes when the modes differed.

## Checks

- `cargo test --locked -p vello_cpu`
- `cargo test --locked -p vello_cpu --all-features`
- `cargo clippy -p vello_cpu --locked --all-targets --all-features -- -D warnings`
- `cargo check --locked -p vello_cpu --no-default-features --features libm,f32_pipeline`
- `cargo fmt --all --check`
- `git diff --check`
