### PR TITLE
vello_hybrid: Make GPU rect quads byte-identical to the CPU strip path

### DIFF
--- a/sparse_strips/vello_common/CHANGELOG.md
+++ b/sparse_strips/vello_common/CHANGELOG.md
@@ -12,6 +12,10 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 This release has an [MSRV][] of 1.88.
 
+### Added
+
+- Public helpers in `rect` (`pixel_coverage`, `coverage_to_u8`, `corner_coverage_u8`, `combine_coverage_u8`) exposing the strip renderer's exact rectangle coverage quantization, so other rasterizers can reproduce its bytes. ([#1784][] by [@AdrianEddy][])
+
 ## [0.2.0][] - 2026-08-07
 
 This release has an [MSRV][] of 1.88.
@@ -224,6 +228,7 @@ This is the initial release. No changelog was kept for this release.
 
 See also the [vello_cpu 0.0.1](../vello_cpu/CHANGELOG.md#001---2025-05-10) release.
 
+[@AdrianEddy]: https://github.com/AdrianEddy
 [@b0nes164]: https://github.com/b0nes164
 [@conor-93]: https://github.com/conor-93
 [@dipeshbabu]: https://github.com/dipeshbabu
@@ -310,6 +315,7 @@ See also the [vello_cpu 0.0.1](../vello_cpu/CHANGELOG.md#001---2025-05-10) relea
 [#1768]: https://github.com/linebender/vello/pull/1768
 [#1778]: https://github.com/linebender/vello/pull/1778
 [#1779]: https://github.com/linebender/vello/pull/1779
+[#1784]: https://github.com/linebender/vello/pull/1784
 [#1801]: https://github.com/linebender/vello/pull/1801
 
 [Unreleased]: https://github.com/linebender/vello/compare/sparse-strips-v0.2.0...HEAD

--- a/sparse_strips/vello_common/CHANGELOG.md
+++ b/sparse_strips/vello_common/CHANGELOG.md
@@ -12,6 +12,10 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 This release has an [MSRV][] of 1.88.
 
+### Added
+
+- Public helpers in `rect` (`pixel_coverage`, `coverage_to_u8`, `corner_coverage_u8`, `combine_coverage_u8`) exposing the strip renderer's exact rectangle coverage quantization, so other rasterizers can reproduce its bytes. ([#1784][] by [@AdrianEddy][])
+
 ## [0.1.0][] - 2026-07-29
 
 This release has an [MSRV][] of 1.88.
@@ -211,6 +215,7 @@ This is the initial release. No changelog was kept for this release.
 
 See also the [vello_cpu 0.0.1](../vello_cpu/CHANGELOG.md#001---2025-05-10) release.
 
+[@AdrianEddy]: https://github.com/AdrianEddy
 [@b0nes164]: https://github.com/b0nes164
 [@conor-93]: https://github.com/conor-93
 [@dipeshbabu]: https://github.com/dipeshbabu
@@ -295,6 +300,7 @@ See also the [vello_cpu 0.0.1](../vello_cpu/CHANGELOG.md#001---2025-05-10) relea
 [#1762]: https://github.com/linebender/vello/pull/1762
 [#1763]: https://github.com/linebender/vello/pull/1763
 [#1768]: https://github.com/linebender/vello/pull/1768
+[#1784]: https://github.com/linebender/vello/pull/1784
 
 [Unreleased]: https://github.com/linebender/vello/compare/sparse-strips-v0.1.0...HEAD
 [0.1.0]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.9...sparse-strips-v0.1.0

--- a/sparse_strips/vello_common/src/rect.rs
+++ b/sparse_strips/vello_common/src/rect.rs
@@ -136,9 +136,44 @@ fn coverage<const N: usize>(start: u16, rect_lo: f32, rect_hi: f32) -> [f32; N] 
     #[allow(clippy::needless_range_loop, reason = "better clarity")]
     for i in 0..N {
         let px = (start as usize + i) as f32;
-        cov[i] = (rect_hi.min(px + 1.0) - rect_lo.max(px)).clamp(0.0, 1.0);
+        cov[i] = pixel_coverage(px, rect_lo, rect_hi);
     }
     cov
+}
+
+/// How much of the 1-pixel span starting at `px` is covered by `[rect_lo, rect_hi]`, in `[0, 1]`.
+#[inline(always)]
+pub fn pixel_coverage(px: f32, rect_lo: f32, rect_hi: f32) -> f32 {
+    (rect_hi.min(px + 1.0) - rect_lo.max(px)).clamp(0.0, 1.0)
+}
+
+/// Quantize a `[0, 1]` single-axis coverage value to a byte.
+///
+/// This is the quantization the strip renderer applies to axis-aligned rectangle coverage. The
+/// GPU rect quad in `vello_hybrid` derives its per-pixel alpha from bytes produced by this
+/// function and [`corner_coverage_u8`], which is what keeps the two rasterizers byte-identical.
+#[inline(always)]
+pub fn coverage_to_u8(cov: f32) -> u8 {
+    (cov * 255.0 + 0.5) as u8
+}
+
+/// The alpha byte of a pixel covered by `cov_x * cov_y` of its area (a rectangle corner pixel),
+/// quantized from the exact product — the same value [`render`] writes for that pixel.
+#[inline(always)]
+pub fn corner_coverage_u8(cov_x: f32, cov_y: f32) -> u8 {
+    (cov_x * cov_y * 255.0 + 0.5) as u8
+}
+
+/// `round(x * y / 255)` computed exactly in integer arithmetic.
+///
+/// This approximates [`corner_coverage_u8`] from the two already-quantized axis bytes; the result
+/// is always within 1 of it (quantizing each axis first loses strictly less than half an alpha
+/// step per axis). The GPU rect quad evaluates this expression in its shader and applies a
+/// precomputed 2-bit correction to land exactly on the [`corner_coverage_u8`] value.
+#[inline(always)]
+pub fn combine_coverage_u8(x: u8, y: u8) -> u8 {
+    let p = u32::from(x) * u32::from(y) + 128;
+    ((p + (p >> 8)) >> 8) as u8
 }
 
 /// Build an alpha mask for the 4x4 tile from the given horizontal coverages,
@@ -149,7 +184,7 @@ fn alpha_mask_from_x_coverage<S: Simd>(s: S, cov: &[f32; Tile::WIDTH as usize]) 
 
     #[allow(clippy::needless_range_loop, reason = "better clarity")]
     for col in 0..Tile::WIDTH as usize {
-        let alpha = (cov[col] * 255.0 + 0.5) as u8;
+        let alpha = coverage_to_u8(cov[col]);
         let base = col * Tile::HEIGHT as usize;
         buf[base..base + Tile::HEIGHT as usize].fill(alpha);
     }
@@ -168,7 +203,7 @@ fn combined_tile_alpha<S: Simd>(
     let mut buf = [0_u8; 16];
     for (col, xc) in x_cov.iter().copied().enumerate() {
         for (row, yc) in y_cov.iter().copied().enumerate() {
-            buf[col * Tile::HEIGHT as usize + row] = (xc * yc * 255.0 + 0.5) as u8;
+            buf[col * Tile::HEIGHT as usize + row] = corner_coverage_u8(xc, yc);
         }
     }
 

--- a/sparse_strips/vello_hybrid/CHANGELOG.md
+++ b/sparse_strips/vello_hybrid/CHANGELOG.md
@@ -12,6 +12,10 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 This release has an [MSRV][] of 1.88.
 
+### Fixed
+
+- Rectangles drawn through the GPU rect fast path now produce exactly the same bytes as the CPU strip path. The two rasterizers used to round anti-aliased coverage differently (up to one alpha step at fractional edges and corners, more at large coordinates), so pushing a clip (which routes rects through strips) changed pixels the clip didn't even touch. ([#1784][] by [@AdrianEddy][])
+
 ## [0.1.0][] - 2026-07-29
 
 This release has an [MSRV][] of 1.88.
@@ -175,6 +179,7 @@ This is the initial release. No changelog was kept for this release.
 
 See also the [vello_cpu 0.0.4](../vello_cpu/CHANGELOG.md#004---2025-10-17) and [vello_common 0.0.4](../vello_common/CHANGELOG.md#004---2025-10-17) releases.
 
+[@AdrianEddy]: https://github.com/AdrianEddy
 [@DJMcNab]: https://github.com/DJMcNab
 [@b0nes164]: https://github.com/b0nes164
 [@dipeshbabu]: https://github.com/dipeshbabu
@@ -268,6 +273,7 @@ See also the [vello_cpu 0.0.4](../vello_cpu/CHANGELOG.md#004---2025-10-17) and [
 [#1760]: https://github.com/linebender/vello/pull/1760
 [#1763]: https://github.com/linebender/vello/pull/1763
 [#1769]: https://github.com/linebender/vello/pull/1769
+[#1784]: https://github.com/linebender/vello/pull/1784
 
 [Unreleased]: https://github.com/linebender/vello/compare/sparse-strips-v0.1.0...HEAD
 [0.1.0]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.9...sparse-strips-v0.1.0

--- a/sparse_strips/vello_hybrid/CHANGELOG.md
+++ b/sparse_strips/vello_hybrid/CHANGELOG.md
@@ -12,6 +12,10 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 This release has an [MSRV][] of 1.88.
 
+### Fixed
+
+- Rectangles drawn through the GPU rect fast path now produce exactly the same bytes as the CPU strip path. The two rasterizers used to round anti-aliased coverage differently (up to one alpha step at fractional edges and corners, more at large coordinates), so pushing a clip (which routes rects through strips) changed pixels the clip didn't even touch. ([#1784][] by [@AdrianEddy][])
+
 ## [0.2.0][] - 2026-08-07
 
 This release has an [MSRV][] of 1.88.
@@ -201,6 +205,7 @@ This is the initial release. No changelog was kept for this release.
 
 See also the [vello_cpu 0.0.4](../vello_cpu/CHANGELOG.md#004---2025-10-17) and [vello_common 0.0.4](../vello_common/CHANGELOG.md#004---2025-10-17) releases.
 
+[@AdrianEddy]: https://github.com/AdrianEddy
 [@DJMcNab]: https://github.com/DJMcNab
 [@b0nes164]: https://github.com/b0nes164
 [@dipeshbabu]: https://github.com/dipeshbabu
@@ -297,6 +302,7 @@ See also the [vello_cpu 0.0.4](../vello_cpu/CHANGELOG.md#004---2025-10-17) and [
 [#1778]: https://github.com/linebender/vello/pull/1778
 [#1779]: https://github.com/linebender/vello/pull/1779
 [#1781]: https://github.com/linebender/vello/pull/1781
+[#1784]: https://github.com/linebender/vello/pull/1784
 [#1791]: https://github.com/linebender/vello/pull/1791
 [#1792]: https://github.com/linebender/vello/pull/1792
 [#1794]: https://github.com/linebender/vello/pull/1794

--- a/sparse_strips/vello_hybrid/src/draw.rs
+++ b/sparse_strips/vello_hybrid/src/draw.rs
@@ -5,7 +5,7 @@
 
 use crate::GpuStrip;
 use crate::paint::{COLOR_SOURCE_LAYER, COLOR_SOURCE_SHIFT, PaintResolver};
-use crate::rect::{RectPart, split_rect};
+use crate::rect::{FULL_COVERAGE, FULLY_OPAQUE_ADJUST, RectPart, split_rect};
 use crate::scene::{RecordedDraw, RecordedPath};
 use crate::target::{DrawTarget, LayerTextureRegion};
 use crate::util::{Ranges, VecExt, pack_opacity, pack_u16_pair};
@@ -195,7 +195,9 @@ impl<'a, T: DrawTarget> DrawBuilder<'a, T> {
         let paint = paint_resolver.pack(paint);
         let depth_index = self.state.depth_counter.next(paint.opaque);
 
-        let split = split_rect(&clipped_rect);
+        let Some(split) = split_rect(&clipped_rect) else {
+            return;
+        };
 
         for part in [
             Some(split.main),
@@ -217,7 +219,10 @@ impl<'a, T: DrawTarget> DrawBuilder<'a, T> {
                 depth_index,
             );
 
-            if !(paint.opaque && part.frac == 0 && self.push_opaque(strip)) {
+            if !(paint.opaque
+                && part.corner_adjust == FULLY_OPAQUE_ADJUST
+                && self.push_opaque(strip))
+            {
                 self.draw
                     .push(self.strips, strip, paint.external_texture_id);
             }
@@ -270,7 +275,8 @@ impl<'a, T: DrawTarget> DrawBuilder<'a, T> {
 
             let rect_part = RectPart {
                 rect: sample_bbox.shift(self.state.target.geometry_shift()),
-                frac: 0,
+                frac: FULL_COVERAGE,
+                corner_adjust: FULLY_OPAQUE_ADJUST,
             };
 
             self.draw.has_child_layer = true;
@@ -375,6 +381,10 @@ impl GpuStrip {
     }
 
     fn from_rect(part: RectPart, payload: u32, paint: u32, depth_index: u32) -> Self {
+        debug_assert!(
+            depth_index < (1 << 24),
+            "depth indices are 24-bit; the top byte carries rect corner corrections"
+        );
         Self {
             x: part.rect.x0,
             y: part.rect.y0,
@@ -383,7 +393,9 @@ impl GpuStrip {
             col_idx_or_rect_frac: part.frac,
             payload,
             paint_and_rect_flag: paint | RECT_STRIP_FLAG,
-            depth_index,
+            // The z value only uses the low 24 bits (see `render.wesl`), so the top byte is
+            // free to carry the rect's corner corrections.
+            depth_index: depth_index | (u32::from(part.corner_adjust) << 24),
         }
     }
 }
@@ -465,6 +477,7 @@ impl StripAlphaFillSegmentExt for StripAlphaFillSegment {
 mod tests {
     use super::{Draw, DrawBuffers, DrawBuilder, DrawState, ExternalTextureRun};
     use crate::paint::PaintResolver;
+    use crate::rect::FULLY_OPAQUE_ADJUST;
     use crate::scene::{RecordedDraw, RecordedRect};
     use crate::target::{
         DrawTarget, LayerTextureId, LayerTextureRegion, RootTarget, TextureParity, TextureRegion,
@@ -712,12 +725,14 @@ mod tests {
             case.rect(&mut draw, rect(x), solid(alpha), no_paints());
         }
 
+        // The z value lives in the low 24 bits; the top byte carries the
+        // rect's corner corrections (all-opaque marker for these full rects).
         assert_eq!(
             case.buffers
                 .strips
                 .ranged(&draw.strip_ranges)
                 .iter()
-                .map(|strip| strip.depth_index)
+                .map(|strip| strip.depth_index & 0xff_ffff)
                 .collect::<Vec<_>>(),
             [0, 0, 1, 1, 2]
         );
@@ -725,9 +740,18 @@ mod tests {
             case.buffers
                 .opaque_strips
                 .iter()
-                .map(|strip| strip.depth_index)
+                .map(|strip| strip.depth_index & 0xff_ffff)
                 .collect::<Vec<_>>(),
             [1, 2]
         );
+        for strip in case
+            .buffers
+            .strips
+            .ranged(&draw.strip_ranges)
+            .iter()
+            .chain(case.buffers.opaque_strips.iter())
+        {
+            assert_eq!(strip.depth_index >> 24, u32::from(FULLY_OPAQUE_ADJUST));
+        }
     }
 }

--- a/sparse_strips/vello_hybrid/src/draw.rs
+++ b/sparse_strips/vello_hybrid/src/draw.rs
@@ -5,7 +5,7 @@
 
 use crate::GpuStrip;
 use crate::paint::{COLOR_SOURCE_LAYER, COLOR_SOURCE_SHIFT, PaintResolver};
-use crate::rect::{RectPart, split_rect};
+use crate::rect::{FULL_COVERAGE, FULLY_OPAQUE_ADJUST, RectPart, split_rect};
 use crate::scene::{RecordedDraw, RecordedPath};
 use crate::target::{DrawTarget, LayerTextureRegion};
 use crate::util::{Ranges, VecExt, pack_opacity, pack_u16_pair};
@@ -233,7 +233,9 @@ impl<'a, T: DrawTarget> DrawBuilder<'a, T> {
         let paint = paint_resolver.pack(paint);
         let depth_index = self.state.depth_counter.next(paint.opaque);
 
-        let split = split_rect(&clipped_rect);
+        let Some(split) = split_rect(&clipped_rect) else {
+            return;
+        };
 
         for part in [
             Some(split.main),
@@ -256,7 +258,7 @@ impl<'a, T: DrawTarget> DrawBuilder<'a, T> {
             );
 
             if !(paint.opaque
-                && part.frac == 0
+                && part.corner_adjust == FULLY_OPAQUE_ADJUST
                 && self.push_opaque(strip, paint.external_texture_id))
             {
                 self.draw
@@ -311,7 +313,8 @@ impl<'a, T: DrawTarget> DrawBuilder<'a, T> {
 
             let rect_part = RectPart {
                 rect: sample_bbox.shift(self.state.target.geometry_shift()),
-                frac: 0,
+                frac: FULL_COVERAGE,
+                corner_adjust: FULLY_OPAQUE_ADJUST,
             };
 
             self.draw.has_child_layer = true;
@@ -419,6 +422,10 @@ impl GpuStrip {
     }
 
     fn from_rect(part: RectPart, payload: u32, paint: u32, depth_index: u32) -> Self {
+        debug_assert!(
+            depth_index < (1 << 24),
+            "depth indices are 24-bit; the top byte carries rect corner corrections"
+        );
         Self {
             x: part.rect.x0,
             y: part.rect.y0,
@@ -427,7 +434,9 @@ impl GpuStrip {
             col_idx_or_rect_frac: part.frac,
             payload,
             paint_and_rect_flag: paint | RECT_STRIP_FLAG,
-            depth_index,
+            // The z value only uses the low 24 bits (see `render.wesl`), so the top byte is
+            // free to carry the rect's corner corrections.
+            depth_index: depth_index | (u32::from(part.corner_adjust) << 24),
         }
     }
 }
@@ -527,6 +536,7 @@ mod tests {
     use super::{Draw, DrawBuffers, DrawBuilder, DrawState, ExternalTextureRun, OpaqueDraw};
     use crate::GpuStrip;
     use crate::paint::PaintResolver;
+    use crate::rect::FULLY_OPAQUE_ADJUST;
     use crate::scene::{RecordedDraw, RecordedRect};
     use crate::target::{
         DrawTarget, LayerTextureId, LayerTextureRegion, RootTarget, TextureParity, TextureRegion,
@@ -861,12 +871,14 @@ mod tests {
             case.rect(&mut draw, rect(x), solid(alpha), no_paints());
         }
 
+        // The z value lives in the low 24 bits; the top byte carries the
+        // rect's corner corrections (all-opaque marker for these full rects).
         assert_eq!(
             case.buffers
                 .strips
                 .ranged(&draw.strip_ranges)
                 .iter()
-                .map(|strip| strip.depth_index)
+                .map(|strip| strip.depth_index & 0xff_ffff)
                 .collect::<Vec<_>>(),
             [0, 0, 1, 1, 2]
         );
@@ -875,9 +887,18 @@ mod tests {
                 .opaque
                 .strips()
                 .iter()
-                .map(|strip| strip.depth_index)
+                .map(|strip| strip.depth_index & 0xff_ffff)
                 .collect::<Vec<_>>(),
             [1, 2]
         );
+        for strip in case
+            .buffers
+            .strips
+            .ranged(&draw.strip_ranges)
+            .iter()
+            .chain(case.buffers.opaque.strips().iter())
+        {
+            assert_eq!(strip.depth_index >> 24, u32::from(FULLY_OPAQUE_ADJUST));
+        }
     }
 }

--- a/sparse_strips/vello_hybrid/src/rect.rs
+++ b/sparse_strips/vello_hybrid/src/rect.rs
@@ -5,18 +5,48 @@
 
 use vello_common::geometry::RectU16;
 use vello_common::kurbo::Rect;
+use vello_common::rect::{combine_coverage_u8, corner_coverage_u8, coverage_to_u8, pixel_coverage};
 
 /// The threshold of the rectangle size after which a rectangle should be split up
 /// into multiple smaller ones.
 const LARGE_RECT_SPLIT_THRESHOLD: u16 = 32;
 
-/// Integer rectangle geometry and its packed fractional edge coverage.
+/// The packed coverage value of a part whose boundary bytes are all 255.
+///
+/// This alone does not mean every pixel is exactly 255: an edge less than half
+/// an alpha step inside an integer boundary still rounds its axis byte to 255
+/// while the exact corner alpha is 254. Only together with
+/// [`FULLY_OPAQUE_ADJUST`] does it mark a part the shader may skip entirely.
+pub(crate) const FULL_COVERAGE: u32 = 0xFFFF_FFFF;
+
+/// The `corner_adjust` marker for a part whose pixels are all exactly 255.
+///
+/// Real corrections store `correction + 1` per 2-bit slot, so every slot is at
+/// most 2 and `0xFF` is unreachable — it is free to act as the "no
+/// anti-aliasing work at all" flag. Such parts skip the shader's AA branch and
+/// are eligible for the opaque (depth-tested) pass when their paint is opaque.
+pub(crate) const FULLY_OPAQUE_ADJUST: u8 = 0xFF;
+
+/// Integer rectangle geometry and its packed per-pixel boundary coverage.
+///
+/// The shader reconstructs each pixel's alpha from `frac` exactly as the CPU strip renderer
+/// (`vello_common::rect`) would have written it: boundary rows/columns use their coverage byte
+/// directly, and corner pixels combine the two axis bytes with `round(x * y / 255)` plus the
+/// matching 2-bit correction from `corner_adjust`. This keeps a rect drawn as a GPU quad
+/// byte-identical to the same rect drawn as strips (e.g. when a clip forces the strip path).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct RectPart {
     /// Pixel-aligned bounds of this rectangle part.
     pub(crate) rect: RectU16,
-    /// Packed fractional coverage for the four edges.
+    /// Coverage bytes of the part's boundary pixels: first column, last column, first row,
+    /// last row (low byte to high byte). Interior pixels are always fully covered.
     pub(crate) frac: u32,
+    /// Corner corrections, 2 bits per corner, storing `correction + 1` where `correction` is
+    /// the difference between the exact corner alpha and the shader's integer
+    /// `round(x * y / 255)` of the two axis bytes (always -1, 0, or 1). Corner slot index is
+    /// `is_last_column | (is_last_row << 1)`. [`FULLY_OPAQUE_ADJUST`] when every pixel of the
+    /// part is exactly 255.
+    pub(crate) corner_adjust: u8,
 }
 
 impl RectPart {
@@ -43,29 +73,83 @@ pub(crate) struct SplitRect {
     pub(crate) right: Option<RectPart>,
 }
 
+/// Split `rect` into pixel-aligned parts with packed boundary coverage, or `None` when the
+/// rectangle covers no pixels after `f32` conversion.
+///
+/// The edges are converted to `f32` before anything else, in the same order as the CPU strip
+/// renderer (`vello_common::rect::render`), and the coverage bytes come from the same per-pixel
+/// formula — so the quads drawn from these parts produce exactly the bytes strips would.
 #[expect(
     clippy::cast_possible_truncation,
     reason = "recorded rect coordinates are clipped to the u16 viewport domain before packing"
 )]
-pub(crate) fn split_rect(rect: &Rect) -> SplitRect {
-    let sx0 = rect.x0.floor();
-    let sy0 = rect.y0.floor();
-    let sx1 = rect.x1.ceil();
-    let sy1 = rect.y1.ceil();
+pub(crate) fn split_rect(rect: &Rect) -> Option<SplitRect> {
+    let rect_x0 = rect.x0 as f32;
+    let rect_y0 = rect.y0 as f32;
+    let rect_x1 = rect.x1 as f32;
+    let rect_y1 = rect.y1 as f32;
+
+    let sx0 = rect_x0.floor();
+    let sy0 = rect_y0.floor();
+    let sx1 = rect_x1.ceil();
+    let sy1 = rect_y1.ceil();
 
     let x = sx0 as u16;
     let y = sy0 as u16;
-    // Are guaranteed to be > 0 since we rejected negative rectangles.
+    // Are guaranteed to be >= 0 since we rejected negative rectangles.
     let width = (sx1 - sx0) as u16;
     let height = (sy1 - sy0) as u16;
 
-    // Note that `top_frac` and `left_frac` store the actual coverage, while
-    // `right_frac` and `bottom_frac` store one minus the coverage. This is on purpose
-    // and handled that way in the shader.
-    let left_frac = (rect.x0 - sx0) as f32;
-    let top_frac = (rect.y0 - sy0) as f32;
-    let right_frac = (sx1 - rect.x1) as f32;
-    let bottom_frac = (sy1 - rect.y1) as f32;
+    if width == 0 || height == 0 {
+        return None;
+    }
+
+    let part = |part_rect: RectU16| -> RectPart {
+        let cov_x0 = pixel_coverage(f32::from(part_rect.x0), rect_x0, rect_x1);
+        let cov_x1 = pixel_coverage(f32::from(part_rect.x1 - 1), rect_x0, rect_x1);
+        let cov_y0 = pixel_coverage(f32::from(part_rect.y0), rect_y0, rect_y1);
+        let cov_y1 = pixel_coverage(f32::from(part_rect.y1 - 1), rect_y0, rect_y1);
+        let bx0 = coverage_to_u8(cov_x0);
+        let bx1 = coverage_to_u8(cov_x1);
+        let by0 = coverage_to_u8(cov_y0);
+        let by1 = coverage_to_u8(cov_y1);
+
+        let frac = u32::from(bx0)
+            | (u32::from(bx1) << 8)
+            | (u32::from(by0) << 16)
+            | (u32::from(by1) << 24);
+
+        let adjust = |cov_x: f32, cov_y: f32, bx: u8, by: u8| -> u8 {
+            let correction = i16::from(corner_coverage_u8(cov_x, cov_y))
+                - i16::from(combine_coverage_u8(bx, by));
+            debug_assert!(
+                (-1..=1).contains(&correction),
+                "corner correction out of range: {correction}"
+            );
+            (correction + 1) as u8
+        };
+        let corner_adjust = adjust(cov_x0, cov_y0, bx0, by0)
+            | (adjust(cov_x1, cov_y0, bx1, by0) << 2)
+            | (adjust(cov_x0, cov_y1, bx0, by1) << 4)
+            | (adjust(cov_x1, cov_y1, bx1, by1) << 6);
+
+        // All-255 boundary bytes do not by themselves make the part fully
+        // opaque: an edge less than half an alpha step inside an integer
+        // rounds its byte to 255 while the exact corner alpha is 254 (a -1
+        // correction). Only when the corrections are all zero too may the
+        // shader skip the part's anti-aliasing work entirely.
+        let corner_adjust = if frac == FULL_COVERAGE && corner_adjust == 0b0101_0101 {
+            FULLY_OPAQUE_ADJUST
+        } else {
+            corner_adjust
+        };
+
+        RectPart {
+            rect: part_rect,
+            frac,
+            corner_adjust,
+        }
+    };
 
     // There's a balance to strike between reducing work in the fragment shader by splitting
     // out the inner part of the rectangle without anti-aliasing, and additional overhead
@@ -75,22 +159,19 @@ pub(crate) fn split_rect(rect: &Rect) -> SplitRect {
     if rect.x1 - rect.x0 < f64::from(LARGE_RECT_SPLIT_THRESHOLD)
         || rect.y1 - rect.y0 < f64::from(LARGE_RECT_SPLIT_THRESHOLD)
     {
-        return SplitRect {
-            main: RectPart {
-                rect: RectU16::new(x, y, x + width, y + height),
-                frac: pack_unorm4x8([left_frac, top_frac, right_frac, bottom_frac]),
-            },
+        return Some(SplitRect {
+            main: part(RectU16::new(x, y, x + width, y + height)),
             top: None,
             bottom: None,
             left: None,
             right: None,
-        };
+        });
     }
 
-    let has_left_aa = left_frac > 0.0;
-    let has_top_aa = top_frac > 0.0;
-    let has_right_aa = right_frac > 0.0;
-    let has_bottom_aa = bottom_frac > 0.0;
+    let has_left_aa = rect_x0 > sx0;
+    let has_top_aa = rect_y0 > sy0;
+    let has_right_aa = rect_x1 < sx1;
+    let has_bottom_aa = rect_y1 < sy1;
     let has_top_strip = has_top_aa || has_left_aa || has_right_aa;
     let has_bottom_strip = has_bottom_aa || has_left_aa || has_right_aa;
     let left_inset = u16::from(has_left_aa);
@@ -104,7 +185,7 @@ pub(crate) fn split_rect(rect: &Rect) -> SplitRect {
     let inner_width = width - left_inset - right_inset;
     let inner_height = height - top_inset - bottom_inset;
 
-    SplitRect {
+    Some(SplitRect {
         main: RectPart {
             rect: RectU16::new(
                 inner_x,
@@ -112,62 +193,65 @@ pub(crate) fn split_rect(rect: &Rect) -> SplitRect {
                 inner_x + inner_width,
                 inner_y + inner_height,
             ),
-            frac: 0,
+            frac: FULL_COVERAGE,
+            corner_adjust: FULLY_OPAQUE_ADJUST,
         },
-        top: has_top_strip.then_some(RectPart {
-            rect: RectU16::new(x, y, x + width, y + 1),
-            frac: pack_unorm4x8([left_frac, top_frac, right_frac, 0.0]),
+        top: has_top_strip.then(|| part(RectU16::new(x, y, x + width, y + 1))),
+        bottom: has_bottom_strip
+            .then(|| part(RectU16::new(x, y + height - 1, x + width, y + height))),
+        left: has_left_aa.then(|| part(RectU16::new(x, inner_y, x + 1, inner_y + inner_height))),
+        right: has_right_aa.then(|| {
+            part(RectU16::new(
+                x + width - 1,
+                inner_y,
+                x + width,
+                inner_y + inner_height,
+            ))
         }),
-        bottom: has_bottom_strip.then_some(RectPart {
-            rect: RectU16::new(x, y + height - 1, x + width, y + height),
-            frac: pack_unorm4x8([left_frac, 0.0, right_frac, bottom_frac]),
-        }),
-        left: has_left_aa.then_some(RectPart {
-            rect: RectU16::new(x, inner_y, x + 1, inner_y + inner_height),
-            frac: pack_unorm4x8([left_frac, 0.0, 0.0, 0.0]),
-        }),
-        right: has_right_aa.then_some(RectPart {
-            rect: RectU16::new(x + width - 1, inner_y, x + width, inner_y + inner_height),
-            frac: pack_unorm4x8([0.0, 0.0, right_frac, 0.0]),
-        }),
-    }
-}
-
-#[expect(
-    clippy::cast_possible_truncation,
-    reason = "normalized color channels are packed into u8 lanes"
-)]
-fn pack_unorm4x8(v: [f32; 4]) -> u32 {
-    let q = |f: f32| -> u8 { (f * 255.0 + 0.5) as u8 };
-    u32::from(q(v[0]))
-        | (u32::from(q(v[1])) << 8)
-        | (u32::from(q(v[2])) << 16)
-        | (u32::from(q(v[3])) << 24)
+    })
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{RectPart, SplitRect, pack_unorm4x8, split_rect};
+    use super::{FULL_COVERAGE, FULLY_OPAQUE_ADJUST, RectPart, SplitRect, split_rect};
 
     use vello_common::geometry::RectU16;
     use vello_common::kurbo::Rect;
+    use vello_common::rect::{combine_coverage_u8, corner_coverage_u8, coverage_to_u8};
 
-    fn part(x: u16, y: u16, width: u16, height: u16, frac: [f32; 4]) -> RectPart {
+    /// The all-zero-correction encoding: every corner stores `0 + 1`.
+    const NO_ADJUST: u8 = 0b0101_0101;
+
+    fn part(x: u16, y: u16, width: u16, height: u16, frac: [u8; 4], corner_adjust: u8) -> RectPart {
         RectPart {
             rect: RectU16::new(x, y, x + width, y + height),
-            frac: pack_unorm4x8(frac),
+            frac: u32::from(frac[0])
+                | (u32::from(frac[1]) << 8)
+                | (u32::from(frac[2]) << 16)
+                | (u32::from(frac[3]) << 24),
+            corner_adjust,
+        }
+    }
+
+    fn full_part(x: u16, y: u16, width: u16, height: u16) -> RectPart {
+        RectPart {
+            rect: RectU16::new(x, y, x + width, y + height),
+            frac: FULL_COVERAGE,
+            corner_adjust: FULLY_OPAQUE_ADJUST,
         }
     }
 
     #[test]
     fn splitter_keeps_small_rect_whole() {
         let rect = Rect::new(10.25, 20.5, 25.75, 35.25);
-        let split = split_rect(&rect);
+        let split = split_rect(&rect).unwrap();
 
+        // Boundary pixel coverages: left column [10.25, 11) -> 0.75, right column
+        // [25, 25.75) -> 0.75, top row [20.5, 21) -> 0.5, bottom row [35, 35.25) -> 0.25.
         assert_eq!(
             split,
             SplitRect {
-                main: part(10, 20, 16, 16, [0.25, 0.5, 0.25, 0.75]),
+                main: part(10, 20, 16, 16, [191, 191, 128, 64], NO_ADJUST),
                 top: None,
                 bottom: None,
                 left: None,
@@ -179,12 +263,14 @@ mod tests {
     #[test]
     fn splitter_keeps_subpixel_rect_inside_one_pixel() {
         let rect = Rect::new(10.125, 20.25, 10.875, 20.75);
-        let split = split_rect(&rect);
+        let split = split_rect(&rect).unwrap();
 
+        // A single pixel holds both edges of each axis: x coverage 0.75, y coverage 0.5,
+        // stored in both the first and last slot.
         assert_eq!(
             split,
             SplitRect {
-                main: part(10, 20, 1, 1, [0.125, 0.25, 0.125, 0.25]),
+                main: part(10, 20, 1, 1, [191, 191, 128, 128], NO_ADJUST),
                 top: None,
                 bottom: None,
                 left: None,
@@ -196,12 +282,12 @@ mod tests {
     #[test]
     fn splitter_keeps_subpixel_rect_spanning_two_pixels_in_width() {
         let rect = Rect::new(10.75, 20.125, 11.25, 20.875);
-        let split = split_rect(&rect);
+        let split = split_rect(&rect).unwrap();
 
         assert_eq!(
             split,
             SplitRect {
-                main: part(10, 20, 2, 1, [0.75, 0.125, 0.75, 0.125]),
+                main: part(10, 20, 2, 1, [64, 64, 191, 191], NO_ADJUST),
                 top: None,
                 bottom: None,
                 left: None,
@@ -213,12 +299,12 @@ mod tests {
     #[test]
     fn splitter_keeps_subpixel_rect_spanning_two_pixels_in_height() {
         let rect = Rect::new(10.125, 20.75, 10.875, 21.25);
-        let split = split_rect(&rect);
+        let split = split_rect(&rect).unwrap();
 
         assert_eq!(
             split,
             SplitRect {
-                main: part(10, 20, 1, 2, [0.125, 0.75, 0.125, 0.75]),
+                main: part(10, 20, 1, 2, [191, 191, 64, 64], NO_ADJUST),
                 top: None,
                 bottom: None,
                 left: None,
@@ -230,12 +316,12 @@ mod tests {
     #[test]
     fn splitter_keeps_multi_pixel_width_rect_within_one_pixel_height() {
         let rect = Rect::new(10.25, 20.125, 14.75, 20.875);
-        let split = split_rect(&rect);
+        let split = split_rect(&rect).unwrap();
 
         assert_eq!(
             split,
             SplitRect {
-                main: part(10, 20, 5, 1, [0.25, 0.125, 0.25, 0.125]),
+                main: part(10, 20, 5, 1, [191, 191, 191, 191], NO_ADJUST),
                 top: None,
                 bottom: None,
                 left: None,
@@ -247,12 +333,12 @@ mod tests {
     #[test]
     fn splitter_keeps_multi_pixel_height_rect_within_one_pixel_width() {
         let rect = Rect::new(10.125, 20.25, 10.875, 24.75);
-        let split = split_rect(&rect);
+        let split = split_rect(&rect).unwrap();
 
         assert_eq!(
             split,
             SplitRect {
-                main: part(10, 20, 1, 5, [0.125, 0.25, 0.125, 0.25]),
+                main: part(10, 20, 1, 5, [191, 191, 191, 191], NO_ADJUST),
                 top: None,
                 bottom: None,
                 left: None,
@@ -264,16 +350,19 @@ mod tests {
     #[test]
     fn splitter_splits_large_rect_into_five_parts() {
         let rect = Rect::new(10.25, 20.5, 42.75, 52.75);
-        let split = split_rect(&rect);
+        let split = split_rect(&rect).unwrap();
 
+        // Boundary coverages: left 0.75 -> 191, right 0.75 -> 191, top 0.5 -> 128,
+        // bottom 0.75 -> 191. A 1-pixel-thick strip has the same pixel as first and last
+        // on its thin axis, so that byte repeats in both slots.
         assert_eq!(
             split,
             SplitRect {
-                main: part(11, 21, 31, 31, [0.0, 0.0, 0.0, 0.0]),
-                top: Some(part(10, 20, 33, 1, [0.25, 0.5, 0.25, 0.0])),
-                bottom: Some(part(10, 52, 33, 1, [0.25, 0.0, 0.25, 0.25])),
-                left: Some(part(10, 21, 1, 31, [0.25, 0.0, 0.0, 0.0])),
-                right: Some(part(42, 21, 1, 31, [0.0, 0.0, 0.25, 0.0])),
+                main: full_part(11, 21, 31, 31),
+                top: Some(part(10, 20, 33, 1, [191, 191, 128, 128], NO_ADJUST)),
+                bottom: Some(part(10, 52, 33, 1, [191, 191, 191, 191], NO_ADJUST)),
+                left: Some(part(10, 21, 1, 31, [191, 191, 255, 255], NO_ADJUST)),
+                right: Some(part(42, 21, 1, 31, [191, 191, 255, 255], NO_ADJUST)),
             }
         );
     }
@@ -281,13 +370,13 @@ mod tests {
     #[test]
     fn splitter_omits_unneeded_edge_parts() {
         let rect = Rect::new(10.0, 20.5, 42.0, 53.0);
-        let split = split_rect(&rect);
+        let split = split_rect(&rect).unwrap();
 
         assert_eq!(
             split,
             SplitRect {
-                main: part(10, 21, 32, 32, [0.0, 0.0, 0.0, 0.0]),
-                top: Some(part(10, 20, 32, 1, [0.0, 0.5, 0.0, 0.0])),
+                main: full_part(10, 21, 32, 32),
+                top: Some(part(10, 20, 32, 1, [255, 255, 128, 128], NO_ADJUST)),
                 bottom: None,
                 left: None,
                 right: None,
@@ -298,14 +387,14 @@ mod tests {
     #[test]
     fn splitter_handles_large_rect_with_only_vertical_aa() {
         let rect = Rect::new(5.0, 2.25, 37.0, 34.75);
-        let split = split_rect(&rect);
+        let split = split_rect(&rect).unwrap();
 
         assert_eq!(
             split,
             SplitRect {
-                main: part(5, 3, 32, 31, [0.0, 0.0, 0.0, 0.0]),
-                top: Some(part(5, 2, 32, 1, [0.0, 0.25, 0.0, 0.0])),
-                bottom: Some(part(5, 34, 32, 1, [0.0, 0.0, 0.0, 0.25])),
+                main: full_part(5, 3, 32, 31),
+                top: Some(part(5, 2, 32, 1, [255, 255, 191, 191], NO_ADJUST)),
+                bottom: Some(part(5, 34, 32, 1, [255, 255, 191, 191], NO_ADJUST)),
                 left: None,
                 right: None,
             }
@@ -315,17 +404,134 @@ mod tests {
     #[test]
     fn splitter_keeps_large_aligned_rect_as_single_main_rect() {
         let rect = Rect::new(10.0, 20.0, 42.0, 60.0);
-        let split = split_rect(&rect);
+        let split = split_rect(&rect).unwrap();
 
         assert_eq!(
             split,
             SplitRect {
-                main: part(10, 20, 32, 40, [0.0, 0.0, 0.0, 0.0]),
+                main: full_part(10, 20, 32, 40),
                 top: None,
                 bottom: None,
                 left: None,
                 right: None,
             }
         );
+    }
+
+    #[test]
+    fn splitter_rejects_rect_collapsing_to_zero_pixels() {
+        assert_eq!(split_rect(&Rect::new(10.0, 20.0, 10.0, 25.0)), None);
+    }
+
+    /// Sweep sub-pixel offsets and sizes and check that, for every part, applying the packed
+    /// correction to the shader's integer combine of the packed bytes reproduces the exact
+    /// corner byte the CPU strip renderer writes (`corner_coverage_u8`).
+    #[test]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "mirrors split_rect's f32 conversion and reconstructs a u8 alpha"
+    )]
+    fn corner_corrections_reproduce_exact_corner_bytes() {
+        let mut checked = 0_u64;
+        let mut full_seen = 0_u64;
+        // The 1/64 grid plus offsets inside (0, 1/510]: edges that close to an
+        // integer round their axis byte to 255 while the exact corner alpha is
+        // 254, which is precisely the case the fully-opaque marker must not
+        // swallow.
+        let offsets = || {
+            (0..64_u32)
+                .map(|i| f64::from(i) / 64.0)
+                .chain([0.0005, 0.001, 0.0019])
+        };
+        for dx in offsets() {
+            for dy in offsets() {
+                for (w, h) in [
+                    (0.4, 0.7),
+                    (3.3, 2.6),
+                    (9.5, 1.2),
+                    (29.999, 19.999),
+                    (40.7, 35.2),
+                ] {
+                    let rect = Rect::new(7.0 + dx, 11.0 + dy, 7.0 + dx + w, 11.0 + dy + h);
+                    let Some(split) = split_rect(&rect) else {
+                        continue;
+                    };
+                    let rect_x0 = rect.x0 as f32;
+                    let rect_y0 = rect.y0 as f32;
+                    let rect_x1 = rect.x1 as f32;
+                    let rect_y1 = rect.y1 as f32;
+                    for part in [
+                        Some(split.main),
+                        split.top,
+                        split.bottom,
+                        split.left,
+                        split.right,
+                    ]
+                    .into_iter()
+                    .flatten()
+                    {
+                        let bytes = part.frac.to_le_bytes();
+                        for (slot, (px, py)) in [
+                            (part.rect.x0, part.rect.y0),
+                            (part.rect.x1 - 1, part.rect.y0),
+                            (part.rect.x0, part.rect.y1 - 1),
+                            (part.rect.x1 - 1, part.rect.y1 - 1),
+                        ]
+                        .into_iter()
+                        .enumerate()
+                        {
+                            let cov_x = super::pixel_coverage(f32::from(px), rect_x0, rect_x1);
+                            let cov_y = super::pixel_coverage(f32::from(py), rect_y0, rect_y1);
+                            let exact = corner_coverage_u8(cov_x, cov_y);
+                            assert_eq!(coverage_to_u8(cov_x), bytes[slot & 1]);
+                            assert_eq!(coverage_to_u8(cov_y), bytes[2 + (slot >> 1)]);
+                            if part.corner_adjust == FULLY_OPAQUE_ADJUST {
+                                // The fully-opaque marker asserts every pixel
+                                // is exactly 255 — including the corners.
+                                assert_eq!(
+                                    exact, 255,
+                                    "fully-opaque part with a non-255 corner for {rect:?} slot {slot}"
+                                );
+                                full_seen += 1;
+                            } else {
+                                let combined =
+                                    combine_coverage_u8(bytes[slot & 1], bytes[2 + (slot >> 1)]);
+                                let adj = (part.corner_adjust >> (slot * 2)) & 0x3;
+                                let reconstructed =
+                                    (i16::from(combined) + i16::from(adj) - 1) as u8;
+                                assert_eq!(
+                                    reconstructed, exact,
+                                    "corner mismatch for {rect:?} part {part:?} slot {slot}"
+                                );
+                            }
+                            checked += 1;
+                        }
+                    }
+                }
+            }
+        }
+        // Make sure the sweep exercised a meaningful number of corners on
+        // both sides of the fully-opaque split.
+        assert!(checked > 100_000, "only checked {checked} corners");
+        assert!(full_seen > 100, "only saw {full_seen} fully-opaque corners");
+    }
+
+    /// The near-integer regression: all four boundary bytes quantize to 255,
+    /// but the exact corner alpha is 254 — the part must carry the -1
+    /// corrections instead of the fully-opaque marker.
+    #[test]
+    fn near_integer_edges_keep_their_corner_corrections() {
+        let split = split_rect(&Rect::new(10.001, 20.001, 30.0, 40.0)).unwrap();
+        let part = split.main;
+        assert_eq!(part.frac, FULL_COVERAGE);
+        assert_ne!(part.corner_adjust, FULLY_OPAQUE_ADJUST);
+        // Top-left corner (slot 0): both axis coverages just under 1.0, the
+        // exact alpha is 254, combine(255, 255) is 255, so the correction is
+        // -1 (encoded 0); the other three corners are exact (encoded 1).
+        assert_eq!(part.corner_adjust, 0b0101_0100);
+
+        // A genuinely integer rectangle is fully opaque.
+        let split = split_rect(&Rect::new(10.0, 20.0, 30.0, 40.0)).unwrap();
+        assert_eq!(split.main.corner_adjust, FULLY_OPAQUE_ADJUST);
     }
 }

--- a/sparse_strips/vello_hybrid/src/render/common.rs
+++ b/sparse_strips/vello_hybrid/src/render/common.rs
@@ -374,9 +374,10 @@ pub struct GpuStrip {
     pub payload: u32,
     /// See `StripInstance::paint_and_rect_flag` documentation in `render.wesl`.
     pub paint_and_rect_flag: u32,
-    /// Painter's-order index used to compute z-depth for early-z rejection in shader.
-    /// In other words, the back-most draw has index 0 and every additional draw in front
-    /// has an incrementing index.
+    /// Painter's-order index used to compute z-depth for early-z rejection in shader,
+    /// in the low 24 bits: the back-most draw has index 0 and every additional draw in
+    /// front has an incrementing index. For rect strips, the top byte carries the corner
+    /// corrections (see `RectPart::corner_adjust`).
     pub depth_index: u32,
 }
 

--- a/sparse_strips/vello_hybrid/src/render/common.rs
+++ b/sparse_strips/vello_hybrid/src/render/common.rs
@@ -378,9 +378,10 @@ pub struct GpuStrip {
     pub payload: u32,
     /// See `StripInstance::paint_and_rect_flag` documentation in `render.wesl`.
     pub paint_and_rect_flag: u32,
-    /// Painter's-order index used to compute z-depth for early-z rejection in shader.
-    /// In other words, the back-most draw has index 0 and every additional draw in front
-    /// has an incrementing index.
+    /// Painter's-order index used to compute z-depth for early-z rejection in shader,
+    /// in the low 24 bits: the back-most draw has index 0 and every additional draw in
+    /// front has an incrementing index. For rect strips, the top byte carries the corner
+    /// corrections (see `RectPart::corner_adjust`).
     pub depth_index: u32,
 }
 

--- a/sparse_strips/vello_sparse_shaders/shaders/render.wesl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render.wesl
@@ -115,7 +115,7 @@ struct Config {
 //   ----------------------+-----------------------------------+-----------------------------------
 //   xy                    | Strip position                    | Rect top-left (snapped outward)
 //   widths_or_rect_height | [width, dense_width]              | [width, height] (both snapped)
-//   col_idx_or_rect_frac  | Alpha column index                | Packed AA edge fractions (4 × u8)
+//   col_idx_or_rect_frac  | Alpha column index                | Boundary coverage bytes (4 × u8)
 //   payload               | Color / scene coords / layer xy   | Color / scene coords / layer xy
 //   paint_and_rect_flag   | Paint encoding                    | Paint encoding | RECT_STRIP_FLAG
 //
@@ -174,7 +174,8 @@ struct StripInstance {
     widths_or_rect_height: u32,
     // For normal strips: alpha texture column index where this strip's alpha values begin.
     // There are [`Config::strip_height`] alpha values per column.
-    // For rect strips: packed fractional edge offsets for AA.
+    // For rect strips: packed coverage bytes of the rect's boundary pixels
+    // (first column, last column, first row, last row); 0xffffffff = fully covered.
     @location(2)
     col_idx_or_rect_frac: u32,
     // See StripInstance documentation above.
@@ -205,11 +206,15 @@ struct VertexOutput {
     // Packed paint payload or layer sample coordinate.
     @location(4) @interpolate(flat)
     payload: u32,
-    // Packed fractional edge offsets for rectangles.
-    // Bits 0-7: x0, 8-15: y0, 16-23: x1, 24-31: y1.
+    // Packed boundary-pixel coverage bytes for rectangles.
+    // Bits 0-7: first column, 8-15: last column, 16-23: first row, 24-31: last row.
     // Zero for normal strips.
     @location(5) @interpolate(flat)
     rect_frac: u32,
+    // Corner corrections for rectangles (2 bits per corner, biased by 1); see
+    // `RectPart::corner_adjust`. Zero for normal strips.
+    @location(6) @interpolate(flat)
+    rect_corner_adjust: u32,
     // Normalized device coordinates (NDC) for the current vertex
     @builtin(position)
     position: vec4<f32>,
@@ -257,9 +262,13 @@ fn vs_main(
         height = dense_width;
         out.dense_end_or_rect_size = width | (dense_width << 16u);
         out.rect_frac = instance.col_idx_or_rect_frac;
+        // Rect strips carry their corner corrections in the depth index's top byte
+        // (the z value only uses the low 24 bits).
+        out.rect_corner_adjust = instance.depth_index >> 24u;
     } else {
         out.dense_end_or_rect_size = instance.col_idx_or_rect_frac + dense_width;
         out.rect_frac = 0u;
+        out.rect_corner_adjust = 0u;
     }
     // Calculate the pixel coordinates of the current vertex within the strip.
     // Don't forget to apply the strip offset!
@@ -310,7 +319,7 @@ fn vs_main(
 
     // Divide by a power of 2 to ensure exact f32 arithmetic (and divide by the expected depth
     // buffer precision of 24 bits).
-    let z = 1.0 - f32(instance.depth_index) / f32(1u << 24u);
+    let z = 1.0 - f32(instance.depth_index & 0xffffffu) / f32(1u << 24u);
     // Flip it based on the flag.
     let final_ndc_y = select(ndc.y, -ndc.y, config.ndc_y_negate != 0u);
     out.position = vec4<f32>(ndc.x, final_ndc_y, z, 1.0);
@@ -334,26 +343,52 @@ fn fs_main(
     @location(3) @interpolate(flat) dense_end_or_rect_size: u32,
     @location(4) @interpolate(flat) payload: u32,
     @location(5) @interpolate(flat) rect_frac: u32,
+    @location(6) @interpolate(flat) rect_corner_adjust: u32,
     @builtin(position) position: vec4<f32>,
 ) -> @location(0) vec4<f32> {
     var alpha = 1.0;
     let is_rect = (paint_and_rect_flag & RECT_STRIP_FLAG) != 0u;
     // TODO: Explore doing these calculations only for rectangle parts that actually need anti-aliasing. See
     // https://github.com/linebender/vello/pull/1482#discussion_r2861311034
-    if is_rect && rect_frac != 0u {
-        let frac = unpack4x8unorm(rect_frac);
-        // Calculate how much of the pixel is actually covered by the rect.
-        // We do this by simply calculating the fractions in the x and y direction, and
-        // then multiplying them.
-        // For (maybe?) better performance, we calculate the x and y dimension in a single
-        // pass by packing everything into a vec2.
-        let rect_size = vec2<f32>(unpack_u16_pair(dense_end_or_rect_size));
-        let tc = tex_coord;
-        // + 0.5 and -0.5 since the fragment shader positions the coordinates in the center of the pixel.
-        let bottom_and_right = min(tc + 0.5, rect_size - frac.zw);
-        let top_and_left = max(tc - 0.5, frac.xy);
-        let a = clamp(bottom_and_right - top_and_left, vec2(0.0), vec2(1.0));
-        alpha = a.x * a.y;
+    // A part is skippable only when its boundary bytes are all 255 AND its
+    // corner corrections carry the all-exactly-255 marker (0xff): edges less
+    // than half an alpha step inside an integer round their byte to 255 while
+    // the exact corner alpha is 254.
+    if is_rect && !(rect_frac == 0xffffffffu && rect_corner_adjust == 0xffu) {
+        // Only the rect's boundary pixels can be partially covered; their coverage bytes
+        // arrive precomputed in rect_frac (first column, last column, first row, last row).
+        // A pixel in both a boundary column and a boundary row (a corner) combines the two
+        // bytes with round(x * y / 255), evaluated in integer arithmetic. The CPU strip
+        // renderer quantizes coverage with the same rules (see vello_common::rect), so a
+        // rect drawn as this quad is byte-identical to the same rect drawn as strips.
+        let col = u32(tex_coord.x);
+        let row = u32(tex_coord.y);
+        let rect_size = unpack_u16_pair(dense_end_or_rect_size);
+        let last_col = rect_size.x - 1u;
+        let last_row = rect_size.y - 1u;
+
+        var cov_x = 255u;
+        if col == 0u {
+            cov_x = rect_frac & 0xffu;
+        } else if col == last_col {
+            cov_x = (rect_frac >> 8u) & 0xffu;
+        }
+        var cov_y = 255u;
+        if row == 0u {
+            cov_y = (rect_frac >> 16u) & 0xffu;
+        } else if row == last_row {
+            cov_y = (rect_frac >> 24u) & 0xffu;
+        }
+
+        let p = cov_x * cov_y + 128u;
+        var alpha_u8 = (p + (p >> 8u)) >> 8u;
+        // Corner pixels (boundary on both axes) apply their precomputed 2-bit correction so
+        // the result lands exactly on the byte the CPU strip renderer writes for this pixel.
+        if (col == 0u || col == last_col) && (row == 0u || row == last_row) {
+            let slot = select(1u, 0u, col == 0u) | (select(1u, 0u, row == 0u) << 1u);
+            alpha_u8 = alpha_u8 + ((rect_corner_adjust >> (slot * 2u)) & 0x3u) - 1u;
+        }
+        alpha = f32(alpha_u8) * (1.0 / 255.0);
     } else if !is_rect && dense_end_or_rect_size != 0u {
         let x = u32(floor(tex_coord.x));
         let y = u32(floor(tex_coord.y));

--- a/sparse_strips/vello_sparse_shaders/shaders/render.wesl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render.wesl
@@ -106,7 +106,7 @@ struct Config {
 //   ----------------------+-----------------------------------+-----------------------------------
 //   xy                    | Strip position                    | Rect top-left (snapped outward)
 //   widths_or_rect_height | [width, dense_width]              | [width, height] (both snapped)
-//   col_idx_or_rect_frac  | Alpha column index                | Packed AA edge fractions (4 × u8)
+//   col_idx_or_rect_frac  | Alpha column index                | Boundary coverage bytes (4 × u8)
 //   payload               | Color / scene coords / layer xy   | Color / scene coords / layer xy
 //   paint_and_rect_flag   | Paint encoding                    | Paint encoding | RECT_STRIP_FLAG
 //
@@ -163,7 +163,8 @@ struct StripInstance {
     @location(1) widths_or_rect_height: u32,
     // For normal strips: alpha texture column index where this strip's alpha values begin.
     // There are [`Config::strip_height`] alpha values per column.
-    // For rect strips: packed fractional edge offsets for AA.
+    // For rect strips: packed coverage bytes of the rect's boundary pixels
+    // (first column, last column, first row, last row); 0xffffffff = fully covered.
     @location(2) col_idx_or_rect_frac: u32,
     // See StripInstance documentation above.
     @location(3) payload: u32,
@@ -185,10 +186,13 @@ struct VertexOutput {
     @location(3) @interpolate(flat) dense_end_or_rect_size: u32,
     // Packed paint payload or layer sample coordinate.
     @location(4) @interpolate(flat) payload: u32,
-    // Packed fractional edge offsets for rectangles.
-    // Bits 0-7: x0, 8-15: y0, 16-23: x1, 24-31: y1.
+    // Packed boundary-pixel coverage bytes for rectangles.
+    // Bits 0-7: first column, 8-15: last column, 16-23: first row, 24-31: last row.
     // Zero for normal strips.
     @location(5) @interpolate(flat) rect_frac: u32,
+    // Corner corrections for rectangles (2 bits per corner, biased by 1); see
+    // `RectPart::corner_adjust`. Zero for normal strips.
+    @location(6) @interpolate(flat) rect_corner_adjust: u32,
     // Normalized device coordinates (NDC) for the current vertex
     @builtin(position) position: vec4<f32>,
 };
@@ -232,9 +236,13 @@ fn vs_main(
         height = dense_width;
         out.dense_end_or_rect_size = width | (dense_width << 16u);
         out.rect_frac = instance.col_idx_or_rect_frac;
+        // Rect strips carry their corner corrections in the depth index's top byte
+        // (the z value only uses the low 24 bits).
+        out.rect_corner_adjust = instance.depth_index >> 24u;
     } else {
         out.dense_end_or_rect_size = instance.col_idx_or_rect_frac + dense_width;
         out.rect_frac = 0u;
+        out.rect_corner_adjust = 0u;
     }
     // Calculate the pixel coordinates of the current vertex within the strip.
     // Don't forget to apply the strip offset!
@@ -283,7 +291,7 @@ fn vs_main(
 
     // Divide by a power of 2 to ensure exact f32 arithmetic (and divide by the expected depth
     // buffer precision of 24 bits).
-    let z = 1.0 - f32(instance.depth_index) / f32(1u << 24u);
+    let z = 1.0 - f32(instance.depth_index & 0xffffffu) / f32(1u << 24u);
     // Flip it based on the flag.
     let final_ndc_y = select(ndc_y, -ndc_y, config.ndc_y_negate != 0u);
     out.position = vec4<f32>(ndc_x, final_ndc_y, z, 1.0);
@@ -307,26 +315,51 @@ fn fs_main(
     @location(3) @interpolate(flat) dense_end_or_rect_size: u32,
     @location(4) @interpolate(flat) payload: u32,
     @location(5) @interpolate(flat) rect_frac: u32,
+    @location(6) @interpolate(flat) rect_corner_adjust: u32,
     @builtin(position) position: vec4<f32>,
 ) -> @location(0) vec4<f32> {
     var alpha = 1.0;
     let is_rect = (paint_and_rect_flag & RECT_STRIP_FLAG) != 0u;
     // TODO: Explore doing these calculations only for rectangle parts that actually need anti-aliasing. See
     // https://github.com/linebender/vello/pull/1482#discussion_r2861311034
-    if is_rect && rect_frac != 0u {
-        let frac = unpack4x8unorm(rect_frac);
-        // Calculate how much of the pixel is actually covered by the rect.
-        // We do this by simply calculating the fractions in the x and y direction, and
-        // then multiplying them.
-        // For (maybe?) better performance, we calculate the x and y dimension in a single
-        // pass by packing everything into a vec2.
-        let rect_size = vec2<f32>(f32(dense_end_or_rect_size & 0xFFFFu), f32(dense_end_or_rect_size >> 16u));
-        let tc = tex_coord;
-        // + 0.5 and -0.5 since the fragment shader positions the coordinates in the center of the pixel.
-        let bottom_and_right = min(tc + 0.5, rect_size - frac.zw);
-        let top_and_left = max(tc - 0.5, frac.xy);
-        let a = clamp(bottom_and_right - top_and_left, vec2(0.0), vec2(1.0));
-        alpha = a.x * a.y;
+    // A part is skippable only when its boundary bytes are all 255 AND its
+    // corner corrections carry the all-exactly-255 marker (0xff): edges less
+    // than half an alpha step inside an integer round their byte to 255 while
+    // the exact corner alpha is 254.
+    if is_rect && !(rect_frac == 0xffffffffu && rect_corner_adjust == 0xffu) {
+        // Only the rect's boundary pixels can be partially covered; their coverage bytes
+        // arrive precomputed in rect_frac (first column, last column, first row, last row).
+        // A pixel in both a boundary column and a boundary row (a corner) combines the two
+        // bytes with round(x * y / 255), evaluated in integer arithmetic. The CPU strip
+        // renderer quantizes coverage with the same rules (see vello_common::rect), so a
+        // rect drawn as this quad is byte-identical to the same rect drawn as strips.
+        let col = u32(tex_coord.x);
+        let row = u32(tex_coord.y);
+        let last_col = (dense_end_or_rect_size & 0xFFFFu) - 1u;
+        let last_row = (dense_end_or_rect_size >> 16u) - 1u;
+
+        var cov_x = 255u;
+        if col == 0u {
+            cov_x = rect_frac & 0xffu;
+        } else if col == last_col {
+            cov_x = (rect_frac >> 8u) & 0xffu;
+        }
+        var cov_y = 255u;
+        if row == 0u {
+            cov_y = (rect_frac >> 16u) & 0xffu;
+        } else if row == last_row {
+            cov_y = (rect_frac >> 24u) & 0xffu;
+        }
+
+        let p = cov_x * cov_y + 128u;
+        var alpha_u8 = (p + (p >> 8u)) >> 8u;
+        // Corner pixels (boundary on both axes) apply their precomputed 2-bit correction so
+        // the result lands exactly on the byte the CPU strip renderer writes for this pixel.
+        if (col == 0u || col == last_col) && (row == 0u || row == last_row) {
+            let slot = select(1u, 0u, col == 0u) | (select(1u, 0u, row == 0u) << 1u);
+            alpha_u8 = alpha_u8 + ((rect_corner_adjust >> (slot * 2u)) & 0x3u) - 1u;
+        }
+        alpha = f32(alpha_u8) * (1.0 / 255.0);
     } else if !is_rect && dense_end_or_rect_size != 0u {
         let x = u32(floor(tex_coord.x));
         let y = u32(floor(tex_coord.y));

--- a/sparse_strips/vello_sparse_tests/tests/mod.rs
+++ b/sparse_strips/vello_sparse_tests/tests/mod.rs
@@ -48,6 +48,7 @@ mod layer;
 mod mask;
 mod mix;
 mod opacity;
+mod rect_parity;
 mod renderer;
 mod scenes;
 #[macro_use]

--- a/sparse_strips/vello_sparse_tests/tests/mod.rs
+++ b/sparse_strips/vello_sparse_tests/tests/mod.rs
@@ -47,6 +47,7 @@ mod layer;
 mod mask;
 mod mix;
 mod opacity;
+mod rect_parity;
 mod renderer;
 mod scenes;
 #[macro_use]

--- a/sparse_strips/vello_sparse_tests/tests/rect_parity.rs
+++ b/sparse_strips/vello_sparse_tests/tests/rect_parity.rs
@@ -1,0 +1,300 @@
+// Copyright 2026 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Byte-exactness pins for the two rectangle rasterizers in `vello_hybrid`.
+//!
+//! An axis-aligned `fill_rect` normally renders as a GPU quad (the rect fast path). As soon as a
+//! clip is active it renders through the CPU strip path instead. These are two different
+//! rasterizers for the same rectangle, and both quantize anti-aliased coverage to 8 bits — if
+//! they round differently, pushing a clip changes pixels the clip does not even touch.
+//!
+//! The GPU quad reconstructs per-pixel alpha from the exact bytes the CPU strip renderer would
+//! write (see `vello_common::rect` and `RectPart` in `vello_hybrid`), so a clip that removes
+//! nothing must change nothing. These tests pin that: they render fractional-edge content with
+//! and without integer-rectangle clips and compare raw bytes. An integer clip edge is a 0/255
+//! coverage step, so inside the clip the strip path is a pure pass-through and any byte
+//! difference is a rasterizer divergence.
+
+#[cfg(not(all(target_arch = "wasm32", feature = "webgl")))]
+mod tests {
+    use vello_common::geometry::RectU16;
+    use vello_common::kurbo::{BezPath, Rect, Shape, Stroke};
+    use vello_common::peniko::{Color, Extend, ImageQuality, ImageSampler};
+    use vello_common::pixmap::Pixmap;
+    use vello_hybrid::ExternalTextureRect;
+
+    use crate::load_image;
+    use crate::renderer::{HybridRenderer, Renderer};
+    use crate::util::{get_ctx, render_pixmap};
+    use vello_cpu::RenderMode;
+
+    const W: u16 = 128;
+    const H: u16 = 64;
+
+    fn hybrid(width: u16, height: u16) -> HybridRenderer {
+        get_ctx::<HybridRenderer>(
+            width,
+            height,
+            false,
+            0,
+            "fallback",
+            RenderMode::OptimizeQuality,
+        )
+    }
+
+    fn rect_path(x0: f64, y0: f64, x1: f64, y1: f64) -> BezPath {
+        Rect::new(x0, y0, x1, y1).to_path(0.1)
+    }
+
+    fn paint_backdrop(ctx: &mut HybridRenderer) {
+        ctx.set_paint(Color::new([0.086, 0.106, 0.133, 1.0]));
+        ctx.fill_rect(&Rect::new(
+            0.0,
+            0.0,
+            f64::from(ctx.width()),
+            f64::from(ctx.height()),
+        ));
+    }
+
+    /// Fractional-edge content of every rect-fast-path class plus a non-rect path and a stroke:
+    /// opaque rect, translucent rect, blurred rounded rect, filled path, stroked rect. The
+    /// near-integer rect's boundary bytes all quantize to 255 while its exact top-left corner
+    /// alpha is 254 — the case where a "fully covered" shortcut would diverge from strips.
+    fn paint_content(ctx: &mut HybridRenderer) {
+        ctx.set_paint(Color::new([0.941, 0.533, 0.243, 1.0]));
+        ctx.fill_rect(&Rect::new(10.3, 8.7, 40.6, 30.2));
+        ctx.set_paint(Color::new([0.15, 0.45, 0.85, 1.0]));
+        ctx.fill_rect(&Rect::new(102.001, 44.001, 122.0, 60.0));
+        ctx.set_paint(Color::new([0.2, 0.8, 0.4, 0.5]));
+        ctx.fill_rect(&Rect::new(60.5, 12.25, 95.75, 40.5));
+        ctx.set_paint(Color::new([0.3, 0.2, 0.7, 0.9]));
+        ctx.fill_blurred_rounded_rect(&Rect::new(44.4, 34.6, 74.2, 58.9), 4.0, 3.0, false);
+        let mut p = BezPath::new();
+        p.move_to((100.3, 10.4));
+        p.line_to((120.7, 18.9));
+        p.line_to((104.2, 44.6));
+        p.close_path();
+        ctx.set_paint(Color::new([0.4, 0.4, 0.9, 1.0]));
+        ctx.fill_path(&p);
+        ctx.set_paint(Color::new([0.9, 0.2, 0.3, 0.8]));
+        ctx.set_stroke(Stroke::new(2.5));
+        ctx.stroke_path(&rect_path(30.6, 35.3, 70.4, 55.8));
+    }
+
+    fn pixel(pixmap: &Pixmap, width: u16, x: u16, y: u16) -> &[u8] {
+        let i = (usize::from(y) * usize::from(width) + usize::from(x)) * 4;
+        &pixmap.data_as_u8_slice()[i..i + 4]
+    }
+
+    fn assert_identical(a: &Pixmap, b: &Pixmap, what: &str) {
+        let diffs = a
+            .data_as_u8_slice()
+            .iter()
+            .zip(b.data_as_u8_slice())
+            .filter(|(x, y)| x != y)
+            .count();
+        assert_eq!(diffs, 0, "{what}: {diffs} differing bytes");
+    }
+
+    /// A full-viewport integer-aligned rect clip removes nothing, so it must change nothing —
+    /// even though it moves every rect from the GPU quad to the CPU strip path.
+    #[test]
+    fn rect_parity_full_viewport_integer_clip_is_byte_identical() {
+        let mut plain = hybrid(W, H);
+        paint_backdrop(&mut plain);
+        paint_content(&mut plain);
+        let plain = render_pixmap(&mut plain);
+
+        let mut clipped = hybrid(W, H);
+        paint_backdrop(&mut clipped);
+        clipped.push_clip_path(&rect_path(0.0, 0.0, f64::from(W), f64::from(H)));
+        paint_content(&mut clipped);
+        clipped.pop_clip_path();
+        let clipped = render_pixmap(&mut clipped);
+
+        assert_identical(&plain, &clipped, "full-viewport integer clip");
+    }
+
+    /// An interior integer-rect clip: bytes inside the clip equal the unclipped render, bytes
+    /// outside are exactly the backdrop.
+    #[test]
+    fn rect_parity_interior_integer_clip_confines_and_preserves() {
+        const CLIP: [u16; 4] = [16, 12, 112, 56]; // x0, y0, x1, y1
+
+        let mut reference = hybrid(W, H);
+        paint_backdrop(&mut reference);
+        paint_content(&mut reference);
+        let reference = render_pixmap(&mut reference);
+
+        let mut backdrop_only = hybrid(W, H);
+        paint_backdrop(&mut backdrop_only);
+        let backdrop_only = render_pixmap(&mut backdrop_only);
+
+        let mut clipped = hybrid(W, H);
+        paint_backdrop(&mut clipped);
+        clipped.push_clip_path(&rect_path(
+            f64::from(CLIP[0]),
+            f64::from(CLIP[1]),
+            f64::from(CLIP[2]),
+            f64::from(CLIP[3]),
+        ));
+        paint_content(&mut clipped);
+        clipped.pop_clip_path();
+        let clipped = render_pixmap(&mut clipped);
+
+        for y in 0..H {
+            for x in 0..W {
+                let inside = x >= CLIP[0] && x < CLIP[2] && y >= CLIP[1] && y < CLIP[3];
+                let want = if inside {
+                    pixel(&reference, W, x, y)
+                } else {
+                    pixel(&backdrop_only, W, x, y)
+                };
+                assert_eq!(
+                    pixel(&clipped, W, x, y),
+                    want,
+                    "({x},{y}) inside={inside}: clip must {}",
+                    if inside {
+                        "preserve the unclipped bytes"
+                    } else {
+                        "remove the content"
+                    }
+                );
+            }
+        }
+    }
+
+    /// Texture rects at a fractional offset under an integer clip: in-clip bytes equal the
+    /// unclipped render (sampling positions must not shift when the rect goes through strips).
+    #[test]
+    fn rect_parity_texture_rects_byte_identical_inside_clip() {
+        const CLIP: [u16; 4] = [16, 12, 112, 56];
+        let sample = |texture_id| ExternalTextureRect {
+            texture_id,
+            src_rect: RectU16::new(0, 0, 56, 56),
+            dest_rect: Rect::new(10.3, 8.7, 10.3 + 56., 8.7 + 56.),
+            sampler: ImageSampler {
+                x_extend: Extend::Pad,
+                y_extend: Extend::Pad,
+                quality: ImageQuality::Low,
+                alpha: 1.0,
+            },
+            may_have_transparency: true,
+        };
+
+        let mut reference = hybrid(W, H);
+        paint_backdrop(&mut reference);
+        let id = reference.register_external_texture(load_image!("glyphs_colr_noto"));
+        reference.draw_texture_rect(sample(id));
+        let reference = render_pixmap(&mut reference);
+
+        let mut backdrop_only = hybrid(W, H);
+        paint_backdrop(&mut backdrop_only);
+        let backdrop_only = render_pixmap(&mut backdrop_only);
+
+        let mut clipped = hybrid(W, H);
+        paint_backdrop(&mut clipped);
+        let id = clipped.register_external_texture(load_image!("glyphs_colr_noto"));
+        clipped.push_clip_path(&rect_path(
+            f64::from(CLIP[0]),
+            f64::from(CLIP[1]),
+            f64::from(CLIP[2]),
+            f64::from(CLIP[3]),
+        ));
+        clipped.draw_texture_rect(sample(id));
+        clipped.pop_clip_path();
+        let clipped = render_pixmap(&mut clipped);
+
+        for y in 0..H {
+            for x in 0..W {
+                let inside = x >= CLIP[0] && x < CLIP[2] && y >= CLIP[1] && y < CLIP[3];
+                let want = if inside {
+                    pixel(&reference, W, x, y)
+                } else {
+                    pixel(&backdrop_only, W, x, y)
+                };
+                assert_eq!(pixel(&clipped, W, x, y), want, "({x},{y}) inside={inside}");
+            }
+        }
+    }
+
+    /// A deterministic sweep of sub-pixel rect geometries (sizes from sub-pixel slivers to
+    /// multi-tile, opaque and translucent), rendered once plain and once under a full-viewport
+    /// integer clip.
+    #[test]
+    fn rect_parity_randomized_fractional_rects() {
+        // Simple LCG so the scene is deterministic without a rand dependency.
+        let mut state = 0x2545_F491_4F6C_DD1D_u64;
+        let mut next = move || {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            (state >> 33) as f64 / f64::from(u32::MAX >> 1)
+        };
+
+        let mut rects = Vec::new();
+        for _ in 0..40 {
+            let x0 = next() * f64::from(W - 12);
+            let y0 = next() * f64::from(H - 12);
+            let w = 0.3 + next() * 11.0;
+            let h = 0.3 + next() * 11.0;
+            let color = Color::new([
+                next() as f32,
+                next() as f32,
+                next() as f32,
+                (0.3 + 0.7 * next()) as f32,
+            ]);
+            rects.push((Rect::new(x0, y0, x0 + w, y0 + h), color));
+        }
+
+        let paint = |ctx: &mut HybridRenderer| {
+            paint_backdrop(ctx);
+            for (rect, color) in &rects {
+                ctx.set_paint(*color);
+                ctx.fill_rect(rect);
+            }
+        };
+
+        let mut plain = hybrid(W, H);
+        paint(&mut plain);
+        let plain = render_pixmap(&mut plain);
+
+        let mut clipped = hybrid(W, H);
+        clipped.push_clip_path(&rect_path(0.0, 0.0, f64::from(W), f64::from(H)));
+        paint(&mut clipped);
+        clipped.pop_clip_path();
+        let clipped = render_pixmap(&mut clipped);
+
+        assert_identical(&plain, &clipped, "randomized fractional rects");
+    }
+
+    /// Same pin far from the origin. Converting an `f64` edge to `f32` moves it by up to half
+    /// an `f32` ulp (about 2.4e-4 px at x ~ 4400), which crosses a byte-decision boundary for a
+    /// few percent of fractional positions — so the quad's coverage bytes must be computed from
+    /// the same `f32`-converted edges the strip renderer uses, or the two paths disagree here.
+    #[test]
+    fn rect_parity_holds_at_large_coordinates() {
+        const BIG_W: u16 = 4400;
+        const BIG_H: u16 = 16;
+
+        let paint = |ctx: &mut HybridRenderer| {
+            paint_backdrop(ctx);
+            ctx.set_paint(Color::new([0.941, 0.533, 0.243, 1.0]));
+            ctx.fill_rect(&Rect::new(4300.3, 2.7, 4390.6, 12.2));
+            ctx.set_paint(Color::new([0.2, 0.8, 0.4, 0.5]));
+            ctx.fill_rect(&Rect::new(4210.55, 5.25, 4285.75, 9.5));
+        };
+
+        let mut plain = hybrid(BIG_W, BIG_H);
+        paint(&mut plain);
+        let plain = render_pixmap(&mut plain);
+
+        let mut clipped = hybrid(BIG_W, BIG_H);
+        clipped.push_clip_path(&rect_path(0.0, 0.0, f64::from(BIG_W), f64::from(BIG_H)));
+        paint(&mut clipped);
+        clipped.pop_clip_path();
+        let clipped = render_pixmap(&mut clipped);
+
+        assert_identical(&plain, &clipped, "large-coordinate rects");
+    }
+}

--- a/sparse_strips/vello_sparse_tests/tests/rect_parity.rs
+++ b/sparse_strips/vello_sparse_tests/tests/rect_parity.rs
@@ -1,0 +1,292 @@
+// Copyright 2026 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Byte-exactness pins for the two rectangle rasterizers in `vello_hybrid`.
+//!
+//! An axis-aligned `fill_rect` normally renders as a GPU quad (the rect fast path). As soon as a
+//! clip is active it renders through the CPU strip path instead. These are two different
+//! rasterizers for the same rectangle, and both quantize anti-aliased coverage to 8 bits — if
+//! they round differently, pushing a clip changes pixels the clip does not even touch.
+//!
+//! The GPU quad reconstructs per-pixel alpha from the exact bytes the CPU strip renderer would
+//! write (see `vello_common::rect` and `RectPart` in `vello_hybrid`), so a clip that removes
+//! nothing must change nothing. These tests pin that: they render fractional-edge content with
+//! and without integer-rectangle clips and compare raw bytes. An integer clip edge is a 0/255
+//! coverage step, so inside the clip the strip path is a pure pass-through and any byte
+//! difference is a rasterizer divergence.
+
+#[cfg(not(all(target_arch = "wasm32", feature = "webgl")))]
+mod tests {
+    use vello_common::geometry::RectU16;
+    use vello_common::kurbo::{Affine, BezPath, Rect, Shape, Stroke};
+    use vello_common::peniko::{Color, ImageQuality};
+    use vello_common::pixmap::Pixmap;
+    use vello_hybrid::SampleRect;
+
+    use crate::load_image;
+    use crate::renderer::{HybridRenderer, Renderer};
+    use crate::util::{get_ctx, render_pixmap};
+    use vello_cpu::RenderMode;
+
+    const W: u16 = 128;
+    const H: u16 = 64;
+
+    fn hybrid(width: u16, height: u16) -> HybridRenderer {
+        get_ctx::<HybridRenderer>(
+            width,
+            height,
+            false,
+            0,
+            "fallback",
+            RenderMode::OptimizeQuality,
+        )
+    }
+
+    fn rect_path(x0: f64, y0: f64, x1: f64, y1: f64) -> BezPath {
+        Rect::new(x0, y0, x1, y1).to_path(0.1)
+    }
+
+    fn paint_backdrop(ctx: &mut HybridRenderer) {
+        ctx.set_paint(Color::new([0.086, 0.106, 0.133, 1.0]));
+        ctx.fill_rect(&Rect::new(
+            0.0,
+            0.0,
+            f64::from(ctx.width()),
+            f64::from(ctx.height()),
+        ));
+    }
+
+    /// Fractional-edge content of every rect-fast-path class plus a non-rect path and a stroke:
+    /// opaque rect, translucent rect, blurred rounded rect, filled path, stroked rect. The
+    /// near-integer rect's boundary bytes all quantize to 255 while its exact top-left corner
+    /// alpha is 254 — the case where a "fully covered" shortcut would diverge from strips.
+    fn paint_content(ctx: &mut HybridRenderer) {
+        ctx.set_paint(Color::new([0.941, 0.533, 0.243, 1.0]));
+        ctx.fill_rect(&Rect::new(10.3, 8.7, 40.6, 30.2));
+        ctx.set_paint(Color::new([0.15, 0.45, 0.85, 1.0]));
+        ctx.fill_rect(&Rect::new(102.001, 44.001, 122.0, 60.0));
+        ctx.set_paint(Color::new([0.2, 0.8, 0.4, 0.5]));
+        ctx.fill_rect(&Rect::new(60.5, 12.25, 95.75, 40.5));
+        ctx.set_paint(Color::new([0.3, 0.2, 0.7, 0.9]));
+        ctx.fill_blurred_rounded_rect(&Rect::new(44.4, 34.6, 74.2, 58.9), 4.0, 3.0, false);
+        let mut p = BezPath::new();
+        p.move_to((100.3, 10.4));
+        p.line_to((120.7, 18.9));
+        p.line_to((104.2, 44.6));
+        p.close_path();
+        ctx.set_paint(Color::new([0.4, 0.4, 0.9, 1.0]));
+        ctx.fill_path(&p);
+        ctx.set_paint(Color::new([0.9, 0.2, 0.3, 0.8]));
+        ctx.set_stroke(Stroke::new(2.5));
+        ctx.stroke_path(&rect_path(30.6, 35.3, 70.4, 55.8));
+    }
+
+    fn pixel(pixmap: &Pixmap, width: u16, x: u16, y: u16) -> &[u8] {
+        let i = (usize::from(y) * usize::from(width) + usize::from(x)) * 4;
+        &pixmap.data_as_u8_slice()[i..i + 4]
+    }
+
+    fn assert_identical(a: &Pixmap, b: &Pixmap, what: &str) {
+        let diffs = a
+            .data_as_u8_slice()
+            .iter()
+            .zip(b.data_as_u8_slice())
+            .filter(|(x, y)| x != y)
+            .count();
+        assert_eq!(diffs, 0, "{what}: {diffs} differing bytes");
+    }
+
+    /// A full-viewport integer-aligned rect clip removes nothing, so it must change nothing —
+    /// even though it moves every rect from the GPU quad to the CPU strip path.
+    #[test]
+    fn rect_parity_full_viewport_integer_clip_is_byte_identical() {
+        let mut plain = hybrid(W, H);
+        paint_backdrop(&mut plain);
+        paint_content(&mut plain);
+        let plain = render_pixmap(&mut plain);
+
+        let mut clipped = hybrid(W, H);
+        paint_backdrop(&mut clipped);
+        clipped.push_clip_path(&rect_path(0.0, 0.0, f64::from(W), f64::from(H)));
+        paint_content(&mut clipped);
+        clipped.pop_clip_path();
+        let clipped = render_pixmap(&mut clipped);
+
+        assert_identical(&plain, &clipped, "full-viewport integer clip");
+    }
+
+    /// An interior integer-rect clip: bytes inside the clip equal the unclipped render, bytes
+    /// outside are exactly the backdrop.
+    #[test]
+    fn rect_parity_interior_integer_clip_confines_and_preserves() {
+        const CLIP: [u16; 4] = [16, 12, 112, 56]; // x0, y0, x1, y1
+
+        let mut reference = hybrid(W, H);
+        paint_backdrop(&mut reference);
+        paint_content(&mut reference);
+        let reference = render_pixmap(&mut reference);
+
+        let mut backdrop_only = hybrid(W, H);
+        paint_backdrop(&mut backdrop_only);
+        let backdrop_only = render_pixmap(&mut backdrop_only);
+
+        let mut clipped = hybrid(W, H);
+        paint_backdrop(&mut clipped);
+        clipped.push_clip_path(&rect_path(
+            f64::from(CLIP[0]),
+            f64::from(CLIP[1]),
+            f64::from(CLIP[2]),
+            f64::from(CLIP[3]),
+        ));
+        paint_content(&mut clipped);
+        clipped.pop_clip_path();
+        let clipped = render_pixmap(&mut clipped);
+
+        for y in 0..H {
+            for x in 0..W {
+                let inside = x >= CLIP[0] && x < CLIP[2] && y >= CLIP[1] && y < CLIP[3];
+                let want = if inside {
+                    pixel(&reference, W, x, y)
+                } else {
+                    pixel(&backdrop_only, W, x, y)
+                };
+                assert_eq!(
+                    pixel(&clipped, W, x, y),
+                    want,
+                    "({x},{y}) inside={inside}: clip must {}",
+                    if inside {
+                        "preserve the unclipped bytes"
+                    } else {
+                        "remove the content"
+                    }
+                );
+            }
+        }
+    }
+
+    /// Texture rects at a fractional offset under an integer clip: in-clip bytes equal the
+    /// unclipped render (sampling positions must not shift when the rect goes through strips).
+    #[test]
+    fn rect_parity_texture_rects_byte_identical_inside_clip() {
+        const CLIP: [u16; 4] = [16, 12, 112, 56];
+        let sample = SampleRect {
+            source_region: RectU16::new(0, 0, 56, 56),
+            transform: Affine::translate((10.3, 8.7)),
+        };
+
+        let mut reference = hybrid(W, H);
+        paint_backdrop(&mut reference);
+        let id = reference.register_external_texture(load_image!("glyphs_colr_noto"));
+        reference.draw_texture_rects(id, ImageQuality::Low, [sample]);
+        let reference = render_pixmap(&mut reference);
+
+        let mut backdrop_only = hybrid(W, H);
+        paint_backdrop(&mut backdrop_only);
+        let backdrop_only = render_pixmap(&mut backdrop_only);
+
+        let mut clipped = hybrid(W, H);
+        paint_backdrop(&mut clipped);
+        let id = clipped.register_external_texture(load_image!("glyphs_colr_noto"));
+        clipped.push_clip_path(&rect_path(
+            f64::from(CLIP[0]),
+            f64::from(CLIP[1]),
+            f64::from(CLIP[2]),
+            f64::from(CLIP[3]),
+        ));
+        clipped.draw_texture_rects(id, ImageQuality::Low, [sample]);
+        clipped.pop_clip_path();
+        let clipped = render_pixmap(&mut clipped);
+
+        for y in 0..H {
+            for x in 0..W {
+                let inside = x >= CLIP[0] && x < CLIP[2] && y >= CLIP[1] && y < CLIP[3];
+                let want = if inside {
+                    pixel(&reference, W, x, y)
+                } else {
+                    pixel(&backdrop_only, W, x, y)
+                };
+                assert_eq!(pixel(&clipped, W, x, y), want, "({x},{y}) inside={inside}");
+            }
+        }
+    }
+
+    /// A deterministic sweep of sub-pixel rect geometries (sizes from sub-pixel slivers to
+    /// multi-tile, opaque and translucent), rendered once plain and once under a full-viewport
+    /// integer clip.
+    #[test]
+    fn rect_parity_randomized_fractional_rects() {
+        // Simple LCG so the scene is deterministic without a rand dependency.
+        let mut state = 0x2545_F491_4F6C_DD1D_u64;
+        let mut next = move || {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            (state >> 33) as f64 / f64::from(u32::MAX >> 1)
+        };
+
+        let mut rects = Vec::new();
+        for _ in 0..40 {
+            let x0 = next() * f64::from(W - 12);
+            let y0 = next() * f64::from(H - 12);
+            let w = 0.3 + next() * 11.0;
+            let h = 0.3 + next() * 11.0;
+            let color = Color::new([
+                next() as f32,
+                next() as f32,
+                next() as f32,
+                (0.3 + 0.7 * next()) as f32,
+            ]);
+            rects.push((Rect::new(x0, y0, x0 + w, y0 + h), color));
+        }
+
+        let paint = |ctx: &mut HybridRenderer| {
+            paint_backdrop(ctx);
+            for (rect, color) in &rects {
+                ctx.set_paint(*color);
+                ctx.fill_rect(rect);
+            }
+        };
+
+        let mut plain = hybrid(W, H);
+        paint(&mut plain);
+        let plain = render_pixmap(&mut plain);
+
+        let mut clipped = hybrid(W, H);
+        clipped.push_clip_path(&rect_path(0.0, 0.0, f64::from(W), f64::from(H)));
+        paint(&mut clipped);
+        clipped.pop_clip_path();
+        let clipped = render_pixmap(&mut clipped);
+
+        assert_identical(&plain, &clipped, "randomized fractional rects");
+    }
+
+    /// Same pin far from the origin. Converting an `f64` edge to `f32` moves it by up to half
+    /// an `f32` ulp (about 2.4e-4 px at x ~ 4400), which crosses a byte-decision boundary for a
+    /// few percent of fractional positions — so the quad's coverage bytes must be computed from
+    /// the same `f32`-converted edges the strip renderer uses, or the two paths disagree here.
+    #[test]
+    fn rect_parity_holds_at_large_coordinates() {
+        const BIG_W: u16 = 4400;
+        const BIG_H: u16 = 16;
+
+        let paint = |ctx: &mut HybridRenderer| {
+            paint_backdrop(ctx);
+            ctx.set_paint(Color::new([0.941, 0.533, 0.243, 1.0]));
+            ctx.fill_rect(&Rect::new(4300.3, 2.7, 4390.6, 12.2));
+            ctx.set_paint(Color::new([0.2, 0.8, 0.4, 0.5]));
+            ctx.fill_rect(&Rect::new(4210.55, 5.25, 4285.75, 9.5));
+        };
+
+        let mut plain = hybrid(BIG_W, BIG_H);
+        paint(&mut plain);
+        let plain = render_pixmap(&mut plain);
+
+        let mut clipped = hybrid(BIG_W, BIG_H);
+        clipped.push_clip_path(&rect_path(0.0, 0.0, f64::from(BIG_W), f64::from(BIG_H)));
+        paint(&mut clipped);
+        clipped.pop_clip_path();
+        let clipped = render_pixmap(&mut clipped);
+
+        assert_identical(&plain, &clipped, "large-coordinate rects");
+    }
+}


### PR DESCRIPTION
`fill_rect` has two rasterizers: unclipped, a rect is drawn as a single GPU quad with analytic edge anti-aliasing; under a clip, the same rect goes through the CPU strip renderer instead. The two rounded anti-aliased coverage differently, so pushing a clip changed pixels the clip didn't even touch. This is the rasterizer divergence discussed in #1737, fixed at the root.

There were three separate divergences:

1. **Edge half-ties.** The quad stored quantized edge *positions* (and, for right/bottom edges, their complements). Rounding `x` up is not symmetric with rounding `255 - x` up, so an edge landing exactly on half an alpha step came out 1 off.
2. **Corners.** The shader multiplied two already-quantized values and never re-quantized; the strip renderer quantizes the exact product once.
3. **Large coordinates.** The quad derived edge fractions from the `f64` rect, but the strip renderer converts the rect to `f32` first. That conversion moves an edge by up to half an `f32` ulp, enough to cross a rounding boundary for a few percent of fractional positions.

The strip renderer is now the single source of truth, and the quad reproduces its bytes exactly:

- `split_rect` converts to `f32` in the same order as the strip renderer and packs the boundary pixels' coverage *bytes*, computed with helpers shared with `vello_common::rect`.
- Corner alphas can't be reconstructed from the axis bytes alone, but the difference between the integer `round(x*y/255)` of the two bytes and the exact corner byte is provably in {-1, 0, +1} (quantizing each axis first loses strictly less than half an alpha step per axis, and exact ties are impossible: `2xy = 255 * odd` has no solution). Those 2-bit corrections ride in the unused top byte of `depth_index` — z is 24-bit, so the instance layout doesn't grow.
- The fragment shader picks the byte by pixel position, combines corners with the same integer expression, and applies the correction. All-integer math, so there is no float-precision story left in the comparison.
- A part is only skipped as fully opaque when its corner corrections are all zero too: an edge less than half an alpha step *inside* an integer rounds its byte to 255 while the exact corner alpha is 254.

CPU rendering is unchanged — the `vello_common::rect` change is a pure refactor, and the existing rect-fast-path == general-path invariant still holds. The full snapshot suite passes without regenerating anything.

New `rect_parity` GPU tests pin clipped == unclipped byte equality: a full-viewport integer clip (which removes nothing and must change nothing), an interior clip, texture rects, a randomized fractional battery, near-integer corners, and large coordinates. On main, the full-viewport and large-coordinate pins fail with 106 and 97 differing bytes respectively; with this change everything passes.

With this landed, clipping a scene to a damage region at construction time is byte-exact with no special casing — the "fix the bug, then design the best API assuming no bug" direction from the #1737 review.

<sub>This PR was generated by Claude.</sub>
