### PR TITLE
vello_cpu: Allow rasterizing a range of scene rows

### DIFF
--- a/sparse_strips/vello_cpu/src/coarse/bucketer.rs
+++ b/sparse_strips/vello_cpu/src/coarse/bucketer.rs
@@ -662,7 +662,9 @@ impl CommandBucketer {
         // layer bbox could unnecessarily balloon the size of the pixmap we allocate if it is
         // very large, since those don't actually contribute any visible output. However, this does
         // mean that this method might be called with strips that do not lie within the viewport.
-        // Therefore, we need to make sure to clip those appropriately.
+        // Therefore, we need to make sure to clip those appropriately. The same holds when the
+        // viewport is a band of the scene (`RasterizerSettings::scene_rows`), where most strips
+        // routinely lie outside it.
 
         let origin_tile_x = origin.0 / Tile::WIDTH;
         let origin_tile_y = origin.1 / Tile::HEIGHT;

--- a/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
@@ -398,7 +398,8 @@ impl MultiThreadedDispatcher {
     ) {
         let mut bucketer = self.bucketer.lock().unwrap();
         let filters = FilterContext::new(0);
-        bucketer.reset(RectU16::new(0, 0, scene_width, scene_height));
+        let viewport = settings.scene_viewport(scene_width, scene_height);
+        bucketer.reset(viewport);
         bucketer.bucket_commands(
             &self.recorder.nodes,
             &self.recorder.draws,
@@ -419,7 +420,7 @@ impl MultiThreadedDispatcher {
                 image_resolver,
             };
             let params = FineRenderParams {
-                scene_size: (scene_width, scene_height),
+                scene_size: (scene_width, viewport.height()),
                 target_offset: settings.offset,
             };
 

--- a/sparse_strips/vello_cpu/src/dispatch/single_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/single_threaded.rs
@@ -110,15 +110,16 @@ impl SingleThreadedDispatcher {
     ) {
         let filters = self.rasterize_filter_layers::<S, F>(simd, encoded_paints, image_resolver);
         let use_src_over = settings.composite_mode == CompositeMode::SrcOver;
+        let viewport = settings.scene_viewport(scene_width, scene_height);
         let params = FineRenderParams {
-            scene_size: (scene_width, scene_height),
+            scene_size: (scene_width, viewport.height()),
             target_offset: settings.offset,
         };
 
         self.bucket_and_rasterize::<S, F>(
             simd,
             &self.recorder.nodes,
-            RectU16::new(0, 0, scene_width, scene_height),
+            viewport,
             &filters,
             target,
             params,

--- a/sparse_strips/vello_cpu/src/lib.rs
+++ b/sparse_strips/vello_cpu/src/lib.rs
@@ -169,6 +169,7 @@ pub mod region;
 
 pub use render::{
     CompositeMode, PixelFormat, RasterizerSettings, RenderContext, RenderSettings, Resources,
+    SCENE_ROW_ALIGNMENT,
 };
 // Note: The first one is not something that should be
 // exposed, but is currently needed by vello_sparse_tests.

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -24,6 +24,7 @@ use vello_common::encode::{EncodeExt, EncodedPaint};
 use vello_common::fearless_simd::Level;
 use vello_common::filter::FilterData;
 use vello_common::filter_effects::Filter;
+use vello_common::geometry::RectU16;
 use vello_common::kurbo::{Affine, BezPath, Rect, Stroke};
 use vello_common::mask::Mask;
 use vello_common::paint::{ImageId, ImageResolver, Paint, PaintType, Tint};
@@ -114,6 +115,9 @@ pub enum PixelFormat {
     Rgba8,
 }
 
+/// Required alignment for the start of [`RasterizerSettings::scene_rows`].
+pub const SCENE_ROW_ALIGNMENT: u16 = vello_common::tile::Tile::HEIGHT;
+
 /// Settings used when rasterizing a scene into a pixmap.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct RasterizerSettings {
@@ -135,6 +139,35 @@ pub struct RasterizerSettings {
     ///
     /// See [`RenderContext::render_with`] for more information.
     pub offset: (u16, u16),
+    /// Half-open range of scene rows to rasterize, or `None` for the whole scene.
+    ///
+    /// Rasterizing `y0..y1` writes those scene rows starting at
+    /// [`RasterizerSettings::offset`] in the destination, letting a tall scene
+    /// be rasterized one horizontal band at a time into a band-sized pixmap
+    /// without re-recording it.
+    ///
+    /// The start must be a multiple of [`SCENE_ROW_ALIGNMENT`], since
+    /// rasterization works in strips of that height and an unaligned start
+    /// would silently shift the output; rasterizing panics if it is not. The
+    /// end is snapped outwards and clamped to the scene height for you.
+    pub scene_rows: Option<(u16, u16)>,
+}
+
+impl RasterizerSettings {
+    /// The scene-space viewport to rasterize: the rows selected by
+    /// [`Self::scene_rows`] snapped outwards to the tile grid and clamped to
+    /// the scene, or the whole scene.
+    pub(crate) fn scene_viewport(self, scene_width: u16, scene_height: u16) -> RectU16 {
+        let Some((y0, y1)) = self.scene_rows else {
+            return RectU16::new(0, 0, scene_width, scene_height);
+        };
+        assert!(
+            y0.is_multiple_of(SCENE_ROW_ALIGNMENT),
+            "`scene_rows` must start on a multiple of {SCENE_ROW_ALIGNMENT}"
+        );
+        let y1 = y1.next_multiple_of(SCENE_ROW_ALIGNMENT).min(scene_height);
+        RectU16::new(0, y0.min(y1), scene_width, y1)
+    }
 }
 
 impl Default for RasterizerSettings {
@@ -144,6 +177,7 @@ impl Default for RasterizerSettings {
             composite_mode: CompositeMode::Replace,
             pixel_format: PixelFormat::Rgba8,
             offset: (0, 0),
+            scene_rows: None,
         }
     }
 }
@@ -806,7 +840,7 @@ impl RenderContext {
         let mut target = target.into();
         let target_fully_covered = settings.offset == (0, 0)
             && self.width >= target.width()
-            && self.height >= target.height();
+            && settings.scene_viewport(self.width, self.height).height() >= target.height();
         // If the scene covers the whole pixmap than packing will take care
         // of clearing everything anyway, so no reason to clear it explicitly
         // here.
@@ -962,7 +996,7 @@ impl ImageResolver for ImageRegistry {
 mod tests {
     #[cfg(feature = "text")]
     use crate::peniko::{Blob, FontData};
-    use crate::{CompositeMode, RasterizerSettings, RenderContext, Resources};
+    use crate::{CompositeMode, RasterizerSettings, RenderContext, RenderSettings, Resources};
     #[cfg(feature = "text")]
     use alloc::sync::Arc;
     use alloc::vec;
@@ -970,7 +1004,7 @@ mod tests {
     use glifo::Glyph;
     use vello_common::color::PremulRgba8;
     use vello_common::color::palette::css::{BLUE, RED};
-    use vello_common::kurbo::{Rect, Shape};
+    use vello_common::kurbo::{Affine, Rect, Shape};
     use vello_common::pixmap::{Pixmap, PixmapMut};
     use vello_common::tile::Tile;
 
@@ -1312,5 +1346,80 @@ mod tests {
             .fill_glyphs(glyphs.into_iter());
 
         assert!(resources.glyph_resources.is_some());
+    }
+
+    #[test]
+    #[should_panic(expected = "must start on a multiple")]
+    fn scene_rows_unaligned_start_panics() {
+        let ctx = RenderContext::new(16, 16);
+        let mut resources = Resources::new();
+        let mut pixmap = Pixmap::new(16, 16);
+        ctx.render_with(
+            &mut pixmap,
+            &mut resources,
+            RasterizerSettings {
+                scene_rows: Some((2, 8)),
+                ..Default::default()
+            },
+        );
+    }
+
+    #[test]
+    fn scene_rows_bands_match_a_full_rasterization() {
+        scene_rows_bands_match(RenderSettings::default());
+    }
+
+    #[cfg(feature = "multithreading")]
+    #[test]
+    fn scene_rows_bands_match_a_full_rasterization_multithreaded() {
+        scene_rows_bands_match(RenderSettings {
+            num_threads: 4,
+            ..Default::default()
+        });
+    }
+
+    fn scene_rows_bands_match(render_settings: RenderSettings) {
+        const W: u16 = 64;
+        const H: u16 = 64;
+
+        let mut ctx = RenderContext::new_with(W, H, render_settings);
+        // Content that straddles band boundaries in both directions.
+        ctx.set_paint(RED);
+        ctx.fill_path(&Rect::new(4.0, 2.0, 60.0, 33.0).to_path(0.1));
+        ctx.set_transform(Affine::rotate(0.4));
+        ctx.set_paint(BLUE);
+        ctx.fill_path(&Rect::new(10.0, 10.0, 50.0, 55.0).to_path(0.1));
+        ctx.reset_transform();
+        ctx.flush();
+
+        let mut resources = Resources::new();
+        let mut full = Pixmap::new(W, H);
+        ctx.render(&mut full, &mut resources);
+
+        // The smallest legal band, and one that doesn't divide the scene
+        // height so the last band is truncated.
+        for band in [4_u16, 20] {
+            let mut y = 0;
+            while y < H {
+                let rows = band.min(H - y);
+                let mut strip = Pixmap::new(W, rows);
+                ctx.render_with(
+                    &mut strip,
+                    &mut resources,
+                    RasterizerSettings {
+                        scene_rows: Some((y, y + rows)),
+                        ..Default::default()
+                    },
+                );
+                let start = usize::from(y) * usize::from(W);
+                assert_eq!(
+                    strip.data(),
+                    &full.data()[start..start + strip.data().len()],
+                    "band height {band}: scene rows {y}..{} differ from a full render",
+                    y + rows
+                );
+                y += rows;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Motivation

A recorded scene can currently only be rasterized from row 0.
`RasterizerSettings::offset` is unsigned, so it can only push a scene down
and to the right — it can never shift the scene up to bring lower rows into
view. Callers that render a tall scene in horizontal bands (to bound peak
memory, or to stream rows to a consumer — e.g. rasterizing PDF pages at
high DPI without holding the full page in memory) therefore have to
re-record the whole scene for every band.

## Changes

Adds `RasterizerSettings::scene_rows`, an optional half-open range of scene
rows to rasterize. The selected rows are written starting at
`RasterizerSettings::offset`, so a band-sized pixmap receives exactly that
band:

```rust
let mut band = Pixmap::new(width, band_height);
ctx.render_with(
    &mut band,
    &mut resources,
    RasterizerSettings {
        scene_rows: Some((y, y + band_height)),
        ..Default::default()
    },
);
```

`None` keeps the existing whole-scene behaviour, so the change is additive.

## How it works

The range is passed straight through as the bucketing viewport, which the
coarse pass already supports with a non-zero origin for filter layers. Rows
outside the range are never bucketed or rasterized, rather than being
produced and discarded, so each band only pays for its own rows.

Two contract details:

- The start of the range must be a multiple of the new public
  `SCENE_ROW_ALIGNMENT` constant (the tile height), since rasterization
  works in strips of that height. Rasterization asserts this — an
  unaligned start would otherwise silently shift the output. The end is
  snapped outwards and clamped to the scene height for the caller.
- With `CompositeMode::Replace`, the "destination fully covered" check now
  uses the band height rather than the scene height, so a band shorter
  than the target pixmap still clears the uncovered rows.

## Testing

Adds a test asserting that 4- and 20-row bands are byte-identical to the
corresponding rows of a single full rasterization, on a scene whose content
straddles band boundaries in both directions (including a rotated path).
The 20-row case covers a truncated final band. The test runs against both
the single- and multi-threaded dispatchers; the multi-threaded case is the
first use of a non-zero bucketing origin in that dispatcher. A
`#[should_panic]` test pins the alignment contract.

## Open questions

- Is `Option<(u16, u16)>` the right shape, or would a full scene-space
  viewport (`Option<RectU16>`) be preferred? The underlying bucketing
  viewport mechanism supports x-restriction too; I limited the API to rows
  for the banded-rendering use case and to keep the surface minimal, but
  I'm happy to generalize if that's the direction you'd want.

## AI Disclosure

The code in this PR has been written with the help of AI coding tools.
I am not an expert in graphics rendering, so any feedback is welcome!