### PR TITLE
glifo: Make glyph pixel-snapping decisions stable under last-ulp noise

### DIFF
--- a/glifo/CHANGELOG.md
+++ b/glifo/CHANGELOG.md
@@ -12,6 +12,10 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 This release has an [MSRV][] of 1.88.
 
+### Fixed
+
+- Glyph pixel-snapping decisions (the atlas quad's floor/fract split and the hinting baseline round) are now stable under last-ulp noise in the translation, so two passes that compute the same glyph position through different floating-point op orders (e.g. a live render and a recorded or cached one) place the glyph on the same pixel. ([#1785][] by [@AdrianEddy][])
+
 ## [0.2.0][] - 2026-07-29
 
 This release has an [MSRV][] of 1.88.
@@ -40,6 +44,7 @@ The first release of Glifo!
 
 Glifo moved to the Vello repo in [#1539][] and was prepared for release by [@conor-93][], [@grebmeg][], [@jrmoulton][], [@LaurenzV][], [@nicoburns][], [@oscargus][], [@taj-p][], and [@xStrom][].
 
+[@AdrianEddy]: https://github.com/AdrianEddy
 [@conor-93]: https://github.com/conor-93
 [@grebmeg]: https://github.com/grebmeg
 [@jrmoulton]: https://github.com/jrmoulton
@@ -54,6 +59,7 @@ Glifo moved to the Vello repo in [#1539][] and was prepared for release by [@con
 [#1668]: https://github.com/linebender/vello/pull/1668
 [#1672]: https://github.com/linebender/vello/pull/1672
 [#1774]: https://github.com/linebender/vello/pull/1774
+[#1785]: https://github.com/linebender/vello/pull/1785
 
 [Unreleased]: https://github.com/linebender/vello/compare/glifo-v0.2.0...HEAD
 [0.2.0]: https://github.com/linebender/vello/compare/glifo-v0.1.1...glifo-v0.2.0

--- a/glifo/CHANGELOG.md
+++ b/glifo/CHANGELOG.md
@@ -12,6 +12,10 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 This release has an [MSRV][] of 1.88.
 
+### Fixed
+
+- Glyph pixel-snapping decisions (the atlas quad's floor/fract split and the hinting baseline round) are now stable under last-ulp noise in the translation, so two passes that compute the same glyph position through different floating-point op orders (e.g. a live render and a recorded or cached one) place the glyph on the same pixel. ([#1785][] by [@AdrianEddy][])
+
 ## [0.3.0][] - 2026-08-07
 
 This release has an [MSRV][] of 1.88.
@@ -48,6 +52,7 @@ The first release of Glifo!
 
 Glifo moved to the Vello repo in [#1539][] and was prepared for release by [@conor-93][], [@grebmeg][], [@jrmoulton][], [@LaurenzV][], [@nicoburns][], [@oscargus][], [@taj-p][], and [@xStrom][].
 
+[@AdrianEddy]: https://github.com/AdrianEddy
 [@conor-93]: https://github.com/conor-93
 [@grebmeg]: https://github.com/grebmeg
 [@jrmoulton]: https://github.com/jrmoulton
@@ -62,6 +67,7 @@ Glifo moved to the Vello repo in [#1539][] and was prepared for release by [@con
 [#1668]: https://github.com/linebender/vello/pull/1668
 [#1672]: https://github.com/linebender/vello/pull/1672
 [#1774]: https://github.com/linebender/vello/pull/1774
+[#1785]: https://github.com/linebender/vello/pull/1785
 
 [Unreleased]: https://github.com/linebender/vello/compare/glifo-v0.3.0...HEAD
 [0.3.0]: https://github.com/linebender/vello/compare/glifo-v0.2.0...glifo-v0.3.0

--- a/glifo/src/atlas/key.rs
+++ b/glifo/src/atlas/key.rs
@@ -182,25 +182,22 @@ pub(crate) fn pack_color(color: AlphaColor<Srgb>) -> u32 {
     color.premultiply().to_rgba8().to_u32()
 }
 
-/// Quantize a fractional pixel offset into one of [`SUBPIXEL_BUCKETS`] buckets.
+/// Quantize a fractional pixel offset in `[0, 1]` into one of
+/// [`SUBPIXEL_BUCKETS`] buckets.
 ///
-/// Values near 1.0 (>= 0.875 with 4 buckets) are clamped to the last bucket
-/// rather than wrapping to 0. Wrapping to bucket 0 without also incrementing the
-/// integer pixel coordinate would shift the glyph by ~0.75px in the wrong
-/// direction. Clamping keeps the worst-case error to 0.125px.
+/// Values near 1.0 (>= 0.875 with 4 buckets, including exactly 1.0 — the
+/// `f32` narrowing of [`crate::util::biased_fract`] can produce it) are
+/// clamped to the last bucket rather than wrapping to 0. Wrapping to bucket 0
+/// without also incrementing the integer pixel coordinate would shift the
+/// glyph by ~0.75px in the wrong direction. Clamping keeps the worst-case
+/// error to 0.125px.
 #[expect(
     clippy::cast_possible_truncation,
     reason = "result is clamped to SUBPIXEL_BUCKETS-1 which fits in u8"
 )]
 #[inline]
 fn quantize_subpixel(frac: f32) -> u8 {
-    let normalized = frac.fract();
-    let normalized = if normalized < 0.0 {
-        normalized + 1.0
-    } else {
-        normalized
-    };
-    ((normalized * SUBPIXEL_BUCKETS as f32).round() as u8).min(SUBPIXEL_BUCKETS - 1)
+    ((frac * SUBPIXEL_BUCKETS as f32).round() as u8).min(SUBPIXEL_BUCKETS - 1)
 }
 
 /// Convert a quantized bucket index back to the fractional pixel offset it represents.
@@ -228,7 +225,35 @@ mod tests {
         assert_eq!(quantize_subpixel(0.7), 3);
         assert_eq!(quantize_subpixel(0.75), 3);
         assert_eq!(quantize_subpixel(0.9), 3);
-        assert_eq!(quantize_subpixel(1.0), 0);
+        // Exactly 1.0 (the f32 narrowing of a biased fract just below an
+        // integer) clamps to the last bucket instead of wrapping to 0, which
+        // would shift the glyph in the wrong direction.
+        assert_eq!(quantize_subpixel(1.0), 3);
+    }
+
+    /// The end-to-end decision chain: the subpixel bucket derived from
+    /// `biased_fract` (through the `f32` narrowing) must be stable under
+    /// last-ulp noise at integer glyph origins, in lockstep with
+    /// `biased_floor`.
+    #[test]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "mirrors the production f32 narrowing of the cache key"
+    )]
+    fn subpixel_bucket_is_stable_at_integer_origins() {
+        use crate::util::{biased_floor, biased_fract};
+        const DUST: f64 = 1e-9;
+        for k in [-1234.0, -3.0, 0.0, 7.0, 341.0, 4096.0] {
+            for d in [-DUST, 0.0, DUST] {
+                let v = k + d;
+                assert_eq!(biased_floor(v), k, "floor stable at {k} + {d}");
+                assert_eq!(
+                    quantize_subpixel(biased_fract(v) as f32),
+                    0,
+                    "bucket stable at {k} + {d}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/glifo/src/glyph.rs
+++ b/glifo/src/glyph.rs
@@ -23,7 +23,7 @@ use crate::kurbo::Vec2;
 use crate::kurbo::{self, Affine, BezPath, Diagonal2, Join, Line, ParamCurve as _, PathSeg, Shape};
 use crate::peniko::FontData;
 use crate::renderer::{fill_glyph, render_cached_glyph, stroke_glyph};
-use crate::util::AffineExt;
+use crate::util::{AffineExt, biased_fract, biased_round_half_up};
 use alloc::boxed::Box;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
@@ -422,7 +422,12 @@ impl<'a, 'b, Glyphs: Iterator<Item = Glyph> + Clone> GlyphRunRenderer<'a, 'b, Gl
             // Therefore, we can calculate the relative paint transform for
             // the glyph by pre-concatenating it with the inverted outline transform.
             let outline_cache_key = outline_cache_enabled.then(|| {
-                let fractional_x = outline_transform.translation().x.fract() as f32;
+                // Biased split, paired with `render_outline_glyph_from_atlas`'s
+                // `biased_floor`: the subpixel bucket and the quad pixel are the
+                // two halves of one decision and must agree even when the
+                // translation carries last-ulp noise (see
+                // `util::PIXEL_DECISION_BIAS`).
+                let fractional_x = biased_fract(outline_transform.translation().x) as f32;
                 GlyphCacheKey::new(
                     font_info.id,
                     font_info.index,
@@ -1173,7 +1178,11 @@ fn calculate_outline_transform(
         .as_coeffs();
 
     if hinting_instance.is_some() {
-        final_transform[5] = final_transform[5].round();
+        // Biased half-up round (see `util::PIXEL_DECISION_BIAS`): a bare
+        // `round()` flips on the exact halves fractional scale factors
+        // produce, shifting a whole glyph run by one device pixel between
+        // two evaluations of the same baseline.
+        final_transform[5] = biased_round_half_up(final_transform[5]);
     }
 
     Affine::new(final_transform)

--- a/glifo/src/renderer.rs
+++ b/glifo/src/renderer.rs
@@ -12,7 +12,7 @@ use crate::glyph::{
     OutlineCacheSession, PreparedGlyph,
 };
 use crate::interface::{DrawSink, GlyphRenderer};
-use crate::util::AffineExt;
+use crate::util::{AffineExt, biased_floor};
 use crate::{kurbo, peniko};
 use alloc::sync::Arc;
 use alloc::vec::Vec;
@@ -525,9 +525,13 @@ fn render_outline_glyph_from_atlas(
     tint_color: AlphaColor<Srgb>,
 ) {
     let [_, _, _, _, tx, ty] = outline_transform.as_coeffs();
+    // Biased floor, paired with the `biased_fract` that keyed the subpixel
+    // bucket: both halves of the decision must agree under last-ulp noise
+    // (see `util::PIXEL_DECISION_BIAS`). Hinted `ty` is already
+    // integer-exact, so the bias is a no-op there.
     let rect_transform = Affine::translate((
-        tx.floor() + atlas_slot.bearing_x as f64,
-        ty.floor() + atlas_slot.bearing_y as f64,
+        biased_floor(tx) + atlas_slot.bearing_x as f64,
+        biased_floor(ty) + atlas_slot.bearing_y as f64,
     ));
     let area = Rect::new(0.0, 0.0, atlas_slot.width as f64, atlas_slot.height as f64);
     render_from_atlas(

--- a/glifo/src/util.rs
+++ b/glifo/src/util.rs
@@ -4,6 +4,8 @@
 //! Utility helper functions.
 
 use core::ops::Sub;
+#[cfg(not(feature = "std"))]
+use core_maths::CoreFloat as _;
 use peniko::kurbo::Affine;
 
 // From <https://github.com/linebender/tiny-skia/blob/68b198a7210a6bbf752b43d6bc4db62445730313/path/src/scalar.rs#L12>
@@ -84,9 +86,55 @@ impl AffineExt for Affine {
     }
 }
 
+/// Bias added before every discrete glyph-placement decision.
+///
+/// Glyph placement makes per-pixel decisions (the floor/fract split behind the
+/// atlas quad position and subpixel-bucket key, and the hinting baseline
+/// round) from an `f64` translation. A consumer that produces the same content
+/// twice — a live pass and a recorded or cached one — computes that
+/// translation through different floating-point op orders and gets answers
+/// agreeing only to ~1e-12, while glyph origins routinely sit exactly on the
+/// decision boundary (integer coordinates; exact halves under fractional
+/// scale factors). A bare `floor`/`round` lets that last-ulp noise decide the
+/// pixel, so the two passes can place the same glyph one device pixel apart.
+///
+/// Biasing every decision by 1e-6 — far above the noise, far below the
+/// 0.25-px subpixel buckets — moves the boundary off those structured values,
+/// so any two evaluations agreeing within 1e-6 decide identically. All sites
+/// operate in `f64` (ulp ~1.8e-12 at 16384 px), so the bias survives any
+/// realistic coordinate.
+pub(crate) const PIXEL_DECISION_BIAS: f64 = 1e-6;
+
+/// Biased floor: the integer half of a glyph pixel decision. Pair with
+/// [`biased_fract`] on the same value — mixing a biased and a raw operation
+/// re-opens the 1-px gap at integer boundaries.
+#[inline]
+pub(crate) fn biased_floor(v: f64) -> f64 {
+    (v + PIXEL_DECISION_BIAS).floor()
+}
+
+/// Biased fractional part in `[0, 1]`: the subpixel half of the decision,
+/// consistent with [`biased_floor`] by construction. The closed upper bound
+/// is real: for inputs a hair below a multiple of the bias, `b - b.floor()`
+/// rounds to exactly `1.0` — consumers must clamp, not wrap.
+#[inline]
+pub(crate) fn biased_fract(v: f64) -> f64 {
+    let b = v + PIXEL_DECISION_BIAS;
+    b - b.floor()
+}
+
+/// Biased round, half up (`floor(v + 0.5 + bias)`): the hinting baseline
+/// snap. Half-up rather than `f64::round`'s half-away-from-zero, so exact
+/// negative halves decide the same way as positive ones.
+#[inline]
+pub(crate) fn biased_round_half_up(v: f64) -> f64 {
+    (v + (0.5 + PIXEL_DECISION_BIAS)).floor()
+}
+
 #[cfg(test)]
 mod tests {
     use super::AffineExt;
+    use super::{PIXEL_DECISION_BIAS, biased_floor, biased_fract, biased_round_half_up};
     use peniko::kurbo::Affine;
 
     #[test]
@@ -141,5 +189,45 @@ mod tests {
         assert!(!flip_x.has_non_unit_skew_or_scale());
         assert!(!flip_y.has_non_unit_skew_or_scale());
         assert!(!flip_xy.has_non_unit_skew_or_scale());
+    }
+
+    /// Producing the same content twice (a live pass and a recorded or cached
+    /// one) yields translations that differ by last-ulp noise. The discrete
+    /// decisions must not flip on that noise at the values glyph origins
+    /// actually sit on: exact integers and exact halves.
+    #[test]
+    fn pixel_decisions_are_stable_under_last_ulp_noise() {
+        // Far above the real cross-evaluation divergence, far below the bias.
+        const DUST: f64 = 1e-9;
+        // Integer boundaries: the floor/fract split.
+        for k in [-1234.0, -3.0, 0.0, 7.0, 341.0, 4096.0] {
+            for d in [-DUST, 0.0, DUST] {
+                assert_eq!(biased_floor(k + d), k, "floor stable at {k} + {d}");
+                assert!(
+                    biased_fract(k + d) < 0.125,
+                    "fract in bucket 0 at {k} + {d}"
+                );
+            }
+        }
+        // Half boundaries: the hinting round, half-up, including exact
+        // negative halves.
+        for k in [-12.5, -0.5, 0.5, 33.5, 2047.5] {
+            for d in [-DUST, 0.0, DUST] {
+                assert_eq!(
+                    biased_round_half_up(k + d),
+                    k + 0.5,
+                    "half-up stable at {k} + {d}"
+                );
+            }
+        }
+        // The split reassembles its input (modulo the bias); one biased and
+        // one raw operation would not.
+        for v in [-3.0, -0.25, 0.0, 9.0, 9.75, 341.5] {
+            let rebuilt = biased_floor(v) + biased_fract(v);
+            assert!(
+                (rebuilt - v).abs() <= 2.0 * PIXEL_DECISION_BIAS,
+                "split reassembles {v}"
+            );
+        }
     }
 }


### PR DESCRIPTION
Glyph placement makes discrete per-pixel decisions from an `f64` translation: the floor/fract split behind the atlas quad position and the subpixel-bucket cache key, and the vertical-hinting baseline round. A consumer that produces the same content twice — a live pass and a recorded or cached one — computes that translation through different floating-point op orders, and the two results agree only to ~1e-12. Glyph origins routinely sit *exactly* on the decision boundary (integer coordinates, or exact halves under fractional scale factors), so that last-ulp noise decides the pixel: the same glyph can render one device pixel apart between the two passes. In a caching compositor this shows up as text popping by a pixel when a cached layer is swapped in for a live render — the same "two producers must agree byte-for-byte" requirement behind the damage-rendering work in #1737.

The fix biases every decision by 1e-6 — far above the noise, far below the 0.25-px subpixel buckets — so the boundaries move off those structured values, and any two evaluations agreeing within 1e-6 decide identically. Details:

- The floor and fract halves of the split share the biased value; mixing a biased and a raw operation would reopen the 1-px gap.
- The hinting round becomes half-up, which also makes it shift-invariant across zero (`f64::round`'s half-away-from-zero is not: translating a scene by a whole pixel could flip a baseline the old way).
- Auditing the decision chain surfaced that the subpixel quantizer could receive exactly 1.0 through the `f32` narrowing of the fract and wrapped it to bucket 0 — shifting the glyph in the wrong direction. It now clamps to the last bucket.

Away from the boundaries nothing changes: the full snapshot suite passes untouched. New tests pin decision stability at integers and exact halves under injected noise, plus the end-to-end lockstep of the bucket and the quad pixel.

An alternative would be snapping the translation to fixed point (FreeType-style) before all decisions — strictly stronger, but it changes the placement of every fractional position and guarantees snapshot churn. This is the minimal zero-churn version, and the helper call sites are exactly where a snap would slot in if that direction is preferred later.

<sub>This PR was generated by Claude.</sub>
