### PR TITLE
vello_hybrid: Set the `failIfMajorPerformanceCaveat` flag

### DIFF
--- a/sparse_strips/vello_hybrid/src/render/webgl/mod.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl/mod.rs
@@ -208,8 +208,7 @@ impl WebGlRenderer {
         // context.
         let context_options = js_sys::Object::new();
         js_sys::Reflect::set(&context_options, &"antialias".into(), &JsValue::FALSE).unwrap();
-        // Reject contexts that would be dramatically slower than native rendering, such as a
-        // software-rasterized fallback.
+        // Avoid running Vello Hybrid if it's gonna be super slow.
         js_sys::Reflect::set(
             &context_options,
             &"failIfMajorPerformanceCaveat".into(),

--- a/sparse_strips/vello_hybrid/src/render/webgl/mod.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl/mod.rs
@@ -208,6 +208,14 @@ impl WebGlRenderer {
         // context.
         let context_options = js_sys::Object::new();
         js_sys::Reflect::set(&context_options, &"antialias".into(), &JsValue::FALSE).unwrap();
+        // Reject contexts that would be dramatically slower than native rendering, such as a
+        // software-rasterized fallback.
+        js_sys::Reflect::set(
+            &context_options,
+            &"failIfMajorPerformanceCaveat".into(),
+            &JsValue::TRUE,
+        )
+        .unwrap();
         // Vello only supports 24+ bit depth buffers. If the hardware falls back to a 16 bit depth buffer,
         // correctness issues will arise. For all intents and purposes, a device manufactured in the past 10 years
         // should support 24+ bit depth buffers (certainly those within the realm of what we consider "supported" devices)


### PR DESCRIPTION
In case the device is expected to be super slow on GPU (for example because it uses a software rasterizer behind the scenes), we would rather not run Vello Hybrid at all. In the future, maybe this should become a configurable option in case some users do desire this?

See: https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext#failifmajorperformancecaveat