### PR TITLE
sparse_strips: CoverageContrast, an opt-in coverage transfer for glyph sharpening

### DIFF
--- a/glifo/CHANGELOG.md
+++ b/glifo/CHANGELOG.md
@@ -14,7 +14,7 @@ This release has an [MSRV][] of 1.88.
 
 ### Added
 
-- `GlyphRenderer::glyph_coverage_contrast` (default `CoverageContrast::NONE`), applied to atlas-cached outline glyphs with the weight term resolved per draw against the tint color's luminance. ([#1790][] by [@AdrianEddy][])
+- `GlyphRenderer::glyph_coverage_contrast` (default `CoverageContrast::NONE`), applied to solid-painted outline glyphs with the weight term resolved per draw against the text color's luminance. Atlas-cached glyphs receive the transfer through their alpha-mask tint at sample time; glyphs drawn directly from their outlines receive the same transfer at fill time through the new `GlyphRenderer::fill_glyph_path` hook, so appearance does not depend on whether a glyph is cached. ([#1790][] by [@AdrianEddy][])
 
 ## [0.3.0][] - 2026-08-07
 

--- a/glifo/CHANGELOG.md
+++ b/glifo/CHANGELOG.md
@@ -12,6 +12,10 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 This release has an [MSRV][] of 1.88.
 
+### Added
+
+- `GlyphRenderer::glyph_coverage_contrast` (default `CoverageContrast::NONE`), applied to atlas-cached outline glyphs with the weight term resolved per draw against the tint color's luminance. ([#1790][] by [@AdrianEddy][])
+
 ## [0.2.0][] - 2026-07-29
 
 This release has an [MSRV][] of 1.88.
