### PR TITLE
vello_hybrid: Add support for setting a transparency hint for external textures

### DIFF
--- a/sparse_strips/vello_example_scenes/src/spritesheet.rs
+++ b/sparse_strips/vello_example_scenes/src/spritesheet.rs
@@ -106,6 +106,7 @@ impl ExampleScene for SpritesheetScene {
 
                 rects.push(SampleRect {
                     source_region: sprite,
+                    may_have_transparency: true,
                     transform,
                 });
             }

--- a/sparse_strips/vello_example_scenes/src/spritesheet.rs
+++ b/sparse_strips/vello_example_scenes/src/spritesheet.rs
@@ -104,11 +104,7 @@ impl ExampleScene for SpritesheetScene {
                     * Affine::scale(scale)
                     * Affine::translate((-half_w, -half_h));
 
-                rects.push(SampleRect {
-                    source_region: sprite,
-                    may_have_transparency: true,
-                    transform,
-                });
+                rects.push(SampleRect::new(sprite, transform));
             }
         }
 

--- a/sparse_strips/vello_hybrid/src/draw.rs
+++ b/sparse_strips/vello_hybrid/src/draw.rs
@@ -79,6 +79,7 @@ impl OpaqueDraw {
     pub(crate) fn reverse(&mut self) {
         self.strips.reverse();
 
+        // We also need to reassign the indices for external textures.
         let mut original_end = self.strips.len();
         for run in self.external_texture_runs.iter_mut().rev() {
             let original_start = run.strips_start;

--- a/sparse_strips/vello_hybrid/src/draw.rs
+++ b/sparse_strips/vello_hybrid/src/draw.rs
@@ -39,25 +39,11 @@ impl Draw {
         gpu_strip: GpuStrip,
         external_texture_id: Option<TextureId>,
     ) {
-        if let Some(texture_id) = external_texture_id {
-            let needs_new_run = self
-                .external_texture_runs
-                .last()
-                .is_none_or(|run| run.texture_id != texture_id);
-
-            if needs_new_run {
-                let strips_start = if self.external_texture_runs.is_empty() {
-                    0
-                } else {
-                    self.strip_ranges.len()
-                };
-
-                self.external_texture_runs.push(ExternalTextureRun {
-                    strips_start,
-                    texture_id,
-                });
-            }
-        }
+        push_external_texture_run(
+            &mut self.external_texture_runs,
+            self.strip_ranges.len(),
+            external_texture_id,
+        );
 
         strips.push_ranged(&mut self.strip_ranges, gpu_strip);
     }
@@ -71,6 +57,57 @@ impl Clear for Draw {
     }
 }
 
+/// Root-level opaque strips and the external texture bindings needed to render them.
+#[derive(Debug, Default)]
+pub(crate) struct OpaqueDraw {
+    strips: Vec<GpuStrip>,
+    external_texture_runs: Vec<ExternalTextureRun>,
+}
+
+impl OpaqueDraw {
+    fn push(&mut self, strip: GpuStrip, external_texture_id: Option<TextureId>) {
+        push_external_texture_run(
+            &mut self.external_texture_runs,
+            self.strips.len(),
+            external_texture_id,
+        );
+
+        self.strips.push(strip);
+    }
+
+    /// Reverse opaque strips for front-to-back rendering.
+    pub(crate) fn reverse(&mut self) {
+        self.strips.reverse();
+
+        let mut original_end = self.strips.len();
+        for run in self.external_texture_runs.iter_mut().rev() {
+            let original_start = run.strips_start;
+            run.strips_start = self.strips.len() - original_end;
+            original_end = original_start;
+        }
+        self.external_texture_runs.reverse();
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.strips.is_empty()
+    }
+
+    pub(crate) fn strips(&self) -> &[GpuStrip] {
+        &self.strips
+    }
+
+    pub(crate) fn external_texture_runs(&self) -> &[ExternalTextureRun] {
+        &self.external_texture_runs
+    }
+}
+
+impl Clear for OpaqueDraw {
+    fn clear(&mut self) {
+        self.strips.clear();
+        self.external_texture_runs.clear();
+    }
+}
+
 /// Appends recorded draws to a scheduled [`Draw`] and its shared buffers.
 #[derive(Debug)]
 pub(crate) struct DrawBuilder<'a, T: DrawTarget> {
@@ -78,8 +115,8 @@ pub(crate) struct DrawBuilder<'a, T: DrawTarget> {
     draw: &'a mut Draw,
     /// Shared buffer receiving alpha-blended strips.
     strips: &'a mut Vec<GpuStrip>,
-    /// Shared buffer receiving root-level opaque strips.
-    opaque: &'a mut Vec<GpuStrip>,
+    /// Root-level opaque draw receiving fully covered strips.
+    opaque: &'a mut OpaqueDraw,
     /// Target and depth state used to encode strips.
     state: &'a mut DrawState<T>,
 }
@@ -93,7 +130,7 @@ impl<'a, T: DrawTarget> DrawBuilder<'a, T> {
         Self {
             draw,
             strips: &mut draw_buffers.strips,
-            opaque: &mut draw_buffers.opaque_strips,
+            opaque: &mut draw_buffers.opaque,
             state,
         }
     }
@@ -112,12 +149,12 @@ impl<'a, T: DrawTarget> DrawBuilder<'a, T> {
         }
     }
 
