### PR TITLE
vello_hybrid: Tie `Resources` to a specific renderer instance

### DIFF
--- a/sparse_strips/vello_hybrid/CHANGELOG.md
+++ b/sparse_strips/vello_hybrid/CHANGELOG.md
@@ -18,6 +18,8 @@ This release has an [MSRV][] of 1.88.
 
 ### Changed
 
+- Breaking change: `Renderer::new`, `Renderer::new_with`, `WebGlRenderer::new`, and `WebGlRenderer::new_with` now return the renderer and its associated `Resources` as a tuple. The given `Resources` should only be used in conjunction with the renderer instance that generated it. 
+- Breaking change: `Scene::new_with` now takes a `Level` instead of `RenderSettings`.
 - Breaking change: `WebGlRenderer::render` and `WebGlRenderer::render_to_atlas` now take a `WebGlTextureBindings`, providing the external textures referenced by the scene. Pass `&WebGlTextureBindings::new()` if the scene does not use any.
 
 ## [0.1.0][] - 2026-07-29

--- a/sparse_strips/vello_hybrid/examples/native_webgl/src/lib.rs
+++ b/sparse_strips/vello_hybrid/examples/native_webgl/src/lib.rs
@@ -30,9 +30,7 @@ struct RendererWrapper {
 impl RendererWrapper {
     fn new(canvas: HtmlCanvasElement) -> Self {
         let settings = RenderSettings::default();
-        let resources =
-            vello_hybrid::Resources::new_with_config(settings.memory_settings.image_atlas_config);
-        let renderer = vello_hybrid::WebGlRenderer::new_with(&canvas, settings);
+        let (renderer, resources) = vello_hybrid::WebGlRenderer::new_with(&canvas, settings);
 
         Self {
             renderer,

--- a/sparse_strips/vello_hybrid/examples/render_to_file.rs
+++ b/sparse_strips/vello_hybrid/examples/render_to_file.rs
@@ -10,7 +10,7 @@ use std::io::BufWriter;
 use vello_common::kurbo::{Affine, Stroke};
 use vello_common::pico_svg::{Item, PicoSvg};
 use vello_common::pixmap::Pixmap;
-use vello_hybrid::{DimensionConstraints, Resources, Scene};
+use vello_hybrid::{DimensionConstraints, Scene};
 
 /// Main entry point for the headless rendering example.
 /// Takes two command line arguments:
@@ -74,7 +74,7 @@ async fn run() {
     let texture_view = texture.create_view(&wgpu::TextureViewDescriptor::default());
 
     // Create renderer and render the scene to the texture
-    let mut renderer = vello_hybrid::Renderer::new(
+    let (mut renderer, mut resources) = vello_hybrid::Renderer::new(
         &device,
         &vello_hybrid::RenderTargetConfig {
             format: texture.format(),
@@ -82,7 +82,6 @@ async fn run() {
             height: height.into(),
         },
     );
-    let mut resources = Resources::new();
     let render_size = vello_hybrid::RenderSize {
         width: width.into(),
         height: height.into(),

--- a/sparse_strips/vello_hybrid/examples/wgpu_webgl/src/lib.rs
+++ b/sparse_strips/vello_hybrid/examples/wgpu_webgl/src/lib.rs
@@ -93,9 +93,7 @@ impl RendererWrapper {
             level: Level::try_detect().unwrap_or(Level::baseline()),
             ..Default::default()
         };
-        let resources =
-            vello_hybrid::Resources::new_with_config(settings.memory_settings.image_atlas_config);
-        let renderer = Renderer::new_with(
+        let (renderer, resources) = Renderer::new_with(
             &device,
             &RenderTargetConfig {
                 format: surface_format,

--- a/sparse_strips/vello_hybrid/examples/winit/src/main.rs
+++ b/sparse_strips/vello_hybrid/examples/winit/src/main.rs
@@ -31,8 +31,7 @@ struct App<'s> {
     context: RenderContext,
     scenes: Box<[AnyScene<Scene>]>,
     current_scene: usize,
-    renderers: Vec<Option<Renderer>>,
-    resources: Vec<Option<Resources>>,
+    renderers: Vec<Option<(Renderer, Resources)>>,
     uploaded_images: Vec<bool>,
     spritesheet_textures: Vec<Option<wgpu::Texture>>,
     render_state: RenderState<'s>,
@@ -99,7 +98,6 @@ fn main() {
     let mut app = App {
         context: RenderContext::new(),
         renderers: vec![],
-        resources: vec![],
         uploaded_images: vec![],
         spritesheet_textures: vec![],
         scenes,
@@ -163,15 +161,12 @@ impl ApplicationHandler for App<'_> {
 
         self.renderers
             .resize_with(self.context.devices.len(), || None);
-        self.resources
-            .resize_with(self.context.devices.len(), || None);
         self.uploaded_images
             .resize(self.context.devices.len(), false);
         self.spritesheet_textures
             .resize_with(self.context.devices.len(), || None);
         self.renderers[surface.dev_id]
             .get_or_insert_with(|| create_vello_renderer(&self.context, &surface));
-        self.resources[surface.dev_id].get_or_insert_with(Resources::new);
 
         self.upload_images_to_atlas(surface.dev_id);
         self.ensure_spritesheet_uploaded(surface.dev_id);
@@ -346,11 +341,8 @@ impl ApplicationHandler for App<'_> {
                 let render_start = Instant::now();
 
                 self.scene.set_transform(self.transform);
-                self.scenes[self.current_scene].render(
-                    &mut self.scene,
-                    self.resources[surface.dev_id].as_mut().unwrap(),
-                    self.transform,
-                );
+                let (_, resources) = self.renderers[surface.dev_id].as_mut().unwrap();
+                self.scenes[self.current_scene].render(&mut self.scene, resources, self.transform);
 
                 let device_handle = &self.context.devices[surface.dev_id];
                 let render_size = RenderSize {
@@ -391,12 +383,11 @@ impl ApplicationHandler for App<'_> {
                         texture.create_view(&wgpu::TextureViewDescriptor::default()),
                     );
                 }
-                self.renderers[surface.dev_id]
-                    .as_mut()
-                    .unwrap()
+                let (renderer, resources) = self.renderers[surface.dev_id].as_mut().unwrap();
+                renderer
                     .render(
                         &self.scene,
-                        self.resources[surface.dev_id].as_mut().unwrap(),
+                        resources,
                         &device_handle.device,
                         &device_handle.queue,
                         &mut encoder,
@@ -437,8 +428,9 @@ impl App<'_> {
 
         // 1st example — uploading pixmap directly
         let pixmap1 = ImageScene::read_flower_image();
-        self.renderers[device_id].as_mut().unwrap().upload_image(
-            self.resources[device_id].as_mut().unwrap(),
+        let (renderer, resources) = self.renderers[device_id].as_mut().unwrap();
+        renderer.upload_image(
+            resources,
             &device_handle.device,
             &device_handle.queue,
             &mut encoder,
@@ -449,8 +441,9 @@ impl App<'_> {
         let pixmap2 = ImageScene::read_cowboy_image();
         let texture2 =
             self.upload_image_to_texture(&device_handle.device, &device_handle.queue, &pixmap2);
-        self.renderers[device_id].as_mut().unwrap().upload_image(
-            self.resources[device_id].as_mut().unwrap(),
+        let (renderer, resources) = self.renderers[device_id].as_mut().unwrap();
+        renderer.upload_image(
+            resources,
             &device_handle.device,
             &device_handle.queue,
             &mut encoder,

--- a/sparse_strips/vello_hybrid/examples/winit/src/render_context.rs
+++ b/sparse_strips/vello_hybrid/examples/winit/src/render_context.rs
@@ -8,7 +8,7 @@
 
 use std::sync::Arc;
 
-use vello_hybrid::{RenderTargetConfig, Renderer};
+use vello_hybrid::{RenderTargetConfig, Renderer, Resources};
 use wgpu::{
     Adapter, Device, Features, Instance, Limits, Queue, Surface, SurfaceConfiguration,
     SurfaceTarget, TextureFormat,
@@ -35,7 +35,7 @@ pub(crate) fn create_winit_window(
 pub(crate) fn create_vello_renderer(
     render_cx: &RenderContext,
     surface: &RenderSurface<'_>,
-) -> Renderer {
+) -> (Renderer, Resources) {
     Renderer::new(
         &render_cx.devices[surface.dev_id].device,
         &RenderTargetConfig {

--- a/sparse_strips/vello_hybrid/src/render/webgl/mod.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl/mod.rs
@@ -184,13 +184,13 @@ pub struct AtlasTextureInfo {
 }
 
 impl WebGlRenderer {
-    /// Creates a new WebGL2 renderer
-    pub fn new(canvas: &HtmlCanvasElement) -> Self {
+    /// Creates a new WebGL2 renderer and its persistent resources.
+    pub fn new(canvas: &HtmlCanvasElement) -> (Self, Resources) {
         Self::new_with(canvas, RenderSettings::default())
     }
 
-    /// Creates a new WebGL2 renderer with specific settings.
-    pub fn new_with(canvas: &HtmlCanvasElement, mut settings: RenderSettings) -> Self {
+    /// Creates a new WebGL2 renderer and its persistent resources with specific settings.
+    pub fn new_with(canvas: &HtmlCanvasElement, mut settings: RenderSettings) -> (Self, Resources) {
         #[allow(
             clippy::assertions_on_constants,
             reason = "intentional guard against non-wasm32 use"
@@ -276,7 +276,7 @@ impl WebGlRenderer {
                 >= 24.0,
             "Depth buffer must be at least 24 bits"
         );
-        let image_cache = ImageCache::new_with_config(settings.memory_settings.image_atlas_config);
+        let resources = Resources::new(settings.memory_settings.image_atlas_config);
         let max_texture_dimension_2d = device_limits.max_texture_dimension_2d;
 
         // Estimate the maximum number of gradient cache entries based on the max texture dimension
@@ -285,8 +285,8 @@ impl WebGlRenderer {
             max_texture_dimension_2d * max_texture_dimension_2d / MAX_GRADIENT_LUT_SIZE as u32;
         let gradient_cache = GradientRampCache::new(max_gradient_cache_size, settings.level);
         let layer_config = settings.memory_settings.layers_config;
-        Self {
-            programs: WebGlPrograms::new(gl.clone(), &image_cache, layer_config),
+        let renderer = Self {
+            programs: WebGlPrograms::new(gl.clone(), &resources.image_cache, layer_config),
             gl,
             encoded_paints: Vec::new(),
             paint_idxs: Vec::new(),
@@ -295,7 +295,9 @@ impl WebGlRenderer {
             schedule_storage: ScheduleStorage::default(),
             scratch_buffers: ScratchBuffers::default(),
             layers_config: layer_config,
-        }
+        };
+
+        (renderer, resources)
     }
 
     /// Render `scene` using WebGL2

--- a/sparse_strips/vello_hybrid/src/render/wgpu/mod.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu/mod.rs
@@ -167,17 +167,17 @@ pub struct Renderer {
 }
 
 impl Renderer {
-    /// Creates a new renderer.
-    pub fn new(device: &Device, render_target_config: &RenderTargetConfig) -> Self {
+    /// Creates a new renderer and its persistent resources.
+    pub fn new(device: &Device, render_target_config: &RenderTargetConfig) -> (Self, Resources) {
         Self::new_with(device, render_target_config, RenderSettings::default())
     }
 
-    /// Creates a new renderer with specific settings.
+    /// Creates a new renderer and its persistent resources with specific settings.
     pub fn new_with(
         device: &Device,
         render_target_config: &RenderTargetConfig,
         settings: RenderSettings,
-    ) -> Self {
+    ) -> (Self, Resources) {
         super::common::maybe_warn_about_webgl_feature_conflict();
 
         let mut settings = settings;
@@ -187,7 +187,7 @@ impl Renderer {
             max_texture_array_layers: limits.max_texture_array_layers,
         };
         settings.memory_settings.normalize(&device_limits);
-        let image_cache = ImageCache::new_with_config(settings.memory_settings.image_atlas_config);
+        let resources = Resources::new(settings.memory_settings.image_atlas_config);
         let max_texture_dimension_2d = device_limits.max_texture_dimension_2d;
         // Estimate the maximum number of gradient cache entries based on the max texture dimension
         // and the maximum gradient LUT size - worst case scenario.
@@ -196,8 +196,13 @@ impl Renderer {
         let gradient_cache = GradientRampCache::new(max_gradient_cache_size, settings.level);
         let layer_config = settings.memory_settings.layers_config;
 
-        Self {
-            programs: Programs::new(device, &image_cache, render_target_config, layer_config),
+        let renderer = Self {
+            programs: Programs::new(
+                device,
+                &resources.image_cache,
+                render_target_config,
+                layer_config,
+            ),
             gradient_cache,
             encoded_paints: Vec::new(),
             paint_idxs: Vec::new(),
@@ -207,7 +212,9 @@ impl Renderer {
             layers_config: layer_config,
             #[cfg(feature = "text")]
             atlas_clear_scratch: Vec::new(),
-        }
+        };
+
+        (renderer, resources)
     }
 
     /// Render `scene`.

--- a/sparse_strips/vello_hybrid/src/resources.rs
+++ b/sparse_strips/vello_hybrid/src/resources.rs
@@ -12,7 +12,7 @@ use vello_common::multi_atlas::AtlasConfig;
 
 /// Persistent resources required by Vello Hybrid for rendering.
 ///
-/// You should create one such instance per renderer.
+/// A set of resources must only be used with the renderer instance associated with it.
 #[derive(Debug)]
 pub struct Resources {
     pub(crate) image_cache: ImageCache,
@@ -23,21 +23,7 @@ pub struct Resources {
 }
 
 impl Resources {
-    /// Create a new set of renderer resources.
-    pub fn new() -> Self {
-        Self::new_with_config(AtlasConfig::default())
-    }
-
-    /// Create a new set of renderer resources with a custom image/glyph atlas configuration.
-    ///
-    /// This should match the
-    /// [`image_atlas_config`](crate::MemorySettings::image_atlas_config) passed to the renderer so
-    /// that allocations and the GPU atlas texture agree on the atlas size.
-    // TODO: Requiring callers to keep this config in sync with the renderer's
-    // `memory_settings.image_atlas_config` by hand is a footgun; tie them together so they can't
-    // diverge. Note the renderer also normalizes the config against the device limits, so even
-    // matching configs here can still end up disagreeing.
-    pub fn new_with_config(image_atlas_config: AtlasConfig) -> Self {
+    pub(crate) fn new(image_atlas_config: AtlasConfig) -> Self {
         Self {
             image_cache: ImageCache::new_with_config(image_atlas_config),
             #[cfg(feature = "text")]
@@ -46,11 +32,5 @@ impl Resources {
             #[cfg(feature = "text")]
             glyph_resources: None,
         }
-    }
-}
-
-impl Default for Resources {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -230,15 +230,19 @@ pub struct Scene {
 impl Scene {
     /// Create a new render context with the given width and height in pixels.
     pub fn new(width: u16, height: u16) -> Self {
-        Self::new_with(width, height, RenderSettings::default())
+        Self::new_with(
+            width,
+            height,
+            Level::try_detect().unwrap_or(Level::baseline()),
+        )
     }
 
-    /// Create a new render context with specific settings.
-    pub fn new_with(width: u16, height: u16, settings: RenderSettings) -> Self {
+    /// Create a new render context with a specific SIMD level.
+    pub fn new_with(width: u16, height: u16, level: Level) -> Self {
         Self {
             width,
             height,
-            viewport_state: ViewportState::new(width, height, settings.level),
+            viewport_state: ViewportState::new(width, height, level),
             render_state: RenderState::default(),
             root_transforms: RootTransforms::default(),
             aliasing_threshold: None,
@@ -1080,7 +1084,7 @@ mod tests {
         }];
 
         let mut scene = Scene::new(200, 200);
-        let mut resources = Resources::new();
+        let mut resources = Resources::new(vello_common::multi_atlas::AtlasConfig::default());
         let mut triangle = BezPath::new();
         triangle.move_to((10.0, 10.0));
         triangle.line_to((90.0, 50.0));

--- a/sparse_strips/vello_sparse_tests/tests/image_atlas.rs
+++ b/sparse_strips/vello_sparse_tests/tests/image_atlas.rs
@@ -4,9 +4,7 @@
 //! Tests for the image/glyph atlas configuration of the WebGL renderer.
 
 use vello_common::pixmap::Pixmap;
-use vello_hybrid::{
-    AtlasConfig, AtlasTextureInfo, MemorySettings, RenderSettings, Resources, WebGlRenderer,
-};
+use vello_hybrid::{AtlasConfig, AtlasTextureInfo, MemorySettings, RenderSettings, WebGlRenderer};
 use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
 use web_sys::{HtmlCanvasElement, WebGl2RenderingContext};
@@ -34,8 +32,7 @@ fn image_atlas_placeholder_is_promoted_on_first_upload() {
         },
         ..RenderSettings::default()
     };
-    let mut renderer = WebGlRenderer::new_with(&canvas, settings);
-    let mut resources = Resources::new_with_config(atlas_config);
+    let (mut renderer, mut resources) = WebGlRenderer::new_with(&canvas, settings);
 
     assert_eq!(
         renderer.atlas_info(),
@@ -73,8 +70,8 @@ fn image_atlas_placeholder_is_promoted_on_first_upload() {
 /// Uploading an image that is larger than the configured atlas must fail with
 /// `AtlasError::TextureTooLarge`.
 ///
-/// The renderer and the resources are both configured with a 10x10 atlas: the renderer sizes the
-/// GPU atlas texture, while the resources own the allocator that runs the `TextureTooLarge` check.
+/// The renderer constructor configures both the 10x10 GPU atlas texture and the allocator in the
+/// returned resources, which runs the `TextureTooLarge` check.
 #[wasm_bindgen_test]
 #[should_panic(expected = "TextureTooLarge")]
 fn image_atlas_upload_larger_than_atlas_fails() {
@@ -87,7 +84,6 @@ fn image_atlas_upload_larger_than_atlas_fails() {
     canvas.set_width(100);
     canvas.set_height(100);
 
-    // Both the renderer and the resources must use the same 10x10 atlas config.
     let atlas_config = AtlasConfig {
         atlas_size: (10, 10),
         ..AtlasConfig::default()
@@ -100,8 +96,7 @@ fn image_atlas_upload_larger_than_atlas_fails() {
         ..RenderSettings::default()
     };
 
-    let mut renderer = WebGlRenderer::new_with(&canvas, settings);
-    let mut resources = Resources::new_with_config(atlas_config);
+    let (mut renderer, mut resources) = WebGlRenderer::new_with(&canvas, settings);
 
     // The image is much larger than the 10x10 atlas, so the upload must fail.
     let image = Pixmap::new(64, 64);

--- a/sparse_strips/vello_sparse_tests/tests/renderer.rs
+++ b/sparse_strips/vello_sparse_tests/tests/renderer.rs
@@ -290,7 +290,7 @@ pub(crate) struct HybridRenderer {
 #[cfg(not(all(target_arch = "wasm32", feature = "webgl")))]
 impl HybridRenderer {
     fn new_with_settings(width: u16, height: u16, settings: HybridRenderSettings) -> Self {
-        let scene = Scene::new_with(width, height, settings);
+        let scene = Scene::new_with(width, height, settings.level);
         // Initialize wgpu device and queue for GPU rendering
         let instance = wgpu::Instance::default();
         let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
@@ -325,7 +325,7 @@ impl HybridRenderer {
         let texture_view = texture.create_view(&wgpu::TextureViewDescriptor::default());
 
         // Create renderer and render the scene to the texture
-        let renderer = vello_hybrid::Renderer::new_with(
+        let (renderer, resources) = vello_hybrid::Renderer::new_with(
             &device,
             &vello_hybrid::RenderTargetConfig {
                 format: texture.format(),
@@ -337,7 +337,7 @@ impl HybridRenderer {
 
         Self {
             scene,
-            resources: HybridResources::new(),
+            resources,
             device,
             queue,
             texture,
@@ -729,7 +729,7 @@ impl Renderer for HybridRenderer {
         let mut settings = HybridRenderSettings::default();
         // See the comment above for why we change the `min_texture_size`.
         settings.memory_settings.layers_config.min_texture_size = vello_hybrid::SizeU16::new(100);
-        let scene = Scene::new_with(width, height, settings);
+        let scene = Scene::new_with(width, height, settings.level);
         // Create an offscreen HTMLCanvasElement, render the test image to it, and finally read off
         // the pixmap for diff checking.
         let document = web_sys::window().unwrap().document().unwrap();
@@ -740,7 +740,7 @@ impl Renderer for HybridRenderer {
             .unwrap();
         canvas.set_width(width.into());
         canvas.set_height(height.into());
-        let renderer = vello_hybrid::WebGlRenderer::new_with(&canvas, settings);
+        let (renderer, resources) = vello_hybrid::WebGlRenderer::new_with(&canvas, settings);
         let gl = canvas
             .get_context("webgl2")
             .unwrap()
@@ -749,7 +749,7 @@ impl Renderer for HybridRenderer {
             .unwrap();
         Self {
             scene,
-            resources: HybridResources::new(),
+            resources,
             renderer,
             gl,
             external_textures: vello_hybrid::WebGlTextureBindings::new(),

--- a/sparse_strips/vello_sparse_tests/tests/wasm_binary_invariants.rs
+++ b/sparse_strips/vello_sparse_tests/tests/wasm_binary_invariants.rs
@@ -69,7 +69,7 @@ async fn webgl_probe_succeeds() {
     canvas.set_width(200);
     canvas.set_height(200);
 
-    let mut renderer = vello_hybrid::WebGlRenderer::new(&canvas);
+    let (mut renderer, _) = vello_hybrid::WebGlRenderer::new(&canvas);
     let mut pending = renderer
         .probe()
         .unwrap_or_else(|error| panic!("WebGlRenderer::probe() failed to render: {error:?}"));


### PR DESCRIPTION
The `AtlasConfig` struct defines the settings that should be used for the image atlas array as well as intermediate textures. Unfortunately, right now, those are passed in two different places. **Currently, the user needs to manually ensure that they are the same, otherwise silent corruption will happen.** In addition, even if the user does so, the two settings might run out of sync because the renderer needs to normalize the settings to the capabilities of the device.

The reason why the information is needed in two different places is glyph caching. On the one hand, `Renderer` needs it to actually allocate appropriately sized textures. On the other hand, `Scene` needs it because glyph caching is currently tightly coupled with it. In the future, we can hopefully disentangle this, but it's a bigger project.

Therefore, as a stopgap measure, I made the following change: The configuration is now only supplied **once** during renderer construction. The constructor will normalize the settings, and then generate and return a new `Resources` struct based on this instead of having the user construct it. This way, it's always guaranteed that the two match. The downside is that it forces the user to create the renderer before the scene (at least if they want to use glyph caching), but I think this is acceptable for now.

I also don't really like the constructor returning a tuple, but for now that's by far the better option than users accidentally misusing the API and having silent failures.