### PR TITLE
vello_hybrid: Respect the `WEBGL_provoking_vertex` flag

### DIFF
--- a/sparse_strips/vello_hybrid/src/render/webgl/mod.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl/mod.rs
@@ -229,6 +229,28 @@ impl WebGlRenderer {
             .dyn_into::<WebGl2RenderingContext>()
             .expect("Context to be a WebGL2 context");
 
+        // See https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices#use_webgl_provoking_vertex_when_its_available
+        // for why we need to set this. This has been confirmed by benchmarks, where doing just a
+        // couple of draw calls with external textures tanks performance on any
+        // Apple device, especially low-tier iOS devices.
+        // IMPORTANT: This assumes that any use of flat parameters in shaders is the same across
+        // each vertex! In case this ever changes, we need to revisit this.
+        // https://web3dsurvey.com/webgl2/extensions/WEBGL_provoking_vertex
+        if let Some(ext) = gl.get_extension("WEBGL_provoking_vertex").unwrap() {
+            // See https://registry.khronos.org/webgl/extensions/WEBGL_provoking_vertex
+            const FIRST_VERTEX_CONVENTION_WEBGL: u32 = 0x8E4D;
+
+            // In WebGL, the _last_ vertex supplies the value for flat shader varyings by default.
+            // According to the spec, implementations should only expose this flag if the _first_
+            // convention is faster by default. Therefore, if the extension is available, we always
+            // set it to _first_.
+            js_sys::Reflect::get(ext.as_ref(), &"provokingVertexWEBGL".into())
+                .unwrap()
+                .unchecked_into::<js_sys::Function>()
+                .call1(ext.as_ref(), &JsValue::from(FIRST_VERTEX_CONVENTION_WEBGL))
+                .unwrap();
+        }
+
         let cloned_gl = gl.clone();
         let _state_guard = WebGlStateGuard::with_config(
             &cloned_gl,


### PR DESCRIPTION
See the comments, which should explain the rationale in enough detail. Below you can see data from a benchmark that compares the current `set_paint` against drawing with external texture rects.

Before: iPhone 12 struggles to keep 60 FPS with more than 10 images.
<img width="405" height="329" alt="image" src="https://github.com/user-attachments/assets/c2dade17-20b3-4383-904b-5359f074cd63" />

After: iPhone 12 can handle more thousands of external texture rects without performance tanking.
<img width="383" height="754" alt="image" src="https://github.com/user-attachments/assets/424a921b-fd7f-40e1-9f18-8aaa79e5571e" />

