### PR TITLE
refactor: move hybrid depth texture ownership to callers

### DIFF
--- a/sparse_strips/vello_hybrid/examples/native_webgl/src/lib.rs
+++ b/sparse_strips/vello_hybrid/examples/native_webgl/src/lib.rs
@@ -30,7 +30,7 @@ struct RendererWrapper {
 impl RendererWrapper {
     fn new(canvas: HtmlCanvasElement) -> Self {
         let settings = RenderSettings::default();
-        let (renderer, resources) = vello_hybrid::WebGlRenderer::new_with(&canvas, settings);
+        let (renderer, resources) = vello_hybrid::WebGlRenderer::new_with(&canvas, settings, true);
 
         Self {
             renderer,

--- a/sparse_strips/vello_hybrid/examples/render_to_file.rs
+++ b/sparse_strips/vello_hybrid/examples/render_to_file.rs
@@ -86,6 +86,8 @@ async fn run() {
         width: width.into(),
         height: height.into(),
     };
+    let depth_texture_view =
+        vello_hybrid::Renderer::create_depth_texture_view(&device, &render_size);
     // Copy texture to buffer
     let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
         label: Some("Vello Render To Buffer"),
@@ -99,6 +101,7 @@ async fn run() {
             &mut encoder,
             &render_size,
             &texture_view,
+            Some(&depth_texture_view),
             &vello_hybrid::TextureBindings::new(),
         )
         .unwrap();

--- a/sparse_strips/vello_hybrid/examples/wgpu_webgl/src/lib.rs
+++ b/sparse_strips/vello_hybrid/examples/wgpu_webgl/src/lib.rs
@@ -39,6 +39,7 @@ struct RendererWrapper {
     device: wgpu::Device,
     queue: wgpu::Queue,
     surface: wgpu::Surface<'static>,
+    depth_texture_view: wgpu::TextureView,
 }
 
 impl RendererWrapper {
@@ -102,6 +103,10 @@ impl RendererWrapper {
             },
             settings,
         );
+        let depth_texture_view = Renderer::create_depth_texture_view(
+            &device,
+            &vello_hybrid::RenderSize { width, height },
+        );
 
         Self {
             renderer,
@@ -109,6 +114,7 @@ impl RendererWrapper {
             device,
             queue,
             surface,
+            depth_texture_view,
         }
     }
 
@@ -124,6 +130,10 @@ impl RendererWrapper {
             view_formats: vec![],
         };
         self.surface.configure(&self.device, &surface_config);
+        self.depth_texture_view = Renderer::create_depth_texture_view(
+            &self.device,
+            &vello_hybrid::RenderSize { width, height },
+        );
     }
 }
 
@@ -223,6 +233,7 @@ impl AppState {
                 &mut encoder,
                 &render_size,
                 &surface_texture_view,
+                Some(&self.renderer_wrapper.depth_texture_view),
                 &vello_hybrid::TextureBindings::new(),
             )
             .unwrap();
@@ -628,6 +639,7 @@ pub async fn render_scene(scene: Scene, width: u16, height: u16) {
         device,
         queue,
         surface,
+        depth_texture_view,
     } = RendererWrapper::new(canvas).await;
 
     let render_size = vello_hybrid::RenderSize {
@@ -654,6 +666,7 @@ pub async fn render_scene(scene: Scene, width: u16, height: u16) {
             &mut encoder,
             &render_size,
             &surface_texture_view,
+            Some(&depth_texture_view),
             &vello_hybrid::TextureBindings::new(),
         )
         .unwrap();

--- a/sparse_strips/vello_hybrid/examples/winit/src/main.rs
+++ b/sparse_strips/vello_hybrid/examples/winit/src/main.rs
@@ -31,7 +31,7 @@ struct App<'s> {
     context: RenderContext,
     scenes: Box<[AnyScene<Scene>]>,
     current_scene: usize,
-    renderers: Vec<Option<(Renderer, Resources)>>,
+    renderers: Vec<Option<(Renderer, Resources, RenderSize, wgpu::TextureView)>>,
     uploaded_images: Vec<bool>,
     spritesheet_textures: Vec<Option<wgpu::Texture>>,
     render_state: RenderState<'s>,
@@ -341,7 +341,7 @@ impl ApplicationHandler for App<'_> {
                 let render_start = Instant::now();
 
                 self.scene.set_transform(self.transform);
-                let (_, resources) = self.renderers[surface.dev_id].as_mut().unwrap();
+                let (_, resources, ..) = self.renderers[surface.dev_id].as_mut().unwrap();
                 self.scenes[self.current_scene].render(&mut self.scene, resources, self.transform);
 
                 let device_handle = &self.context.devices[surface.dev_id];
@@ -383,7 +383,13 @@ impl ApplicationHandler for App<'_> {
                         texture.create_view(&wgpu::TextureViewDescriptor::default()),
                     );
                 }
-                let (renderer, resources) = self.renderers[surface.dev_id].as_mut().unwrap();
+                let (renderer, resources, depth_render_size, depth_texture_view) =
+                    self.renderers[surface.dev_id].as_mut().unwrap();
+                if *depth_render_size != render_size {
+                    *depth_render_size = render_size.clone();
+                    *depth_texture_view =
+                        Renderer::create_depth_texture_view(&device_handle.device, &render_size);
+                }
                 renderer
                     .render(
                         &self.scene,
@@ -393,6 +399,7 @@ impl ApplicationHandler for App<'_> {
                         &mut encoder,
                         &render_size,
                         &texture_view,
+                        Some(depth_texture_view),
                         &texture_bindings,
                     )
                     .unwrap();
@@ -428,7 +435,7 @@ impl App<'_> {
 
         // 1st example — uploading pixmap directly
         let pixmap1 = ImageScene::read_flower_image();
-        let (renderer, resources) = self.renderers[device_id].as_mut().unwrap();
+        let (renderer, resources, ..) = self.renderers[device_id].as_mut().unwrap();
         renderer.upload_image(
             resources,
             &device_handle.device,
@@ -441,7 +448,7 @@ impl App<'_> {
         let pixmap2 = ImageScene::read_cowboy_image();
         let texture2 =
             self.upload_image_to_texture(&device_handle.device, &device_handle.queue, &pixmap2);
-        let (renderer, resources) = self.renderers[device_id].as_mut().unwrap();
+        let (renderer, resources, ..) = self.renderers[device_id].as_mut().unwrap();
         renderer.upload_image(
             resources,
             &device_handle.device,

--- a/sparse_strips/vello_hybrid/examples/winit/src/render_context.rs
+++ b/sparse_strips/vello_hybrid/examples/winit/src/render_context.rs
@@ -8,10 +8,10 @@
 
 use std::sync::Arc;
 
-use vello_hybrid::{RenderTargetConfig, Renderer, Resources};
+use vello_hybrid::{RenderSize, RenderTargetConfig, Renderer, Resources};
 use wgpu::{
     Adapter, Device, Features, Instance, Limits, Queue, Surface, SurfaceConfiguration,
-    SurfaceTarget, TextureFormat,
+    SurfaceTarget, TextureFormat, TextureView,
 };
 use winit::{event_loop::ActiveEventLoop, window::Window};
 
@@ -35,15 +35,22 @@ pub(crate) fn create_winit_window(
 pub(crate) fn create_vello_renderer(
     render_cx: &RenderContext,
     surface: &RenderSurface<'_>,
-) -> (Renderer, Resources) {
-    Renderer::new(
-        &render_cx.devices[surface.dev_id].device,
+) -> (Renderer, Resources, RenderSize, TextureView) {
+    let device = &render_cx.devices[surface.dev_id].device;
+    let render_size = RenderSize {
+        width: surface.config.width,
+        height: surface.config.height,
+    };
+    let (renderer, resources) = Renderer::new(
+        device,
         &RenderTargetConfig {
             format: surface.config.format,
-            width: surface.config.width,
-            height: surface.config.height,
+            width: render_size.width,
+            height: render_size.height,
         },
-    )
+    );
+    let depth_texture_view = Renderer::create_depth_texture_view(device, &render_size);
+    (renderer, resources, render_size, depth_texture_view)
 }
 
 /// Simple render context that maintains wgpu state for rendering the pipeline.

--- a/sparse_strips/vello_hybrid/src/render/webgl/mod.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl/mod.rs
@@ -188,11 +188,19 @@ pub struct AtlasTextureInfo {
 impl WebGlRenderer {
     /// Creates a new WebGL2 renderer and its persistent resources.
     pub fn new(canvas: &HtmlCanvasElement) -> (Self, Resources) {
-        Self::new_with(canvas, RenderSettings::default())
+        Self::new_with(canvas, RenderSettings::default(), true)
     }
 
     /// Creates a new WebGL2 renderer and its persistent resources with specific settings.
-    pub fn new_with(canvas: &HtmlCanvasElement, mut settings: RenderSettings) -> (Self, Resources) {
+    ///
+    /// When `use_depth_buffer` is true, the WebGL context allocates a depth buffer and the renderer
+    /// uses it for opaque-strip occlusion. Disabling it reduces GPU memory usage, but can increase
+    /// overdraw.
+    pub fn new_with(
+        canvas: &HtmlCanvasElement,
+        mut settings: RenderSettings,
+        use_depth_buffer: bool,
+    ) -> (Self, Resources) {
         #[allow(
             clippy::assertions_on_constants,
             reason = "intentional guard against non-wasm32 use"
@@ -228,7 +236,7 @@ impl WebGlRenderer {
         //
         // TODO: The above understanding is encoded in a below assertion, but this should be encapsulated within a
         // "this device can run Vello correctly" check function.
-        let depth = if settings.use_depth_buffer {
+        let depth = if use_depth_buffer {
             &JsValue::TRUE
         } else {
             &JsValue::FALSE
@@ -304,7 +312,7 @@ impl WebGlRenderer {
             max_texture_array_layers: get_max_texture_array_layers(&gl),
         };
         settings.memory_settings.normalize(&device_limits);
-        if settings.use_depth_buffer {
+        if use_depth_buffer {
             assert!(
                 gl.get_parameter(WebGl2RenderingContext::DEPTH_BITS)
                     .unwrap()
@@ -333,7 +341,7 @@ impl WebGlRenderer {
             schedule_storage: ScheduleStorage::default(),
             scratch_buffers: ScratchBuffers::default(),
             layers_config: layer_config,
-            use_depth_buffer: settings.use_depth_buffer,
+            use_depth_buffer,
         };
 
         (renderer, resources)

--- a/sparse_strips/vello_hybrid/src/render/wgpu/mod.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu/mod.rs
@@ -221,7 +221,7 @@ impl Renderer {
     ///
     /// The returned view has the same dimensions as `render_size`, uses
     /// [`TextureFormat::Depth24Plus`](wgpu::TextureFormat::Depth24Plus), and can be used as a
-    /// render attachment. Callers choose when to create, cache, or replace the view.
+    /// render attachment.
     pub fn create_depth_texture_view(device: &Device, render_size: &RenderSize) -> TextureView {
         device
             .create_texture(&wgpu::TextureDescriptor {
@@ -249,9 +249,9 @@ impl Renderer {
     ///
     /// To render without any texture bindings, you can pass an empty [`TextureBindings`].
     ///
-    /// Passing `Some(depth_view)` enables opaque-strip occlusion. The depth view must use
-    /// [`TextureFormat::Depth24Plus`](wgpu::TextureFormat::Depth24Plus), have the same dimensions
-    /// as `render_size`, have a sample count of one, and support
+    /// Passing `Some(depth_view)` enables depth buffering to reduce overdraw. The depth view must
+    /// use [`TextureFormat::Depth24Plus`](wgpu::TextureFormat::Depth24Plus), have the same
+    /// dimensions as `render_size`, have a sample count of one, and support
     /// [`TextureUsages::RENDER_ATTACHMENT`](wgpu::TextureUsages::RENDER_ATTACHMENT). Pass `None`
     /// to render without a depth buffer.
     ///

--- a/sparse_strips/vello_hybrid/src/render/wgpu/mod.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu/mod.rs
@@ -162,7 +162,6 @@ pub struct Renderer {
     schedule_storage: ScheduleStorage,
     scratch_buffers: ScratchBuffers,
     layers_config: LayersConfig,
-    use_depth_buffer: bool,
     #[cfg(feature = "text")]
     atlas_clear_scratch: Vec<u8>,
 }
@@ -203,7 +202,6 @@ impl Renderer {
                 &resources.image_cache,
                 render_target_config,
                 layer_config,
-                settings.use_depth_buffer,
             ),
             gradient_cache,
             encoded_paints: Vec::new(),
@@ -212,12 +210,35 @@ impl Renderer {
             schedule_storage: ScheduleStorage::default(),
             scratch_buffers: ScratchBuffers::default(),
             layers_config: layer_config,
-            use_depth_buffer: settings.use_depth_buffer,
             #[cfg(feature = "text")]
             atlas_clear_scratch: Vec::new(),
         };
 
         (renderer, resources)
+    }
+
+    /// Creates a depth texture view compatible with [`render`](Self::render).
+    ///
+    /// The returned view has the same dimensions as `render_size`, uses
+    /// [`TextureFormat::Depth24Plus`](wgpu::TextureFormat::Depth24Plus), and can be used as a
+    /// render attachment. Callers choose when to create, cache, or replace the view.
+    pub fn create_depth_texture_view(device: &Device, render_size: &RenderSize) -> TextureView {
+        device
+            .create_texture(&wgpu::TextureDescriptor {
+                label: Some("Vello Hybrid Depth Texture"),
+                size: Extent3d {
+                    width: render_size.width.max(1),
+                    height: render_size.height.max(1),
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: wgpu::TextureFormat::Depth24Plus,
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                view_formats: &[],
+            })
+            .create_view(&TextureViewDescriptor::default())
     }
 
     /// Render `scene`.
@@ -227,6 +248,17 @@ impl Renderer {
     /// requirements on the bound texture views.
     ///
     /// To render without any texture bindings, you can pass an empty [`TextureBindings`].
+    ///
+    /// Passing `Some(depth_view)` enables opaque-strip occlusion. The depth view must use
+    /// [`TextureFormat::Depth24Plus`](wgpu::TextureFormat::Depth24Plus), have the same dimensions
+    /// as `render_size`, have a sample count of one, and support
+    /// [`TextureUsages::RENDER_ATTACHMENT`](wgpu::TextureUsages::RENDER_ATTACHMENT). Pass `None`
+    /// to render without a depth buffer.
+    ///
+    /// The [WebGPU render pass validation rules] require every color and depth attachment view in
+    /// a render pass to have matching render extents.
+    ///
+    /// [WebGPU render pass validation rules]: https://gpuweb.github.io/gpuweb/#abstract-opdef-gpurenderpassdescriptor-valid-usage
     pub fn render(
         &mut self,
         scene: &Scene,
@@ -236,6 +268,7 @@ impl Renderer {
         encoder: &mut CommandEncoder,
         render_size: &RenderSize,
         view: &TextureView,
+        depth_view: Option<&TextureView>,
         texture_bindings: &TextureBindings,
     ) -> Result<(), RenderError> {
         #[cfg(feature = "text")]
@@ -276,6 +309,7 @@ impl Renderer {
             encoder,
             render_size,
             view,
+            depth_view,
             &resources.image_cache,
             &scene.encoded_paints,
             true,
@@ -373,6 +407,7 @@ impl Renderer {
             &mut encoder,
             &atlas_render_size,
             &layer_view,
+            None,
             &dummy_image_cache,
             encoded_paints,
             false,
@@ -419,6 +454,7 @@ impl Renderer {
         encoder: &mut CommandEncoder,
         render_size: &RenderSize,
         view: &TextureView,
+        depth_view: Option<&TextureView>,
         image_cache: &ImageCache,
         encoded_paints: &[EncodedPaint],
         clear: bool,
@@ -444,7 +480,7 @@ impl Renderer {
             &mut self.schedule_storage,
             scene,
             root_output_target,
-            self.use_depth_buffer,
+            depth_view.is_some(),
             paint_resolver,
             texture_size,
             current_allocations,
@@ -475,10 +511,10 @@ impl Renderer {
             queue,
             encoder,
             view,
+            depth_view,
             texture_bindings,
             external_paint_source_bind_groups: HashMap::new(),
             scratch_buffers: &mut self.scratch_buffers,
-            use_depth_buffer: self.use_depth_buffer,
         };
 
         crate::schedule::execute(
@@ -921,10 +957,10 @@ struct Programs {
     intermediate_strip_pipeline: RenderPipeline,
     /// Root alpha-strip pipeline.
     alpha_strip_pipeline: RenderPipeline,
+    /// Root alpha-strip pipeline with depth testing.
+    depth_alpha_strip_pipeline: RenderPipeline,
     /// Root opaque-strip pipeline.
     opaque_strip_pipeline: RenderPipeline,
-    /// View of the depth texture used for early-z rejection on the Output target.
-    depth_texture_view: Option<TextureView>,
     /// Whether the depth buffer has been cleared this frame.
     depth_cleared_this_frame: bool,
     /// Bind group layout for strip draws
@@ -1073,7 +1109,6 @@ impl Programs {
         image_cache: &ImageCache,
         render_target_config: &RenderTargetConfig,
         layer_config: LayersConfig,
-        use_depth_buffer: bool,
     ) -> Self {
         let strip_bind_group_layout =
             device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
@@ -1257,7 +1292,14 @@ impl Programs {
             "Strip Alpha Pipeline",
             render_target_config.format,
             Some(BlendState::PREMULTIPLIED_ALPHA_BLENDING),
-            use_depth_buffer.then(|| depth_stencil(false)),
+            None,
+        );
+
+        let depth_alpha_strip_pipeline = create_strip_pipeline(
+            "Strip Depth Alpha Pipeline",
+            render_target_config.format,
+            Some(BlendState::PREMULTIPLIED_ALPHA_BLENDING),
+            Some(depth_stencil(false)),
         );
 
         let opaque_strip_pipeline = create_strip_pipeline(
@@ -1729,20 +1771,11 @@ impl Programs {
             view_config_buffer,
         };
 
-        let depth_texture_view = use_depth_buffer.then(|| {
-            Self::create_depth_texture(
-                device,
-                render_target_config.width,
-                render_target_config.height,
-            )
-            .create_view(&TextureViewDescriptor::default())
-        });
-
         Self {
             intermediate_strip_pipeline,
             alpha_strip_pipeline,
+            depth_alpha_strip_pipeline,
             opaque_strip_pipeline,
-            depth_texture_view,
             depth_cleared_this_frame: false,
             strip_bind_group_layout,
             encoded_paints_bind_group_layout,
@@ -1769,24 +1802,6 @@ impl Programs {
             blend_layer_bind_groups: HashMap::new(),
             filter_pair_bind_groups: HashMap::new(),
         }
-    }
-
-    #[inline]
-    fn create_depth_texture(device: &Device, width: u32, height: u32) -> Texture {
-        device.create_texture(&wgpu::TextureDescriptor {
-            label: Some("Depth Texture"),
-            size: Extent3d {
-                width: width.max(1),
-                height: height.max(1),
-                depth_or_array_layers: 1,
-            },
-            mip_level_count: 1,
-            sample_count: 1,
-            dimension: wgpu::TextureDimension::D2,
-            format: wgpu::TextureFormat::Depth24Plus,
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-            view_formats: &[],
-        })
     }
 
     fn create_strips_buffer(device: &Device, required_strips_size: u64) -> Buffer {
@@ -2223,7 +2238,7 @@ impl Programs {
         self.maybe_resize_alphas_tex(device, max_texture_dimension_2d, alphas.len());
         self.maybe_resize_encoded_paints_tex(device, max_texture_dimension_2d, paint_idxs);
         self.maybe_resize_filter_tex(device, max_texture_dimension_2d, filter_context);
-        self.maybe_update_config_buffer(device, queue, max_texture_dimension_2d, new_render_size);
+        self.maybe_update_config_buffer(queue, max_texture_dimension_2d, new_render_size);
 
         self.upload_alpha_texture(queue, alphas);
         self.upload_encoded_paints_texture(queue, encoded_paints);
@@ -2391,7 +2406,6 @@ impl Programs {
     /// Update config buffer if dimensions changed.
     fn maybe_update_config_buffer(
         &mut self,
-        device: &Device,
         queue: &Queue,
         max_texture_dimension_2d: u32,
         new_render_size: &RenderSize,
@@ -2411,17 +2425,6 @@ impl Programs {
                 .write_buffer_with(&self.resources.view_config_buffer, 0, SIZE_OF_CONFIG)
                 .expect("Buffer only ever holds `Config`");
             buffer.copy_from_slice(bytemuck::bytes_of(&config));
-
-            if self.depth_texture_view.is_some() {
-                self.depth_texture_view = Some(
-                    Self::create_depth_texture(
-                        device,
-                        new_render_size.width,
-                        new_render_size.height,
-                    )
-                    .create_view(&TextureViewDescriptor::default()),
-                );
-            }
 
             self.render_size = new_render_size.clone();
         }
@@ -2724,10 +2727,10 @@ struct RendererContext<'a> {
     queue: &'a Queue,
     encoder: &'a mut CommandEncoder,
     view: &'a TextureView,
+    depth_view: Option<&'a TextureView>,
     texture_bindings: &'a TextureBindings,
     external_paint_source_bind_groups: HashMap<TextureId, BindGroup>,
     scratch_buffers: &'a mut ScratchBuffers,
-    use_depth_buffer: bool,
 }
 
 impl RendererContext<'_> {
@@ -2819,7 +2822,7 @@ impl RendererContext<'_> {
 
         let bind_group = &self.programs.strip_layer_bind_groups[&bind_group_key];
 
-        let enable_opaque = self.use_depth_buffer && target.enable_opaque();
+        let enable_opaque = self.depth_view.is_some() && target.enable_opaque();
 
         let depth_stencil_attachment = if enable_opaque {
             let depth_load = if self.programs.depth_cleared_this_frame {
@@ -2830,10 +2833,8 @@ impl RendererContext<'_> {
             };
             Some(wgpu::RenderPassDepthStencilAttachment {
                 view: self
-                    .programs
-                    .depth_texture_view
-                    .as_ref()
-                    .expect("enabled depth buffering requires a depth texture"),
+                    .depth_view
+                    .expect("enabled depth buffering requires a depth texture view"),
                 depth_ops: Some(wgpu::Operations {
                     load: depth_load,
                     store: wgpu::StoreOp::Store,
@@ -2879,7 +2880,12 @@ impl RendererContext<'_> {
         if alpha_count > 0 {
             // Alpha pass
             if matches!(target, DrawPassTarget::Root(RootTarget::UserSurface)) {
-                render_pass.set_pipeline(&self.programs.alpha_strip_pipeline);
+                let pipeline = if enable_opaque {
+                    &self.programs.depth_alpha_strip_pipeline
+                } else {
+                    &self.programs.alpha_strip_pipeline
+                };
+                render_pass.set_pipeline(pipeline);
             } else {
                 render_pass.set_pipeline(&self.programs.intermediate_strip_pipeline);
             }

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -111,10 +111,6 @@ impl Drawable for RecordedDraw {
 pub struct RenderSettings {
     /// The SIMD level that should be used for rendering operations.
     pub level: Level,
-    /// Whether to allocate and use a depth buffer for opaque-strip occlusion.
-    ///
-    /// Disabling this reduces GPU memory usage, but can increase overdraw.
-    pub use_depth_buffer: bool,
     /// Configuration for GPU memory used while rendering.
     pub memory_settings: MemorySettings,
 }
@@ -198,7 +194,6 @@ impl Default for RenderSettings {
     fn default() -> Self {
         Self {
             level: Level::try_detect().unwrap_or(Level::baseline()),
-            use_depth_buffer: true,
             memory_settings: MemorySettings::default(),
         }
     }

--- a/sparse_strips/vello_sparse_tests/tests/image_atlas.rs
+++ b/sparse_strips/vello_sparse_tests/tests/image_atlas.rs
@@ -32,7 +32,7 @@ fn image_atlas_placeholder_is_promoted_on_first_upload() {
         },
         ..RenderSettings::default()
     };
-    let (mut renderer, mut resources) = WebGlRenderer::new_with(&canvas, settings);
+    let (mut renderer, mut resources) = WebGlRenderer::new_with(&canvas, settings, true);
 
     assert_eq!(
         renderer.atlas_info(),
@@ -96,7 +96,7 @@ fn image_atlas_upload_larger_than_atlas_fails() {
         ..RenderSettings::default()
     };
 
-    let (mut renderer, mut resources) = WebGlRenderer::new_with(&canvas, settings);
+    let (mut renderer, mut resources) = WebGlRenderer::new_with(&canvas, settings, true);
 
     // The image is much larger than the 10x10 atlas, so the upload must fail.
     let image = Pixmap::new(64, 64);

--- a/sparse_strips/vello_sparse_tests/tests/renderer.rs
+++ b/sparse_strips/vello_sparse_tests/tests/renderer.rs
@@ -296,6 +296,7 @@ pub(crate) struct HybridRenderer {
     queue: wgpu::Queue,
     texture: wgpu::Texture,
     texture_view: wgpu::TextureView,
+    depth_texture_view: Option<wgpu::TextureView>,
     renderer: vello_hybrid::Renderer,
     external_textures: HashMap<TextureId, wgpu::TextureView>,
     next_external_texture_id: u64,
@@ -303,7 +304,12 @@ pub(crate) struct HybridRenderer {
 
 #[cfg(not(all(target_arch = "wasm32", feature = "webgl")))]
 impl HybridRenderer {
-    fn new_with_settings(width: u16, height: u16, settings: HybridRenderSettings) -> Self {
+    fn new_with_settings(
+        width: u16,
+        height: u16,
+        settings: HybridRenderSettings,
+        use_depth_buffer: bool,
+    ) -> Self {
         let scene = Scene::new_with(width, height, settings.level);
         // Initialize wgpu device and queue for GPU rendering
         let instance = wgpu::Instance::default();
@@ -348,6 +354,12 @@ impl HybridRenderer {
             },
             settings,
         );
+        let render_size = vello_hybrid::RenderSize {
+            width: width.into(),
+            height: height.into(),
+        };
+        let depth_texture_view = use_depth_buffer
+            .then(|| vello_hybrid::Renderer::create_depth_texture_view(&device, &render_size));
 
         Self {
             scene,
@@ -356,6 +368,7 @@ impl HybridRenderer {
             queue,
             texture,
             texture_view,
+            depth_texture_view,
             renderer,
             external_textures: HashMap::new(),
             next_external_texture_id: 1,
@@ -417,8 +430,7 @@ impl Renderer for HybridRenderer {
         // (for example situations where we need to spill to a new page, etc.). Therefore,
         // we make the minimum size smaller than the default.
         settings.memory_settings.layers_config.min_texture_size = vello_hybrid::SizeU16::new(100);
-        settings.use_depth_buffer = use_depth_buffer;
-        Self::new_with_settings(width, height, settings)
+        Self::new_with_settings(width, height, settings, use_depth_buffer)
     }
 
     fn fill_path(&mut self, path: &BezPath) {
@@ -590,6 +602,7 @@ impl Renderer for HybridRenderer {
                 &mut encoder,
                 &render_size,
                 &self.texture_view,
+                self.depth_texture_view.as_ref(),
                 &texture_bindings,
             )
             .unwrap();
@@ -780,7 +793,6 @@ impl Renderer for HybridRenderer {
         let mut settings = HybridRenderSettings::default();
         // See the comment above for why we change the `min_texture_size`.
         settings.memory_settings.layers_config.min_texture_size = vello_hybrid::SizeU16::new(100);
-        settings.use_depth_buffer = use_depth_buffer;
         let scene = Scene::new_with(width, height, settings.level);
         // Create an offscreen HTMLCanvasElement, render the test image to it, and finally read off
         // the pixmap for diff checking.
@@ -792,7 +804,8 @@ impl Renderer for HybridRenderer {
             .unwrap();
         canvas.set_width(width.into());
         canvas.set_height(height.into());
-        let (renderer, resources) = vello_hybrid::WebGlRenderer::new_with(&canvas, settings);
+        let (renderer, resources) =
+            vello_hybrid::WebGlRenderer::new_with(&canvas, settings, use_depth_buffer);
         let gl = canvas
             .get_context("webgl2")
             .unwrap()


### PR DESCRIPTION
Move wgpu depth texture ownership to callers, allowing applications to choose their own resizing and caching policy. Rendering now accepts an optional depth view, while webgl depth remains a construction-time option because it belongs to the default framebuffer.

Addressing [this comment](https://github.com/linebender/vello/pull/1808#discussion_r3748181636) in #1808.

Created with assistance from GPT-5.6 Sol.