-    fn push_opaque(&mut self, strip: GpuStrip) -> bool {
+    fn push_opaque(&mut self, strip: GpuStrip, external_texture_id: Option<TextureId>) -> bool {
         if !self.state.use_depth_buffer || !self.state.target.enable_depth() {
             return false;
         }
 
-        self.opaque.push(strip);
+        self.opaque.push(strip, external_texture_id);
         true
     }
 
@@ -172,7 +209,7 @@ impl<'a, T: DrawTarget> DrawBuilder<'a, T> {
                     depth_index,
                 );
 
-                if !paint.opaque || !builder.push_opaque(strip) {
+                if !paint.opaque || !builder.push_opaque(strip, paint.external_texture_id) {
                     builder
                         .draw
                         .push(builder.strips, strip, paint.external_texture_id);
@@ -217,7 +254,10 @@ impl<'a, T: DrawTarget> DrawBuilder<'a, T> {
                 depth_index,
             );
 
-            if !(paint.opaque && part.frac == 0 && self.push_opaque(strip)) {
+            if !(paint.opaque
+                && part.frac == 0
+                && self.push_opaque(strip, paint.external_texture_id))
+            {
                 self.draw
                     .push(self.strips, strip, paint.external_texture_id);
             }
@@ -309,15 +349,15 @@ impl<'a, T: DrawTarget> DrawBuilder<'a, T> {
 /// Reusable strip storage shared by all draws in a schedule.
 #[derive(Debug, Default)]
 pub(crate) struct DrawBuffers {
-    /// Opaque root strips rendered in the early depth-writing pass.
-    pub(crate) opaque_strips: Vec<GpuStrip>,
+    /// Root-level opaque draw rendered in the early depth-writing pass.
+    pub(crate) opaque: OpaqueDraw,
     /// Alpha-blended strips selected by each draw's ranges.
     pub(crate) strips: Vec<GpuStrip>,
 }
 
 impl DrawBuffers {
     pub(crate) fn clear(&mut self) {
-        self.opaque_strips.clear();
+        self.opaque.clear();
         self.strips.clear();
     }
 }
@@ -403,15 +443,32 @@ impl LayerTextureRegion {
     }
 }
 
-/// Specifies a run of strips inside a draw that can be drawn with the same external texture
-/// binding.
+/// Specifies a run of strips that can be drawn with the same external texture binding.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ExternalTextureRun {
     /// External texture bound for the run.
     pub(crate) texture_id: TextureId,
     /// Start index of the strip range for this run. The end is implicitly the start of the next
-    /// run, or, for the last run, the total number of strips.
+    /// run, or, for the last run, the total number of strips in the pass.
     pub(crate) strips_start: usize,
+}
+
+fn push_external_texture_run(
+    runs: &mut Vec<ExternalTextureRun>,
+    strips_len: usize,
+    external_texture_id: Option<TextureId>,
+) {
+    let Some(texture_id) = external_texture_id else {
+        return;
+    };
+    if runs.last().is_some_and(|run| run.texture_id == texture_id) {
+        return;
+    }
+
+    runs.push(ExternalTextureRun {
+        texture_id,
+        strips_start: if runs.is_empty() { 0 } else { strips_len },
+    });
 }
 
 /// Assigns monotonically increasing depth values to opaque strips.
@@ -466,7 +523,8 @@ impl StripAlphaFillSegmentExt for StripAlphaFillSegment {
 
 #[cfg(test)]
 mod tests {
-    use super::{Draw, DrawBuffers, DrawBuilder, DrawState, ExternalTextureRun};
+    use super::{Draw, DrawBuffers, DrawBuilder, DrawState, ExternalTextureRun, OpaqueDraw};
+    use crate::GpuStrip;
     use crate::paint::PaintResolver;
     use crate::scene::{RecordedDraw, RecordedRect};
     use crate::target::{
@@ -540,6 +598,29 @@ mod tests {
         PaintResolver::new(&[], &[])
     }
 
+    fn gpu_strip(x: u16) -> GpuStrip {
+        GpuStrip {
+            x,
+            y: 0,
+            width: 1,
+            dense_width_or_rect_height: 0,
+            col_idx_or_rect_frac: 0,
+            payload: 0,
+            paint_and_rect_flag: 0,
+            depth_index: 0,
+        }
+    }
+
+    fn strip_xs(draw: &OpaqueDraw) -> Vec<u16> {
+        draw.strips().iter().map(|strip| strip.x).collect()
+    }
+
+    fn run_starts(runs: &[ExternalTextureRun]) -> Vec<(TextureId, usize)> {
+        runs.iter()
+            .map(|run| (run.texture_id, run.strips_start))
+            .collect()
+    }
+
     fn external(texture_id: TextureId) -> EncodedPaint {
         EncodedPaint::ExternalTexture(EncodedExternalTexture {
             texture_id,
@@ -603,21 +684,8 @@ mod tests {
         }
 
         assert_eq!(
-            draw.external_texture_runs,
-            [
-                ExternalTextureRun {
-                    texture_id: texture_a,
-                    strips_start: 0,
-                },
-                ExternalTextureRun {
-                    texture_id: texture_b,
-                    strips_start: 2,
-                },
-                ExternalTextureRun {
-                    texture_id: texture_a,
-                    strips_start: 4,
-                },
-            ]
+            run_starts(&draw.external_texture_runs),
+            [(texture_a, 0), (texture_b, 2), (texture_a, 4)]
         );
     }
 
@@ -636,13 +704,76 @@ mod tests {
         assert_eq!(draw.strip_ranges.len(), 3);
         // Images in the atlas are handled separately from external textures, so
         // it's fine to collapse them.
+        assert_eq!(run_starts(&draw.external_texture_runs), [(texture, 0)]);
+    }
+
+    #[test]
+    fn opaque_reverse_rebases_texture_runs() {
+        let texture_a = TextureId(10);
+        let texture_b = TextureId(20);
+        let texture_c = TextureId(30);
+        let mut draw = OpaqueDraw::default();
+
+        for (x, texture_id) in [
+            (0, None),
+            (1, Some(texture_a)),
+            (2, Some(texture_a)),
+            (3, None),
+            (4, None),
+            (5, None),
+            (6, Some(texture_b)),
+            (7, Some(texture_b)),
+            (8, Some(texture_c)),
+            (9, None),
+            (10, Some(texture_c)),
+            (11, None),
+            (12, None),
+            (13, Some(texture_a)),
+            (14, None),
+            (15, Some(texture_b)),
+        ] {
+            draw.push(gpu_strip(x), texture_id);
+        }
         assert_eq!(
-            draw.external_texture_runs,
-            [ExternalTextureRun {
-                texture_id: texture,
-                strips_start: 0,
-            }]
+            run_starts(draw.external_texture_runs()),
+            [
+                (texture_a, 0),
+                (texture_b, 6),
+                (texture_c, 8),
+                (texture_a, 13),
+                (texture_b, 15),
+            ]
         );
+
+        draw.reverse();
+
+        assert_eq!(
+            strip_xs(&draw),
+            [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+        );
+        assert_eq!(
+            run_starts(draw.external_texture_runs()),
+            [
+                (texture_b, 0),
+                (texture_a, 1),
+                (texture_c, 3),
+                (texture_b, 8),
+                (texture_a, 10),
+            ]
+        );
+    }
+
+    #[test]
+    fn opaque_reverse_without_texture_runs() {
+        let mut draw = OpaqueDraw::default();
+        for x in 0..3 {
+            draw.push(gpu_strip(x), None);
+        }
+
+        draw.reverse();
+
+        assert_eq!(strip_xs(&draw), [2, 1, 0]);
+        assert_eq!(run_starts(draw.external_texture_runs()), []);
     }
 
     #[test]
@@ -683,14 +814,14 @@ mod tests {
             no_paints(),
         );
 
-        assert_eq!(user_case.buffers.opaque_strips.len(), 1);
+        assert_eq!(user_case.buffers.opaque.strips().len(), 1);
         assert_eq!(user_draw.strip_ranges.len(), 1);
 
         let mut atlas_case = DrawCase::new(RootTarget::AtlasLayer, RectU16::new(0, 0, 8, 8));
         let mut atlas_draw = Draw::default();
         atlas_case.rect(&mut atlas_draw, rect(0.0), solid(1.0), no_paints());
 
-        assert!(atlas_case.buffers.opaque_strips.is_empty());
+        assert!(atlas_case.buffers.opaque.is_empty());
         assert_eq!(atlas_draw.strip_ranges.len(), 1);
     }
 
@@ -726,7 +857,8 @@ mod tests {
         );
         assert_eq!(
             case.buffers
-                .opaque_strips
+                .opaque
+                .strips()
                 .iter()
                 .map(|strip| strip.depth_index)
                 .collect::<Vec<_>>(),

--- a/sparse_strips/vello_hybrid/src/render/webgl/mod.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl/mod.rs
@@ -2833,12 +2833,7 @@ impl WebGlRendererContext<'_> {
             if opaque_count > 0 {
                 self.gl.depth_mask(true);
                 self.gl.disable(WebGl2RenderingContext::BLEND);
-                self.gl.draw_arrays_instanced(
-                    WebGl2RenderingContext::TRIANGLE_STRIP,
-                    0,
-                    4,
-                    opaque_count,
-                );
+                self.draw_strips(external_texture_runs, 0, opaque_count);
             }
 
             // Alpha pass: back-to-front, depth test ON, depth write OFF, blend ON.
@@ -3127,11 +3122,15 @@ impl WebGlRendererContext<'_> {
 }
 
 impl Backend for WebGlRendererContext<'_> {
-    fn opaque_draw_pass(&mut self, strips: &[GpuStrip]) {
+    fn opaque_draw_pass(
+        &mut self,
+        strips: &[GpuStrip],
+        external_texture_runs: &[ExternalTextureRun],
+    ) {
         self.strip_pass_inner(
             strips,
             RangedSlice::empty(),
-            &[],
+            external_texture_runs,
             DrawPassTarget::Root(RootTarget::UserSurface),
             None,
         );

--- a/sparse_strips/vello_hybrid/src/render/wgpu/mod.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu/mod.rs
@@ -2865,6 +2865,31 @@ impl RendererContext<'_> {
         render_pass.set_bind_group(3, &self.programs.resources.gradient_bind_group, &[]);
         render_pass.set_vertex_buffer(0, self.programs.resources.strips_buffer.slice(..));
 
+        let draw_strip_runs = |render_pass: &mut wgpu::RenderPass<'_>, first_instance, count| {
+            if external_texture_runs.is_empty() {
+                render_pass.set_bind_group(1, &self.programs.resources.atlas_bind_group, &[]);
+                render_pass.draw(0..4, first_instance..first_instance + count);
+
+                return;
+            }
+
+            // Each run is drawn with a different external texture binding. Runs go from
+            // `run.strips_start` to the next run's `strips_start`; the last run goes to the end of
+            // the strips buffer.
+            for (i, run) in external_texture_runs.iter().enumerate() {
+                let paint_source_bind_group = self
+                    .external_paint_source_bind_groups
+                    .get(&run.texture_id)
+                    .unwrap();
+                render_pass.set_bind_group(1, paint_source_bind_group, &[]);
+                let start = u32::try_from(run.strips_start).unwrap();
+                let end = external_texture_runs
+                    .get(i + 1)
+                    .map_or(count, |next| u32::try_from(next.strips_start).unwrap());
+                render_pass.draw(0..4, first_instance + start..first_instance + end);
+            }
+        };
+
         if opaque_count > 0 {
             // Opaque pass
             debug_assert!(
@@ -2872,8 +2897,7 @@ impl RendererContext<'_> {
                 "opaque strips require the final view depth attachment"
             );
             render_pass.set_pipeline(&self.programs.opaque_strip_pipeline);
-            render_pass.set_bind_group(1, &self.programs.resources.atlas_bind_group, &[]);
-            render_pass.draw(0..4, 0..opaque_count);
+            draw_strip_runs(&mut render_pass, 0, opaque_count);
         }
 
         if alpha_count > 0 {
@@ -2884,29 +2908,7 @@ impl RendererContext<'_> {
                 render_pass.set_pipeline(&self.programs.intermediate_strip_pipeline);
             }
 
-            let alpha_start = opaque_count;
-            if external_texture_runs.is_empty() {
-                render_pass.set_bind_group(1, &self.programs.resources.atlas_bind_group, &[]);
-                render_pass.draw(0..4, alpha_start..alpha_start + alpha_count);
-            } else {
-                // Each run is drawn with a different external texture binding. Runs go from
-                // `run.strips_start` to the next run's `strips_start`; the last run goes to the end of
-                // the strips buffer.
-                for (i, run) in external_texture_runs.iter().enumerate() {
-                    let paint_source_bind_group = self
-                        .external_paint_source_bind_groups
-                        .get(&run.texture_id)
-                        .unwrap();
-                    render_pass.set_bind_group(1, paint_source_bind_group, &[]);
-                    let start = u32::try_from(run.strips_start).unwrap();
-                    let end = external_texture_runs
-                        .get(i + 1)
-                        .map_or(alpha_count, |next| {
-                            u32::try_from(next.strips_start).unwrap()
-                        });
-                    render_pass.draw(0..4, alpha_start + start..alpha_start + end);
-                }
-            }
+            draw_strip_runs(&mut render_pass, opaque_count, alpha_count);
         }
     }
 
@@ -3123,11 +3125,15 @@ impl RendererContext<'_> {
 }
 
 impl Backend for RendererContext<'_> {
-    fn opaque_draw_pass(&mut self, strips: &[GpuStrip]) {
+    fn opaque_draw_pass(
+        &mut self,
+        strips: &[GpuStrip],
+        external_texture_runs: &[ExternalTextureRun],
+    ) {
         self.strip_pass_inner(
             strips,
             RangedSlice::empty(),
-            &[],
+            external_texture_runs,
             DrawPassTarget::Root(RootTarget::UserSurface),
             None,
         );

--- a/sparse_strips/vello_hybrid/src/sampling.rs
+++ b/sparse_strips/vello_hybrid/src/sampling.rs
@@ -28,3 +28,21 @@ pub struct SampleRect {
     /// [`Self::source_region`].
     pub transform: Affine,
 }
+
+impl SampleRect {
+    /// Create a new [`SampleRect`].
+    pub fn new(source_region: RectU16, transform: Affine) -> Self {
+        Self {
+            source_region,
+            may_have_transparency: true,
+            transform,
+        }
+    }
+
+    /// Indicate that the sample rect only contains opaque pixels.
+    #[must_use]
+    pub fn with_opaque_hint(mut self) -> Self {
+        self.may_have_transparency = false;
+        self
+    }
+}

--- a/sparse_strips/vello_hybrid/src/sampling.rs
+++ b/sparse_strips/vello_hybrid/src/sampling.rs
@@ -13,6 +13,15 @@ pub struct SampleRect {
     /// Source region in texel coordinates.
     pub source_region: RectU16,
 
+    /// Whether the sampled source region may contain non-opaque pixels.
+    ///
+    /// Only set this to `false` if every pixel is guaranteed to be opaque (e.g. in a texture
+    /// generated from a JPEG image). If you set this to `false` even though there are non-opaque
+    /// pixels, you will get wrong rendering.
+    ///
+    /// If unsure, always set this to `true`.
+    pub may_have_transparency: bool,
+
     /// Transform mapping the local source region to the destination.
     ///
     /// This maps from the *local* rectangle into the destination, ignoring the origin of

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -316,22 +316,27 @@ impl Scene {
         x_extend: Extend,
         y_extend: Extend,
         transform: Affine,
+        may_have_transparency: bool,
     ) -> Paint {
         let idx = self.encoded_paints.len();
+        let sampler = ImageSampler {
+            x_extend,
+            y_extend,
+            quality,
+            alpha: 1.0,
+        };
+        let has_opacity = self
+            .render_state
+            .tint
+            .is_some_and(|tint| tint.color.components[3] < 1.0)
+            // Not supported yet, but just to future-proof.
+            || sampler.alpha != 1.0;
+
         let encoded = EncodedExternalTexture {
             texture_id,
             source_region,
-            sampler: ImageSampler {
-                x_extend,
-                y_extend,
-                quality,
-                alpha: 1.0,
-            },
-            // TODO: Make this configurable by the user, and also take `ImageSampler` alpha into
-            // account.
-            // **IMPORTANT**: If this ever can become false, we need to make sure to update
-            // Vello Hybrid so the opaque pass supports external textures as well!
-            may_have_transparency: true,
+            sampler,
+            may_have_transparency: may_have_transparency || has_opacity,
             transform: transform.inverse(),
             tint: self.render_state.tint,
         };
@@ -554,6 +559,7 @@ impl Scene {
                         x_extend,
                         y_extend,
                         transform,
+                        rect.may_have_transparency,
                     );
 
                     ctx.recorder
@@ -566,6 +572,7 @@ impl Scene {
                         x_extend,
                         y_extend,
                         transform,
+                        rect.may_have_transparency,
                     );
                     let dst_rect = Rect::new(0., 0., w, h);
                     ctx.fill_path_with(

--- a/sparse_strips/vello_hybrid/src/schedule/execute.rs
+++ b/sparse_strips/vello_hybrid/src/schedule/execute.rs
@@ -21,7 +21,11 @@ pub(crate) trait Backend {
     /// ever called, it's called before any of the other ones and only once.
     ///
     /// The strips are guaranteed to be non-empty.
-    fn opaque_draw_pass(&mut self, strips: &[GpuStrip]);
+    fn opaque_draw_pass(
+        &mut self,
+        strips: &[GpuStrip],
+        external_texture_runs: &[ExternalTextureRun],
+    );
 
     /// Execute a draw pass against the given target.
     ///
@@ -78,9 +82,12 @@ impl Schedule {
         filter_plan: &mut FilterPassPlan,
     ) {
         if DrawPassTarget::Root(root_output_target).enable_opaque()
-            && !buffers.draw_buffers.opaque_strips.is_empty()
+            && !buffers.draw_buffers.opaque.is_empty()
         {
-            renderer.opaque_draw_pass(&buffers.draw_buffers.opaque_strips);
+            renderer.opaque_draw_pass(
+                buffers.draw_buffers.opaque.strips(),
+                buffers.draw_buffers.opaque.external_texture_runs(),
+            );
         }
 
         self.rounds.execute(
@@ -209,7 +216,11 @@ mod tests {
     }
 
     impl Backend for Recorder {
-        fn opaque_draw_pass(&mut self, _strips: &[GpuStrip]) {
+        fn opaque_draw_pass(
+            &mut self,
+            _strips: &[GpuStrip],
+            _external_texture_runs: &[ExternalTextureRun],
+        ) {
             self.calls.push(Call::Opaque);
         }
 

--- a/sparse_strips/vello_hybrid/src/schedule/mod.rs
+++ b/sparse_strips/vello_hybrid/src/schedule/mod.rs
@@ -322,7 +322,7 @@ impl<'a, 'p> Scheduler<'a, 'p> {
         self.schedule_root(&mut rounds)?;
 
         // Since the strips should be rendered front-to-back.
-        self.storage.buffers.draw_buffers.opaque_strips.reverse();
+        self.storage.buffers.draw_buffers.opaque.reverse();
 
         #[cfg(any(test, debug_assertions))]
         rounds.validate(&self.storage.buffers);

--- a/sparse_strips/vello_hybrid/src/schedule/schedule_tests.rs
+++ b/sparse_strips/vello_hybrid/src/schedule/schedule_tests.rs
@@ -884,7 +884,7 @@ fn storage_reuse() {
         .unwrap();
 
     assert_eq!(storage.buffers.draw_buffers.strips.len(), 1);
-    assert!(storage.buffers.draw_buffers.opaque_strips.is_empty());
+    assert!(storage.buffers.draw_buffers.opaque.is_empty());
     assert!(storage.buffers.blend_ops.is_empty());
     assert!(storage.buffers.blend_strips.is_empty());
     assert!(storage.buffers.filter_ops.is_empty());

--- a/sparse_strips/vello_hybrid/src/schedule/test_support.rs
+++ b/sparse_strips/vello_hybrid/src/schedule/test_support.rs
@@ -204,7 +204,8 @@ impl ScheduledCase {
         self.storage
             .buffers
             .draw_buffers
-            .opaque_strips
+            .opaque
+            .strips()
             .iter()
             .map(|strip| strip.x)
             .collect()

--- a/sparse_strips/vello_sparse_tests/snapshots/external_texture_root_painter_order.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/external_texture_root_painter_order.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15b84b78e387a1a0b49cd9d9af887eb62fe5f4725baada75926ec46d34883b6c
+size 334

--- a/sparse_strips/vello_sparse_tests/tests/external_texture.rs
+++ b/sparse_strips/vello_sparse_tests/tests/external_texture.rs
@@ -42,6 +42,7 @@ mod tests {
     fn texture_rect_at(x: f64, y: f64) -> [SampleRect; 1] {
         [SampleRect {
             source_region: RectU16::new(0, 0, 1, 1),
+            may_have_transparency: true,
             transform: Affine::translate((x, y)) * Affine::scale(40.),
         }]
     }
@@ -74,6 +75,7 @@ mod tests {
             ImageQuality::Medium,
             [SampleRect {
                 source_region: RectU16::new(0, 0, 1, 1),
+                may_have_transparency: true,
                 transform: Affine::translate((rect.x0, rect.y0))
                     * Affine::scale_non_uniform(rect.width(), rect.height()),
             }],
@@ -94,6 +96,7 @@ mod tests {
             ImageQuality::Low,
             [SampleRect {
                 source_region: SPRITES[0],
+                may_have_transparency: true,
                 transform: Affine::translate((12., 15.)),
             }],
         );
@@ -104,6 +107,7 @@ mod tests {
             ImageQuality::Low,
             [SampleRect {
                 source_region: SPRITES[3],
+                may_have_transparency: true,
                 transform: Affine::translate((25., 25.)),
             }],
         );
@@ -153,6 +157,7 @@ mod tests {
             ImageQuality::Low,
             [SampleRect {
                 source_region: RectU16::new(0, 0, 1, 1),
+                may_have_transparency: true,
                 transform: Affine::translate((66., 10.)) * Affine::scale(24.),
             }],
         );
@@ -162,6 +167,7 @@ mod tests {
             ImageQuality::Low,
             [SampleRect {
                 source_region: RectU16::new(0, 0, 1, 1),
+                may_have_transparency: true,
                 transform: Affine::translate((10., 66.)) * Affine::scale(24.),
             }],
         );
@@ -281,6 +287,7 @@ mod tests {
             ImageQuality::High,
             [SampleRect {
                 source_region: SPRITES[0],
+                may_have_transparency: true,
                 transform: Affine::translate((15., 15.)) * Affine::skew(0.2, 0.1),
             }],
         );
@@ -298,10 +305,12 @@ mod tests {
             [
                 SampleRect {
                     source_region: SPRITES[1],
+                    may_have_transparency: true,
                     transform: Affine::translate((18., 18.)),
                 },
                 SampleRect {
                     source_region: SPRITES[3],
+                    may_have_transparency: true,
                     transform: Affine::translate((34., 34.)),
                 },
             ],
@@ -323,6 +332,7 @@ mod tests {
             ImageQuality::Low,
             [SampleRect {
                 source_region: SPRITES[2],
+                may_have_transparency: true,
                 transform: Affine::translate((20., 20.)),
             }],
         );
@@ -352,6 +362,7 @@ mod tests {
             ImageQuality::Low,
             placements.map(|(source_region, x, y)| SampleRect {
                 source_region,
+                may_have_transparency: true,
                 transform: Affine::translate((x, y)),
             }),
         );
@@ -372,14 +383,17 @@ mod tests {
             [
                 SampleRect {
                     source_region: SPRITES[0],
+                    may_have_transparency: true,
                     transform: Affine::translate((6., 8.)),
                 },
                 SampleRect {
                     source_region: SPRITES[3],
+                    may_have_transparency: true,
                     transform: Affine::translate((28., 5.)) * Affine::skew(0.18, -0.08),
                 },
                 SampleRect {
                     source_region: SPRITES[2],
+                    may_have_transparency: true,
                     transform: Affine::translate((48., 6.)),
                 },
             ],

--- a/sparse_strips/vello_sparse_tests/tests/external_texture.rs
+++ b/sparse_strips/vello_sparse_tests/tests/external_texture.rs
@@ -1,8 +1,6 @@
 // Copyright 2026 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// TODO: Increase test coverage to cover things like tinted external textures, etc.
-
 mod tests {
     use std::sync::Arc;
 
@@ -11,8 +9,8 @@ mod tests {
     use vello_common::filter_effects::{EdgeMode, Filter, FilterPrimitive};
     use vello_common::geometry::RectU16;
     use vello_common::kurbo::{Affine, Circle, Rect, Shape};
-    use vello_common::paint::{Image, ImageSource};
-    use vello_common::peniko::{Extend, ImageQuality, ImageSampler};
+    use vello_common::paint::{Image, ImageSource, Tint, TintMode};
+    use vello_common::peniko::{Color, Extend, ImageQuality, ImageSampler};
     use vello_common::pixmap::Pixmap;
     use vello_dev_macros::vello_test;
     use vello_hybrid::SampleRect;
@@ -39,12 +37,22 @@ mod tests {
         ))
     }
 
-    fn texture_rect_at(x: f64, y: f64) -> [SampleRect; 1] {
-        [SampleRect {
+    fn texture_rect(
+        x: f64,
+        y: f64,
+        width: f64,
+        height: f64,
+        may_have_transparency: bool,
+    ) -> SampleRect {
+        SampleRect {
             source_region: RectU16::new(0, 0, 1, 1),
-            may_have_transparency: true,
-            transform: Affine::translate((x, y)) * Affine::scale(40.),
-        }]
+            may_have_transparency,
+            transform: Affine::translate((x, y)) * Affine::scale_non_uniform(width, height),
+        }
+    }
+
+    fn texture_rect_at(x: f64, y: f64) -> [SampleRect; 1] {
+        [texture_rect(x, y, 40., 40., true)]
     }
 
     fn draw_atlas_rect(ctx: &mut impl Renderer, image: ImageSource, rect: Rect) {
@@ -141,6 +149,65 @@ mod tests {
 
         ctx.draw_texture_rects(green_texture, ImageQuality::Low, texture_rect_at(28., 28.));
         ctx.draw_texture_rects(red_texture, ImageQuality::Low, texture_rect_at(48., 48.));
+    }
+
+    #[vello_test(hybrid_only, hybrid_no_depth)]
+    fn external_texture_root_painter_order(ctx: &mut impl Renderer) {
+        let coral = ctx.register_external_texture(solid_pixmap(225, 87, 89, 255));
+        let teal = ctx.register_external_texture(solid_pixmap(42, 157, 143, 255));
+        let navy = ctx.register_external_texture(solid_pixmap(38, 70, 83, 255));
+        let gold = ctx.register_external_texture(solid_pixmap(153, 102, 61, 160));
+        let tint_source = ctx.register_external_texture(solid_pixmap(255, 255, 255, 255));
+
+        ctx.draw_texture_rects(
+            coral,
+            ImageQuality::Low,
+            [texture_rect(6., 6., 88., 88., false)],
+        );
+        ctx.draw_texture_rects(
+            gold,
+            ImageQuality::Low,
+            [
+                texture_rect(11.5, 33.5, 77., 33., true),
+                texture_rect(33.5, 11.5, 33., 77., true),
+            ],
+        );
+        ctx.draw_texture_rects(
+            teal,
+            ImageQuality::Low,
+            [texture_rect(21.5, 21.5, 57., 57., false)],
+        );
+        ctx.set_tint(Some(Tint {
+            color: Color::from_rgba8(128, 102, 204, 160),
+            mode: TintMode::Multiply,
+        }));
+        ctx.draw_texture_rects(
+            tint_source,
+            ImageQuality::Low,
+            [
+                texture_rect(16., 38., 68., 24., false),
+                texture_rect(38., 16., 24., 68., false),
+            ],
+        );
+        ctx.set_tint(None);
+        ctx.draw_texture_rects(
+            navy,
+            ImageQuality::Low,
+            [texture_rect(33.5, 33.5, 33., 33., false)],
+        );
+        ctx.draw_texture_rects(
+            gold,
+            ImageQuality::Low,
+            [
+                texture_rect(28., 44., 44., 12., true),
+                texture_rect(44., 28., 12., 44., true),
+            ],
+        );
+        ctx.draw_texture_rects(
+            coral,
+            ImageQuality::Low,
+            [texture_rect(44., 44., 12., 12., false)],
+        );
     }
 
     #[vello_test(hybrid_only)]

--- a/sparse_strips/vello_sparse_tests/tests/external_texture.rs
+++ b/sparse_strips/vello_sparse_tests/tests/external_texture.rs
@@ -44,10 +44,14 @@ mod tests {
         height: f64,
         may_have_transparency: bool,
     ) -> SampleRect {
-        SampleRect {
-            source_region: RectU16::new(0, 0, 1, 1),
-            may_have_transparency,
-            transform: Affine::translate((x, y)) * Affine::scale_non_uniform(width, height),
+        let rect = SampleRect::new(
+            RectU16::new(0, 0, 1, 1),
+            Affine::translate((x, y)) * Affine::scale_non_uniform(width, height),
+        );
+        if may_have_transparency {
+            rect
+        } else {
+            rect.with_opaque_hint()
         }
     }
 
@@ -81,12 +85,11 @@ mod tests {
         ctx.draw_texture_rects(
             texture_id,
             ImageQuality::Medium,
-            [SampleRect {
-                source_region: RectU16::new(0, 0, 1, 1),
-                may_have_transparency: true,
-                transform: Affine::translate((rect.x0, rect.y0))
+            [SampleRect::new(
+                RectU16::new(0, 0, 1, 1),
+                Affine::translate((rect.x0, rect.y0))
                     * Affine::scale_non_uniform(rect.width(), rect.height()),
-            }],
+            )],
         );
         ctx.pop_clip_path();
     }
@@ -102,22 +105,14 @@ mod tests {
         ctx.draw_texture_rects(
             texture_id,
             ImageQuality::Low,
-            [SampleRect {
-                source_region: SPRITES[0],
-                may_have_transparency: true,
-                transform: Affine::translate((12., 15.)),
-            }],
+            [SampleRect::new(SPRITES[0], Affine::translate((12., 15.)))],
         );
         ctx.set_paint(color::palette::css::PALE_GOLDENROD.with_alpha(0.7));
         ctx.fill_rect(&Rect::new(10., 7., 65., 55.));
         ctx.draw_texture_rects(
             texture_id,
             ImageQuality::Low,
-            [SampleRect {
-                source_region: SPRITES[3],
-                may_have_transparency: true,
-                transform: Affine::translate((25., 25.)),
-            }],
+            [SampleRect::new(SPRITES[3], Affine::translate((25., 25.)))],
         );
     }
 
@@ -222,21 +217,19 @@ mod tests {
         ctx.draw_texture_rects(
             external_green,
             ImageQuality::Low,
-            [SampleRect {
-                source_region: RectU16::new(0, 0, 1, 1),
-                may_have_transparency: true,
-                transform: Affine::translate((66., 10.)) * Affine::scale(24.),
-            }],
+            [SampleRect::new(
+                RectU16::new(0, 0, 1, 1),
+                Affine::translate((66., 10.)) * Affine::scale(24.),
+            )],
         );
         draw_atlas_rect(ctx, atlas_blue, Rect::new(38., 38., 62., 62.));
         ctx.draw_texture_rects(
             external_yellow,
             ImageQuality::Low,
-            [SampleRect {
-                source_region: RectU16::new(0, 0, 1, 1),
-                may_have_transparency: true,
-                transform: Affine::translate((10., 66.)) * Affine::scale(24.),
-            }],
+            [SampleRect::new(
+                RectU16::new(0, 0, 1, 1),
+                Affine::translate((10., 66.)) * Affine::scale(24.),
+            )],
         );
         draw_atlas_rect(ctx, atlas_magenta, Rect::new(66., 66., 90., 90.));
     }
@@ -352,11 +345,10 @@ mod tests {
         ctx.draw_texture_rects(
             texture_id,
             ImageQuality::High,
-            [SampleRect {
-                source_region: SPRITES[0],
-                may_have_transparency: true,
-                transform: Affine::translate((15., 15.)) * Affine::skew(0.2, 0.1),
-            }],
+            [SampleRect::new(
+                SPRITES[0],
+                Affine::translate((15., 15.)) * Affine::skew(0.2, 0.1),
+            )],
         );
     }
 
@@ -370,16 +362,8 @@ mod tests {
             texture_id,
             ImageQuality::Medium,
             [
-                SampleRect {
-                    source_region: SPRITES[1],
-                    may_have_transparency: true,
-                    transform: Affine::translate((18., 18.)),
-                },
-                SampleRect {
-                    source_region: SPRITES[3],
-                    may_have_transparency: true,
-                    transform: Affine::translate((34., 34.)),
-                },
+                SampleRect::new(SPRITES[1], Affine::translate((18., 18.))),
+                SampleRect::new(SPRITES[3], Affine::translate((34., 34.))),
             ],
         );
         ctx.pop_layer();
@@ -397,11 +381,7 @@ mod tests {
         ctx.draw_texture_rects(
             texture_id,
             ImageQuality::Low,
-            [SampleRect {
-                source_region: SPRITES[2],
-                may_have_transparency: true,
-                transform: Affine::translate((20., 20.)),
-            }],
+            [SampleRect::new(SPRITES[2], Affine::translate((20., 20.)))],
         );
         ctx.pop_layer();
     }
@@ -427,10 +407,8 @@ mod tests {
         ctx.draw_texture_rects(
             texture_id,
             ImageQuality::Low,
-            placements.map(|(source_region, x, y)| SampleRect {
-                source_region,
-                may_have_transparency: true,
-                transform: Affine::translate((x, y)),
+            placements.map(|(source_region, x, y)| {
+                SampleRect::new(source_region, Affine::translate((x, y)))
             }),
         );
     }
@@ -448,21 +426,12 @@ mod tests {
             texture_id,
             ImageQuality::Medium,
             [
-                SampleRect {
-                    source_region: SPRITES[0],
-                    may_have_transparency: true,
-                    transform: Affine::translate((6., 8.)),
-                },
-                SampleRect {
-                    source_region: SPRITES[3],
-                    may_have_transparency: true,
-                    transform: Affine::translate((28., 5.)) * Affine::skew(0.18, -0.08),
-                },
-                SampleRect {
-                    source_region: SPRITES[2],
-                    may_have_transparency: true,
-                    transform: Affine::translate((48., 6.)),
-                },
+                SampleRect::new(SPRITES[0], Affine::translate((6., 8.))),
+                SampleRect::new(
+                    SPRITES[3],
+                    Affine::translate((28., 5.)) * Affine::skew(0.18, -0.08),
+                ),
+                SampleRect::new(SPRITES[2], Affine::translate((48., 6.))),
             ],
         );
     }


### PR DESCRIPTION
As per description. This requires making the opaque pass aware of external textures. An unfortunate consequence of this is that opaque external images that are not aligned to integer coordinates will need to be drawn twice: Once during the opaque pass, and another time for the fractional edges during the alpha pass. But at least they can now be drawn with depth occlusion, which should be a huge win.

This PR was done with assistance of GPT 5.6 Sol.