### PR TITLE
Upgrade to fearless_simd v0.7 development state plus PR 300

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1084,9 +1084,8 @@ dependencies = [
 
 [[package]]
 name = "fearless_simd"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76258897e51fd156ee03b6246ea53f3e0eb395d0b327e9961c4fc4c8b2fa151a"
+version = "0.6.0"
+source = "git+https://github.com/Shnatsel/fearless_simd.git?branch=load-interleaved-4-way#f62652d90cbc423dc967a5ea6b05158da388519a"
 dependencies = [
  "libm",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,7 +1085,7 @@ dependencies = [
 [[package]]
 name = "fearless_simd"
 version = "0.6.0"
-source = "git+https://github.com/Shnatsel/fearless_simd.git?branch=load-interleaved-4-way#f62652d90cbc423dc967a5ea6b05158da388519a"
+source = "git+https://github.com/Shnatsel/fearless_simd.git?branch=widen-narrow#21c107f14858d11e8851e32f7a38f167aa6825a5"
 dependencies = [
  "libm",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ rayon = { version = "1.12.0" }
 thread_local = "1.1.9"
 crossbeam-channel = "0.5.15"
 ordered-channel = { version = "1.2.0", features = ["crossbeam-channel"] }
-fearless_simd = { version = "0.4.0", default-features = false }
+fearless_simd = { version = "0.6.0", default-features = false }
 
 # Unlike the other crates, please do not update these before a release
 # unless absolutely necessary.
@@ -176,3 +176,6 @@ codegen-units = 1
 inherits = "release"
 debug = true
 strip = "none"
+
+[patch.crates-io]
+fearless_simd = { git = "https://github.com/Shnatsel/fearless_simd.git", branch = "load-interleaved-4-way"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,4 +178,4 @@ debug = true
 strip = "none"
 
 [patch.crates-io]
-fearless_simd = { git = "https://github.com/Shnatsel/fearless_simd.git", branch = "load-interleaved-4-way"}
+fearless_simd = { git = "https://github.com/Shnatsel/fearless_simd.git", branch = "widen-narrow"}

--- a/sparse_strips/vello_common/src/clip.rs
+++ b/sparse_strips/vello_common/src/clip.rs
@@ -8,11 +8,11 @@ use crate::kurbo::{Affine, BezPath, PathEl};
 use crate::strip::Strip;
 use crate::strip_generator::{GenerationMode, StripGenerator, StripStorage};
 use crate::tile::Tile;
-use crate::util::{Clear, Pool, normalized_mul_u8x16, strip_bbox};
+use crate::util::{Clear, Pool, normalized_mul_u8, strip_bbox};
 use alloc::vec;
 use alloc::vec::Vec;
 use core::ops::Range;
-use fearless_simd::{Level, Simd, SimdBase, dispatch, u8x16};
+use fearless_simd::{Level, dispatch, prelude::*, u8x16};
 use peniko::Fill;
 
 #[derive(Debug)]
@@ -461,7 +461,8 @@ fn intersect_impl<S: Simd>(
                                 let s2 = u8x16::from_slice(simd, s2_alpha);
 
                                 // Combine them.
-                                let res = simd.narrow_u16x16(normalized_mul_u8x16(s1, s2));
+                                let (res_lo, res_hi) = normalized_mul_u8(s1, s2).split();
+                                let res = res_lo.narrow(res_hi);
                                 target.alphas.extend(res.as_slice());
                             }
                         }

--- a/sparse_strips/vello_common/src/tile.rs
+++ b/sparse_strips/vello_common/src/tile.rs
@@ -478,7 +478,7 @@ impl Tiles {
     pub fn sort_tiles(&mut self) {
         self.sorted = true;
         // To enable auto-vectorization.
-        self.level.dispatch(|_| self.tile_buf.sort_unstable());
+        dispatch!(self.level, _ => self.tile_buf.sort_unstable() );
     }
 
     /// Get the tile at a certain index.

--- a/sparse_strips/vello_common/src/util.rs
+++ b/sparse_strips/vello_common/src/util.rs
@@ -9,9 +9,7 @@ use crate::strip::{Strip, visit_strip_fill_segments};
 use crate::tile::Tile;
 use alloc::vec::Vec;
 use core::ops::{Index, IndexMut};
-use fearless_simd::{
-    Bytes, Simd, SimdBase, SimdFloat, f32x16, u8x16, u8x32, u16x16, u16x32, u32x16,
-};
+use fearless_simd::{f32x16, prelude::*, u8x16, u16x8, u16x16, u16x32, u32x16};
 #[cfg(not(feature = "std"))]
 use peniko::kurbo::common::FloatFuncs as _;
 use peniko::kurbo::{Affine, Rect};
@@ -60,16 +58,29 @@ impl<S: Simd> Div255Ext for u16x16<S> {
     }
 }
 
-/// Perform a normalized multiplication for u8x32.
-#[inline(always)]
-pub fn normalized_mul_u8x32<S: Simd>(a: u8x32<S>, b: u8x32<S>) -> u16x32<S> {
-    (S::widen_u8x32(a.simd, a) * S::widen_u8x32(b.simd, b)).div_255()
+impl<S: Simd> Div255Ext for u16x8<S> {
+    #[inline(always)]
+    fn div_255(self) -> Self {
+        let p1 = Self::splat(self.simd, 255);
+        let p2 = self + p1;
+        p2 >> 8
+    }
 }
 
-/// Perform a normalized multiplication for u8x16.
+/// Perform a normalized multiplication for a SIMD vector of `u8` values.
 #[inline(always)]
-pub fn normalized_mul_u8x16<S: Simd>(a: u8x16<S>, b: u8x16<S>) -> u16x16<S> {
-    (S::widen_u8x16(a.simd, a) * S::widen_u8x16(b.simd, b)).div_255()
+pub fn normalized_mul_u8<S, V>(a: V, b: V) -> <V::Widened as SimdCombine<S>>::Combined
+where
+    S: Simd,
+    V: SimdWiden<S>,
+    V::Widened: SimdCombine<S>,
+    <V::Widened as SimdCombine<S>>::Combined: Div255Ext,
+{
+    let (low_a, high_a) = a.widen();
+    let (low_b, high_b) = b.widen();
+    let a = low_a.combine(high_a);
+    let b = low_b.combine(high_b);
+    (a * b).div_255()
 }
 
 /// Check if an affine transform is a pure integer translation.

--- a/sparse_strips/vello_cpu/src/fine/common/rounded_blurred_rect.rs
+++ b/sparse_strips/vello_cpu/src/fine/common/rounded_blurred_rect.rs
@@ -94,11 +94,8 @@ impl<S: Simd> crate::fine::Painter for BlurredRoundedRectFiller<S> {
                     let b = u8x16::from_f32(simd, simd.combine_f32x8(first.b, second.b));
                     let a = u8x16::from_f32(simd, simd.combine_f32x8(first.a, second.a));
 
-                    let combined =
-                        simd.combine_u8x32(simd.combine_u8x16(r, g), simd.combine_u8x16(b, a));
-
-                    simd.store_interleaved_128_u8x64(
-                        combined,
+                    simd.store_four_interleaved_u8x16(
+                        [r, g, b, a],
                         (&mut chunk[..]).try_into().unwrap(),
                     );
                 }
@@ -111,11 +108,13 @@ impl<S: Simd> crate::fine::Painter for BlurredRoundedRectFiller<S> {
             #[inline(always)]
             || {
                 for chunk in buf.chunks_exact_mut(32) {
-                    let (c1, c2) = self.next().unwrap().get();
-                    c1.simd
-                        .store_interleaved_128_f32x16(c1, (&mut chunk[..16]).try_into().unwrap());
-                    c2.simd
-                        .store_interleaved_128_f32x16(c2, (&mut chunk[16..]).try_into().unwrap());
+                    let [c1, c2] = self.next().unwrap().get();
+                    c1[0]
+                        .simd
+                        .store_four_interleaved_f32x4(c1, (&mut chunk[..16]).try_into().unwrap());
+                    c2[0]
+                        .simd
+                        .store_four_interleaved_f32x4(c2, (&mut chunk[16..]).try_into().unwrap());
                 }
             },
         );

--- a/sparse_strips/vello_cpu/src/fine/highp/blend.rs
+++ b/sparse_strips/vello_cpu/src/fine/highp/blend.rs
@@ -51,25 +51,16 @@ fn mix_inner<S: Simd>(src_c: f32x16<S>, bg: f32x16<S>, blend_mode: BlendMode) ->
     res_bg.g = apply_alpha(bg_a, src_a, unpremultiplied_src.g, mix_src.g);
     res_bg.b = apply_alpha(bg_a, src_a, unpremultiplied_src.b, mix_src.b);
 
-    let combined = simd.combine_f32x8(
-        simd.combine_f32x4(res_bg.r, res_bg.g),
-        simd.combine_f32x4(res_bg.b, src_a),
-    );
-
     let mut storage = [0.0; 16];
-    simd.store_interleaved_128_f32x16(combined, &mut storage);
+    simd.store_four_interleaved_f32x4([res_bg.r, res_bg.g, res_bg.b, src_a], &mut storage);
     f32x16::from_slice(simd, &storage)
 }
 
 #[inline(always)]
 fn split<S: Simd>(simd: S, input: f32x16<S>) -> (Channels<S>, f32x4<S>) {
     let mut storage = [0.0; 16];
-    simd.store_interleaved_128_f32x16(input, &mut storage);
-    let input_v = f32x16::from_slice(simd, &storage);
-
-    let p1 = simd.split_f32x16(input_v);
-    let (r, g) = simd.split_f32x8(p1.0);
-    let (b, a) = simd.split_f32x8(p1.1);
+    input.store_slice(&mut storage);
+    let [r, g, b, a] = simd.load_four_interleaved_f32x4(&storage);
 
     (Channels { r, g, b }, a)
 }

--- a/sparse_strips/vello_cpu/src/fine/lowp/blend.rs
+++ b/sparse_strips/vello_cpu/src/fine/lowp/blend.rs
@@ -4,7 +4,7 @@
 use crate::fine::{Splat4thExt, highp, u8_to_f32};
 use crate::peniko::{BlendMode, Mix};
 use vello_common::fearless_simd::*;
-use vello_common::util::{Div255Ext, f32_to_u8, normalized_mul_u8x32};
+use vello_common::util::{Div255Ext, f32_to_u8, normalized_mul_u8};
 
 pub(crate) fn mix<S: Simd>(src_c: u8x32<S>, bg_c: u8x32<S>, blend_mode: BlendMode) -> u8x32<S> {
     src_c.simd.vectorize(
@@ -80,9 +80,15 @@ fn try_u8_mix<S: Simd>(blend_mode: BlendMode, src_c: u8x32<S>, bg_c: u8x32<S>) -
 }
 
 #[inline(always)]
-fn narrow_saturating_u16x32<S: Simd>(simd: S, val: u16x32<S>) -> u8x32<S> {
-    // In case we had an overflow, make sure to clamp back to `u8::MAX`.
-    simd.narrow_u16x32(val.min(u16x32::splat(simd, 255)))
+fn narrow_saturating_u16x32<S: Simd>(val: u16x32<S>) -> u8x32<S> {
+    let (low, high) = val.split();
+    low.saturating_narrow(high)
+}
+
+#[inline(always)]
+fn widen_u8x32<S: Simd>(val: u8x32<S>) -> u16x32<S> {
+    let (low, high) = val.widen();
+    low.combine(high)
 }
 
 macro_rules! u8_mix {
@@ -115,12 +121,11 @@ macro_rules! u8_mix {
 //   M = S * (1 - Ab) + As * Ab * Cb * Cs
 //     = S * (1 - Ab) + S * D
 u8_mix!(Multiply, |src_c: u8x32<S>, bg_c: u8x32<S>| {
-    let simd = src_c.simd;
     let one_minus_bg_a = 255 - bg_c.splat_4th();
-    let p1 = normalized_mul_u8x32(src_c, one_minus_bg_a);
-    let p2 = normalized_mul_u8x32(src_c, bg_c);
+    let p1 = normalized_mul_u8(src_c, one_minus_bg_a);
+    let p2 = normalized_mul_u8(src_c, bg_c);
 
-    narrow_saturating_u16x32(simd, p1 + p2)
+    narrow_saturating_u16x32(p1 + p2)
 });
 
 // Screen:
@@ -128,12 +133,11 @@ u8_mix!(Multiply, |src_c: u8x32<S>, bg_c: u8x32<S>| {
 //   M = S * (1 - Ab) + As * D + S * Ab - S * D
 //     = S + As * D - S * D
 u8_mix!(Screen, |src_c: u8x32<S>, bg_c: u8x32<S>| {
-    let simd = src_c.simd;
-    let p1 = normalized_mul_u8x32(src_c.splat_4th(), bg_c);
-    let p2 = normalized_mul_u8x32(src_c, bg_c);
-    let res = simd.widen_u8x32(src_c) + p1 - p2;
+    let p1 = normalized_mul_u8(src_c.splat_4th(), bg_c);
+    let p2 = normalized_mul_u8(src_c, bg_c);
+    let res = widen_u8x32(src_c) + p1 - p2;
 
-    narrow_saturating_u16x32(simd, res)
+    narrow_saturating_u16x32(res)
 });
 
 // Overlay is hard-light with source and backdrop swapped.
@@ -145,26 +149,24 @@ u8_mix!(Overlay, |src_c: u8x32<S>, bg_c: u8x32<S>| {
 //   B(Cb, Cs) = min(Cb, Cs)
 //   M = S * (1 - Ab) + min(S * Ab, D * As)
 u8_mix!(Darken, |src_c: u8x32<S>, bg_c: u8x32<S>| {
-    let simd = src_c.simd;
     let src_a = src_c.splat_4th();
     let bg_a = bg_c.splat_4th();
-    let p1 = normalized_mul_u8x32(src_c, 255 - bg_a);
-    let p2 = normalized_mul_u8x32(src_c, bg_a).min(normalized_mul_u8x32(bg_c, src_a));
+    let p1 = normalized_mul_u8(src_c, 255 - bg_a);
+    let p2 = normalized_mul_u8(src_c, bg_a).min(normalized_mul_u8(bg_c, src_a));
 
-    narrow_saturating_u16x32(simd, p1 + p2)
+    narrow_saturating_u16x32(p1 + p2)
 });
 
 // Lighten:
 //   B(Cb, Cs) = max(Cb, Cs)
 //   M = S * (1 - Ab) + max(S * Ab, D * As)
 u8_mix!(Lighten, |src_c: u8x32<S>, bg_c: u8x32<S>| {
-    let simd = src_c.simd;
     let src_a = src_c.splat_4th();
     let bg_a = bg_c.splat_4th();
-    let p1 = normalized_mul_u8x32(src_c, 255 - bg_a);
-    let p2 = normalized_mul_u8x32(src_c, bg_a).max(normalized_mul_u8x32(bg_c, src_a));
+    let p1 = normalized_mul_u8(src_c, 255 - bg_a);
+    let p2 = normalized_mul_u8(src_c, bg_a).max(normalized_mul_u8(bg_c, src_a));
 
-    narrow_saturating_u16x32(simd, p1 + p2)
+    narrow_saturating_u16x32(p1 + p2)
 });
 
 // Hard-light:
@@ -178,15 +180,14 @@ u8_mix!(HardLight, |src_c: u8x32<S>, bg_c: u8x32<S>| {
 //   B(Cb, Cs) = abs(Cb - Cs)
 //   M = S * (1 - Ab) + abs(S * Ab - D * As)
 u8_mix!(Difference, |src_c: u8x32<S>, bg_c: u8x32<S>| {
-    let simd = src_c.simd;
     let src_a = src_c.splat_4th();
     let bg_a = bg_c.splat_4th();
-    let p1 = normalized_mul_u8x32(src_c, 255 - bg_a);
-    let p2 = normalized_mul_u8x32(src_c, bg_a);
-    let p3 = normalized_mul_u8x32(bg_c, src_a);
+    let p1 = normalized_mul_u8(src_c, 255 - bg_a);
+    let p2 = normalized_mul_u8(src_c, bg_a);
+    let p3 = normalized_mul_u8(bg_c, src_a);
     let diff = p2.max(p3) - p2.min(p3);
 
-    narrow_saturating_u16x32(simd, p1 + diff)
+    narrow_saturating_u16x32(p1 + diff)
 });
 
 // Exclusion:
@@ -195,24 +196,24 @@ u8_mix!(Difference, |src_c: u8x32<S>, bg_c: u8x32<S>| {
 //     = S + As * D - 2 * S * D
 u8_mix!(Exclusion, |src_c: u8x32<S>, bg_c: u8x32<S>| {
     let simd = src_c.simd;
-    let p1 = normalized_mul_u8x32(src_c.splat_4th(), bg_c);
-    let p2 = normalized_mul_u8x32(src_c, bg_c);
-    let res = simd.widen_u8x32(src_c) + p1;
+    let p1 = normalized_mul_u8(src_c.splat_4th(), bg_c);
+    let p2 = normalized_mul_u8(src_c, bg_c);
+    let res = widen_u8x32(src_c) + p1;
     let sub = p2 + p2;
     let res = simd.select_u16x32(res.simd_ge(sub), res - sub, u16x32::splat(simd, 0));
 
-    narrow_saturating_u16x32(simd, res)
+    narrow_saturating_u16x32(res)
 });
 
 #[inline(always)]
 fn hard_light_inner<S: Simd>(src_c: u8x32<S>, bg_c: u8x32<S>, condition: u8x32<S>) -> u8x32<S> {
     let simd = src_c.simd;
-    let src = simd.widen_u8x32(src_c);
-    let bg = simd.widen_u8x32(bg_c);
-    let src_a = simd.widen_u8x32(src_c.splat_4th());
-    let bg_a = simd.widen_u8x32(bg_c.splat_4th());
-    let condition_a = simd.widen_u8x32(condition.splat_4th());
-    let condition = simd.widen_u8x32(condition);
+    let src = widen_u8x32(src_c);
+    let bg = widen_u8x32(bg_c);
+    let src_a = widen_u8x32(src_c.splat_4th());
+    let bg_a = widen_u8x32(bg_c.splat_4th());
+    let condition_a = widen_u8x32(condition.splat_4th());
+    let condition = widen_u8x32(condition);
 
     let base = src * (255 - bg_a);
     // Multiply branch: As * Ab * 2 * Cb * Cs = 2 * S * D.
@@ -230,7 +231,7 @@ fn hard_light_inner<S: Simd>(src_c: u8x32<S>, bg_c: u8x32<S>, condition: u8x32<S
     );
     let res = (base + blended).div_255();
 
-    narrow_saturating_u16x32(simd, res)
+    narrow_saturating_u16x32(res)
 }
 
 #[inline(always)]

--- a/sparse_strips/vello_cpu/src/fine/lowp/compose.rs
+++ b/sparse_strips/vello_cpu/src/fine/lowp/compose.rs
@@ -7,6 +7,18 @@ use crate::util::NormalizedMulExt;
 use vello_common::fearless_simd::*;
 use vello_common::util::Div255Ext;
 
+#[inline(always)]
+fn widen_u8x32<S: Simd>(val: u8x32<S>) -> u16x32<S> {
+    let (low, high) = val.widen();
+    low.combine(high)
+}
+
+#[inline(always)]
+fn narrow_u16x32<S: Simd>(val: u16x32<S>) -> u8x32<S> {
+    let (low, high) = val.split();
+    low.narrow(high)
+}
+
 pub(crate) trait ComposeExt {
     fn compose<S: Simd>(
         &self,
@@ -60,9 +72,9 @@ fn compose_inner<S: Simd>(
 
     if let Some(alpha_mask) = alpha_mask {
         let alpha_mask_inv = 255 - alpha_mask;
-        let p1 = simd.widen_u8x32(alpha_mask) * simd.widen_u8x32(res);
-        let p2 = simd.widen_u8x32(alpha_mask_inv) * simd.widen_u8x32(bg_c);
-        res = simd.narrow_u16x32((p1 + p2).div_255());
+        let p1 = widen_u8x32(alpha_mask) * widen_u8x32(res);
+        let p2 = widen_u8x32(alpha_mask_inv) * widen_u8x32(bg_c);
+        res = narrow_u16x32((p1 + p2).div_255());
     }
 
     res
@@ -82,9 +94,9 @@ macro_rules! compose {
                 let fb = $fb(simd, al_s, al_b);
 
                 if $sat {
-                    simd.narrow_u16x32(
-                        (simd.widen_u8x32(src_c.normalized_mul(fa))
-                            + simd.widen_u8x32(fb.normalized_mul(bg_c)))
+                    narrow_u16x32(
+                        (widen_u8x32(src_c.normalized_mul(fa))
+                            + widen_u8x32(fb.normalized_mul(bg_c)))
                         .min(u16x32::splat(simd, 255))
                         .max(u16x32::splat(simd, 0)),
                     )

--- a/sparse_strips/vello_cpu/src/fine/lowp/image.rs
+++ b/sparse_strips/vello_cpu/src/fine/lowp/image.rs
@@ -5,10 +5,22 @@ use crate::fine::PosExt;
 use crate::fine::common::image::{ImagePainterData, extend, fract_floor, sample};
 use crate::fine::macros::u8x16_painter;
 use vello_common::encode::EncodedImage;
-use vello_common::fearless_simd::{Simd, SimdBase, SimdFloat, f32x4, u8x16, u16x16};
+use vello_common::fearless_simd::{f32x4, prelude::*, u8x16, u16x16};
 use vello_common::pixmap::Pixmap;
 use vello_common::simd::element_wise_splat;
 use vello_common::util::{Div255Ext, f32_to_u8};
+
+#[inline(always)]
+fn widen_u8x16<S: Simd>(value: u8x16<S>) -> u16x16<S> {
+    let (low, high) = value.widen();
+    low.combine(high)
+}
+
+#[inline(always)]
+fn narrow_u16x16<S: Simd>(value: u16x16<S>) -> u8x16<S> {
+    let (low, high) = value.split();
+    low.narrow(high)
+}
 
 /// A faster bilinear image renderer for the u8 pipeline.
 #[derive(Debug)]
@@ -79,8 +91,8 @@ impl<S: Simd> Iterator for BilinearImagePainter<'_, S> {
             fract_floor(y_positions + 0.5).mul_add(255.0, 0.5),
         ));
 
-        let fx = self.simd.widen_u8x16(fx);
-        let fy = self.simd.widen_u8x16(fy);
+        let fx = widen_u8x16(fx);
+        let fy = widen_u8x16(fy);
         let fx_inv = u16x16::splat(self.simd, 255) - fx;
         let fy_inv = u16x16::splat(self.simd, 255) - fy;
 
@@ -89,22 +101,14 @@ impl<S: Simd> Iterator for BilinearImagePainter<'_, S> {
         let y_pos1 = extend_y(y_positions - 0.5);
         let y_pos2 = extend_y(y_positions + 0.5);
 
-        let p00 = self
-            .simd
-            .widen_u8x16(sample(self.simd, &self.data, x_pos1, y_pos1));
-        let p10 = self
-            .simd
-            .widen_u8x16(sample(self.simd, &self.data, x_pos2, y_pos1));
-        let p01 = self
-            .simd
-            .widen_u8x16(sample(self.simd, &self.data, x_pos1, y_pos2));
-        let p11 = self
-            .simd
-            .widen_u8x16(sample(self.simd, &self.data, x_pos2, y_pos2));
+        let p00 = widen_u8x16(sample(self.simd, &self.data, x_pos1, y_pos1));
+        let p10 = widen_u8x16(sample(self.simd, &self.data, x_pos2, y_pos1));
+        let p01 = widen_u8x16(sample(self.simd, &self.data, x_pos1, y_pos2));
+        let p11 = widen_u8x16(sample(self.simd, &self.data, x_pos2, y_pos2));
 
         let ip1 = (p00 * fx_inv + p10 * fx).div_255();
         let ip2 = (p01 * fx_inv + p11 * fx).div_255();
-        let res = self.simd.narrow_u16x16((ip1 * fy_inv + ip2 * fy).div_255());
+        let res = narrow_u16x16((ip1 * fy_inv + ip2 * fy).div_255());
 
         self.data.cur_pos += self.data.image.x_advance;
 
@@ -178,7 +182,7 @@ impl<'a, S: Simd> PlainBilinearImagePainter<'a, S> {
                     simd,
                     fract_floor(y_positions + 0.5).mul_add(255.0, 0.5),
                 ));
-                let fy = simd.widen_u8x16(fy);
+                let fy = widen_u8x16(fy);
                 let fy_inv = u16x16::splat(simd, 255) - fy;
 
                 let cur_x_pos = f32x4::splat_pos(
@@ -232,29 +236,19 @@ impl<S: Simd> Iterator for PlainBilinearImagePainter<'_, S> {
             self.simd,
             fract_floor(x_plus_half).mul_add(255.0, 0.5),
         ));
-        let fx = self.simd.widen_u8x16(fx);
+        let fx = widen_u8x16(fx);
         let fx_inv = u16x16::splat(self.simd, 255) - fx;
 
         // Sample the 4 corners using pre-computed y positions
-        let p00 = self
-            .simd
-            .widen_u8x16(sample(self.simd, &self.data, x_pos1, self.y_pos1));
-        let p10 = self
-            .simd
-            .widen_u8x16(sample(self.simd, &self.data, x_pos2, self.y_pos1));
-        let p01 = self
-            .simd
-            .widen_u8x16(sample(self.simd, &self.data, x_pos1, self.y_pos2));
-        let p11 = self
-            .simd
-            .widen_u8x16(sample(self.simd, &self.data, x_pos2, self.y_pos2));
+        let p00 = widen_u8x16(sample(self.simd, &self.data, x_pos1, self.y_pos1));
+        let p10 = widen_u8x16(sample(self.simd, &self.data, x_pos2, self.y_pos1));
+        let p01 = widen_u8x16(sample(self.simd, &self.data, x_pos1, self.y_pos2));
+        let p11 = widen_u8x16(sample(self.simd, &self.data, x_pos2, self.y_pos2));
 
         // Bilinear interpolation
         let ip1 = (p00 * fx_inv + p10 * fx).div_255();
         let ip2 = (p01 * fx_inv + p11 * fx).div_255();
-        let res = self
-            .simd
-            .narrow_u16x16((ip1 * self.fy_inv + ip2 * self.fy).div_255());
+        let res = narrow_u16x16((ip1 * self.fy_inv + ip2 * self.fy).div_255());
 
         self.cur_x_pos += self.advance;
 

--- a/sparse_strips/vello_cpu/src/fine/lowp/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/lowp/mod.rs
@@ -360,10 +360,9 @@ fn pack_block<S: Simd>(simd: S, scratch: &[u8], width: usize, region: &mut Regio
     for col in scratch[..width * TILE_HEIGHT_COMPONENTS].chunks_exact(CHUNK_LENGTH) {
         let casted: &[u32; 16] = cast_slice::<u8, u32>(col).try_into().unwrap();
 
-        let loaded = simd.load_interleaved_128_u32x16(casted).to_bytes();
-        let (loaded_lo, loaded_hi) = simd.split_u8x64(loaded);
-        let (loaded_1, loaded_2) = simd.split_u8x32(loaded_lo);
-        let (loaded_3, loaded_4) = simd.split_u8x32(loaded_hi);
+        let [loaded_1, loaded_2, loaded_3, loaded_4] = simd
+            .load_four_interleaved_u32x4(casted)
+            .map(u32x4::to_bytes);
 
         let (dest0, rest0) = row0.split_at_mut(Tile::WIDTH as usize * COLOR_COMPONENTS);
         let (dest1, rest1) = row1.split_at_mut(Tile::WIDTH as usize * COLOR_COMPONENTS);
@@ -440,9 +439,7 @@ fn unpack_block<S: Simd>(simd: S, region: &mut Region<'_>, width: usize, scratch
         let r1 = f32x4::from_bytes(u8x16::from_slice(simd, src1));
         let r2 = f32x4::from_bytes(u8x16::from_slice(simd, src2));
         let r3 = f32x4::from_bytes(u8x16::from_slice(simd, src3));
-        let combined = simd.combine_f32x8(simd.combine_f32x4(r0, r1), simd.combine_f32x4(r2, r3));
-
-        simd.store_interleaved_128_f32x16(combined, col);
+        simd.store_four_interleaved_f32x4([r0, r1, r2, r3], col);
 
         row0 = rest0;
         row1 = rest1;

--- a/sparse_strips/vello_cpu/src/fine/lowp/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/lowp/mod.rs
@@ -31,7 +31,7 @@ use vello_common::mask::Mask;
 use vello_common::paint::{PremulColor, Tint, TintMode};
 use vello_common::pixmap::Pixmap;
 use vello_common::tile::Tile;
-use vello_common::util::Div255Ext;
+use vello_common::util::normalized_mul_u8;
 
 /// The kernel for doing rendering using u8/u16.
 #[derive(Clone, Copy, Debug)]
@@ -138,10 +138,8 @@ impl<S: Simd> FineKernel<S> for U8Kernel {
             || {
                 for el in dest.chunks_exact_mut(16) {
                     let loaded = u8x16::from_slice(simd, el);
-                    let mulled = simd.narrow_u16x16(
-                        (simd.widen_u8x16(loaded) * simd.widen_u8x16(src.next().unwrap()))
-                            .div_255(),
-                    );
+                    let (low, high) = normalized_mul_u8(loaded, src.next().unwrap()).split();
+                    let mulled = low.narrow(high);
                     mulled.store_slice(el);
                 }
             },
@@ -470,7 +468,7 @@ mod fill {
     use crate::fine::lowp::compose::ComposeExt;
     use crate::peniko::{BlendMode, Mix};
     use vello_common::fearless_simd::*;
-    use vello_common::util::normalized_mul_u8x32;
+    use vello_common::util::normalized_mul_u8;
 
     /// Applies blend mode compositing to a buffer without per-pixel masks.
     pub(super) fn blend<S: Simd, T: Iterator<Item = u8x32<S>>>(
@@ -548,12 +546,13 @@ mod fill {
     /// This implements the Porter-Duff "source over" operator.
     #[inline(always)]
     fn alpha_composite_inner<S: Simd>(
-        s: S,
+        _s: S,
         bg: u8x32<S>,
         src: u8x32<S>,
         one_minus_alpha: u8x32<S>,
     ) -> u8x32<S> {
-        s.narrow_u16x32(normalized_mul_u8x32(bg, one_minus_alpha)) + src
+        let (low, high) = normalized_mul_u8(bg, one_minus_alpha).split();
+        low.narrow(high) + src
     }
 }
 
@@ -568,7 +567,7 @@ mod alpha_fill {
     use crate::fine::lowp::{blend, extract_masks};
     use crate::peniko::{BlendMode, Mix};
     use vello_common::fearless_simd::*;
-    use vello_common::util::{Div255Ext, normalized_mul_u8x32};
+    use vello_common::util::{Div255Ext, normalized_mul_u8};
 
     /// Applies blend mode compositing with per-pixel alpha masks.
     pub(super) fn blend<S: Simd, T: Iterator<Item = u8x32<S>>>(
@@ -669,11 +668,20 @@ mod alpha_fill {
                 let bg_v = u8x32::from_slice(s, dest);
 
                 let mask_v = extract_masks(s, masks);
-                let inv_src_a_mask_a = one - s.narrow_u16x32(normalized_mul_u8x32(src_a, mask_v));
+                let (low, high) = normalized_mul_u8(src_a, mask_v).split();
+                let inv_src_a_mask_a = one - low.narrow(high);
 
-                let p1 = s.widen_u8x32(bg_v) * s.widen_u8x32(inv_src_a_mask_a);
-                let p2 = s.widen_u8x32(src_c) * s.widen_u8x32(mask_v);
-                let res = s.narrow_u16x32((p1 + p2).div_255());
+                let (bg_low, bg_high) = bg_v.widen();
+                let (inv_low, inv_high) = inv_src_a_mask_a.widen();
+                let (src_low, src_high) = src_c.widen();
+                let (mask_low, mask_high) = mask_v.widen();
+                let bg = bg_low.combine(bg_high);
+                let inv = inv_low.combine(inv_high);
+                let src = src_low.combine(src_high);
+                let mask = mask_low.combine(mask_high);
+                let result = (bg * inv + src * mask).div_255();
+                let (low, high) = result.split();
+                let res = low.narrow(high);
 
                 res.store_slice(dest);
             },

--- a/sparse_strips/vello_cpu/src/fine/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/mod.rs
@@ -1165,26 +1165,16 @@ pub(crate) struct ShaderResultF32<S: Simd> {
 impl<S: Simd> ShaderResultF32<S> {
     /// Convert from planar format to interleaved RGBA format.
     ///
-    /// Returns two f32x16 vectors containing 8 pixels (4 RGBA components each)
-    /// with channels interleaved in the standard RGBA order.
+    /// Returns two sets of four f32x4 vectors containing 8 pixels (4 RGBA components each),
+    /// ready to be stored with `store_four_interleaved_f32x4`.
     #[inline(always)]
-    pub(crate) fn get(&self) -> (f32x16<S>, f32x16<S>) {
+    pub(crate) fn get(&self) -> [[f32x4<S>; 4]; 2] {
         let (r_1, r_2) = self.r.simd.split_f32x8(self.r);
         let (g_1, g_2) = self.g.simd.split_f32x8(self.g);
         let (b_1, b_2) = self.b.simd.split_f32x8(self.b);
         let (a_1, a_2) = self.a.simd.split_f32x8(self.a);
 
-        let first = self.r.simd.combine_f32x8(
-            self.r.simd.combine_f32x4(r_1, g_1),
-            self.r.simd.combine_f32x4(b_1, a_1),
-        );
-
-        let second = self.r.simd.combine_f32x8(
-            self.r.simd.combine_f32x4(r_2, g_2),
-            self.r.simd.combine_f32x4(b_2, a_2),
-        );
-
-        (first, second)
+        [[r_1, g_1, b_1, a_1], [r_2, g_2, b_2, a_2]]
     }
 }
 

--- a/sparse_strips/vello_cpu/src/lib.rs
+++ b/sparse_strips/vello_cpu/src/lib.rs
@@ -158,7 +158,7 @@ mod filter;
 mod record;
 #[cfg(feature = "text")]
 mod text;
-#[cfg(all(feature = "text", feature = "std", debug_assertions))]
+#[cfg(all(feature = "text", feature = "std", debug_assertions, not(doc)))]
 mod text_debug;
 mod util;
 

--- a/sparse_strips/vello_cpu/src/util.rs
+++ b/sparse_strips/vello_cpu/src/util.rs
@@ -3,7 +3,7 @@
 
 use crate::peniko::ImageQuality;
 use vello_common::encode::EncodedImage;
-use vello_common::fearless_simd::{Simd, SimdBase, f32x4, u8x32};
+use vello_common::fearless_simd::{f32x4, prelude::*, u8x32};
 use vello_common::math::FloatExt;
 use vello_common::tile::Tile;
 use vello_common::util::Div255Ext;
@@ -71,8 +71,13 @@ pub(crate) trait NormalizedMulExt {
 impl<S: Simd> NormalizedMulExt for u8x32<S> {
     #[inline(always)]
     fn normalized_mul(self, other: Self) -> Self {
-        let divided = (self.simd.widen_u8x32(self) * other.simd.widen_u8x32(other)).div_255();
-        self.simd.narrow_u16x32(divided)
+        let (self_low, self_high) = self.widen();
+        let (other_low, other_high) = other.widen();
+        let self_wide = self_low.combine(self_high);
+        let other_wide = other_low.combine(other_high);
+        let result = (self_wide * other_wide).div_255();
+        let (low, high) = result.split();
+        low.narrow(high)
     }
 }
 

--- a/sparse_strips/vello_sparse_tests/tests/util.rs
+++ b/sparse_strips/vello_sparse_tests/tests/util.rs
@@ -126,7 +126,7 @@ pub(crate) fn get_ctx<T: Renderer>(
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         "sse42" => {
             if std::arch::is_x86_feature_detected!("sse4.2") {
-                Level::Sse4_2(unsafe { fearless_simd::Sse4_2::new_unchecked() })
+                Level::Sse4_2(unsafe { fearless_simd::Sse4_2::assume_supported() })
             } else {
                 panic!("sse4.2 feature not detected");
             }
@@ -136,7 +136,7 @@ pub(crate) fn get_ctx<T: Renderer>(
             if std::arch::is_x86_feature_detected!("avx2")
                 && std::arch::is_x86_feature_detected!("fma")
             {
-                Level::Avx2(unsafe { fearless_simd::Avx2::new_unchecked() })
+                Level::Avx2(unsafe { fearless_simd::Avx2::assume_supported() })
             } else {
                 panic!("avx2 or fma feature not detected");
             }


### PR DESCRIPTION
Shows the impact of https://github.com/linebender/fearless_simd/pull/300 and other recent changes to fearless_simd

This is performance-neutral on x86 AVX2 on the Ghostscript tiger benchmarks.

AVX-512 is not comparable since main doesn't have AVX-512 support.

The new widen/narrow API is more boilerplate, but can work with hardware-width vectors such as `S::f32s` and can widen 512-bit vectors into two 512-bit vectors, which is inexpressible in the API that immediately combines the halves.