### PR TITLE
Clamp the discarded select arm's index in prefix-sum lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This release has an [MSRV][] of 1.88.
 ### Fixed
 
 - Rendering scenes whose binning requires more than 256 bins. ([#1700][] by [@b0nes164][])
+- Prefix-sum lookups no longer index workgroup arrays with an underflowed index in the discarded arm of a `select`, which caused a device loss on Mali GPUs for any scene containing a path. ([#1817][] by [@lexoliu][])
 
 ## [0.9.0][] - 2026-05-15
 
@@ -327,6 +328,7 @@ This release has an [MSRV][] of 1.75.
 [@Keavon]: https://github.com/Keavon
 [@kmoon2437]: https://github.com/kmoon2437
 [@LaurenzV]: https://github.com/LaurenzV
+[@lexoliu]: https://github.com/lexoliu
 [@msiglreith]: https://github.com/msiglreith
 [@nicoburns]: https://github.com/nicoburns
 [@oscargus]: https://github.com/oscargus
@@ -450,6 +452,7 @@ This release has an [MSRV][] of 1.75.
 [#1638]: https://github.com/linebender/vello/pull/1638
 [#1643]: https://github.com/linebender/vello/pull/1643
 [#1700]: https://github.com/linebender/vello/pull/1700
+[#1817]: https://github.com/linebender/vello/pull/1817
 
 [Unreleased]: https://github.com/linebender/vello/compare/v0.9.0...HEAD
 [0.9.0]: https://github.com/linebender/vello/compare/v0.8.0...v0.9.0

--- a/vello_shaders/shader/backdrop_dyn.wgsl
+++ b/vello_shaders/shader/backdrop_dyn.wgsl
@@ -73,7 +73,7 @@ fn main(
         }
         let width = sh_row_width[el_ix];
         if width > 0u {
-            var seq_ix = row - select(0u, sh_row_count[el_ix - 1u], el_ix > 0u);
+            var seq_ix = row - select(0u, sh_row_count[max(el_ix, 1u) - 1u], el_ix > 0u);
             var tile_ix = sh_offset[el_ix] + seq_ix * width;
             var sum = tiles[tile_ix].backdrop;
             for (var x = 1u; x < width; x += 1u) {

--- a/vello_shaders/shader/coarse.wgsl
+++ b/vello_shaders/shader/coarse.wgsl
@@ -248,7 +248,7 @@ fn main(
                         part_ix = probe;
                     }
                 }
-                ix -= select(part_start_ix, sh_part_count[part_ix - 1u], part_ix > 0u);
+                ix -= select(part_start_ix, sh_part_count[max(part_ix, 1u) - 1u], part_ix > 0u);
                 let offset = config.bin_data_start + sh_part_offsets[part_ix];
                 sh_drawobj_ix[local_id.x] = info_bin_data[offset + ix];
             }
@@ -312,7 +312,7 @@ fn main(
             }
             drawobj_ix = sh_drawobj_ix[el_ix];
             tag = scene[config.drawtag_base + drawobj_ix];
-            let seq_ix = ix - select(0u, sh_tile_count[el_ix - 1u], el_ix > 0u);
+            let seq_ix = ix - select(0u, sh_tile_count[max(el_ix, 1u) - 1u], el_ix > 0u);
             let width = sh_tile_width[el_ix];
             let x0y0 = sh_tile_x0y0[el_ix];
             let x = (x0y0 & 0xffffu) + seq_ix % width;

--- a/vello_shaders/shader/fine.wgsl
+++ b/vello_shaders/shader/fine.wgsl
@@ -220,7 +220,7 @@ fn fill_path_ms(fill: CmdFill, local_id: vec2<u32>, result: ptr<function, array<
             }
             let el_ix = lo;
             let last_pixel = i + 1u == sh_count[el_ix];
-            let sub_ix = i - select(0u, sh_count[el_ix - 1u], el_ix > 0u);
+            let sub_ix = i - select(0u, sh_count[max(el_ix, 1u) - 1u], el_ix > 0u);
             let seg_off = fill.seg_data + batch * WG_SIZE + el_ix;
             let segment = segments[seg_off];
             // Coordinates are relative to tile origin
@@ -576,7 +576,7 @@ fn fill_path_ms_evenodd(fill: CmdFill, local_id: vec2<u32>, result: ptr<function
             }
             let el_ix = lo;
             let last_pixel = i + 1u == sh_count[el_ix];
-            let sub_ix = i - select(0u, sh_count[el_ix - 1u], el_ix > 0u);
+            let sub_ix = i - select(0u, sh_count[max(el_ix, 1u) - 1u], el_ix > 0u);
             let seg_off = fill.seg_data + batch * WG_SIZE + el_ix;
             let segment = segments[seg_off];
             let xy0_in = segment.point0;

--- a/vello_shaders/shader/tile_alloc.wgsl
+++ b/vello_shaders/shader/tile_alloc.wgsl
@@ -104,7 +104,7 @@ fn main(
     let tile_offset = paths[drawobj_ix | (WG_SIZE - 1u)].tiles;
     storageBarrier();
     if drawobj_ix < config.n_drawobj {
-        let tile_subix = select(0u, sh_tile_count[local_id.x - 1u], local_id.x > 0u);
+        let tile_subix = select(0u, sh_tile_count[max(local_id.x, 1u) - 1u], local_id.x > 0u);
         let bbox = vec4(ux0, uy0, ux1, uy1);
         let path = Path(bbox, tile_offset + tile_subix);
         paths[drawobj_ix] = path;


### PR DESCRIPTION
Fixes #1816.

Several prefix-sum lookups have the shape
`select(default, sh_array[ix - 1u], ix > 0u)`. Both arms of `select` are
evaluated, so lanes with `ix == 0` compute `sh_array[0u - 1u]` before
discarding it. Mali lowers workgroup arrays to ordinary memory, so the
underflowed index becomes a wild address and the driver reports a device loss;
on a Pixel 9 Pro (Immortalis-G715, Android 16) any scene containing a path
lost the device on the first frame. The shaders run unchecked since #1093, so
there is no bounds check to mask it.

This clamps the index in the discarded arm, `sh_array[max(ix, 1u) - 1u]`,
which changes nothing when `ix > 0` and keeps the dead access in bounds when
`ix == 0`. Six sites: one each in `tile_alloc` and `backdrop_dyn`, two in
`coarse` (these four fault on the device), and two in `fine` which have the
same pattern but didn't fault in my scenes.

Verified on the Pixel 9 Pro with fully unchecked shaders: the scenes that
previously lost the device render correctly. `vello_tests` passes on Metal, so
the selected values are unchanged. An explicit `if` would avoid the dual
evaluation altogether; I kept the clamp since it's the smallest diff and it's
what I tested on hardware, but happy to change the shape.
