### PR TITLE
Switch to proposed load_four_interleaved() API in fearless_simd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1084,9 +1084,8 @@ dependencies = [
 
 [[package]]
 name = "fearless_simd"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76258897e51fd156ee03b6246ea53f3e0eb395d0b327e9961c4fc4c8b2fa151a"
+version = "0.6.0"
+source = "git+https://github.com/Shnatsel/fearless_simd.git?branch=load-interleaved-4-way#f62652d90cbc423dc967a5ea6b05158da388519a"
 dependencies = [
  "libm",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ rayon = { version = "1.12.0" }
 thread_local = "1.1.9"
 crossbeam-channel = "0.5.15"
 ordered-channel = { version = "1.2.0", features = ["crossbeam-channel"] }
-fearless_simd = { version = "0.4.0", default-features = false }
+fearless_simd = { version = "0.6.0", default-features = false }
 
 # Unlike the other crates, please do not update these before a release
 # unless absolutely necessary.
@@ -176,3 +176,6 @@ codegen-units = 1
 inherits = "release"
 debug = true
 strip = "none"
+
+[patch.crates-io]
+fearless_simd = { git = "https://github.com/Shnatsel/fearless_simd.git", branch = "load-interleaved-4-way"}

--- a/sparse_strips/vello_cpu/src/fine/common/rounded_blurred_rect.rs
+++ b/sparse_strips/vello_cpu/src/fine/common/rounded_blurred_rect.rs
@@ -94,11 +94,8 @@ impl<S: Simd> crate::fine::Painter for BlurredRoundedRectFiller<S> {
                     let b = u8x16::from_f32(simd, simd.combine_f32x8(first.b, second.b));
                     let a = u8x16::from_f32(simd, simd.combine_f32x8(first.a, second.a));
 
-                    let combined =
-                        simd.combine_u8x32(simd.combine_u8x16(r, g), simd.combine_u8x16(b, a));
-
-                    simd.store_interleaved_128_u8x64(
-                        combined,
+                    simd.store_four_interleaved_u8x16(
+                        [r, g, b, a],
                         (&mut chunk[..]).try_into().unwrap(),
                     );
                 }
@@ -111,11 +108,13 @@ impl<S: Simd> crate::fine::Painter for BlurredRoundedRectFiller<S> {
             #[inline(always)]
             || {
                 for chunk in buf.chunks_exact_mut(32) {
-                    let (c1, c2) = self.next().unwrap().get();
-                    c1.simd
-                        .store_interleaved_128_f32x16(c1, (&mut chunk[..16]).try_into().unwrap());
-                    c2.simd
-                        .store_interleaved_128_f32x16(c2, (&mut chunk[16..]).try_into().unwrap());
+                    let [c1, c2] = self.next().unwrap().get();
+                    c1[0]
+                        .simd
+                        .store_four_interleaved_f32x4(c1, (&mut chunk[..16]).try_into().unwrap());
+                    c2[0]
+                        .simd
+                        .store_four_interleaved_f32x4(c2, (&mut chunk[16..]).try_into().unwrap());
                 }
             },
         );

--- a/sparse_strips/vello_cpu/src/fine/highp/blend.rs
+++ b/sparse_strips/vello_cpu/src/fine/highp/blend.rs
@@ -51,25 +51,16 @@ fn mix_inner<S: Simd>(src_c: f32x16<S>, bg: f32x16<S>, blend_mode: BlendMode) ->
     res_bg.g = apply_alpha(bg_a, src_a, unpremultiplied_src.g, mix_src.g);
     res_bg.b = apply_alpha(bg_a, src_a, unpremultiplied_src.b, mix_src.b);
 
-    let combined = simd.combine_f32x8(
-        simd.combine_f32x4(res_bg.r, res_bg.g),
-        simd.combine_f32x4(res_bg.b, src_a),
-    );
-
     let mut storage = [0.0; 16];
-    simd.store_interleaved_128_f32x16(combined, &mut storage);
+    simd.store_four_interleaved_f32x4([res_bg.r, res_bg.g, res_bg.b, src_a], &mut storage);
     f32x16::from_slice(simd, &storage)
 }
 
 #[inline(always)]
 fn split<S: Simd>(simd: S, input: f32x16<S>) -> (Channels<S>, f32x4<S>) {
     let mut storage = [0.0; 16];
-    simd.store_interleaved_128_f32x16(input, &mut storage);
-    let input_v = f32x16::from_slice(simd, &storage);
-
-    let p1 = simd.split_f32x16(input_v);
-    let (r, g) = simd.split_f32x8(p1.0);
-    let (b, a) = simd.split_f32x8(p1.1);
+    input.store_slice(&mut storage);
+    let [r, g, b, a] = simd.load_four_interleaved_f32x4(&storage);
 
     (Channels { r, g, b }, a)
 }

--- a/sparse_strips/vello_cpu/src/fine/lowp/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/lowp/mod.rs
@@ -360,10 +360,9 @@ fn pack_block<S: Simd>(simd: S, scratch: &[u8], width: usize, region: &mut Regio
     for col in scratch[..width * TILE_HEIGHT_COMPONENTS].chunks_exact(CHUNK_LENGTH) {
         let casted: &[u32; 16] = cast_slice::<u8, u32>(col).try_into().unwrap();
 
-        let loaded = simd.load_interleaved_128_u32x16(casted).to_bytes();
-        let (loaded_lo, loaded_hi) = simd.split_u8x64(loaded);
-        let (loaded_1, loaded_2) = simd.split_u8x32(loaded_lo);
-        let (loaded_3, loaded_4) = simd.split_u8x32(loaded_hi);
+        let [loaded_1, loaded_2, loaded_3, loaded_4] = simd
+            .load_four_interleaved_u32x4(casted)
+            .map(u32x4::to_bytes);
 
         let (dest0, rest0) = row0.split_at_mut(Tile::WIDTH as usize * COLOR_COMPONENTS);
         let (dest1, rest1) = row1.split_at_mut(Tile::WIDTH as usize * COLOR_COMPONENTS);
@@ -440,9 +439,7 @@ fn unpack_block<S: Simd>(simd: S, region: &mut Region<'_>, width: usize, scratch
         let r1 = f32x4::from_bytes(u8x16::from_slice(simd, src1));
         let r2 = f32x4::from_bytes(u8x16::from_slice(simd, src2));
         let r3 = f32x4::from_bytes(u8x16::from_slice(simd, src3));
-        let combined = simd.combine_f32x8(simd.combine_f32x4(r0, r1), simd.combine_f32x4(r2, r3));
-
-        simd.store_interleaved_128_f32x16(combined, col);
+        simd.store_four_interleaved_f32x4([r0, r1, r2, r3], col);
 
         row0 = rest0;
         row1 = rest1;

--- a/sparse_strips/vello_cpu/src/fine/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/mod.rs
@@ -1165,26 +1165,16 @@ pub(crate) struct ShaderResultF32<S: Simd> {
 impl<S: Simd> ShaderResultF32<S> {
     /// Convert from planar format to interleaved RGBA format.
     ///
-    /// Returns two f32x16 vectors containing 8 pixels (4 RGBA components each)
-    /// with channels interleaved in the standard RGBA order.
+    /// Returns two sets of four f32x4 vectors containing 8 pixels (4 RGBA components each),
+    /// ready to be stored with `store_four_interleaved_f32x4`.
     #[inline(always)]
-    pub(crate) fn get(&self) -> (f32x16<S>, f32x16<S>) {
+    pub(crate) fn get(&self) -> [[f32x4<S>; 4]; 2] {
         let (r_1, r_2) = self.r.simd.split_f32x8(self.r);
         let (g_1, g_2) = self.g.simd.split_f32x8(self.g);
         let (b_1, b_2) = self.b.simd.split_f32x8(self.b);
         let (a_1, a_2) = self.a.simd.split_f32x8(self.a);
 
-        let first = self.r.simd.combine_f32x8(
-            self.r.simd.combine_f32x4(r_1, g_1),
-            self.r.simd.combine_f32x4(b_1, a_1),
-        );
-
-        let second = self.r.simd.combine_f32x8(
-            self.r.simd.combine_f32x4(r_2, g_2),
-            self.r.simd.combine_f32x4(b_2, a_2),
-        );
-
-        (first, second)
+        [[r_1, g_1, b_1, a_1], [r_2, g_2, b_2, a_2]]
     }
 }
 


### PR DESCRIPTION
Update to https://github.com/linebender/fearless_simd/pull/298

This removes a whole bunch of redundant split/combine ops.

Marking as draft because this is a breaking change and the matching fearless_simd version is not released yet.

MSRV check on CI fails because recent fearless_simd needs 1.89 while vello MSRV is 1.88