### PR TITLE
vello_hybrid: Properly handle tints with opacity 0

### DIFF
--- a/sparse_strips/vello_hybrid/src/render/common.rs
+++ b/sparse_strips/vello_hybrid/src/render/common.rs
@@ -597,7 +597,7 @@ pub(crate) fn pack_image_params(
 /// Pack an optional [`Tint`](vello_common::paint::Tint) into a (`tint_color_u32`, `tint_mode_u32`) pair for the GPU.
 ///
 /// The tint color is premultiplied before packing into a u32 in the same layout
-/// as WGSL `pack4x8unorm`. No tint is encoded as opaque white in multiply mode.
+/// as WGSL `pack4x8unorm`.
 #[inline(always)]
 pub(crate) fn pack_tint(tint: Option<vello_common::paint::Tint>) -> (u32, u32) {
     match tint {

--- a/sparse_strips/vello_hybrid/src/render/common.rs
+++ b/sparse_strips/vello_hybrid/src/render/common.rs
@@ -594,26 +594,18 @@ pub(crate) fn pack_image_params(
     (atlas_index << 6) | (extend_y << 4) | (extend_x << 2) | quality
 }
 
-const GPU_TINT_MODE_NONE: u32 = 0;
-const GPU_TINT_MODE_ALPHA_MASK: u32 = 1;
-const GPU_TINT_MODE_MULTIPLY: u32 = 2;
-
 /// Pack an optional [`Tint`](vello_common::paint::Tint) into a (`tint_color_u32`, `tint_mode_u32`) pair for the GPU.
 ///
 /// The tint color is premultiplied before packing into a u32 in the same layout
-/// as WGSL `pack4x8unorm`.
+/// as WGSL `pack4x8unorm`. No tint is encoded as opaque white in multiply mode.
 #[inline(always)]
 pub(crate) fn pack_tint(tint: Option<vello_common::paint::Tint>) -> (u32, u32) {
     match tint {
         Some(t) => {
             let color = t.color.premultiply().to_rgba8().to_u32();
-            let mode = match t.mode {
-                vello_common::paint::TintMode::AlphaMask => GPU_TINT_MODE_ALPHA_MASK,
-                vello_common::paint::TintMode::Multiply => GPU_TINT_MODE_MULTIPLY,
-            };
-            (color, mode)
+            (color, t.mode.as_u32())
         }
-        None => (0, GPU_TINT_MODE_NONE),
+        None => (u32::MAX, vello_common::paint::TintMode::Multiply.as_u32()),
     }
 }
 

--- a/sparse_strips/vello_hybrid/src/render/common.rs
+++ b/sparse_strips/vello_hybrid/src/render/common.rs
@@ -439,9 +439,8 @@ pub(crate) struct GpuEncodedImage {
     /// Transform matrix [a, b, c, d, tx, ty].
     pub transform: [f32; 6],
     /// Premultiplied tint color packed as RGBA8 unorm (`pack4x8unorm` layout).
-    /// A value of `0` means no tint is applied.
     pub tint: u32,
-    /// [`TintMode`](vello_common::paint::TintMode) discriminant. Only meaningful when `tint != 0`.
+    /// GPU tint mode.
     pub tint_mode: u32,
     /// Number of transparent padding pixels around the image in the atlas.
     pub image_padding: u32,
@@ -595,19 +594,26 @@ pub(crate) fn pack_image_params(
     (atlas_index << 6) | (extend_y << 4) | (extend_x << 2) | quality
 }
 
+const GPU_TINT_MODE_NONE: u32 = 0;
+const GPU_TINT_MODE_ALPHA_MASK: u32 = 1;
+const GPU_TINT_MODE_MULTIPLY: u32 = 2;
+
 /// Pack an optional [`Tint`](vello_common::paint::Tint) into a (`tint_color_u32`, `tint_mode_u32`) pair for the GPU.
 ///
 /// The tint color is premultiplied before packing into a u32 in the same layout
-/// as WGSL `pack4x8unorm`. Returns `(0, 0)` when no tint is specified, which
-/// the shader interprets as "no tint".
+/// as WGSL `pack4x8unorm`.
 #[inline(always)]
 pub(crate) fn pack_tint(tint: Option<vello_common::paint::Tint>) -> (u32, u32) {
     match tint {
         Some(t) => {
             let color = t.color.premultiply().to_rgba8().to_u32();
-            (color, t.mode.as_u32())
+            let mode = match t.mode {
+                vello_common::paint::TintMode::AlphaMask => GPU_TINT_MODE_ALPHA_MASK,
+                vello_common::paint::TintMode::Multiply => GPU_TINT_MODE_MULTIPLY,
+            };
+            (color, mode)
         }
-        None => (0, 0),
+        None => (0, GPU_TINT_MODE_NONE),
     }
 }
 

--- a/sparse_strips/vello_hybrid/src/render/common.rs
+++ b/sparse_strips/vello_hybrid/src/render/common.rs
@@ -605,6 +605,9 @@ pub(crate) fn pack_tint(tint: Option<vello_common::paint::Tint>) -> (u32, u32) {
             let color = t.color.premultiply().to_rgba8().to_u32();
             (color, t.mode.as_u32())
         }
+        // With no tint, use `u32::MAX` (which corresponds to 1.0 on all lanes).
+        // Since we use `Multiply` this will essentially just yield the original image
+        // sample, having the same effect as no tinting at all.
         None => (u32::MAX, vello_common::paint::TintMode::Multiply.as_u32()),
     }
 }

--- a/sparse_strips/vello_sparse_shaders/shaders/render.wesl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render.wesl
@@ -377,11 +377,10 @@ fn fs_main(
             let image_source_kind = get_image_source_kind(image_texel0);
             let image_padding = get_image_padding(image_texel2);
             let packed_tint = image_texel2.y;
-            let has_tint = packed_tint != 0u;
-            // When packed_tint is zero (no tint), use identity color vec4(1.0) with
-            // Multiply mode so the math reduces to sample_color * 1.0 = sample_color.
+            let tint_mode = image_texel2.z;
+            let has_tint = tint_mode != TINT_MODE_NONE;
             let image_tint = select(vec4<f32>(1.0), unpack4x8unorm(packed_tint), has_tint);
-            let is_multiply = !has_tint || image_texel2.z != TINT_MODE_ALPHA_MASK;
+            let is_multiply = tint_mode != TINT_MODE_ALPHA_MASK;
             let local_xy = sample_xy - image_offset;
             // This offset doesn't exist in vello_cpu, and we use it because 45 degree skewing seems to cause
             // artifacts on the GPU. We have something similar in place for gradients. It might be worth revisiting
@@ -543,8 +542,9 @@ fn fs_main(
 }
 
 /// Tint mode constants.
-const TINT_MODE_ALPHA_MASK: u32 = 0u;
-const TINT_MODE_MULTIPLY: u32 = 1u;
+const TINT_MODE_NONE: u32 = 0u;
+const TINT_MODE_ALPHA_MASK: u32 = 1u;
+const TINT_MODE_MULTIPLY: u32 = 2u;
 
 // Convert a flat texel index to 2D texture coordinates for the encoded paints texture.
 fn encoded_paint_coord(flat_idx: u32) -> vec2<u32> {
@@ -574,8 +574,8 @@ fn load_encoded_paint_texel(paint_tex_idx: u32, texel_offset: u32) -> vec4<u32> 
 // texel0.z: image_offset, packed as [x:16, y:16]
 // texel0.w/texel1.x/texel1.y/texel1.z: transform matrix [a, b, c, d]
 // texel1.w/texel2.x: translation [tx, ty]
-// texel2.y: premultiplied tint color packed as RGBA8 unorm; 0 means no tint
-// texel2.z: tint mode, only meaningful when texel2.y != 0
+// texel2.y: premultiplied tint color packed as RGBA8 unorm
+// texel2.z: GPU tint mode
 // texel2.w: transparent padding pixels around the image in the atlas
 
 /// The rendering quality of the image.

--- a/sparse_strips/vello_sparse_shaders/shaders/render.wesl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render.wesl
@@ -377,10 +377,8 @@ fn fs_main(
             let image_source_kind = get_image_source_kind(image_texel0);
             let image_padding = get_image_padding(image_texel2);
             let packed_tint = image_texel2.y;
-            let tint_mode = image_texel2.z;
-            let has_tint = tint_mode != TINT_MODE_NONE;
-            let image_tint = select(vec4<f32>(1.0), unpack4x8unorm(packed_tint), has_tint);
-            let is_multiply = tint_mode != TINT_MODE_ALPHA_MASK;
+            let image_tint = unpack4x8unorm(packed_tint);
+            let is_multiply = image_texel2.z == TINT_MODE_MULTIPLY;
             let local_xy = sample_xy - image_offset;
             // This offset doesn't exist in vello_cpu, and we use it because 45 degree skewing seems to cause
             // artifacts on the GPU. We have something similar in place for gradients. It might be worth revisiting
@@ -542,9 +540,8 @@ fn fs_main(
 }
 
 /// Tint mode constants.
-const TINT_MODE_NONE: u32 = 0u;
-const TINT_MODE_ALPHA_MASK: u32 = 1u;
-const TINT_MODE_MULTIPLY: u32 = 2u;
+const TINT_MODE_ALPHA_MASK: u32 = 0u;
+const TINT_MODE_MULTIPLY: u32 = 1u;
 
 // Convert a flat texel index to 2D texture coordinates for the encoded paints texture.
 fn encoded_paint_coord(flat_idx: u32) -> vec2<u32> {

--- a/sparse_strips/vello_sparse_tests/snapshots/image_fully_transparent_tint.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/image_fully_transparent_tint.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56f57423e0ff37d0284ae02f3dfa6ceffad893302f86b5aa4d17dabb5ba1b25d
+size 82

--- a/sparse_strips/vello_sparse_tests/tests/external_texture.rs
+++ b/sparse_strips/vello_sparse_tests/tests/external_texture.rs
@@ -1,6 +1,8 @@
 // Copyright 2026 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+// TODO: Increase test coverage to cover things like tinted external textures, etc.
+
 #[cfg(not(all(target_arch = "wasm32", feature = "webgl")))]
 mod tests {
     use std::sync::Arc;

--- a/sparse_strips/vello_sparse_tests/tests/image.rs
+++ b/sparse_strips/vello_sparse_tests/tests/image.rs
@@ -726,3 +726,26 @@ fn image_spritesheet_tinted(ctx: &mut impl Renderer) {
         cursor_x += glyph.width;
     }
 }
+
+#[vello_test]
+fn image_fully_transparent_tint(ctx: &mut impl Renderer) {
+    let image_source = rgb_img_10x10(ctx);
+
+    for (x, mode) in [(0.0, TintMode::AlphaMask), (10.0, TintMode::Multiply)] {
+        ctx.set_transform(Affine::translate((x, 0.0)));
+        ctx.set_tint(Some(Tint {
+            color: Color::from_rgba8(255, 255, 255, 0),
+            mode,
+        }));
+        ctx.set_paint(Image {
+            image: image_source.clone(),
+            sampler: ImageSampler {
+                x_extend: Extend::Pad,
+                y_extend: Extend::Pad,
+                quality: ImageQuality::Low,
+                alpha: 1.0,
+            },
+        });
+        ctx.fill_rect(&Rect::new(0.0, 0.0, 10.0, 10.0));
+    }
+}

--- a/sparse_strips/vello_sparse_tests/tests/image.rs
+++ b/sparse_strips/vello_sparse_tests/tests/image.rs
@@ -729,7 +729,13 @@ fn image_spritesheet_tinted(ctx: &mut impl Renderer) {
 
 #[vello_test]
 fn image_fully_transparent_tint(ctx: &mut impl Renderer) {
-    let image_source = rgb_img_10x10(ctx);
+    let image = Image {
+        image: rgb_img_10x10(ctx),
+        sampler: ImageSampler {
+            quality: ImageQuality::Low,
+            ..ImageSampler::default()
+        },
+    };
 
     for (x, mode) in [(0.0, TintMode::AlphaMask), (10.0, TintMode::Multiply)] {
         ctx.set_transform(Affine::translate((x, 0.0)));
@@ -737,15 +743,7 @@ fn image_fully_transparent_tint(ctx: &mut impl Renderer) {
             color: Color::from_rgba8(255, 255, 255, 0),
             mode,
         }));
-        ctx.set_paint(Image {
-            image: image_source.clone(),
-            sampler: ImageSampler {
-                x_extend: Extend::Pad,
-                y_extend: Extend::Pad,
-                quality: ImageQuality::Low,
-                alpha: 1.0,
-            },
-        });
+        ctx.set_paint(image.clone());
         ctx.fill_rect(&Rect::new(0.0, 0.0, 10.0, 10.0));
     }
 }

--- a/sparse_strips/vello_sparse_tests/tests/image.rs
+++ b/sparse_strips/vello_sparse_tests/tests/image.rs
@@ -737,8 +737,8 @@ fn image_fully_transparent_tint(ctx: &mut impl Renderer) {
         },
     };
 
-    for (x, mode) in [(0.0, TintMode::AlphaMask), (10.0, TintMode::Multiply)] {
-        ctx.set_transform(Affine::translate((x, 0.0)));
+    for (x, mode) in [(0.0, TintMode::AlphaMask), (50.0, TintMode::Multiply)] {
+        ctx.set_transform(Affine::translate((x, 0.0)) * Affine::scale(5.0));
         ctx.set_tint(Some(Tint {
             color: Color::from_rgba8(255, 255, 255, 0),
             mode,


### PR DESCRIPTION
This PR fixes a bug where setting the tint to `0` doesn't actually make the image fully transparent. It's extracted from #1736, but only contains the tinting fix without the `ImageSampler` opacity change, to make it easier to review. 

However, this PR actually uses a different approach: We simply encode no tint as `u32::MAX` (all lanes to 1.0) and use the multiply mode, which means that the color of the pixel will just always stay the same. This way, we don't need to introduce a third `None` mode and can just keep the existing ones.

The operation that does the actual multiplication multiplies in both cases:

```
final_color = alpha * select(
    image_tint * sample_color.a,
    sample_color * image_tint,
    is_multiply
);
```

So by doing this, we are also not incurring more arithmetic operations or anything, it should be the same in terms of efficiency.