### PR TITLE
sparse_strips: Bump to version 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,7 +1353,7 @@ dependencies = [
 
 [[package]]
 name = "glifo"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bytemuck",
  "core_maths",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4477,7 +4477,7 @@ dependencies = [
 
 [[package]]
 name = "vello_common"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bytemuck",
  "fearless_simd",
@@ -4493,7 +4493,7 @@ dependencies = [
 
 [[package]]
 name = "vello_cpu"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bytemuck",
  "crossbeam-channel",
@@ -4557,7 +4557,7 @@ dependencies = [
 
 [[package]]
 name = "vello_hybrid"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bytemuck",
  "glifo",
@@ -4599,7 +4599,7 @@ dependencies = [
 
 [[package]]
 name = "vello_sparse_shaders"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "naga",
  "wesl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,10 +128,10 @@ wasm-bindgen-futures = "0.4.64"
 wasm-bindgen-test = "0.3.64"
 web-sys = "0.3.91"
 
-vello_common = { version = "0.1.0", path = "sparse_strips/vello_common", default-features = false }
-vello_cpu = { version = "0.1.0", path = "sparse_strips/vello_cpu" }
-vello_hybrid = { version = "0.1.0", path = "sparse_strips/vello_hybrid" }
-vello_sparse_shaders = { version = "0.1.0", path = "sparse_strips/vello_sparse_shaders" }
+vello_common = { version = "0.2.0", path = "sparse_strips/vello_common", default-features = false }
+vello_cpu = { version = "0.2.0", path = "sparse_strips/vello_cpu" }
+vello_hybrid = { version = "0.2.0", path = "sparse_strips/vello_hybrid" }
+vello_sparse_shaders = { version = "0.2.0", path = "sparse_strips/vello_sparse_shaders" }
 glifo = { version = "0.2.0", path = "glifo", default-features = false }
 vello_example_scenes = { path = "sparse_strips/vello_example_scenes" }
 vello_dev_macros = { path = "sparse_strips/vello_dev_macros" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,7 @@ vello_common = { version = "0.2.0", path = "sparse_strips/vello_common", default
 vello_cpu = { version = "0.2.0", path = "sparse_strips/vello_cpu" }
 vello_hybrid = { version = "0.2.0", path = "sparse_strips/vello_hybrid" }
 vello_sparse_shaders = { version = "0.2.0", path = "sparse_strips/vello_sparse_shaders" }
-glifo = { version = "0.2.0", path = "glifo", default-features = false }
+glifo = { version = "0.3.0", path = "glifo", default-features = false }
 vello_example_scenes = { path = "sparse_strips/vello_example_scenes" }
 vello_dev_macros = { path = "sparse_strips/vello_dev_macros" }
 

--- a/glifo/CHANGELOG.md
+++ b/glifo/CHANGELOG.md
@@ -12,6 +12,14 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 This release has an [MSRV][] of 1.88.
 
+## [0.3.0][] - 2026-08-07
+
+This release has an [MSRV][] of 1.88.
+
+### Changed
+
+- Breaking change: Updated `vello_common` to v0.2.0.
+
 ## [0.2.0][] - 2026-07-29
 
 This release has an [MSRV][] of 1.88.
@@ -55,7 +63,8 @@ Glifo moved to the Vello repo in [#1539][] and was prepared for release by [@con
 [#1672]: https://github.com/linebender/vello/pull/1672
 [#1774]: https://github.com/linebender/vello/pull/1774
 
-[Unreleased]: https://github.com/linebender/vello/compare/glifo-v0.2.0...HEAD
+[Unreleased]: https://github.com/linebender/vello/compare/glifo-v0.3.0...HEAD
+[0.3.0]: https://github.com/linebender/vello/compare/glifo-v0.2.0...glifo-v0.3.0
 [0.2.0]: https://github.com/linebender/vello/compare/glifo-v0.1.1...glifo-v0.2.0
 [0.1.1]: https://github.com/linebender/vello/compare/glifo-v0.1.0...glifo-v0.1.1
 [0.1.0]: https://github.com/linebender/vello/compare/246912ae692cff7719cd95026107cc1aa077f205...glifo-v0.1.0

--- a/glifo/Cargo.toml
+++ b/glifo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glifo"
-version = "0.2.0"
+version = "0.3.0"
 description = "Glifo provides APIs for efficiently rendering text."
 keywords = ["text", "layout"]
 categories = ["gui", "graphics"]

--- a/sparse_strips/vello_common/CHANGELOG.md
+++ b/sparse_strips/vello_common/CHANGELOG.md
@@ -12,6 +12,18 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 This release has an [MSRV][] of 1.88.
 
+## [0.2.0][] - 2026-08-07
+
+This release has an [MSRV][] of 1.88.
+
+### Added
+
+- `ProbeResult::statistics`, `ProbeStatistics`, and `ProbeFeature` for diagnosing which renderer-probe features and pixels differ from the reference output. ([#1779][] by [@LaurenzV][])
+
+### Changed
+
+- Breaking change: `AtlasError` variants now report configured limits and allocation sizes, with the new `AtlasSpaceDiagnostics` and `AtlasLayerDiagnostics` types providing per-layer free-space, utilization, and fragmentation details. ([#1778][] by [@grebmeg][])
+
 ## [0.1.0][] - 2026-07-29
 
 This release has an [MSRV][] of 1.88.
@@ -295,8 +307,11 @@ See also the [vello_cpu 0.0.1](../vello_cpu/CHANGELOG.md#001---2025-05-10) relea
 [#1762]: https://github.com/linebender/vello/pull/1762
 [#1763]: https://github.com/linebender/vello/pull/1763
 [#1768]: https://github.com/linebender/vello/pull/1768
+[#1778]: https://github.com/linebender/vello/pull/1778
+[#1779]: https://github.com/linebender/vello/pull/1779
 
-[Unreleased]: https://github.com/linebender/vello/compare/sparse-strips-v0.1.0...HEAD
+[Unreleased]: https://github.com/linebender/vello/compare/sparse-strips-v0.2.0...HEAD
+[0.2.0]: https://github.com/linebender/vello/compare/sparse-strips-v0.1.0...sparse-strips-v0.2.0
 [0.1.0]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.9...sparse-strips-v0.1.0
 [0.0.9]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.8...sparse-strips-v0.0.9
 [0.0.8]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.7...sparse-strips-v0.0.8

--- a/sparse_strips/vello_common/CHANGELOG.md
+++ b/sparse_strips/vello_common/CHANGELOG.md
@@ -19,6 +19,7 @@ This release has an [MSRV][] of 1.88.
 ### Added
 
 - `ProbeResult::statistics`, `ProbeStatistics`, and `ProbeFeature` for diagnosing which renderer-probe features and pixels differ from the reference output. ([#1779][] by [@LaurenzV][])
+- `PROBE_ELEMENTS` for inspecting the active features used by the shared probe scene. ([#1801][] by [@LaurenzV][])
 
 ### Changed
 
@@ -309,6 +310,7 @@ See also the [vello_cpu 0.0.1](../vello_cpu/CHANGELOG.md#001---2025-05-10) relea
 [#1768]: https://github.com/linebender/vello/pull/1768
 [#1778]: https://github.com/linebender/vello/pull/1778
 [#1779]: https://github.com/linebender/vello/pull/1779
+[#1801]: https://github.com/linebender/vello/pull/1801
 
 [Unreleased]: https://github.com/linebender/vello/compare/sparse-strips-v0.2.0...HEAD
 [0.2.0]: https://github.com/linebender/vello/compare/sparse-strips-v0.1.0...sparse-strips-v0.2.0

--- a/sparse_strips/vello_common/Cargo.toml
+++ b/sparse_strips/vello_common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vello_common"
 # When updating, also update the version in the workspace dependency in the root Cargo.toml
-version = "0.1.0"
+version = "0.2.0"
 description = "Core data structures and utilities shared across the Vello rendering, including geometry processing and tiling logic."
 categories = ["rendering", "graphics"]
 keywords = ["2d", "vector-graphics"]

--- a/sparse_strips/vello_cpu/CHANGELOG.md
+++ b/sparse_strips/vello_cpu/CHANGELOG.md
@@ -16,6 +16,10 @@ This release has an [MSRV][] of 1.88.
 
 This release has an [MSRV][] of 1.88.
 
+### Fixed
+
+- Wrong application of extend mode in the y-direction. ([#1803][] by [@LaurenzV][], [@ShiroKSH][])
+
 ### Optimized
 
 - Multi-threaded render contexts now initialize task dispatch lazily on the first drawing operation, avoiding unnecessary setup for empty frames and after resets. ([#1787][] by [@LaurenzV][], [@yezhizhen][])
@@ -211,6 +215,7 @@ See also the [vello_common 0.0.1](../vello_common/CHANGELOG.md#001---2025-05-10)
 [@LaurenzV]: https://github.com/LaurenzV
 [@nicoburns]: https://github.com/nicoburns
 [@oscargus]: https://github.com/oscargus
+[@ShiroKSH]: https://github.com/ShiroKSH
 [@taj-p]: https://github.com/taj-p
 [@tomcur]: https://github.com/tomcur
 [@tronical]: https://github.com/tronical
@@ -270,6 +275,7 @@ See also the [vello_common 0.0.1](../vello_common/CHANGELOG.md#001---2025-05-10)
 [#1760]: https://github.com/linebender/vello/pull/1760
 [#1763]: https://github.com/linebender/vello/pull/1763
 [#1787]: https://github.com/linebender/vello/pull/1787
+[#1803]: https://github.com/linebender/vello/pull/1803
 
 [Unreleased]: https://github.com/linebender/vello/compare/sparse-strips-v0.2.0...HEAD
 [0.2.0]: https://github.com/linebender/vello/compare/sparse-strips-v0.1.0...sparse-strips-v0.2.0

--- a/sparse_strips/vello_cpu/CHANGELOG.md
+++ b/sparse_strips/vello_cpu/CHANGELOG.md
@@ -12,6 +12,14 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 This release has an [MSRV][] of 1.88.
 
+## [0.2.0][] - 2026-08-07
+
+This release has an [MSRV][] of 1.88.
+
+### Optimized
+
+- Multi-threaded render contexts now initialize task dispatch lazily on the first drawing operation, avoiding unnecessary setup for empty frames and after resets. ([#1787][] by [@LaurenzV][], [@yezhizhen][])
+
 ## [0.1.0][] - 2026-07-29
 
 This release has an [MSRV][] of 1.88.
@@ -261,8 +269,10 @@ See also the [vello_common 0.0.1](../vello_common/CHANGELOG.md#001---2025-05-10)
 [#1756]: https://github.com/linebender/vello/pull/1756
 [#1760]: https://github.com/linebender/vello/pull/1760
 [#1763]: https://github.com/linebender/vello/pull/1763
+[#1787]: https://github.com/linebender/vello/pull/1787
 
-[Unreleased]: https://github.com/linebender/vello/compare/sparse-strips-v0.1.0...HEAD
+[Unreleased]: https://github.com/linebender/vello/compare/sparse-strips-v0.2.0...HEAD
+[0.2.0]: https://github.com/linebender/vello/compare/sparse-strips-v0.1.0...sparse-strips-v0.2.0
 [0.1.0]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.9...sparse-strips-v0.1.0
 [0.0.9]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.8...sparse-strips-v0.0.9
 [0.0.8]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.7...sparse-strips-v0.0.8

--- a/sparse_strips/vello_cpu/Cargo.toml
+++ b/sparse_strips/vello_cpu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vello_cpu"
-version = "0.1.0"
+version = "0.2.0"
 description = "A CPU-based renderer for Vello, optimized for SIMD and multithreaded execution."
 categories = ["rendering", "graphics"]
 keywords = ["2d", "vector-graphics"]

--- a/sparse_strips/vello_hybrid/CHANGELOG.md
+++ b/sparse_strips/vello_hybrid/CHANGELOG.md
@@ -12,15 +12,29 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 This release has an [MSRV][] of 1.88.
 
+## [0.2.0][] - 2026-08-07
+
+This release has an [MSRV][] of 1.88.
+
 ### Added
 
-- Support for sampling from external textures through `Scene::draw_texture_rects` in the `webgl` backend, bringing it to parity with the `wgpu` backend. Textures are bound at render time through the new `WebGlTextureBindings`.
+- Support for sampling from external textures through `Scene::draw_texture_rects` in the `webgl` backend, bringing it to parity with the `wgpu` backend. Textures are bound at render time through the new `WebGlTextureBindings`. ([#1792][] by [@grebmeg][])
+- `ProbeResult::statistics`, `ProbeStatistics`, and `ProbeFeature` for diagnosing which renderer-probe features and pixels differ from the reference output. ([#1779][] by [@LaurenzV][])
 
 ### Changed
 
-- Breaking change: `Renderer::new`, `Renderer::new_with`, `WebGlRenderer::new`, and `WebGlRenderer::new_with` now return the renderer and its associated `Resources` as a tuple. The given `Resources` should only be used in conjunction with the renderer instance that generated it. 
-- Breaking change: `Scene::new_with` now takes a `Level` instead of `RenderSettings`.
-- Breaking change: `WebGlRenderer::render` and `WebGlRenderer::render_to_atlas` now take a `WebGlTextureBindings`, providing the external textures referenced by the scene. Pass `&WebGlTextureBindings::new()` if the scene does not use any.
+- Breaking change: `Renderer::new`, `Renderer::new_with`, `WebGlRenderer::new`, and `WebGlRenderer::new_with` now return the renderer and its associated `Resources` as a tuple. `Resources` can no longer be constructed directly and must only be used with the renderer instance that generated it. ([#1794][] by [@LaurenzV][])
+- Breaking change: `Scene::new_with` now takes a `Level` instead of `RenderSettings`. ([#1794][] by [@LaurenzV][])
+- Breaking change: `WebGlRenderer::render` and `WebGlRenderer::render_to_atlas` now take `WebGlTextureBindings`, providing the external textures referenced by the scene. Pass `&WebGlTextureBindings::new()` if the scene does not use any. ([#1792][] by [@grebmeg][])
+- Breaking change: Image-atlas allocation errors now include allocation and free-space diagnostics, while intermediate-texture failures use the new `IntermediateTextureError` variants for oversized allocations and texture-count limits. ([#1778][] by [@grebmeg][])
+
+### Fixed
+
+- Image tints with zero opacity now make the image fully transparent. ([#1791][] by [@LaurenzV][])
+
+### Optimized
+
+- WebGL intermediate textures are destroyed before resized replacements are allocated, reducing peak texture memory while render targets grow. ([#1781][] by [@LaurenzV][])
 
 ### Fixed
 
@@ -282,8 +296,15 @@ See also the [vello_cpu 0.0.4](../vello_cpu/CHANGELOG.md#004---2025-10-17) and [
 [#1760]: https://github.com/linebender/vello/pull/1760
 [#1763]: https://github.com/linebender/vello/pull/1763
 [#1769]: https://github.com/linebender/vello/pull/1769
+[#1778]: https://github.com/linebender/vello/pull/1778
+[#1779]: https://github.com/linebender/vello/pull/1779
+[#1781]: https://github.com/linebender/vello/pull/1781
+[#1791]: https://github.com/linebender/vello/pull/1791
+[#1792]: https://github.com/linebender/vello/pull/1792
+[#1794]: https://github.com/linebender/vello/pull/1794
 
-[Unreleased]: https://github.com/linebender/vello/compare/sparse-strips-v0.1.0...HEAD
+[Unreleased]: https://github.com/linebender/vello/compare/sparse-strips-v0.2.0...HEAD
+[0.2.0]: https://github.com/linebender/vello/compare/sparse-strips-v0.1.0...sparse-strips-v0.2.0
 [0.1.0]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.9...sparse-strips-v0.1.0
 [0.0.9]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.8...sparse-strips-v0.0.9
 [0.0.8]: https://github.com/linebender/vello/compare/sparse-strips-v0.0.7...sparse-strips-v0.0.8

--- a/sparse_strips/vello_hybrid/CHANGELOG.md
+++ b/sparse_strips/vello_hybrid/CHANGELOG.md
@@ -20,6 +20,7 @@ This release has an [MSRV][] of 1.88.
 
 - Support for sampling from external textures through `Scene::draw_texture_rects` in the `webgl` backend, bringing it to parity with the `wgpu` backend. Textures are bound at render time through the new `WebGlTextureBindings`. ([#1792][] by [@grebmeg][])
 - `ProbeResult::statistics`, `ProbeStatistics`, and `ProbeFeature` for diagnosing which renderer-probe features and pixels differ from the reference output. ([#1779][] by [@LaurenzV][])
+- `PROBE_ELEMENTS` for inspecting the active features used by the WebGL compatibility probe. ([#1801][] by [@LaurenzV][])
 
 ### Changed
 
@@ -31,14 +32,11 @@ This release has an [MSRV][] of 1.88.
 ### Fixed
 
 - Image tints with zero opacity now make the image fully transparent. ([#1791][] by [@LaurenzV][])
+- WebGL image-atlas allocation and growth on Mali-G52 GPUs, avoiding application-not-responding errors. ([#1800][] by [@grebmeg][])
 
 ### Optimized
 
 - WebGL intermediate textures are destroyed before resized replacements are allocated, reducing peak texture memory while render targets grow. ([#1781][] by [@LaurenzV][])
-
-### Fixed
-
-- Fixed a bug in the `webgl` backend that could cause an ANR on Mali-G52 GPUs. (by [@grebmeg][])
 
 ## [0.1.0][] - 2026-07-29
 
@@ -302,6 +300,8 @@ See also the [vello_cpu 0.0.4](../vello_cpu/CHANGELOG.md#004---2025-10-17) and [
 [#1791]: https://github.com/linebender/vello/pull/1791
 [#1792]: https://github.com/linebender/vello/pull/1792
 [#1794]: https://github.com/linebender/vello/pull/1794
+[#1800]: https://github.com/linebender/vello/pull/1800
+[#1801]: https://github.com/linebender/vello/pull/1801
 
 [Unreleased]: https://github.com/linebender/vello/compare/sparse-strips-v0.2.0...HEAD
 [0.2.0]: https://github.com/linebender/vello/compare/sparse-strips-v0.1.0...sparse-strips-v0.2.0

--- a/sparse_strips/vello_hybrid/Cargo.toml
+++ b/sparse_strips/vello_hybrid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vello_hybrid"
-version = "0.1.0"
+version = "0.2.0"
 description = "A hybrid CPU/GPU renderer for Vello, balancing computation between CPU and GPU for efficiency."
 categories = ["rendering", "graphics"]
 keywords = ["2d", "vector-graphics"]

--- a/sparse_strips/vello_sparse_shaders/Cargo.toml
+++ b/sparse_strips/vello_sparse_shaders/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vello_sparse_shaders"
 # When updating, also update the version in the workspace dependency in the root Cargo.toml
-version = "0.1.0"
+version = "0.2.0"
 description = "Provide WESL shaders linked to WGSL and GLSL for the `vello_hybrid` backends."
 categories = ["rendering", "graphics"]
 keywords = ["2d", "vector-graphics"]


### PR DESCRIPTION
Was requested by the servo folks in https://github.com/linebender/vello/pull/1787#issuecomment-5173097081. Unfortunately can't be a patch bump because of already-landed breaking changes.

Release date is set for tomorrow.