@@ -55,6 +59,8 @@ Glifo moved to the Vello repo in [#1539][] and was prepared for release by [@con
 [#1672]: https://github.com/linebender/vello/pull/1672
 [#1774]: https://github.com/linebender/vello/pull/1774
 
+[#1790]: https://github.com/linebender/vello/pull/1790
+[@AdrianEddy]: https://github.com/AdrianEddy
 [Unreleased]: https://github.com/linebender/vello/compare/glifo-v0.2.0...HEAD
 [0.2.0]: https://github.com/linebender/vello/compare/glifo-v0.1.1...glifo-v0.2.0
 [0.1.1]: https://github.com/linebender/vello/compare/glifo-v0.1.0...glifo-v0.1.1

--- a/glifo/CHANGELOG.md
+++ b/glifo/CHANGELOG.md
@@ -14,7 +14,7 @@ This release has an [MSRV][] of 1.88.
 
 ### Added
 
-- `GlyphRenderer::glyph_coverage_contrast` (default `CoverageContrast::NONE`), applied to atlas-cached outline glyphs with the weight term resolved per draw against the tint color's luminance. ([#1790][] by [@AdrianEddy][])
+- `GlyphRenderer::glyph_coverage_contrast` (default `CoverageContrast::NONE`), applied to solid-painted outline glyphs with the weight term resolved per draw against the text color's luminance. Atlas-cached glyphs receive the transfer through their alpha-mask tint at sample time; glyphs drawn directly from their outlines receive the same transfer at fill time through the new `GlyphRenderer::fill_glyph_path` hook, so appearance does not depend on whether a glyph is cached. ([#1790][] by [@AdrianEddy][])
 
 ## [0.2.0][] - 2026-07-29
 

--- a/glifo/CHANGELOG.md
+++ b/glifo/CHANGELOG.md
@@ -12,6 +12,10 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 This release has an [MSRV][] of 1.88.
 
+### Added
+
+- `GlyphRenderer::glyph_coverage_contrast` (default `CoverageContrast::NONE`), applied to atlas-cached outline glyphs with the weight term resolved per draw against the tint color's luminance. ([#1790][] by [@AdrianEddy][])
+
 ## [0.3.0][] - 2026-08-07
 
 This release has an [MSRV][] of 1.88.
@@ -48,6 +52,7 @@ The first release of Glifo!
 
 Glifo moved to the Vello repo in [#1539][] and was prepared for release by [@conor-93][], [@grebmeg][], [@jrmoulton][], [@LaurenzV][], [@nicoburns][], [@oscargus][], [@taj-p][], and [@xStrom][].
 
+[@AdrianEddy]: https://github.com/AdrianEddy
 [@conor-93]: https://github.com/conor-93
 [@grebmeg]: https://github.com/grebmeg
 [@jrmoulton]: https://github.com/jrmoulton
@@ -62,6 +67,7 @@ Glifo moved to the Vello repo in [#1539][] and was prepared for release by [@con
 [#1668]: https://github.com/linebender/vello/pull/1668
 [#1672]: https://github.com/linebender/vello/pull/1672
 [#1774]: https://github.com/linebender/vello/pull/1774
+[#1790]: https://github.com/linebender/vello/pull/1790
 
 [Unreleased]: https://github.com/linebender/vello/compare/glifo-v0.3.0...HEAD
 [0.3.0]: https://github.com/linebender/vello/compare/glifo-v0.2.0...glifo-v0.3.0

--- a/glifo/src/interface.rs
+++ b/glifo/src/interface.rs
@@ -75,17 +75,36 @@ pub trait GlyphRenderer: DrawSink {
     /// Set the tint for subsequent image draws.
     fn set_tint(&mut self, tint: Option<Tint>);
 
-    /// The coverage transfer to apply to atlas-cached outline glyphs'
-    /// coverage. Its weight term is the white-text strength; glifo scales it
-    /// per draw by the tint color's luminance
-    /// ([`CoverageContrast::resolve_for_color`]).
+    /// The coverage transfer to apply to outline glyphs' coverage. Its weight
+    /// term is the white-text strength; glifo scales it per draw by the text
+    /// color's luminance ([`CoverageContrast::resolve_for_color`]).
     ///
     /// Defaults to [`CoverageContrast::NONE`], which renders exactly as
     /// before this existed. Bitmap and COLR glyphs carry their own color
-    /// rather than a coverage mask and are unaffected, as are glyphs that
-    /// miss the atlas (drawn from outlines with linear coverage).
+    /// rather than a coverage mask and are unaffected. Atlas-cached glyphs
+    /// receive the transfer at sample time through their alpha-mask tint;
+    /// glyphs drawn directly from their outlines (atlas full, oversized,
+    /// rotated/skewed, or caching disabled) receive the same transfer through
+    /// [`Self::fill_glyph_path`], so appearance does not depend on whether a
+    /// glyph is cached.
     fn glyph_coverage_contrast(&self) -> CoverageContrast {
         CoverageContrast::NONE
+    }
+
+    /// Fill a path as glyph coverage, remapping the fill's coverage through
+    /// `coverage_transfer` before compositing (and before any clip
+    /// intersection). Used for solid-painted outline glyphs drawn directly,
+    /// bypassing the atlas, so they match atlas-cached glyphs whose transfer
+    /// is applied at sample time.
+    ///
+    /// The default ignores `coverage_transfer` and fills linearly, which is
+    /// only consistent for renderers whose
+    /// [`glyph_coverage_contrast`](Self::glyph_coverage_contrast) is
+    /// [`CoverageContrast::NONE`]; renderers reporting a transfer must
+    /// override this.
+    fn fill_glyph_path(&mut self, path: &BezPath, coverage_transfer: CoverageContrast) {
+        let _ = coverage_transfer;
+        self.fill_path(path);
     }
 
     /// Get the context color from the renderer's current paint, used for resolving the

--- a/glifo/src/interface.rs
+++ b/glifo/src/interface.rs
@@ -7,7 +7,7 @@ use crate::atlas::{AtlasPaint, AtlasSlot};
 use crate::color::{AlphaColor, Srgb};
 use crate::kurbo::{Affine, BezPath, Rect};
 use crate::peniko::BlendMode;
-use vello_common::paint::{Image, ImageSource, PaintType, Tint};
+use vello_common::paint::{CoverageContrast, Image, ImageSource, PaintType, Tint};
 
 // TODO: This trait is only temporary and will hopefully be replaced once we have a better
 // unifying imaging API.
@@ -74,6 +74,19 @@ pub trait GlyphRenderer: DrawSink {
 
     /// Set the tint for subsequent image draws.
     fn set_tint(&mut self, tint: Option<Tint>);
+
+    /// The coverage transfer to apply to atlas-cached outline glyphs'
+    /// coverage. Its weight term is the white-text strength; glifo scales it
+    /// per draw by the tint color's luminance
+    /// ([`CoverageContrast::resolve_for_color`]).
+    ///
+    /// Defaults to [`CoverageContrast::NONE`], which renders exactly as
+    /// before this existed. Bitmap and COLR glyphs carry their own color
+    /// rather than a coverage mask and are unaffected, as are glyphs that
+    /// miss the atlas (drawn from outlines with linear coverage).
+    fn glyph_coverage_contrast(&self) -> CoverageContrast {
+        CoverageContrast::NONE
+    }
 
     /// Get the context color from the renderer's current paint, used for resolving the
     /// context-dependent colors of COLR glyphs.

--- a/glifo/src/renderer.rs
+++ b/glifo/src/renderer.rs
@@ -536,9 +536,15 @@ fn render_outline_glyph_from_atlas(
         rect_transform,
         area,
         ImageQuality::Low,
+        // NOTE: the coverage transfer reaches atlas-cached outline glyphs
+        // only; glyphs that miss the atlas are filled straight from their
+        // outlines and keep linear coverage.
         Some(Tint {
             color: tint_color,
             mode: TintMode::AlphaMask,
+            contrast: renderer
+                .glyph_coverage_contrast()
+                .resolve_for_color(tint_color),
         }),
     );
 }

--- a/glifo/src/renderer.rs
+++ b/glifo/src/renderer.rs
@@ -22,7 +22,7 @@ use kurbo::{Affine, BezPath, Rect, Shape};
 use peniko::color::palette::css::BLACK;
 use peniko::color::{AlphaColor, Srgb};
 use peniko::{Extend, ImageQuality, ImageSampler};
-use vello_common::paint::{Image, ImageSource, Tint, TintMode};
+use vello_common::paint::{CoverageContrast, Image, ImageSource, PaintType, Tint, TintMode};
 
 /// Outcome of a cache-first render attempt.
 ///
@@ -209,10 +209,22 @@ fn fill_uncached_outline_glyph(
     outline_transform: Affine,
     paint_transform: Affine,
 ) {
+    // Match the atlas path's tinting conditions: the coverage transfer applies
+    // to solid-painted fills only, resolved against the same color the atlas
+    // path tints with, so a glyph looks the same whether it was drawn from the
+    // atlas or directly from its outline.
+    let coverage_transfer = if matches!(renderer.current_paint(), PaintType::Solid(_)) {
+        renderer
+            .glyph_coverage_contrast()
+            .resolve_for_color(renderer.get_context_color())
+    } else {
+        CoverageContrast::NONE
+    };
+
     let state = renderer.save_state();
     renderer.set_transform(outline_transform.pre_scale(scale));
     renderer.set_paint_transform(paint_transform);
-    renderer.fill_path(path);
+    renderer.fill_glyph_path(path, coverage_transfer);
     renderer.restore_state(state);
 }
 
@@ -536,9 +548,8 @@ fn render_outline_glyph_from_atlas(
         rect_transform,
         area,
         ImageQuality::Low,
-        // NOTE: the coverage transfer reaches atlas-cached outline glyphs
-        // only; glyphs that miss the atlas are filled straight from their
-        // outlines and keep linear coverage.
+        // Glyphs that miss the atlas receive the same transfer at fill time;
+        // see `fill_uncached_outline_glyph`.
         Some(Tint {
             color: tint_color,
             mode: TintMode::AlphaMask,

--- a/sparse_strips/vello_common/CHANGELOG.md
+++ b/sparse_strips/vello_common/CHANGELOG.md
@@ -14,7 +14,7 @@ This release has an [MSRV][] of 1.88.
 
 ### Added
 
-- `CoverageContrast`, an opt-in coverage transfer for alpha-mask tints that sharpens glyph edges: a symmetric edge-steepening term plus a luminance-resolved weight term. ([#1790][] by [@AdrianEddy][])
+- `CoverageContrast`, an opt-in coverage transfer for alpha-mask tints that sharpens glyph edges: a symmetric edge-steepening term plus a luminance-resolved weight term. `StripGenerator::generate_filled_path_with_coverage_transfer` applies the same transfer to generated coverage, for glyphs filled directly from their outlines. ([#1790][] by [@AdrianEddy][])
 
 ### Changed
 

--- a/sparse_strips/vello_common/CHANGELOG.md
+++ b/sparse_strips/vello_common/CHANGELOG.md
@@ -12,6 +12,14 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 This release has an [MSRV][] of 1.88.
 
+### Added
+
+- `CoverageContrast`, an opt-in coverage transfer for alpha-mask tints that sharpens glyph edges: a symmetric edge-steepening term plus a luminance-resolved weight term. ([#1790][] by [@AdrianEddy][])
+
+### Changed
+
+- Breaking: `Tint` gained a `contrast` field; use `CoverageContrast::NONE` in struct literals to keep the previous behavior. ([#1790][] by [@AdrianEddy][])
+
 ## [0.1.0][] - 2026-07-29
 
 This release has an [MSRV][] of 1.88.
@@ -296,6 +304,8 @@ See also the [vello_cpu 0.0.1](../vello_cpu/CHANGELOG.md#001---2025-05-10) relea
 [#1763]: https://github.com/linebender/vello/pull/1763
 [#1768]: https://github.com/linebender/vello/pull/1768
 
+[#1790]: https://github.com/linebender/vello/pull/1790
+[@AdrianEddy]: https://github.com/AdrianEddy
 [Unreleased]: https://github.com/linebender/vello/compare/sparse-strips-v0.1.0...HEAD
 [0.1.0]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.9...sparse-strips-v0.1.0
 [0.0.9]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.8...sparse-strips-v0.0.9

--- a/sparse_strips/vello_common/CHANGELOG.md
+++ b/sparse_strips/vello_common/CHANGELOG.md
@@ -12,6 +12,14 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 This release has an [MSRV][] of 1.88.
 
+### Added
+
+- `CoverageContrast`, an opt-in coverage transfer for alpha-mask tints that sharpens glyph edges: a symmetric edge-steepening term plus a luminance-resolved weight term. ([#1790][] by [@AdrianEddy][])
+
+### Changed
+
+- Breaking: `Tint` gained a `contrast` field; use `CoverageContrast::NONE` in struct literals to keep the previous behavior. ([#1790][] by [@AdrianEddy][])
+
 ## [0.2.0][] - 2026-08-07
 
 This release has an [MSRV][] of 1.88.
@@ -224,6 +232,7 @@ This is the initial release. No changelog was kept for this release.
 
 See also the [vello_cpu 0.0.1](../vello_cpu/CHANGELOG.md#001---2025-05-10) release.
 
+[@AdrianEddy]: https://github.com/AdrianEddy
 [@b0nes164]: https://github.com/b0nes164
 [@conor-93]: https://github.com/conor-93
 [@dipeshbabu]: https://github.com/dipeshbabu
@@ -310,6 +319,7 @@ See also the [vello_cpu 0.0.1](../vello_cpu/CHANGELOG.md#001---2025-05-10) relea
 [#1768]: https://github.com/linebender/vello/pull/1768
 [#1778]: https://github.com/linebender/vello/pull/1778
 [#1779]: https://github.com/linebender/vello/pull/1779
+[#1790]: https://github.com/linebender/vello/pull/1790
 [#1801]: https://github.com/linebender/vello/pull/1801
 
 [Unreleased]: https://github.com/linebender/vello/compare/sparse-strips-v0.2.0...HEAD

--- a/sparse_strips/vello_common/src/paint.rs
+++ b/sparse_strips/vello_common/src/paint.rs
@@ -265,6 +265,192 @@ impl TintMode {
     }
 }
 
+/// Opt-in coverage transfer applied to an alpha-mask tint's coverage before
+/// tinting, used to sharpen glyph edges.
+///
+/// Analytic coverage is the exact area of the pixel covered by the outline: a
+/// linear ramp of slope 1.0 alpha/px across an edge, which reads slightly
+/// softer than mainstream text rasterizers. Coverage `a` is remapped as
+///
+/// ```text
+/// a' = a + c * a * (1 - a) * (2a - 1)   // steepen: lerp(identity, smoothstep)
+///        + w * a * (1 - a)              // weight bias: raises the 0.5 crossing by w/4
+/// ```
+///
+/// with strengths `c` (contrast) and `w` (weight) in `[0, 1]`, quantized to
+/// 8 bits so the CPU and GPU pipelines evaluate identical parameters.
+///
+/// Properties:
+///
+/// * `(0, 0)` is a bit-exact identity, and every consumer branches on
+///   [`Self::is_none`], so the disabled path executes unchanged instructions.
+///   Likewise `w = 0` leaves `c`-only output bit-identical: the appended
+///   weight term is exactly `+0.0`.
+/// * The `c` term is symmetric about `a = 0.5`: edges steepen, stem weight is
+///   preserved. The `w` term is Skia's mask-contrast form and adds weight.
+/// * With `t = a - 1/2` the derivative is `1 + c/2 - 6c*t^2 - 2w*t` — concave,
+///   minimized at `a = 1` where it equals `1 - c - w`. [`Self::from_bits`]
+///   therefore caps `w` at `1 - c`; under that invariant the curve is
+///   monotone with range `[0, 1]` and no per-pixel clamp is needed.
+/// * Peak slope of the `c` term is `1 + c/2`, spanning exact-area coverage
+///   (1.0 alpha/px) through a full `smoothstep` (1.5 alpha/px).
+///
+/// The weight term compensates polarity: blending in sRGB-encoded space makes
+/// light-on-dark text read thinner than dark-on-light.
+/// [`Self::resolve_for_color`] scales the stored `w` by the text color's
+/// approximate relative luminance, so black text keeps the weight-free curve
+/// while white text gets the full stored strength. Because the correction
+/// applies to sampled coverage rather than outlines, it never enters glyph
+/// atlas keys — light and dark text share one cached rasterization. This is
+/// distinct from glifo's `FontEmbolden`, which offsets outlines in em space
+/// and re-keys the atlas: the `w` term is a sub-pixel, device-space
+/// adjustment bounded by a fraction of a pixel, free to vary per draw.
+///
+/// Applies only to [`TintMode::AlphaMask`]; ignored for
+/// [`TintMode::Multiply`] and untinted images.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct CoverageContrast {
+    /// Edge-steepening strength `c`.
+    contrast: u8,
+    /// Weight-bias strength `w`. Invariant: `contrast + weight <= 255`,
+    /// enforced by [`Self::from_bits`].
+    weight: u8,
+}
+
+impl CoverageContrast {
+    /// No enhancement; coverage passes through bit-exact. The default.
+    pub const NONE: Self = Self {
+        contrast: 0,
+        weight: 0,
+    };
+
+    /// Build from an edge-steepening strength in `[0, 1]`; `0` disables and
+    /// `1` is a full `smoothstep`. The weight bias is `0`; dial it in with
+    /// [`Self::with_weight_strength`]. Out-of-range values clamp; `NaN` maps
+    /// to [`Self::NONE`].
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "clamped to [0, 1] before scaling, and float->int casts saturate"
+    )]
+    pub fn from_strength(strength: f32) -> Self {
+        Self {
+            contrast: (strength.clamp(0.0, 1.0) * 255.0 + 0.5) as u8,
+            weight: 0,
+        }
+    }
+
+    /// Replace the weight-bias strength, in `[0, 1]`. Clamped and quantized
+    /// like [`Self::from_strength`], then capped at the contrast's headroom.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "clamped to [0, 1] before scaling, and float->int casts saturate"
+    )]
+    pub fn with_weight_strength(self, strength: f32) -> Self {
+        Self::from_bits(
+            self.contrast,
+            (strength.clamp(0.0, 1.0) * 255.0 + 0.5) as u8,
+        )
+    }
+
+    /// Build from the raw 8-bit strengths. The weight is capped at the
+    /// contrast's headroom (`weight <= 255 - contrast`), the condition under
+    /// which the curve is monotone with range `[0, 1]` (see the type docs).
+    pub const fn from_bits(contrast: u8, weight: u8) -> Self {
+        let headroom = 255 - contrast;
+        Self {
+            contrast,
+            weight: if weight > headroom { headroom } else { weight },
+        }
+    }
+
+    /// The raw 8-bit edge-steepening strength.
+    pub const fn contrast_bits(self) -> u8 {
+        self.contrast
+    }
+
+    /// The raw 8-bit weight-bias strength.
+    pub const fn weight_bits(self) -> u8 {
+        self.weight
+    }
+
+    /// The edge-steepening strength `c` in `[0, 1]`.
+    pub fn contrast_strength(self) -> f32 {
+        f32::from(self.contrast) * (1.0 / 255.0)
+    }
+
+    /// The weight-bias strength `w` in `[0, 1]`.
+    pub fn weight_strength(self) -> f32 {
+        f32::from(self.weight) * (1.0 / 255.0)
+    }
+
+    /// Whether this is [`Self::NONE`], i.e. coverage passes through untouched.
+    pub const fn is_none(self) -> bool {
+        self.contrast == 0 && self.weight == 0
+    }
+
+    /// Scale the weight bias by `color`'s approximate relative luminance,
+    /// turning the stored white-text strength into the effective strength for
+    /// text drawn in `color`. The contrast term passes through untouched.
+    ///
+    /// Luminance is `0.2126*r^2 + 0.7152*g^2 + 0.0722*b^2` on channels
+    /// clamped to `[0, 1]` — a gamma-2 approximation of the sRGB transfer,
+    /// chosen because this runs per glyph and the exact piecewise transfer
+    /// costs a `powf` per channel. It is monotone per channel and exact at
+    /// the endpoints: black resolves to `w = 0` (bit-identical to the
+    /// `c`-only curve), white keeps the stored strength. Alpha is ignored.
+    /// `NaN` channels resolve to `w = 0`.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "luminance is clamped to [0, 1] before scaling, and float->int casts saturate"
+    )]
+    pub fn resolve_for_color(self, color: AlphaColor<Srgb>) -> Self {
+        if self.weight == 0 {
+            return self;
+        }
+        let [r, g, b, _] = color.components;
+        let r = r.clamp(0.0, 1.0);
+        let g = g.clamp(0.0, 1.0);
+        let b = b.clamp(0.0, 1.0);
+        let y = (0.2126 * r * r + 0.7152 * g * g + 0.0722 * b * b).clamp(0.0, 1.0);
+        // Scaling only reduces the weight, preserving the headroom invariant.
+        Self::from_bits(self.contrast, (f32::from(self.weight) * y + 0.5) as u8)
+    }
+
+    /// Apply the curve to a coverage value in `[0, 1]`.
+    ///
+    /// The guarantees assume in-range coverage; samplers that can overshoot
+    /// (e.g. bicubic filtering) produce out-of-range values for which the
+    /// result is finite but unspecified.
+    ///
+    /// This is the reference definition; `vello_cpu`'s fine stages and the
+    /// image branch of `render.wesl` evaluate the same expression in the same
+    /// order and must stay in sync. The `w` term is appended rather than
+    /// algebraically merged so that at `w = 0` it contributes exactly `+0.0`.
+    #[inline(always)]
+    pub fn apply(self, alpha: f32) -> f32 {
+        if self.is_none() {
+            return alpha;
+        }
+        let c = self.contrast_strength();
+        let w = self.weight_strength();
+        alpha + c * alpha * (1.0 - alpha) * (2.0 * alpha - 1.0) + w * alpha * (1.0 - alpha)
+    }
+
+    /// Apply the curve to an 8-bit coverage value, rounding as the 8-bit
+    /// pipeline rounds.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "`apply` stays in [0, 1], and float->int casts saturate"
+    )]
+    #[inline(always)]
+    pub fn apply_u8(self, alpha: u8) -> u8 {
+        if self.is_none() {
+            return alpha;
+        }
+        (self.apply(f32::from(alpha) * (1.0 / 255.0)) * 255.0 + 0.5) as u8
+    }
+}
+
 /// A tint applied to image paints.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Tint {
@@ -272,6 +458,10 @@ pub struct Tint {
     pub color: Color,
     /// How the tint is applied.
     pub mode: TintMode,
+    /// Coverage transfer applied to the mask's coverage before tinting.
+    /// Only meaningful for [`TintMode::AlphaMask`]; defaults to
+    /// [`CoverageContrast::NONE`], which is bit-exact with no transfer.
+    pub contrast: CoverageContrast,
 }
 
 /// A kind of paint that can be used for filling and stroking shapes.

--- a/sparse_strips/vello_common/src/paint.rs
+++ b/sparse_strips/vello_common/src/paint.rs
@@ -449,6 +449,22 @@ impl CoverageContrast {
         }
         (self.apply(f32::from(alpha) * (1.0 / 255.0)) * 255.0 + 0.5) as u8
     }
+
+    /// Apply the curve in place to a buffer of 8-bit coverage values, as
+    /// produced by strip generation.
+    ///
+    /// Each byte is remapped through [`Self::apply_u8`], so a glyph filled
+    /// directly from its outline agrees with one round-tripped through an
+    /// atlas, which stores linear 8-bit coverage and applies the transfer to
+    /// the sampled value at tint time.
+    pub fn apply_to_coverage(self, alphas: &mut [u8]) {
+        if self.is_none() {
+            return;
+        }
+        for alpha in alphas {
+            *alpha = self.apply_u8(*alpha);
+        }
+    }
 }
 
 /// A tint applied to image paints.

--- a/sparse_strips/vello_common/src/strip_generator.rs
+++ b/sparse_strips/vello_common/src/strip_generator.rs
@@ -8,6 +8,7 @@ use crate::fearless_simd::Level;
 use crate::flatten::{FlattenCtx, Line};
 use crate::geometry::RectU16;
 use crate::kurbo::{Affine, PathEl, Rect, Stroke};
+use crate::paint::CoverageContrast;
 use crate::peniko::Fill;
 use crate::strip::Strip;
 use crate::tile::Tiles;
@@ -126,6 +127,35 @@ impl StripGenerator {
         strip_storage: &mut StripStorage,
         clip_path: Option<PathDataRef<'_>>,
     ) {
+        self.generate_filled_path_with_coverage_transfer(
+            path,
+            fill_rule,
+            transform,
+            aliasing_threshold,
+            CoverageContrast::NONE,
+            strip_storage,
+            clip_path,
+        );
+    }
+
+    /// Like [`Self::generate_filled_path`], but remaps the generated coverage
+    /// in place through `coverage_transfer` (see [`CoverageContrast`]).
+    ///
+    /// The remap happens before any clip intersection, so a clip attenuates
+    /// the transferred coverage exactly as it attenuates an atlas-sampled
+    /// glyph whose transfer is applied at tint time. Used for outline glyphs
+    /// drawn directly (bypassing the glyph atlas), so they match atlas-cached
+    /// glyphs.
+    pub fn generate_filled_path_with_coverage_transfer(
+        &mut self,
+        path: impl IntoIterator<Item = PathEl>,
+        fill_rule: Fill,
+        transform: Affine,
+        aliasing_threshold: Option<u8>,
+        coverage_transfer: CoverageContrast,
+        strip_storage: &mut StripStorage,
+        clip_path: Option<PathDataRef<'_>>,
+    ) {
         let cull_bbox = clip_path
             .map(|clip_path| clip_path.bbox)
             .unwrap_or(RectU16::new(0, 0, self.width, self.height));
@@ -138,7 +168,13 @@ impl StripGenerator {
             cull_bbox,
         );
 
-        self.generate_with_clip(aliasing_threshold, strip_storage, fill_rule, clip_path);
+        self.generate_with_clip(
+            aliasing_threshold,
+            coverage_transfer,
+            strip_storage,
+            fill_rule,
+            clip_path,
+        );
     }
 
     /// Generate the strips for a stroked path.
@@ -164,12 +200,19 @@ impl StripGenerator {
             &mut self.stroke_ctx,
             cull_bbox,
         );
-        self.generate_with_clip(aliasing_threshold, strip_storage, Fill::NonZero, clip_path);
+        self.generate_with_clip(
+            aliasing_threshold,
+            CoverageContrast::NONE,
+            strip_storage,
+            Fill::NonZero,
+            clip_path,
+        );
     }
 
     fn generate_with_clip(
         &mut self,
         aliasing_threshold: Option<u8>,
+        coverage_transfer: CoverageContrast,
         strip_storage: &mut StripStorage,
         fill_rule: Fill,
         clip_path: Option<PathDataRef<'_>>,
@@ -188,6 +231,7 @@ impl StripGenerator {
             strip_storage,
             clip_path,
             |strips, alphas| {
+                let generated_from = alphas.len();
                 strip::render(
                     level,
                     tiles,
@@ -197,6 +241,7 @@ impl StripGenerator {
                     aliasing_threshold,
                     line_buf,
                 );
+                coverage_transfer.apply_to_coverage(&mut alphas[generated_from..]);
             },
         );
     }

--- a/sparse_strips/vello_common/tests/coverage_contrast.rs
+++ b/sparse_strips/vello_common/tests/coverage_contrast.rs
@@ -394,3 +394,24 @@ fn u8_path_tracks_the_f32_path() {
         }
     }
 }
+
+/// `apply_to_coverage` is `apply_u8` applied element-wise — the form strip
+/// generation uses for glyphs drawn directly from their outlines — and the
+/// `NONE` transfer leaves the buffer untouched.
+#[test]
+fn buffer_transfer_matches_apply_u8() {
+    let all: Vec<u8> = (0..=u8::MAX).collect();
+
+    let mut untouched = all.clone();
+    CoverageContrast::NONE.apply_to_coverage(&mut untouched);
+    assert_eq!(untouched, all, "NONE must be an in-place identity");
+
+    for (contrast, weight) in [(153_u8, 51_u8), (255, 0), (0, 128)] {
+        let c = CoverageContrast::from_bits(contrast, weight);
+        let mut mapped = all.clone();
+        c.apply_to_coverage(&mut mapped);
+        for (byte, out) in all.iter().zip(&mapped) {
+            assert_eq!(*out, c.apply_u8(*byte), "({contrast}, {weight}) at {byte}");
+        }
+    }
+}

--- a/sparse_strips/vello_common/tests/coverage_contrast.rs
+++ b/sparse_strips/vello_common/tests/coverage_contrast.rs
@@ -1,0 +1,396 @@
+// Copyright 2026 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Tests for [`CoverageContrast`], the coverage transfer applied to alpha-mask
+//! (glyph) coverage:
+//!
+//! ```text
+//! a' = a + c * a * (1 - a) * (2a - 1) + w * a * (1 - a)
+//! ```
+//!
+//! Pure arithmetic; nothing here needs a GPU. `render.wesl` and `vello_cpu`'s
+//! fine stages evaluate the same expression in the same order, so the
+//! properties proven here hold for all three consumers.
+
+use vello_common::paint::{Color, CoverageContrast};
+
+/// A full `smoothstep`, i.e. the `c = 1` end of the steepening family.
+fn smoothstep(t: f32) -> f32 {
+    t * t * (3.0 - 2.0 * t)
+}
+
+/// Weight strengths sampled when sweeping the second axis; the `c` axis is
+/// cheap enough to sweep exhaustively.
+const WEIGHT_SAMPLES: [u8; 6] = [0, 1, 64, 128, 191, 255];
+
+/// The default must be the identity bit-for-bit, not merely to within a
+/// tolerance: the feature is opt-in, and every existing snapshot must keep its
+/// exact bytes while it is off.
+#[test]
+fn none_is_bit_exact_identity() {
+    let none = CoverageContrast::NONE;
+    assert!(none.is_none());
+    assert_eq!(none, CoverageContrast::default());
+    assert_eq!(none.contrast_bits(), 0);
+    assert_eq!(none.weight_bits(), 0);
+
+    for byte in 0..=u8::MAX {
+        assert_eq!(none.apply_u8(byte), byte, "u8 identity at {byte}");
+    }
+
+    // Compare bit patterns so a `-0.0` or one-ulp drift would fail.
+    for i in 0..=100_000_u32 {
+        let a = i as f32 / 100_000.0;
+        assert_eq!(none.apply(a).to_bits(), a.to_bits(), "f32 identity at {a}");
+    }
+
+    // Either term alone disqualifies `is_none`.
+    assert!(!CoverageContrast::from_bits(1, 0).is_none());
+    assert!(!CoverageContrast::from_bits(0, 1).is_none());
+}
+
+/// Fully-covered and fully-empty pixels must be fixed points at every strength
+/// pair: interiors and background stay byte-identical, only the transition
+/// band moves.
+#[test]
+fn endpoints_are_fixed_points_at_every_strength() {
+    for contrast in 0..=u8::MAX {
+        for weight in WEIGHT_SAMPLES {
+            let c = CoverageContrast::from_bits(contrast, weight);
+            assert_eq!(c.apply(0.0).to_bits(), 0.0_f32.to_bits());
+            assert_eq!(c.apply(1.0).to_bits(), 1.0_f32.to_bits());
+            assert_eq!(c.apply_u8(0), 0);
+            assert_eq!(c.apply_u8(255), 255);
+        }
+        // At `w = 0` the midpoint is a pivot: stem weight is preserved. (With
+        // `w > 0` it deliberately is not — see `weight_term_adds_weight`.)
+        let c = CoverageContrast::from_bits(contrast, 0);
+        assert_eq!(c.apply(0.5).to_bits(), 0.5_f32.to_bits());
+    }
+}
+
+/// The `c` term is symmetric about `a = 0.5`: it steepens the transition
+/// without moving the 50% crossing, so stems keep their weight. Weight is the
+/// separate, deliberately asymmetric `w` axis.
+#[test]
+fn steepening_term_is_symmetric_about_the_midpoint() {
+    for bits in [0_u8, 1, 64, 128, 200, 255] {
+        let c = CoverageContrast::from_bits(bits, 0);
+        for i in 0..=1000_u32 {
+            let a = i as f32 / 1000.0;
+            let lhs = c.apply(1.0 - a);
+            let rhs = 1.0 - c.apply(a);
+            assert!(
+                (lhs - rhs).abs() < 1e-6,
+                "symmetry at a={a}, bits={bits}: {lhs} vs {rhs}"
+            );
+        }
+    }
+}
+
+/// Monotone and within `[0, 1]` for every constructible pair, so no consumer
+/// needs a clamp and coverage can never invert.
+#[test]
+fn combined_curve_is_monotone_and_in_range() {
+    for contrast in 0..=u8::MAX {
+        for weight in WEIGHT_SAMPLES {
+            let c = CoverageContrast::from_bits(contrast, weight);
+            let mut prev = c.apply(0.0);
+            for i in 0..=2000_u32 {
+                let a = i as f32 / 2000.0;
+                let v = c.apply(a);
+                assert!(
+                    (0.0..=1.0).contains(&v),
+                    "range at a={a}, ({contrast}, {weight}): {v}"
+                );
+                assert!(
+                    v >= prev - 1e-7,
+                    "monotone at a={a}, ({contrast}, {weight}): {v} < {prev}"
+                );
+                prev = v;
+            }
+
+            let mut prev_u8 = c.apply_u8(0);
+            for byte in 0..=u8::MAX {
+                let v = c.apply_u8(byte);
+                assert!(
+                    v >= prev_u8,
+                    "u8 monotone at {byte}, ({contrast}, {weight})"
+                );
+                prev_u8 = v;
+            }
+        }
+    }
+
+    // The derivative `1 + c/2 - 6c*t^2 - 2w*t` (with `t = a - 1/2`) is
+    // concave, minimized at the `a = 1` endpoint where it equals `1 - c - w` —
+    // exactly zero for every capped boundary pair. Probe densely just below
+    // `a = 1`, where the slope vanishes.
+    for contrast in [1_u8, 64, 128, 191, 254] {
+        let c = CoverageContrast::from_bits(contrast, 255); // caps to the boundary
+        assert_eq!(
+            u32::from(c.contrast_bits()) + u32::from(c.weight_bits()),
+            255,
+            "boundary pair"
+        );
+        for i in 0..=10_000_u32 {
+            let a = 1.0 - i as f32 / 1_000_000.0;
+            let v = c.apply(a);
+            assert!(
+                (0.0..=1.0).contains(&v),
+                "range near saturation at a={a}, contrast={contrast}: {v}"
+            );
+        }
+    }
+}
+
+/// The peak slope of the `c` term (at the 50% crossing) is `1 + c/2`, so the
+/// steepening family spans exact-area coverage (1.0 alpha/px) through a full
+/// smoothstep (1.5 alpha/px).
+#[test]
+fn peak_slope_is_one_plus_half_the_strength() {
+    const H: f32 = 1e-3;
+    for bits in [0_u8, 51, 128, 191, 255] {
+        let c = CoverageContrast::from_bits(bits, 0);
+        let slope = (c.apply(0.5 + H) - c.apply(0.5 - H)) / (2.0 * H);
+        let expected = 1.0 + c.contrast_strength() / 2.0;
+        assert!(
+            (slope - expected).abs() < 1e-3,
+            "peak slope at bits={bits}: {slope} vs {expected}"
+        );
+    }
+
+    let full = CoverageContrast::from_bits(255, 0);
+    assert!((full.contrast_strength() - 1.0).abs() < 1e-6);
+    for i in 0..=100_u32 {
+        let a = i as f32 / 100.0;
+        assert!(
+            (full.apply(a) - smoothstep(a)).abs() < 1e-6,
+            "c=1 must be a full smoothstep at a={a}"
+        );
+    }
+}
+
+/// Control for the lerp parameterisation: the "rescaled smoothstep" family
+/// `S(0.5 + (a - 0.5) * k)` does not contain the identity for any `k`, so it
+/// could not be defaulted off. The family's midpoint slope is `1.5 * k`, so
+/// the only candidate is `k = 2/3`, which fails away from the midpoint.
+#[test]
+fn rescaled_smoothstep_family_cannot_express_the_identity() {
+    let rescaled = |k: f32, a: f32| smoothstep((0.5 + (a - 0.5) * k).clamp(0.0, 1.0));
+
+    // k = 1 reads as "no rescaling" but is a full smoothstep.
+    assert!((rescaled(1.0, 0.25) - 0.15625).abs() < 1e-6);
+    // The midpoint-slope candidate still deviates by more than an 8-bit level.
+    assert!((rescaled(2.0 / 3.0, 0.25) - 0.25).abs() > 1.0 / 255.0);
+
+    // Exhaustively: no k comes within half an 8-bit level of the identity
+    // everywhere (the closest, ~0.031, is at k ≈ 0.79).
+    for i in 0..=2000_u32 {
+        let k = i as f32 / 1000.0;
+        let worst = (0..=100_u32)
+            .map(|j| {
+                let a = j as f32 / 100.0;
+                (rescaled(k, a) - a).abs()
+            })
+            .fold(0.0_f32, f32::max);
+        assert!(worst > 0.5 / 255.0, "k={k} must not be the identity");
+    }
+
+    // The family actually used contains the identity exactly.
+    assert_eq!(
+        CoverageContrast::NONE.apply(0.25).to_bits(),
+        0.25_f32.to_bits()
+    );
+}
+
+#[test]
+fn from_strength_clamps_quantises_and_round_trips() {
+    assert_eq!(CoverageContrast::from_strength(0.0), CoverageContrast::NONE);
+    assert_eq!(CoverageContrast::from_strength(-5.0).contrast_bits(), 0);
+    assert_eq!(CoverageContrast::from_strength(5.0).contrast_bits(), 255);
+    assert_eq!(CoverageContrast::from_strength(f32::NAN).contrast_bits(), 0);
+
+    // Same on the weight axis — plus the headroom cap: at contrast 128 the
+    // weight tops out at 127.
+    let base = CoverageContrast::from_strength(0.5);
+    assert_eq!(base.with_weight_strength(-5.0).weight_bits(), 0);
+    assert_eq!(base.with_weight_strength(5.0).weight_bits(), 127);
+    assert_eq!(base.with_weight_strength(f32::NAN).weight_bits(), 0);
+    assert_eq!(base.with_weight_strength(1.0).contrast_bits(), 128);
+
+    for contrast in 0..=u8::MAX {
+        for weight in WEIGHT_SAMPLES {
+            let c = CoverageContrast::from_bits(contrast, weight);
+            assert_eq!(c.contrast_bits(), contrast);
+            assert_eq!(c.weight_bits(), weight.min(255 - contrast), "headroom cap");
+            assert_eq!(
+                CoverageContrast::from_strength(c.contrast_strength())
+                    .with_weight_strength(c.weight_strength()),
+                c
+            );
+        }
+    }
+}
+
+/// The `c + w <= 1` invariant, enforced at the [`CoverageContrast::from_bits`]
+/// choke point. This is the condition under which the curve is monotone with
+/// range `[0, 1]` (the sweeps above run at the capped boundary for every `c`),
+/// which is what lets every kernel stay clamp-free per pixel.
+#[test]
+fn weight_caps_at_contrast_headroom() {
+    assert_eq!(CoverageContrast::from_bits(200, 200).weight_bits(), 55);
+    assert_eq!(CoverageContrast::from_bits(255, 255).weight_bits(), 0);
+    assert_eq!(CoverageContrast::from_bits(0, 255).weight_bits(), 255);
+
+    // The pair that motivates the cap: (1, 255) uncapped overshoots 1.0 just
+    // below full coverage (the `w` bump falls away faster there than the
+    // steepened ramp rises). Capped to (1, 254) it must not.
+    let c = CoverageContrast::from_bits(1, 255);
+    assert_eq!((c.contrast_bits(), c.weight_bits()), (1, 254));
+    for i in 0..=100_000_u32 {
+        let a = i as f32 / 100_000.0;
+        assert!(c.apply(a) <= 1.0, "overshoot at a={a}: {}", c.apply(a));
+    }
+}
+
+/// `w = 0` must leave steepening-only output bit-identical to the plain
+/// single-term expression: the appended weight term is exactly `+0.0`, never a
+/// rounding change.
+#[test]
+fn weight_zero_keeps_steepening_only_output_bit_identical() {
+    let single_term = |c: f32, a: f32| a + c * a * (1.0 - a) * (2.0 * a - 1.0);
+
+    for bits in 0..=u8::MAX {
+        let c = CoverageContrast::from_bits(bits, 0);
+        let c_s = c.contrast_strength();
+        for i in 0..=10_000_u32 {
+            let a = i as f32 / 10_000.0;
+            assert_eq!(
+                c.apply(a).to_bits(),
+                single_term(c_s, a).to_bits(),
+                "bit drift at a={a}, bits={bits}"
+            );
+        }
+    }
+}
+
+/// With `c = 0` the curve is exactly the mask-contrast form used by Skia,
+/// `a' = a + w * a * (1 - a)` — bit-for-bit, since the zeroed steepening term
+/// contributes `±0.0`. The curve only ever adds coverage, and raises the 50%
+/// crossing by `w/4`: it is the weight knob, asymmetric where the steepening
+/// knob is symmetric.
+#[test]
+fn weight_term_adds_weight() {
+    for weight in [1_u8, 64, 128, 191, 255] {
+        let c = CoverageContrast::from_bits(0, weight);
+        let w_s = c.weight_strength();
+
+        for i in 0..=10_000_u32 {
+            let a = i as f32 / 10_000.0;
+            assert_eq!(
+                c.apply(a).to_bits(),
+                (a + w_s * a * (1.0 - a)).to_bits(),
+                "mask-contrast form at a={a}, weight={weight}"
+            );
+            assert!(c.apply(a) >= a, "weight must only add, at a={a}");
+        }
+
+        assert!(
+            (c.apply(0.5) - (0.5 + w_s * 0.25)).abs() < 1e-6,
+            "midpoint shift at weight={weight}"
+        );
+    }
+}
+
+/// [`CoverageContrast::resolve_for_color`] scales the weight by the text
+/// color's approximate relative luminance (gamma-2), leaving the contrast
+/// untouched: white text keeps the stored strength, black text resolves to
+/// the bit-exact `c`-only curve.
+#[test]
+fn resolve_for_color_scales_weight_by_luminance() {
+    // Contrast 55 leaves 200 of headroom, so the requested weight of 200 is
+    // stored unchanged and the scaling is observed undistorted.
+    let policy = CoverageContrast::from_bits(55, 200);
+    assert_eq!(policy.weight_bits(), 200, "cap must not bind in this test");
+
+    let white = policy.resolve_for_color(Color::new([1.0, 1.0, 1.0, 1.0]));
+    assert_eq!(white, policy);
+    let black = policy.resolve_for_color(Color::new([0.0, 0.0, 0.0, 1.0]));
+    assert_eq!(black, CoverageContrast::from_bits(55, 0));
+
+    // Gamma-2: mid-gray has luminance 0.25.
+    let gray = policy.resolve_for_color(Color::new([0.5, 0.5, 0.5, 1.0]));
+    assert_eq!(gray.contrast_bits(), 55, "contrast passes through");
+    assert_eq!(gray.weight_bits(), 50, "200 * 0.25 = 50");
+
+    // Primaries order by the Rec. 709 luma coefficients.
+    let lum = |r: f32, g: f32, b: f32| {
+        policy
+            .resolve_for_color(Color::new([r, g, b, 1.0]))
+            .weight_bits()
+    };
+    let (red, green, blue) = (lum(1.0, 0.0, 0.0), lum(0.0, 1.0, 0.0), lum(0.0, 0.0, 1.0));
+    assert!(green > red && red > blue);
+    assert_eq!(green, 143, "200 * 0.7152");
+    assert_eq!(red, 43, "200 * 0.2126");
+    assert_eq!(blue, 14, "200 * 0.0722");
+
+    // Alpha is ignored: opacity does not change polarity.
+    assert_eq!(
+        policy.resolve_for_color(Color::new([1.0, 1.0, 1.0, 0.0])),
+        policy
+    );
+
+    // Out-of-range channels clamp; NaN disables rather than poisoning.
+    assert_eq!(
+        policy.resolve_for_color(Color::new([2.0, 5.0, 1.5, 1.0])),
+        policy
+    );
+    assert_eq!(
+        policy.resolve_for_color(Color::new([-1.0, -0.5, 0.0, 1.0])),
+        CoverageContrast::from_bits(55, 0)
+    );
+    assert_eq!(
+        policy
+            .resolve_for_color(Color::new([f32::NAN, 0.5, 0.5, 1.0]))
+            .weight_bits(),
+        0
+    );
+
+    // A zero stored weight is returned untouched for any color, keeping the
+    // disabled path branch-only.
+    let contrast_only = CoverageContrast::from_bits(153, 0);
+    for color in [
+        Color::new([1.0, 1.0, 1.0, 1.0]),
+        Color::new([0.0, 0.0, 0.0, 1.0]),
+        Color::new([f32::NAN, 0.0, 0.0, 1.0]),
+    ] {
+        assert_eq!(contrast_only.resolve_for_color(color), contrast_only);
+    }
+}
+
+/// `apply_u8` must be the `apply` curve plus the rounding the 8-bit pipeline
+/// already imposes — not an independent approximation — so the u8 kernel, the
+/// f32 kernel and the shader cannot drift apart.
+#[test]
+fn u8_path_tracks_the_f32_path() {
+    for contrast in [0_u8, 1, 64, 128, 255] {
+        for weight in WEIGHT_SAMPLES {
+            if contrast == 0 && weight == 0 {
+                continue; // the identity path is proven bit-exact above
+            }
+            let c = CoverageContrast::from_bits(contrast, weight);
+            for byte in 0..=u8::MAX {
+                // Same reciprocal form `apply_u8` uses, so this isolates the
+                // rounding rather than a one-ulp conversion difference.
+                let via_f32 = c.apply(f32::from(byte) * (1.0 / 255.0)) * 255.0;
+                let via_u8 = f32::from(c.apply_u8(byte));
+                assert!(
+                    (via_f32 - via_u8).abs() <= 0.5 + 1e-3,
+                    "u8 vs f32 at byte={byte}, ({contrast}, {weight}): {via_u8} vs {via_f32}"
+                );
+            }
+        }
+    }
+}

--- a/sparse_strips/vello_cpu/CHANGELOG.md
+++ b/sparse_strips/vello_cpu/CHANGELOG.md
@@ -14,7 +14,7 @@ This release has an [MSRV][] of 1.88.
 
 ### Added
 
-- `RenderContext::set_glyph_coverage_contrast` for applying a `CoverageContrast` to atlas-cached glyph coverage. ([#1790][] by [@AdrianEddy][])
+- `RenderContext::set_glyph_coverage_contrast` for applying a `CoverageContrast` to outline glyph coverage, whether the glyph is atlas-cached or drawn directly from its outline. ([#1790][] by [@AdrianEddy][])
 
 ## [0.2.0][] - 2026-08-07
 

--- a/sparse_strips/vello_cpu/CHANGELOG.md
+++ b/sparse_strips/vello_cpu/CHANGELOG.md
@@ -12,6 +12,10 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 This release has an [MSRV][] of 1.88.
 
+### Added
+
+- `RenderContext::set_glyph_coverage_contrast` for applying a `CoverageContrast` to atlas-cached glyph coverage. ([#1790][] by [@AdrianEddy][])
+
 ## [0.2.0][] - 2026-08-07
 
 This release has an [MSRV][] of 1.88.
@@ -209,6 +213,7 @@ This is the initial release. No changelog was kept for this release.
 See also the [vello_common 0.0.1](../vello_common/CHANGELOG.md#001---2025-05-10) release.
 
 [@DJMcNab]: https://github.com/DJMcNab
+[@AdrianEddy]: https://github.com/AdrianEddy
 [@b0nes164]: https://github.com/b0nes164
 [@grebmeg]: https://github.com/grebmeg
 [@jrmoulton]: https://github.com/jrmoulton
@@ -275,6 +280,7 @@ See also the [vello_common 0.0.1](../vello_common/CHANGELOG.md#001---2025-05-10)
 [#1760]: https://github.com/linebender/vello/pull/1760
 [#1763]: https://github.com/linebender/vello/pull/1763
 [#1787]: https://github.com/linebender/vello/pull/1787
+[#1790]: https://github.com/linebender/vello/pull/1790
 [#1803]: https://github.com/linebender/vello/pull/1803
 
 [Unreleased]: https://github.com/linebender/vello/compare/sparse-strips-v0.2.0...HEAD

--- a/sparse_strips/vello_cpu/CHANGELOG.md
+++ b/sparse_strips/vello_cpu/CHANGELOG.md
@@ -12,6 +12,10 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 This release has an [MSRV][] of 1.88.
 
+### Added
+
+- `RenderContext::set_glyph_coverage_contrast` for applying a `CoverageContrast` to atlas-cached glyph coverage. ([#1790][] by [@AdrianEddy][])
+
 ## [0.1.0][] - 2026-07-29
 
 This release has an [MSRV][] of 1.88.
@@ -262,6 +266,8 @@ See also the [vello_common 0.0.1](../vello_common/CHANGELOG.md#001---2025-05-10)
 [#1760]: https://github.com/linebender/vello/pull/1760
 [#1763]: https://github.com/linebender/vello/pull/1763
 
+[#1790]: https://github.com/linebender/vello/pull/1790
+[@AdrianEddy]: https://github.com/AdrianEddy
 [Unreleased]: https://github.com/linebender/vello/compare/sparse-strips-v0.1.0...HEAD
 [0.1.0]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.9...sparse-strips-v0.1.0
 [0.0.9]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.8...sparse-strips-v0.0.9

--- a/sparse_strips/vello_cpu/CHANGELOG.md
+++ b/sparse_strips/vello_cpu/CHANGELOG.md
@@ -14,7 +14,7 @@ This release has an [MSRV][] of 1.88.
 
 ### Added
 
-- `RenderContext::set_glyph_coverage_contrast` for applying a `CoverageContrast` to atlas-cached glyph coverage. ([#1790][] by [@AdrianEddy][])
+- `RenderContext::set_glyph_coverage_contrast` for applying a `CoverageContrast` to outline glyph coverage, whether the glyph is atlas-cached or drawn directly from its outline. ([#1790][] by [@AdrianEddy][])
 
 ## [0.1.0][] - 2026-07-29
 

--- a/sparse_strips/vello_cpu/src/dispatch/mod.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/mod.rs
@@ -12,7 +12,7 @@ use core::fmt::Debug;
 use vello_common::encode::EncodedPaint;
 use vello_common::filter::FilterData;
 use vello_common::mask::Mask;
-use vello_common::paint::{ImageResolver, Paint};
+use vello_common::paint::{CoverageContrast, ImageResolver, Paint};
 use vello_common::pixmap::PixmapMut;
 
 pub(crate) trait Dispatcher: Debug + Send {
@@ -26,6 +26,7 @@ pub(crate) trait Dispatcher: Debug + Send {
         blend_mode: BlendMode,
         aliasing_threshold: Option<u8>,
         mask: Option<Mask>,
+        coverage_transfer: CoverageContrast,
     );
     fn stroke_path(
         &mut self,

--- a/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
@@ -31,7 +31,7 @@ use vello_common::fearless_simd::{Level, Simd, dispatch};
 use vello_common::filter::FilterData;
 use vello_common::geometry::RectU16;
 use vello_common::mask::Mask;
-use vello_common::paint::{ImageResolver, Paint};
+use vello_common::paint::{CoverageContrast, ImageResolver, Paint};
 use vello_common::pixmap::PixmapMut;
 use vello_common::record::{CommandRecorder, LayerClip, LayerProps, PoppedLayer};
 use vello_common::strip::Strip;
@@ -472,6 +472,7 @@ impl Dispatcher for MultiThreadedDispatcher {
         blend_mode: BlendMode,
         aliasing_threshold: Option<u8>,
         mask: Option<Mask>,
+        coverage_transfer: CoverageContrast,
     ) {
         let start = self.allocation_group.path.len() as u32;
         self.allocation_group.path.extend(path);
@@ -484,6 +485,7 @@ impl Dispatcher for MultiThreadedDispatcher {
             blend_mode,
             aliasing_threshold,
             mask,
+            coverage_transfer,
         });
     }
 
@@ -537,6 +539,7 @@ impl Dispatcher for MultiThreadedDispatcher {
             blend_mode,
             aliasing_threshold: None,
             mask,
+            coverage_transfer: CoverageContrast::NONE,
         });
     }
 
@@ -852,6 +855,7 @@ pub(crate) enum RenderTaskType {
         blend_mode: BlendMode,
         aliasing_threshold: Option<u8>,
         mask: Option<Mask>,
+        coverage_transfer: CoverageContrast,
     },
     StrokePath {
         path_range: Range<u32>,
@@ -949,7 +953,7 @@ mod tests {
     use crate::dispatch::multi_threaded::MultiThreadedDispatcher;
     use crate::kurbo::{Affine, Rect, Shape};
     use crate::peniko::{BlendMode, Fill};
-    use vello_common::paint::{Paint, PremulColor};
+    use vello_common::paint::{CoverageContrast, Paint, PremulColor};
 
     /// Ensure we don't cause a memory leak.
     #[test]
@@ -964,6 +968,7 @@ mod tests {
                 BlendMode::default(),
                 None,
                 None,
+                CoverageContrast::NONE,
             );
             dispatcher.flush();
         }

--- a/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
@@ -31,7 +31,7 @@ use vello_common::fearless_simd::{Level, Simd, dispatch};
 use vello_common::filter::FilterData;
 use vello_common::geometry::RectU16;
 use vello_common::mask::Mask;
-use vello_common::paint::{ImageResolver, Paint};
+use vello_common::paint::{CoverageContrast, ImageResolver, Paint};
 use vello_common::pixmap::PixmapMut;
 use vello_common::record::{CommandRecorder, LayerClip, LayerProps, PoppedLayer};
 use vello_common::strip::Strip;
@@ -471,6 +471,7 @@ impl Dispatcher for MultiThreadedDispatcher {
         blend_mode: BlendMode,
         aliasing_threshold: Option<u8>,
         mask: Option<Mask>,
+        coverage_transfer: CoverageContrast,
     ) {
         let start = self.allocation_group.path.len() as u32;
         self.allocation_group.path.extend(path);
@@ -483,6 +484,7 @@ impl Dispatcher for MultiThreadedDispatcher {
             blend_mode,
             aliasing_threshold,
             mask,
+            coverage_transfer,
         });
     }
 
@@ -536,6 +538,7 @@ impl Dispatcher for MultiThreadedDispatcher {
             blend_mode,
             aliasing_threshold: None,
             mask,
+            coverage_transfer: CoverageContrast::NONE,
         });
     }
 
@@ -849,6 +852,7 @@ pub(crate) enum RenderTaskType {
         blend_mode: BlendMode,
         aliasing_threshold: Option<u8>,
         mask: Option<Mask>,
+        coverage_transfer: CoverageContrast,
     },
     StrokePath {
         path_range: Range<u32>,
@@ -946,7 +950,7 @@ mod tests {
     use crate::dispatch::multi_threaded::MultiThreadedDispatcher;
     use crate::kurbo::{Affine, Rect, Shape};
     use crate::peniko::{BlendMode, Fill};
-    use vello_common::paint::{Paint, PremulColor};
+    use vello_common::paint::{CoverageContrast, Paint, PremulColor};
 
     /// Ensure we don't cause a memory leak.
     #[test]
@@ -961,6 +965,7 @@ mod tests {
                 BlendMode::default(),
                 None,
                 None,
+                CoverageContrast::NONE,
             );
             dispatcher.flush();
         }

--- a/sparse_strips/vello_cpu/src/dispatch/multi_threaded/worker.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/multi_threaded/worker.rs
@@ -72,19 +72,22 @@ impl Worker {
                     blend_mode,
                     aliasing_threshold,
                     mask,
+                    coverage_transfer,
                 } => {
                     let start = self.strip_storage.strips.len() as u32;
                     let path = &render_task.allocation_group.path
                         [path_range.start as usize..path_range.end as usize];
 
-                    self.strip_generator.generate_filled_path(
-                        path.iter().copied(),
-                        fill_rule,
-                        transform,
-                        aliasing_threshold,
-                        &mut self.strip_storage,
-                        path_clip,
-                    );
+                    self.strip_generator
+                        .generate_filled_path_with_coverage_transfer(
+                            path.iter().copied(),
+                            fill_rule,
+                            transform,
+                            aliasing_threshold,
+                            coverage_transfer,
+                            &mut self.strip_storage,
+                            path_clip,
+                        );
                     let end = self.strip_storage.strips.len() as u32;
 
                     let recorded_command = RecordedCommand::RenderPath {

--- a/sparse_strips/vello_cpu/src/dispatch/single_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/single_threaded.rs
@@ -17,7 +17,7 @@ use vello_common::fearless_simd::{Level, Simd};
 use vello_common::filter::FilterData;
 use vello_common::geometry::RectU16;
 use vello_common::mask::Mask;
-use vello_common::paint::{ImageResolver, Paint};
+use vello_common::paint::{CoverageContrast, ImageResolver, Paint};
 use vello_common::pixmap::{Pixmap, PixmapMut};
 use vello_common::record::{
     CommandRecorder, LayerClip, LayerProps, Node, PoppedLayer, RecordedLayerKind,
@@ -283,16 +283,18 @@ impl Dispatcher for SingleThreadedDispatcher {
         blend_mode: BlendMode,
         aliasing_threshold: Option<u8>,
         mask: Option<Mask>,
+        coverage_transfer: CoverageContrast,
     ) {
         let strip_start = self.strip_storage.strips.len();
         let strip_storage = &mut self.strip_storage;
         self.viewport
             .with_generator_and_clip(|strip_generator, clip_path| {
-                strip_generator.generate_filled_path(
+                strip_generator.generate_filled_path_with_coverage_transfer(
                     path,
                     fill_rule,
                     transform,
                     aliasing_threshold,
+                    coverage_transfer,
                     strip_storage,
                     clip_path,
                 );
@@ -533,7 +535,7 @@ mod tests {
     use super::*;
     use crate::kurbo::Shape;
     use vello_common::color::palette::css::BLUE;
-    use vello_common::paint::PremulColor;
+    use vello_common::paint::{CoverageContrast, PremulColor};
 
     /// Verifies that `reset()` properly clears all internal buffers and state.
     ///
@@ -552,6 +554,7 @@ mod tests {
             BlendMode::default(),
             None,
             None,
+            CoverageContrast::NONE,
         );
 
         // Ensure there is data to clear.

--- a/sparse_strips/vello_cpu/src/fine/highp/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/highp/mod.rs
@@ -116,6 +116,28 @@ impl<S: Simd> FineKernel<S> for F32Kernel {
             || {
                 let tint_v = f32x16::block_splat(f32x4::from_slice(simd, &[r, g, b, a]));
 
+                // Opt-in coverage-contrast path, handled before the mode match
+                // so the default executes the same instructions as before.
+                // Same expression, same order as `CoverageContrast::apply` and
+                // `apply_coverage_contrast` in `render.wesl`.
+                if tint.mode == TintMode::AlphaMask && !tint.contrast.is_none() {
+                    let c = tint.contrast.contrast_strength();
+                    let w = tint.contrast.weight_strength();
+                    let c_v = f32x16::splat(simd, c);
+                    let w_v = f32x16::splat(simd, w);
+                    let one = f32x16::splat(simd, 1.0);
+                    let two = f32x16::splat(simd, 2.0);
+
+                    for chunk in dest.chunks_exact_mut(16) {
+                        let pixel = f32x16::from_slice(simd, chunk);
+                        let a = pixel.splat_4th();
+                        let a = a + c_v * a * (one - a) * (two * a - one) + w_v * a * (one - a);
+                        let tinted = tint_v * a;
+                        tinted.store_slice(chunk);
+                    }
+                    return;
+                }
+
                 match tint.mode {
                     TintMode::AlphaMask => {
                         for chunk in dest.chunks_exact_mut(16) {

--- a/sparse_strips/vello_cpu/src/fine/lowp/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/lowp/mod.rs
@@ -168,6 +168,28 @@ impl<S: Simd> FineKernel<S> for U8Kernel {
             || {
                 let tint_v = u32x8::block_splat(u32x4::splat(simd, color)).to_bytes();
 
+                // Opt-in coverage-contrast path; see the highp counterpart.
+                // The curve is evaluated in f32 per distinct alpha via
+                // `apply_u8`, so this pipeline agrees with `F32Kernel` and the
+                // shader on the function and differs only by the final
+                // rounding the u8 pipeline already imposes. No LUT: this runs
+                // per span, and 256 entries would cost more than they save.
+                if tint.mode == TintMode::AlphaMask && !tint.contrast.is_none() {
+                    let contrast = tint.contrast;
+                    let mut mapped = [0_u8; 32];
+                    for chunk in dest.chunks_exact_mut(32) {
+                        for (px, out) in chunk.chunks_exact(4).zip(mapped.chunks_exact_mut(4)) {
+                            // Replicate across the pixel's 4 lanes, matching
+                            // what `splat_4th` produces on the untouched path.
+                            out.fill(contrast.apply_u8(px[3]));
+                        }
+                        let alphas = u8x32::from_slice(simd, &mapped);
+                        let tinted = tint_v.normalized_mul(alphas);
+                        tinted.store_slice(chunk);
+                    }
+                    return;
+                }
+
                 match tint.mode {
                     TintMode::AlphaMask => {
                         for chunk in dest.chunks_exact_mut(32) {

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -26,7 +26,7 @@ use vello_common::filter::FilterData;
 use vello_common::filter_effects::Filter;
 use vello_common::kurbo::{Affine, BezPath, Rect, Stroke};
 use vello_common::mask::Mask;
-use vello_common::paint::{ImageId, ImageResolver, Paint, PaintType, Tint};
+use vello_common::paint::{CoverageContrast, ImageId, ImageResolver, Paint, PaintType, Tint};
 use vello_common::peniko::color::palette::css::BLACK;
 use vello_common::peniko::{BlendMode, Fill};
 use vello_common::pixmap::{Pixmap, PixmapMut};
@@ -175,6 +175,10 @@ pub struct RenderContext {
         allow(dead_code, reason = "used when the `text` feature is enabled")
     )]
     pub(crate) render_settings: RenderSettings,
+    /// Coverage transfer applied to atlas-cached glyph coverage. A
+    /// renderer-wide display policy, so it lives outside [`RenderState`] and
+    /// survives `reset`, `save_state` and `restore_state`.
+    pub(crate) glyph_coverage_contrast: CoverageContrast,
     dispatcher: Box<dyn Dispatcher>,
 }
 
@@ -244,6 +248,7 @@ impl RenderContext {
             temp_path,
             encoded_paints,
             filter: None,
+            glyph_coverage_contrast: CoverageContrast::NONE,
         }
     }
 
@@ -615,6 +620,21 @@ impl RenderContext {
     /// Clear the tint, so subsequent image paints are drawn without tinting.
     pub fn reset_tint(&mut self) {
         self.state.tint = None;
+    }
+
+    /// Set the coverage transfer applied to atlas-cached glyph coverage.
+    ///
+    /// Defaults to [`CoverageContrast::NONE`], which is bit-exact with
+    /// rendering that predates the setting. A display policy rather than a
+    /// paint attribute: unaffected by `reset`, `save_state` and
+    /// `restore_state`.
+    pub fn set_glyph_coverage_contrast(&mut self, contrast: CoverageContrast) {
+        self.glyph_coverage_contrast = contrast;
+    }
+
+    /// The coverage transfer applied to atlas-cached glyph coverage.
+    pub fn glyph_coverage_contrast(&self) -> CoverageContrast {
+        self.glyph_coverage_contrast
     }
 
     /// Set the blend mode that should be used when drawing objects.

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -281,6 +281,17 @@ impl RenderContext {
 
     /// Fill a path.
     pub fn fill_path(&mut self, path: &BezPath) {
+        self.fill_path_with_coverage_transfer(path, CoverageContrast::NONE);
+    }
+
+    /// Fill a path, remapping its coverage through `coverage_transfer` before
+    /// compositing (and before any clip intersection). Used by the glyph
+    /// integration so outline glyphs drawn directly match atlas-cached ones.
+    pub(crate) fn fill_path_with_coverage_transfer(
+        &mut self,
+        path: &BezPath,
+        coverage_transfer: CoverageContrast,
+    ) {
         // TODO: Similarly to Vello Hybrid, make sure that inline blend + filter are applies
         // to the same layer.
         self.with_optional_filter(|ctx| {
@@ -296,6 +307,7 @@ impl RenderContext {
                 ctx.state.blend_mode,
                 ctx.aliasing_threshold,
                 ctx.mask.clone(),
+                coverage_transfer,
             );
         });
     }
@@ -350,6 +362,7 @@ impl RenderContext {
                     ctx.state.blend_mode,
                     ctx.aliasing_threshold,
                     ctx.mask.clone(),
+                    CoverageContrast::NONE,
                 );
             }
         });
@@ -442,6 +455,7 @@ impl RenderContext {
             self.state.blend_mode,
             self.aliasing_threshold,
             self.mask.clone(),
+            CoverageContrast::NONE,
         );
     }
 

--- a/sparse_strips/vello_cpu/src/text.rs
+++ b/sparse_strips/vello_cpu/src/text.rs
@@ -436,6 +436,15 @@ impl glifo::GlyphRenderer for RenderContext {
     }
 
     #[inline]
+    fn fill_glyph_path(
+        &mut self,
+        path: &BezPath,
+        coverage_transfer: vello_common::paint::CoverageContrast,
+    ) {
+        self.fill_path_with_coverage_transfer(path, coverage_transfer);
+    }
+
+    #[inline]
     fn get_context_color(&self) -> AlphaColor<Srgb> {
         let paint = self.paint().clone();
         match paint {

--- a/sparse_strips/vello_cpu/src/text.rs
+++ b/sparse_strips/vello_cpu/src/text.rs
@@ -431,6 +431,11 @@ impl glifo::GlyphRenderer for RenderContext {
     }
 
     #[inline]
+    fn glyph_coverage_contrast(&self) -> vello_common::paint::CoverageContrast {
+        Self::glyph_coverage_contrast(self)
+    }
+
+    #[inline]
     fn get_context_color(&self) -> AlphaColor<Srgb> {
         let paint = self.paint().clone();
         match paint {

--- a/sparse_strips/vello_hybrid/CHANGELOG.md
+++ b/sparse_strips/vello_hybrid/CHANGELOG.md
@@ -12,6 +12,10 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 This release has an [MSRV][] of 1.88.
 
+### Added
+
+- `Scene::set_glyph_coverage_contrast` for applying a `CoverageContrast` to atlas-cached glyph coverage; the packed tint mode word now carries the strengths in bits 8-23. ([#1790][] by [@AdrianEddy][])
+
 ## [0.2.0][] - 2026-08-07
 
 This release has an [MSRV][] of 1.88.
@@ -297,6 +301,7 @@ See also the [vello_cpu 0.0.4](../vello_cpu/CHANGELOG.md#004---2025-10-17) and [
 [#1778]: https://github.com/linebender/vello/pull/1778
 [#1779]: https://github.com/linebender/vello/pull/1779
 [#1781]: https://github.com/linebender/vello/pull/1781
+[#1790]: https://github.com/linebender/vello/pull/1790
 [#1791]: https://github.com/linebender/vello/pull/1791
 [#1792]: https://github.com/linebender/vello/pull/1792
 [#1794]: https://github.com/linebender/vello/pull/1794

--- a/sparse_strips/vello_hybrid/CHANGELOG.md
+++ b/sparse_strips/vello_hybrid/CHANGELOG.md
@@ -14,7 +14,7 @@ This release has an [MSRV][] of 1.88.
 
 ### Added
 
-- `Scene::set_glyph_coverage_contrast` for applying a `CoverageContrast` to atlas-cached glyph coverage; the packed tint mode word now carries the strengths in bits 8-23. ([#1790][] by [@AdrianEddy][])
+- `Scene::set_glyph_coverage_contrast` for applying a `CoverageContrast` to outline glyph coverage, whether the glyph is atlas-cached (the packed tint mode word carries the strengths in bits 8-23) or drawn directly from its outline (coverage is remapped CPU-side at strip generation). ([#1790][] by [@AdrianEddy][])
 
 ## [0.2.0][] - 2026-08-07
 

--- a/sparse_strips/vello_hybrid/CHANGELOG.md
+++ b/sparse_strips/vello_hybrid/CHANGELOG.md
@@ -12,6 +12,10 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 This release has an [MSRV][] of 1.88.
 
+### Added
+
+- `Scene::set_glyph_coverage_contrast` for applying a `CoverageContrast` to atlas-cached glyph coverage; the packed tint mode word now carries the strengths in bits 8-23. ([#1790][] by [@AdrianEddy][])
+
 ## [0.1.0][] - 2026-07-29
 
 This release has an [MSRV][] of 1.88.
@@ -269,6 +273,8 @@ See also the [vello_cpu 0.0.4](../vello_cpu/CHANGELOG.md#004---2025-10-17) and [
 [#1763]: https://github.com/linebender/vello/pull/1763
 [#1769]: https://github.com/linebender/vello/pull/1769
 
+[#1790]: https://github.com/linebender/vello/pull/1790
+[@AdrianEddy]: https://github.com/AdrianEddy
 [Unreleased]: https://github.com/linebender/vello/compare/sparse-strips-v0.1.0...HEAD
 [0.1.0]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.9...sparse-strips-v0.1.0
 [0.0.9]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.8...sparse-strips-v0.0.9

--- a/sparse_strips/vello_hybrid/CHANGELOG.md
+++ b/sparse_strips/vello_hybrid/CHANGELOG.md
@@ -14,7 +14,7 @@ This release has an [MSRV][] of 1.88.
 
 ### Added
 
-- `Scene::set_glyph_coverage_contrast` for applying a `CoverageContrast` to atlas-cached glyph coverage; the packed tint mode word now carries the strengths in bits 8-23. ([#1790][] by [@AdrianEddy][])
+- `Scene::set_glyph_coverage_contrast` for applying a `CoverageContrast` to outline glyph coverage, whether the glyph is atlas-cached (the packed tint mode word carries the strengths in bits 8-23) or drawn directly from its outline (coverage is remapped CPU-side at strip generation). ([#1790][] by [@AdrianEddy][])
 
 ## [0.1.0][] - 2026-07-29
 

--- a/sparse_strips/vello_hybrid/src/render/common.rs
+++ b/sparse_strips/vello_hybrid/src/render/common.rs
@@ -301,6 +301,49 @@ mod tests {
             })
         ));
     }
+    /// The strengths must occupy their own bytes of the mode word, leaving
+    /// the mode readable in the low byte, and `NONE` must contribute zero
+    /// bits.
+    #[test]
+    fn pack_tint_carries_contrast_without_disturbing_the_mode() {
+        use super::{GPU_TINT_CONTRAST_SHIFT, GPU_TINT_WEIGHT_SHIFT, pack_tint};
+        use vello_common::color::palette::css::RED;
+        use vello_common::paint::{CoverageContrast, Tint, TintMode};
+
+        assert_eq!(pack_tint(None), (0, 0));
+
+        for mode in [TintMode::AlphaMask, TintMode::Multiply] {
+            let off = pack_tint(Some(Tint {
+                color: RED,
+                mode,
+                contrast: CoverageContrast::NONE,
+            }));
+            assert_eq!(off.1, mode.as_u32(), "NONE must add no bits");
+
+            for contrast_bits in [0_u8, 1, 128, 255] {
+                for weight_bits in [0_u8, 1, 128, 255] {
+                    // `from_bits` caps the weight at the contrast's headroom;
+                    // the wire must round-trip the constructed pair.
+                    let contrast = CoverageContrast::from_bits(contrast_bits, weight_bits);
+                    let (color, packed) = pack_tint(Some(Tint {
+                        color: RED,
+                        mode,
+                        contrast,
+                    }));
+                    assert_eq!(color, off.0, "contrast must not touch the color");
+                    assert_eq!(packed & 0xFF, mode.as_u32(), "mode stays in the low byte");
+                    assert_eq!(
+                        (packed >> GPU_TINT_CONTRAST_SHIFT) & 0xFF,
+                        u32::from(contrast.contrast_bits()),
+                    );
+                    assert_eq!(
+                        (packed >> GPU_TINT_WEIGHT_SHIFT) & 0xFF,
+                        u32::from(contrast.weight_bits()),
+                    );
+                }
+            }
+        }
+    }
 }
 
 /// Dimensions of the rendering target.
@@ -595,17 +638,32 @@ pub(crate) fn pack_image_params(
     (atlas_index << 6) | (extend_y << 4) | (extend_x << 2) | quality
 }
 
+/// Bit positions of the packed
+/// [`CoverageContrast`](vello_common::paint::CoverageContrast) strengths
+/// within the tint mode word. Must match `TINT_CONTRAST_SHIFT` /
+/// `TINT_WEIGHT_SHIFT` in `render.wesl`.
+pub(crate) const GPU_TINT_CONTRAST_SHIFT: u32 = 8;
+pub(crate) const GPU_TINT_WEIGHT_SHIFT: u32 = 16;
+
 /// Pack an optional [`Tint`](vello_common::paint::Tint) into a (`tint_color_u32`, `tint_mode_u32`) pair for the GPU.
 ///
 /// The tint color is premultiplied before packing into a u32 in the same layout
 /// as WGSL `pack4x8unorm`. Returns `(0, 0)` when no tint is specified, which
 /// the shader interprets as "no tint".
+///
+/// The mode word carries the tint mode in bits 0-7 and the coverage-contrast
+/// strengths in bits 8-23. [`CoverageContrast::NONE`](vello_common::paint::CoverageContrast::NONE)
+/// contributes zero bits, so paints that do not opt in encode byte-identically
+/// to before the transfer existed.
 #[inline(always)]
 pub(crate) fn pack_tint(tint: Option<vello_common::paint::Tint>) -> (u32, u32) {
     match tint {
         Some(t) => {
             let color = t.color.premultiply().to_rgba8().to_u32();
-            (color, t.mode.as_u32())
+            let mode = t.mode.as_u32()
+                | (u32::from(t.contrast.contrast_bits()) << GPU_TINT_CONTRAST_SHIFT)
+                | (u32::from(t.contrast.weight_bits()) << GPU_TINT_WEIGHT_SHIFT);
+            (color, mode)
         }
         None => (0, 0),
     }

--- a/sparse_strips/vello_hybrid/src/render/common.rs
+++ b/sparse_strips/vello_hybrid/src/render/common.rs
@@ -305,6 +305,53 @@ mod tests {
             })
         ));
     }
+    /// The strengths must occupy their own bytes of the mode word, leaving
+    /// the mode readable in the low byte, and `NONE` must contribute zero
+    /// bits.
+    #[test]
+    fn pack_tint_carries_contrast_without_disturbing_the_mode() {
+        use super::{GPU_TINT_CONTRAST_SHIFT, GPU_TINT_WEIGHT_SHIFT, pack_tint};
+        use vello_common::color::palette::css::RED;
+        use vello_common::paint::{CoverageContrast, Tint, TintMode};
+
+        assert_eq!(
+            pack_tint(None),
+            (u32::MAX, TintMode::Multiply.as_u32()),
+            "the no-tint encoding must carry no contrast bits"
+        );
+
+        for mode in [TintMode::AlphaMask, TintMode::Multiply] {
+            let off = pack_tint(Some(Tint {
+                color: RED,
+                mode,
+                contrast: CoverageContrast::NONE,
+            }));
+            assert_eq!(off.1, mode.as_u32(), "NONE must add no bits");
+
+            for contrast_bits in [0_u8, 1, 128, 255] {
+                for weight_bits in [0_u8, 1, 128, 255] {
+                    // `from_bits` caps the weight at the contrast's headroom;
+                    // the wire must round-trip the constructed pair.
+                    let contrast = CoverageContrast::from_bits(contrast_bits, weight_bits);
+                    let (color, packed) = pack_tint(Some(Tint {
+                        color: RED,
+                        mode,
+                        contrast,
+                    }));
+                    assert_eq!(color, off.0, "contrast must not touch the color");
+                    assert_eq!(packed & 0xFF, mode.as_u32(), "mode stays in the low byte");
+                    assert_eq!(
+                        (packed >> GPU_TINT_CONTRAST_SHIFT) & 0xFF,
+                        u32::from(contrast.contrast_bits()),
+                    );
+                    assert_eq!(
+                        (packed >> GPU_TINT_WEIGHT_SHIFT) & 0xFF,
+                        u32::from(contrast.weight_bits()),
+                    );
+                }
+            }
+        }
+    }
 }
 
 /// Dimensions of the rendering target.
@@ -604,16 +651,31 @@ pub(crate) fn pack_image_params(
         | quality
 }
 
+/// Bit positions of the packed
+/// [`CoverageContrast`](vello_common::paint::CoverageContrast) strengths
+/// within the tint mode word. Must match `TINT_CONTRAST_SHIFT` /
+/// `TINT_WEIGHT_SHIFT` in `render.wesl`.
+pub(crate) const GPU_TINT_CONTRAST_SHIFT: u32 = 8;
+pub(crate) const GPU_TINT_WEIGHT_SHIFT: u32 = 16;
+
 /// Pack an optional [`Tint`](vello_common::paint::Tint) into a (`tint_color_u32`, `tint_mode_u32`) pair for the GPU.
 ///
 /// The tint color is premultiplied before packing into a u32 in the same layout
 /// as WGSL `pack4x8unorm`.
+///
+/// The mode word carries the tint mode in bits 0-7 and the coverage-contrast
+/// strengths in bits 8-23. [`CoverageContrast::NONE`](vello_common::paint::CoverageContrast::NONE)
+/// contributes zero bits, so paints that do not opt in encode byte-identically
+/// to before the transfer existed.
 #[inline(always)]
 pub(crate) fn pack_tint(tint: Option<vello_common::paint::Tint>) -> (u32, u32) {
     match tint {
         Some(t) => {
             let color = t.color.premultiply().to_rgba8().to_u32();
-            (color, t.mode.as_u32())
+            let mode = t.mode.as_u32()
+                | (u32::from(t.contrast.contrast_bits()) << GPU_TINT_CONTRAST_SHIFT)
+                | (u32::from(t.contrast.weight_bits()) << GPU_TINT_WEIGHT_SHIFT);
+            (color, mode)
         }
         // With no tint, use `u32::MAX` (which corresponds to 1.0 on all lanes).
         // Since we use `Multiply` this will essentially just yield the original image

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -344,6 +344,17 @@ impl Scene {
 
     /// Fill a path with the current paint and fill rule.
     pub fn fill_path(&mut self, path: &BezPath) {
+        self.fill_path_with_coverage_transfer(path, CoverageContrast::NONE);
+    }
+
+    /// Fill a path, remapping its coverage through `coverage_transfer` before
+    /// compositing (and before any clip intersection). Used by the glyph
+    /// integration so outline glyphs drawn directly match atlas-cached ones.
+    pub(crate) fn fill_path_with_coverage_transfer(
+        &mut self,
+        path: &BezPath,
+        coverage_transfer: CoverageContrast,
+    ) {
         if !self.paint_visible {
             return;
         }
@@ -356,6 +367,7 @@ impl Scene {
                 ctx.render_state.fill_rule,
                 paint,
                 ctx.aliasing_threshold,
+                coverage_transfer,
             );
         });
     }
@@ -368,13 +380,15 @@ impl Scene {
         fill_rule: Fill,
         paint: Paint,
         aliasing_threshold: Option<u8>,
+        coverage_transfer: CoverageContrast,
     ) {
         self.record_generated_path(paint, |strip_generator, strip_storage, clip_path| {
-            strip_generator.generate_filled_path(
+            strip_generator.generate_filled_path_with_coverage_transfer(
                 path,
                 fill_rule,
                 transform,
                 aliasing_threshold,
+                coverage_transfer,
                 strip_storage,
                 clip_path,
             );
@@ -490,6 +504,7 @@ impl Scene {
                     ctx.render_state.fill_rule,
                     paint,
                     ctx.aliasing_threshold,
+                    CoverageContrast::NONE,
                 );
             }
         });
@@ -524,6 +539,7 @@ impl Scene {
                 ctx.render_state.fill_rule,
                 paint,
                 ctx.aliasing_threshold,
+                CoverageContrast::NONE,
             );
         });
     }
@@ -648,6 +664,7 @@ impl Scene {
                     Fill::NonZero,
                     paint,
                     ctx.aliasing_threshold,
+                    CoverageContrast::NONE,
                 );
             }
         });

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -338,6 +338,17 @@ impl Scene {
 
     /// Fill a path with the current paint and fill rule.
     pub fn fill_path(&mut self, path: &BezPath) {
+        self.fill_path_with_coverage_transfer(path, CoverageContrast::NONE);
+    }
+
+    /// Fill a path, remapping its coverage through `coverage_transfer` before
+    /// compositing (and before any clip intersection). Used by the glyph
+    /// integration so outline glyphs drawn directly match atlas-cached ones.
+    pub(crate) fn fill_path_with_coverage_transfer(
+        &mut self,
+        path: &BezPath,
+        coverage_transfer: CoverageContrast,
+    ) {
         if !self.paint_visible {
             return;
         }
@@ -350,6 +361,7 @@ impl Scene {
                 ctx.render_state.fill_rule,
                 paint,
                 ctx.aliasing_threshold,
+                coverage_transfer,
             );
         });
     }
@@ -362,13 +374,15 @@ impl Scene {
         fill_rule: Fill,
         paint: Paint,
         aliasing_threshold: Option<u8>,
+        coverage_transfer: CoverageContrast,
     ) {
         self.record_generated_path(paint, |strip_generator, strip_storage, clip_path| {
-            strip_generator.generate_filled_path(
+            strip_generator.generate_filled_path_with_coverage_transfer(
                 path,
                 fill_rule,
                 transform,
                 aliasing_threshold,
+                coverage_transfer,
                 strip_storage,
                 clip_path,
             );
@@ -484,6 +498,7 @@ impl Scene {
                     ctx.render_state.fill_rule,
                     paint,
                     ctx.aliasing_threshold,
+                    CoverageContrast::NONE,
                 );
             }
         });
@@ -572,6 +587,7 @@ impl Scene {
                         ctx.render_state.fill_rule,
                         paint,
                         ctx.aliasing_threshold,
+                        CoverageContrast::NONE,
                     );
                 }
             }
@@ -698,6 +714,7 @@ impl Scene {
                     Fill::NonZero,
                     paint,
                     ctx.aliasing_threshold,
+                    CoverageContrast::NONE,
                 );
             }
         });

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -23,7 +23,7 @@ use vello_common::geometry::{RectU16, SizeU16};
 use vello_common::kurbo::{Affine, BezPath, Rect, Shape, Stroke};
 use vello_common::mask::Mask;
 use vello_common::multi_atlas::AtlasConfig;
-use vello_common::paint::{Paint, PaintType, Tint};
+use vello_common::paint::{CoverageContrast, Paint, PaintType, Tint};
 #[cfg(feature = "text")]
 use vello_common::peniko::FontData;
 use vello_common::peniko::color::palette::css::BLACK;
@@ -223,6 +223,10 @@ pub struct Scene {
     pub(crate) strip_storage: RefCell<StripStorage>,
     /// Current filter effect applied to individual draw operations.
     filter: Option<Filter>,
+    /// Coverage transfer applied to atlas-cached glyph coverage. A
+    /// renderer-wide display policy, so it lives outside [`RenderState`] and
+    /// survives `reset`, `save_state` and `restore_state`.
+    glyph_coverage_contrast: CoverageContrast,
     /// The command recorder.
     pub(crate) recorder: CommandRecorder<RecordedDraw>,
 }
@@ -246,6 +250,7 @@ impl Scene {
             paint_visible: true,
             strip_storage: RefCell::new(StripStorage::new(GenerationMode::Append)),
             filter: None,
+            glyph_coverage_contrast: CoverageContrast::NONE,
             recorder: CommandRecorder::new(width, height),
         }
     }
@@ -874,6 +879,21 @@ impl Scene {
     /// Set the tint for subsequent image paint operations.
     pub fn set_tint(&mut self, tint: Option<Tint>) {
         self.render_state.tint = tint;
+    }
+
+    /// Set the coverage transfer applied to atlas-cached glyph coverage.
+    ///
+    /// Defaults to [`CoverageContrast::NONE`], which is bit-exact with
+    /// rendering that predates the setting. A display policy rather than a
+    /// paint attribute: unaffected by `reset`, `save_state` and
+    /// `restore_state`.
+    pub fn set_glyph_coverage_contrast(&mut self, contrast: CoverageContrast) {
+        self.glyph_coverage_contrast = contrast;
+    }
+
+    /// The coverage transfer applied to atlas-cached glyph coverage.
+    pub fn glyph_coverage_contrast(&self) -> CoverageContrast {
+        self.glyph_coverage_contrast
     }
 
     /// Clear the tint, so subsequent image paints are drawn without tinting.

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -23,7 +23,7 @@ use vello_common::geometry::{RectU16, SizeU16};
 use vello_common::kurbo::{Affine, BezPath, Rect, Shape, Stroke};
 use vello_common::mask::Mask;
 use vello_common::multi_atlas::AtlasConfig;
-use vello_common::paint::{Paint, PaintType, Tint};
+use vello_common::paint::{CoverageContrast, Paint, PaintType, Tint};
 #[cfg(feature = "text")]
 use vello_common::peniko::FontData;
 use vello_common::peniko::color::palette::css::BLACK;
@@ -223,6 +223,10 @@ pub struct Scene {
     pub(crate) strip_storage: RefCell<StripStorage>,
     /// Current filter effect applied to individual draw operations.
     filter: Option<Filter>,
+    /// Coverage transfer applied to atlas-cached glyph coverage. A
+    /// renderer-wide display policy, so it lives outside [`RenderState`] and
+    /// survives `reset`, `save_state` and `restore_state`.
+    glyph_coverage_contrast: CoverageContrast,
     /// The command recorder.
     pub(crate) recorder: CommandRecorder<RecordedDraw>,
 }
@@ -250,6 +254,7 @@ impl Scene {
             paint_visible: true,
             strip_storage: RefCell::new(StripStorage::new(GenerationMode::Append)),
             filter: None,
+            glyph_coverage_contrast: CoverageContrast::NONE,
             recorder: CommandRecorder::new(width, height),
         }
     }
@@ -824,6 +829,21 @@ impl Scene {
     /// Set the tint for subsequent image paint operations.
     pub fn set_tint(&mut self, tint: Option<Tint>) {
         self.render_state.tint = tint;
+    }
+
+    /// Set the coverage transfer applied to atlas-cached glyph coverage.
+    ///
+    /// Defaults to [`CoverageContrast::NONE`], which is bit-exact with
+    /// rendering that predates the setting. A display policy rather than a
+    /// paint attribute: unaffected by `reset`, `save_state` and
+    /// `restore_state`.
+    pub fn set_glyph_coverage_contrast(&mut self, contrast: CoverageContrast) {
+        self.glyph_coverage_contrast = contrast;
+    }
+
+    /// The coverage transfer applied to atlas-cached glyph coverage.
+    pub fn glyph_coverage_contrast(&self) -> CoverageContrast {
+        self.glyph_coverage_contrast
     }
 
     /// Clear the tint, so subsequent image paints are drawn without tinting.

--- a/sparse_strips/vello_hybrid/src/text.rs
+++ b/sparse_strips/vello_hybrid/src/text.rs
@@ -316,6 +316,11 @@ impl glifo::GlyphRenderer for Scene {
     }
 
     #[inline]
+    fn glyph_coverage_contrast(&self) -> vello_common::paint::CoverageContrast {
+        Self::glyph_coverage_contrast(self)
+    }
+
+    #[inline]
     fn get_context_color(&self) -> AlphaColor<Srgb> {
         let paint = self.paint().clone();
         match paint {

--- a/sparse_strips/vello_hybrid/src/text.rs
+++ b/sparse_strips/vello_hybrid/src/text.rs
@@ -321,6 +321,15 @@ impl glifo::GlyphRenderer for Scene {
     }
 
     #[inline]
+    fn fill_glyph_path(
+        &mut self,
+        path: &BezPath,
+        coverage_transfer: vello_common::paint::CoverageContrast,
+    ) {
+        self.fill_path_with_coverage_transfer(path, coverage_transfer);
+    }
+
+    #[inline]
     fn get_context_color(&self) -> AlphaColor<Srgb> {
         let paint = self.paint().clone();
         match paint {

--- a/sparse_strips/vello_sparse_shaders/shaders/helpers/image.wesl
+++ b/sparse_strips/vello_sparse_shaders/shaders/helpers/image.wesl
@@ -16,6 +16,12 @@ const IMAGE_SOURCE_EXTERNAL: u32 = 1u;
 const TINT_MODE_ALPHA_MASK: u32 = 0u;
 const TINT_MODE_MULTIPLY: u32 = 1u;
 
+/// Bit positions of the coverage-contrast strengths within texel2.z. Must
+/// match `GPU_TINT_CONTRAST_SHIFT` / `GPU_TINT_WEIGHT_SHIFT` in
+/// `vello_hybrid/src/render/common.rs`.
+const TINT_CONTRAST_SHIFT: u32 = 8u;
+const TINT_WEIGHT_SHIFT: u32 = 16u;
+
 // Encoded image layout. Must match `GpuEncodedImage` in `vello_hybrid/src/render/common.rs`.
 //
 // texel0.x: image_params
@@ -29,8 +35,22 @@ const TINT_MODE_MULTIPLY: u32 = 1u;
 // texel0.w/texel1.x/texel1.y/texel1.z: transform matrix [a, b, c, d]
 // texel1.w/texel2.x: translation [tx, ty]
 // texel2.y: premultiplied tint color packed as RGBA8 unorm
-// texel2.z: GPU tint mode
+// texel2.z: tint mode in bits 0-7, coverage-contrast strength in bits 8-15,
+//           coverage-weight strength in bits 16-23
 // texel2.w: transparent padding pixels around the image in the atlas
+
+/// Tint mode, from the low byte of texel2.z.
+fn get_image_tint_mode(texel2: vec4<u32>) -> u32 { return texel2.z & 0xFFu; }
+
+/// Coverage-contrast steepening strength in [0, 255]; 0 disables the term.
+fn get_image_tint_contrast(texel2: vec4<u32>) -> u32 {
+    return (texel2.z >> TINT_CONTRAST_SHIFT) & 0xFFu;
+}
+
+/// Coverage-contrast weight strength in [0, 255]; 0 disables the term.
+fn get_image_tint_weight(texel2: vec4<u32>) -> u32 {
+    return (texel2.z >> TINT_WEIGHT_SHIFT) & 0xFFu;
+}
 
 /// The rendering quality of the image.
 fn get_image_quality(texel0: vec4<u32>) -> u32 { return texel0.x & 0x3u; }

--- a/sparse_strips/vello_sparse_shaders/shaders/render.wesl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render.wesl
@@ -53,6 +53,9 @@ import package::helpers::image::{
     get_image_quality,
     get_image_size,
     get_image_source_kind,
+    get_image_tint_contrast,
+    get_image_tint_mode,
+    get_image_tint_weight,
     get_image_transform,
     get_image_translate
 };
@@ -405,7 +408,9 @@ fn fs_main(
             let image_padding = get_image_padding(image_texel2);
             let packed_tint = image_texel2.y;
             let image_tint = unpack4x8unorm(packed_tint);
-            let is_multiply = image_texel2.z == TINT_MODE_MULTIPLY;
+            let is_multiply = get_image_tint_mode(image_texel2) == TINT_MODE_MULTIPLY;
+            let tint_contrast = get_image_tint_contrast(image_texel2);
+            let tint_weight = get_image_tint_weight(image_texel2);
             let local_xy = sample_xy - image_offset;
             // This offset doesn't exist in vello_cpu, and we use it because 45 degree skewing seems to cause
             // artifacts on the GPU. We have something similar in place for gradients. It might be worth revisiting
@@ -461,8 +466,12 @@ fn fs_main(
                 );
             }
 
+            // In alpha-mask mode the sampled alpha is a coverage channel, so
+            // it may be contrast-enhanced before tinting. `alpha` (the strip
+            // coverage) is the quad's own anti-aliased edge and is not.
+            let mask_alpha = apply_coverage_contrast(sample_color.a, tint_contrast, tint_weight);
             final_color = alpha * select(
-                image_tint * sample_color.a,
+                image_tint * mask_alpha,
                 sample_color * image_tint,
                 is_multiply
             );
@@ -568,6 +577,24 @@ fn fs_main(
     }
 
     return final_color;
+}
+
+// Coverage transfer for alpha-mask (glyph) coverage:
+//
+//   a' = a + c * a * (1 - a) * (2a - 1)   // steepen
+//          + w * a * (1 - a)              // weight bias
+//
+// The wire satisfies c + w <= 255 (`CoverageContrast::from_bits` caps the
+// weight), under which the curve is monotone within [0, 1] — no clamp needed.
+// Must stay in sync with `CoverageContrast::apply` in vello_common and with
+// vello_cpu's fine stages: same expression, same order.
+fn apply_coverage_contrast(coverage: f32, contrast: u32, weight: u32) -> f32 {
+    if (contrast | weight) == 0u {
+        return coverage;
+    }
+    let c = f32(contrast) * (1.0 / 255.0);
+    let w = f32(weight) * (1.0 / 255.0);
+    return coverage + c * coverage * (1.0 - coverage) * (2.0 * coverage - 1.0) + w * coverage * (1.0 - coverage);
 }
 
 // Convert a flat texel index to 2D texture coordinates for the encoded paints texture.

--- a/sparse_strips/vello_sparse_shaders/shaders/render.wesl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render.wesl
@@ -381,7 +381,9 @@ fn fs_main(
             // When packed_tint is zero (no tint), use identity color vec4(1.0) with
             // Multiply mode so the math reduces to sample_color * 1.0 = sample_color.
             let image_tint = select(vec4<f32>(1.0), unpack4x8unorm(packed_tint), has_tint);
-            let is_multiply = !has_tint || image_texel2.z != TINT_MODE_ALPHA_MASK;
+            let is_multiply = !has_tint || get_image_tint_mode(image_texel2) != TINT_MODE_ALPHA_MASK;
+            let tint_contrast = get_image_tint_contrast(image_texel2);
+            let tint_weight = get_image_tint_weight(image_texel2);
             let local_xy = sample_xy - image_offset;
             // This offset doesn't exist in vello_cpu, and we use it because 45 degree skewing seems to cause
             // artifacts on the GPU. We have something similar in place for gradients. It might be worth revisiting
@@ -436,8 +438,12 @@ fn fs_main(
                 );
             }
 
+            // In alpha-mask mode the sampled alpha is a coverage channel, so
+            // it may be contrast-enhanced before tinting. `alpha` (the strip
+            // coverage) is the quad's own anti-aliased edge and is not.
+            let mask_alpha = apply_coverage_contrast(sample_color.a, tint_contrast, tint_weight);
             final_color = alpha * select(
-                image_tint * sample_color.a,
+                image_tint * mask_alpha,
                 sample_color * image_tint,
                 is_multiply
             );
@@ -546,6 +552,30 @@ fn fs_main(
 const TINT_MODE_ALPHA_MASK: u32 = 0u;
 const TINT_MODE_MULTIPLY: u32 = 1u;
 
+/// Bit positions of the coverage-contrast strengths within texel2.z. Must
+/// match `GPU_TINT_CONTRAST_SHIFT` / `GPU_TINT_WEIGHT_SHIFT` in
+/// `vello_hybrid/src/render/common.rs`.
+const TINT_CONTRAST_SHIFT: u32 = 8u;
+const TINT_WEIGHT_SHIFT: u32 = 16u;
+
+// Coverage transfer for alpha-mask (glyph) coverage:
+//
+//   a' = a + c * a * (1 - a) * (2a - 1)   // steepen
+//          + w * a * (1 - a)              // weight bias
+//
+// The wire satisfies c + w <= 255 (`CoverageContrast::from_bits` caps the
+// weight), under which the curve is monotone within [0, 1] — no clamp needed.
+// Must stay in sync with `CoverageContrast::apply` in vello_common and with
+// vello_cpu's fine stages: same expression, same order.
+fn apply_coverage_contrast(coverage: f32, contrast: u32, weight: u32) -> f32 {
+    if (contrast | weight) == 0u {
+        return coverage;
+    }
+    let c = f32(contrast) * (1.0 / 255.0);
+    let w = f32(weight) * (1.0 / 255.0);
+    return coverage + c * coverage * (1.0 - coverage) * (2.0 * coverage - 1.0) + w * coverage * (1.0 - coverage);
+}
+
 // Convert a flat texel index to 2D texture coordinates for the encoded paints texture.
 fn encoded_paint_coord(flat_idx: u32) -> vec2<u32> {
     return vec2<u32>(
@@ -575,8 +605,23 @@ fn load_encoded_paint_texel(paint_tex_idx: u32, texel_offset: u32) -> vec4<u32> 
 // texel0.w/texel1.x/texel1.y/texel1.z: transform matrix [a, b, c, d]
 // texel1.w/texel2.x: translation [tx, ty]
 // texel2.y: premultiplied tint color packed as RGBA8 unorm; 0 means no tint
-// texel2.z: tint mode, only meaningful when texel2.y != 0
+// texel2.z: tint mode in bits 0-7, coverage-contrast strength in bits 8-15,
+//           coverage-weight strength in bits 16-23; only meaningful when
+//           texel2.y != 0
 // texel2.w: transparent padding pixels around the image in the atlas
+
+/// Tint mode, from the low byte of texel2.z.
+fn get_image_tint_mode(texel2: vec4<u32>) -> u32 { return texel2.z & 0xFFu; }
+
+/// Coverage-contrast steepening strength in [0, 255]; 0 disables the term.
+fn get_image_tint_contrast(texel2: vec4<u32>) -> u32 {
+    return (texel2.z >> TINT_CONTRAST_SHIFT) & 0xFFu;
+}
+
+/// Coverage-contrast weight strength in [0, 255]; 0 disables the term.
+fn get_image_tint_weight(texel2: vec4<u32>) -> u32 {
+    return (texel2.z >> TINT_WEIGHT_SHIFT) & 0xFFu;
+}
 
 /// The rendering quality of the image.
 fn get_image_quality(texel0: vec4<u32>) -> u32 { return texel0.x & 0x3u; }

--- a/sparse_strips/vello_sparse_tests/snapshots/image_spritesheet_tinted_coverage_contrast.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/image_spritesheet_tinted_coverage_contrast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c794d68dc36cf46c94331289dbd6b4838c1c9c9e78a7c029e709298fd79ab4f2
+size 556

--- a/sparse_strips/vello_sparse_tests/snapshots/image_spritesheet_tinted_coverage_contrast_weight.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/image_spritesheet_tinted_coverage_contrast_weight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48a575e2cfcbeaa0231639d8cdd9ddfe7b20a50e3809fabb77183ad58780b7b7
+size 548

--- a/sparse_strips/vello_sparse_tests/tests/external_texture.rs
+++ b/sparse_strips/vello_sparse_tests/tests/external_texture.rs
@@ -9,7 +9,7 @@ mod tests {
     use vello_common::filter_effects::{EdgeMode, Filter, FilterPrimitive};
     use vello_common::geometry::RectU16;
     use vello_common::kurbo::{Affine, Circle, Rect, Shape};
-    use vello_common::paint::{Image, ImageSource, Tint, TintMode};
+    use vello_common::paint::{CoverageContrast, Image, ImageSource, Tint, TintMode};
     use vello_common::peniko::{Color, Extend, ImageQuality, ImageSampler};
     use vello_common::pixmap::Pixmap;
     use vello_dev_macros::vello_test;
@@ -265,6 +265,7 @@ mod tests {
         ctx.set_tint(Some(Tint {
             color: Color::from_rgba8(128, 102, 204, 160),
             mode: TintMode::Multiply,
+            contrast: CoverageContrast::NONE,
         }));
         ctx.draw_texture_rect(texture_rect(tint_source, 16., 38., 68., 24., false));
         ctx.draw_texture_rect(texture_rect(tint_source, 38., 16., 24., 68., false));

--- a/sparse_strips/vello_sparse_tests/tests/glyph.rs
+++ b/sparse_strips/vello_sparse_tests/tests/glyph.rs
@@ -1093,3 +1093,72 @@ fn glyphs_decoration_transformed(ctx: &mut impl Renderer, enable_caching: bool) 
         y += buffer;
     }
 }
+
+/// A solid-painted outline glyph must look the same whether it is rendered
+/// from the atlas (transfer applied to the sampled coverage at tint time) or
+/// directly from its outline (transfer applied to the generated coverage at
+/// fill time). Regression test for the direct path keeping linear coverage,
+/// which made a glyph render softer whenever it bypassed the atlas and change
+/// appearance once cached.
+#[cfg(not(target_arch = "wasm32"))]
+#[test]
+fn coverage_contrast_consistent_between_cached_and_direct_glyphs() {
+    use vello_common::paint::CoverageContrast;
+    use vello_cpu::{RasterizerSettings, RenderContext, RenderMode, Resources};
+
+    const W: u16 = 60;
+    const H: u16 = 60;
+    let font_size = 40_f32;
+
+    let render = |atlas_cache: bool, contrast: CoverageContrast| -> Pixmap {
+        // A single glyph at an integer position: subpixel quantization in the
+        // atlas key would otherwise shift the cached rasterization relative to
+        // the direct one and mask the property under test.
+        let (font, glyphs) = layout_glyphs_roboto("H", font_size);
+        let mut ctx = RenderContext::new(W, H);
+        let mut resources = Resources::new();
+        ctx.set_glyph_coverage_contrast(contrast);
+        ctx.set_paint(REBECCA_PURPLE);
+        ctx.set_transform(Affine::translate((10.0, 50.0)));
+        ctx.glyph_run(&mut resources, &font)
+            .font_size(font_size)
+            .atlas_cache(atlas_cache)
+            .hint(false)
+            .fill_glyphs(glyphs.into_iter());
+        ctx.flush();
+        let mut pixmap = Pixmap::new(W, H);
+        ctx.render_with(
+            &mut pixmap,
+            &mut resources,
+            RasterizerSettings {
+                // The u8 pipeline applies `apply_u8` on both paths, so cached
+                // and direct rendering agree bit-for-bit.
+                render_mode: RenderMode::OptimizeSpeed,
+                ..Default::default()
+            },
+        );
+        pixmap
+    };
+
+    let contrast = CoverageContrast::from_strength(0.8).with_weight_strength(0.3);
+    let baseline = render(false, CoverageContrast::NONE);
+    let direct = render(false, contrast);
+    let cached = render(true, contrast);
+
+    assert!(
+        direct.data_as_u8_slice() != baseline.data_as_u8_slice(),
+        "the transfer must engage on the direct (uncached) glyph path"
+    );
+
+    let max_diff = cached
+        .data_as_u8_slice()
+        .iter()
+        .zip(direct.data_as_u8_slice())
+        .map(|(a, b)| a.abs_diff(*b))
+        .max()
+        .unwrap();
+    assert!(
+        max_diff <= 1,
+        "cached and direct glyph rendering diverged: max channel diff {max_diff}"
+    );
+}

--- a/sparse_strips/vello_sparse_tests/tests/image.rs
+++ b/sparse_strips/vello_sparse_tests/tests/image.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use vello_common::color::palette::css::REBECCA_PURPLE;
 use vello_common::kurbo::{Affine, Point, Rect};
 use vello_common::kurbo::{Shape, Triangle};
-use vello_common::paint::{Image, ImageSource, Tint, TintMode};
+use vello_common::paint::{CoverageContrast, Image, ImageSource, Tint, TintMode};
 use vello_common::peniko::Color;
 use vello_common::peniko::ImageSampler;
 use vello_common::peniko::{BlendMode, Compose, Extend, ImageQuality, Mix};
@@ -690,7 +690,15 @@ fn image_spritesheet(ctx: &mut impl Renderer) {
     let mut cursor_x = start_x;
 
     for glyph in HELLO_WORLD {
-        render_sprite(ctx, &atlas_src, glyph, cursor_x, start_y, None);
+        render_sprite(
+            ctx,
+            &atlas_src,
+            glyph,
+            cursor_x,
+            start_y,
+            None,
+            CoverageContrast::NONE,
+        );
         cursor_x += glyph.width;
     }
 }
@@ -703,10 +711,12 @@ fn render_sprite(
     screen_x: f64,
     screen_y: f64,
     tint: Option<Color>,
+    contrast: CoverageContrast,
 ) {
     ctx.set_tint(tint.map(|color| Tint {
         color,
         mode: TintMode::AlphaMask,
+        contrast,
     }));
     ctx.set_transform(Affine::translate((screen_x, screen_y + glyph.y_offset)));
     ctx.set_paint_transform(Affine::translate((-glyph.atlas_x, -glyph.atlas_y)));
@@ -741,6 +751,60 @@ fn image_spritesheet_tinted(ctx: &mut impl Renderer) {
             cursor_x,
             start_y,
             Some(REBECCA_PURPLE),
+            CoverageContrast::NONE,
+        );
+        cursor_x += glyph.width;
+    }
+}
+
+/// Same as `image_spritesheet_tinted`, with the coverage-contrast steepening
+/// term enabled. Pins the fine-stage kernels and the shader's strength
+/// readers against the reference curve for a non-`NONE` contrast.
+#[vello_test(width = 60, height = 30, skip_multithreaded)]
+fn image_spritesheet_tinted_coverage_contrast(ctx: &mut impl Renderer) {
+    let atlas_id = ctx.register_image(load_image!("glyph_atlas"));
+    let atlas_src = ImageSource::opaque_id(atlas_id);
+
+    let start_x = 10.0;
+    let start_y = 8.0;
+
+    let mut cursor_x = start_x;
+
+    for glyph in HELLO_WORLD {
+        render_sprite(
+            ctx,
+            &atlas_src,
+            glyph,
+            cursor_x,
+            start_y,
+            Some(REBECCA_PURPLE),
+            CoverageContrast::from_strength(0.6),
+        );
+        cursor_x += glyph.width;
+    }
+}
+
+/// Both curve terms enabled: steepening plus the weight bias. Pins the
+/// weight byte's position in the packed tint word on the GPU path.
+#[vello_test(width = 60, height = 30, skip_multithreaded)]
+fn image_spritesheet_tinted_coverage_contrast_weight(ctx: &mut impl Renderer) {
+    let atlas_id = ctx.register_image(load_image!("glyph_atlas"));
+    let atlas_src = ImageSource::opaque_id(atlas_id);
+
+    let start_x = 10.0;
+    let start_y = 8.0;
+
+    let mut cursor_x = start_x;
+
+    for glyph in HELLO_WORLD {
+        render_sprite(
+            ctx,
+            &atlas_src,
+            glyph,
+            cursor_x,
+            start_y,
+            Some(REBECCA_PURPLE),
+            CoverageContrast::from_strength(0.5).with_weight_strength(0.4),
         );
         cursor_x += glyph.width;
     }
@@ -761,6 +825,7 @@ fn image_fully_transparent_tint(ctx: &mut impl Renderer) {
         ctx.set_tint(Some(Tint {
             color: Color::from_rgba8(255, 255, 255, 0),
             mode,
+            contrast: CoverageContrast::NONE,
         }));
         ctx.set_paint(image.clone());
         ctx.fill_rect(&Rect::new(0.0, 0.0, 10.0, 10.0));

--- a/sparse_strips/vello_sparse_tests/tests/image.rs
+++ b/sparse_strips/vello_sparse_tests/tests/image.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use vello_common::color::palette::css::REBECCA_PURPLE;
 use vello_common::kurbo::{Affine, Point, Rect};
 use vello_common::kurbo::{Shape, Triangle};
-use vello_common::paint::{Image, ImageSource, Tint, TintMode};
+use vello_common::paint::{CoverageContrast, Image, ImageSource, Tint, TintMode};
 use vello_common::peniko::Color;
 use vello_common::peniko::ImageSampler;
 use vello_common::peniko::{BlendMode, Compose, Extend, ImageQuality, Mix};
@@ -671,7 +671,15 @@ fn image_spritesheet(ctx: &mut impl Renderer) {
     let mut cursor_x = start_x;
 
     for glyph in HELLO_WORLD {
-        render_sprite(ctx, &atlas_src, glyph, cursor_x, start_y, None);
+        render_sprite(
+            ctx,
+            &atlas_src,
+            glyph,
+            cursor_x,
+            start_y,
+            None,
+            CoverageContrast::NONE,
+        );
         cursor_x += glyph.width;
     }
 }
@@ -684,10 +692,12 @@ fn render_sprite(
     screen_x: f64,
     screen_y: f64,
     tint: Option<Color>,
+    contrast: CoverageContrast,
 ) {
     ctx.set_tint(tint.map(|color| Tint {
         color,
         mode: TintMode::AlphaMask,
+        contrast,
     }));
     ctx.set_transform(Affine::translate((screen_x, screen_y + glyph.y_offset)));
     ctx.set_paint_transform(Affine::translate((-glyph.atlas_x, -glyph.atlas_y)));
@@ -722,6 +732,60 @@ fn image_spritesheet_tinted(ctx: &mut impl Renderer) {
             cursor_x,
             start_y,
             Some(REBECCA_PURPLE),
+            CoverageContrast::NONE,
+        );
+        cursor_x += glyph.width;
+    }
+}
+
+/// Same as `image_spritesheet_tinted`, with the coverage-contrast steepening
+/// term enabled. Pins the fine-stage kernels and the shader's strength
+/// readers against the reference curve for a non-`NONE` contrast.
+#[vello_test(width = 60, height = 30, skip_multithreaded)]
+fn image_spritesheet_tinted_coverage_contrast(ctx: &mut impl Renderer) {
+    let atlas_id = ctx.register_image(load_image!("glyph_atlas"));
+    let atlas_src = ImageSource::opaque_id(atlas_id);
+
+    let start_x = 10.0;
+    let start_y = 8.0;
+
+    let mut cursor_x = start_x;
+
+    for glyph in HELLO_WORLD {
+        render_sprite(
+            ctx,
+            &atlas_src,
+            glyph,
+            cursor_x,
+            start_y,
+            Some(REBECCA_PURPLE),
+            CoverageContrast::from_strength(0.6),
+        );
+        cursor_x += glyph.width;
+    }
+}
+
+/// Both curve terms enabled: steepening plus the weight bias. Pins the
+/// weight byte's position in the packed tint word on the GPU path.
+#[vello_test(width = 60, height = 30, skip_multithreaded)]
+fn image_spritesheet_tinted_coverage_contrast_weight(ctx: &mut impl Renderer) {
+    let atlas_id = ctx.register_image(load_image!("glyph_atlas"));
+    let atlas_src = ImageSource::opaque_id(atlas_id);
+
+    let start_x = 10.0;
+    let start_y = 8.0;
+
+    let mut cursor_x = start_x;
+
+    for glyph in HELLO_WORLD {
+        render_sprite(
+            ctx,
+            &atlas_src,
+            glyph,
+            cursor_x,
+            start_y,
+            Some(REBECCA_PURPLE),
+            CoverageContrast::from_strength(0.5).with_weight_strength(0.4),
         );
         cursor_x += glyph.width;
     }


### PR DESCRIPTION
## Summary

Adds `CoverageContrast`, an opt-in coverage transfer applied to alpha-mask tints (glyph coverage) before tinting:

```
a' = a + c·a(1−a)(2a−1)   // steepen: lerp(identity, smoothstep)
       + w·a(1−a)         // weight bias: raises the 0.5 crossing by w/4
```

The default is bit-exact off: every consumer branches on `is_none()` before evaluating any new math, so existing output does not change by a single byte unless a renderer opts in via `RenderContext::set_glyph_coverage_contrast` / `Scene::set_glyph_coverage_contrast`.

## Motivation

Vello's analytic coverage is the exact area of the pixel square covered by the outline — at a straight edge, a linear ramp with slope exactly 1.0 alpha/px. That is the correct answer to "how much of this pixel is ink," but it is not what any mainstream text stack displays: every one of them deliberately steepens (and, in some regimes, thickens) the transition, because the exact ramp reads as slightly soft, most visibly on low-DPI displays.

This gap is called out in Vello's own planning documents:

- [vision.md, "Improving rendering quality"](https://github.com/linebender/vello/blob/main/doc/vision.md): *"a theoretically 'correct' approach to gamma often yields text and hairline strokes that appear weak and spindly … it's likely that various heuristics will need to be applied to get good results. (Note that stem darkening is one approach used specifically for text rendering …)"*
- [Plan for glyph rendering #204](https://github.com/linebender/vello/issues/204) notes the initial glyph strategy supports neither hinting-adjacent contrast boosts nor stem darkening, with results "suboptimal on low-dpi displays."
- The theme goes back to [*A crate I want: 2d graphics* (2018)](https://raphlinus.github.io/rust/graphics/2018/10/11/2d-graphics.html): *"to match high quality desktop rendering both RGB subpixel rendering and gamma correct blending is desirable."*

This PR is a small, opt-in implementation of exactly that predicted heuristic, in the factoring that fits the sparse-strips architecture.

## Relation to the stem-darkening roadmap thread

[roadmap_2023.md](https://github.com/linebender/vello/blob/main/doc/roadmap_2023.md) and [*Raph's reflections and wishes for 2023*](https://raphlinus.github.io/personal/2022/12/31/raph-2023.html) proposed solving stem darkening geometrically, via a combined flatten + offset operation — *"the same mechanism can apply stroke thickening to glyphs while retaining very high quality."* The geometric half of that vision has since landed: `kurbo::expand_path` plus glifo's `FontEmbolden` (#1628).

This PR adds the complementary coverage-space half, and the two compose rather than compete:

- `FontEmbolden` offsets outlines in em space, can add arbitrary weight, and participates in the glyph cache key — correct for a *global* weight change, but a *per-text-color* weight (see polarity below) would rasterize and cache every glyph once per color class.
- The `w` term here is a sub-pixel, device-space adjustment to *sampled* coverage at fine/shader time — bounded by a fraction of a pixel, matched to the per-pixel blending artifact it corrects, and free to vary per draw: light and dark text share one cached rasterization at zero atlas churn.

## Prior art in other renderers

| Renderer | Mechanism | Relation to this PR |
|---|---|---|
| Skia | `SkMaskGamma`: mask contrast `a + k·a(1−a)` plus luminance-dependent gamma LUTs | the `w` term is exactly Skia's contrast form, minus the LUTs (see below) |
| DirectWrite | enhanced contrast `a(k+1)/(ak+1)`, `k` gated by text luminance (visible in [Windows Terminal's](https://github.com/microsoft/terminal/blob/main/src/renderer/atlas/dwrite_helpers.hlsl) and [Zed's](https://github.com/zed-industries/zed/blob/main/crates/gpui_windows/src/alpha_correction.hlsl) shaders) | same family to first order; its gate boosts *dark* text because DWrite's blend model is gamma-corrected — in an sRGB-blending renderer the boost belongs on *light* text, which is the direction implemented here |
| FreeType / CoreText | stem darkening / font smoothing: geometric outline emboldening | the geometric complement; already available via `FontEmbolden` |
| Qt Quick (distance-field text) | `smoothstep` over a constant 1.2 device-px band → peak slope 1.25 alpha/px | `c = 0.5` reproduces its output to within one 8-bit level across the core of the edge ramp |

The polarity rationale for `w`: compositing in sRGB-encoded space (which vello_cpu/vello_hybrid do) decodes a half-covered pixel darker than the physically correct blend — dark-on-light text reads slightly bolder, light-on-dark slightly thinner. `resolve_for_color` scales the stored `w` by the text color's approximate relative luminance, so black text keeps the weight-free curve bit-exactly and white text receives the full stored strength.

Compared to the Skia/DWrite implementations, the factoring here is deliberately simpler and colorspace-agnostic: one closed-form curve on coverage *before* tinting, no baked LUTs coupled to a destination gamma, CPU and GPU evaluating identical 8-bit-quantized parameters.

## Design notes

- **Provable invariant instead of per-pixel clamps.** With `t = a − ½` the derivative is `1 + c/2 − 6c·t² − 2w·t`, concave, minimized at `a = 1` where it equals `1 − c − w`. `from_bits` therefore caps `w` at the contrast's headroom (`c + w ≤ 1`); under that invariant the curve is monotone with range [0, 1], so none of the three kernels needs a clamp.
- **Bit-exactness guarantees.** `NONE` is a branch, not neutral math; and `w = 0` leaves `c`-only output bit-identical because the appended weight term is exactly `+0.0`. Both are pinned by tests.
- **Wire format.** The packed tint mode word carries the strengths in bits 8–23; `NONE` contributes zero bits, so paints that don't opt in encode byte-identically. The previously whole-word shader mode compare is masked accordingly.
- **glifo integration.** A default-implemented `GlyphRenderer::glyph_coverage_contrast` hook; the atlas outline-glyph path stamps the luminance-resolved value. Bitmap/COLR glyphs (own color, no coverage mask) and atlas-miss outline fills (linear coverage) are unaffected — the latter is a documented limitation shared with hinting and subpixel-offset bucketing.

## What this deliberately does not attempt

- **Gamma-correct (linear) blending** — vision.md's own caution applies: linear blending makes text spindly *without* compensation, so it is a much larger, coupled change. This curve is compatible with such a future: it operates on coverage pre-tint, so only the calibration constant would move.
- **RGB subpixel rendering** — incompatible with transparent-layer compositing, as the roadmap notes.
- **Backdrop-aware correction** — the backdrop is unknowable at paint time in a compositing renderer; the same limitation applies to Skia and DirectWrite.

## Testing

- `vello_common/tests/coverage_contrast.rs`: property tests for bit-exact identity, fixed endpoints, symmetry of the `c` term, exhaustive monotonicity/range sweeps (including dense probing at the capped boundary where the derivative vanishes), the headroom cap, the Skia-form equivalence of the `w` term, luminance resolution (endpoints, gray = ¼, Rec. 709 ordering, NaN/out-of-range handling), and u8/f32 agreement.
- `pack_tint` unit test pinning the wire layout.
- Two new cross-backend snapshot tests (`c`-only and `c + w`) through the existing spritesheet-tint harness, so the CPU fine stages and the WESL shader are pinned against the same references.
- `cargo fmt`, `clippy --all-targets`, and rustdoc are clean.

## Breaking change

`Tint` gained a `contrast` field (`CoverageContrast::NONE` preserves the previous behavior); changelog entries note it under "Changed" for `vello_common` and "Added" for `vello_cpu`, `vello_hybrid`, and `glifo`.

<sup>This PR was generated by Claude</sup>
