### PR TITLE
Don't enable WGPU in std

### DIFF
--- a/sparse_strips/vello_hybrid/Cargo.toml
+++ b/sparse_strips/vello_hybrid/Cargo.toml
@@ -48,7 +48,7 @@ roxmltree = "0.20.0"
 
 [features]
 default = ["wgpu", "wgpu_default", "text"]
-std = ["wgpu", "vello_common/std", "glifo?/std"]
+std = ["vello_common/std", "glifo?/std"]
 libm = ["vello_common/libm", "glifo?/libm"]
 wgpu = ["dep:wgpu", "dep:vello_sparse_shaders"]
 # Enable wgpu with its default features. If you need to customise the set of enabled wgpu features,

--- a/sparse_strips/vello_hybrid/src/lib.rs
+++ b/sparse_strips/vello_hybrid/src/lib.rs
@@ -67,6 +67,14 @@
 //! these and other limitations in future releases.
 
 #![no_std]
+#![cfg_attr(
+    not(any(feature = "wgpu", feature = "webgl")),
+    allow(
+        dead_code,
+        unused_imports,
+        reason = "backend implementations are unused when none is enabled"
+    )
+)]
 
 extern crate alloc;
 


### PR DESCRIPTION
Today, it's impossible to enable `std` and `webgl` without seeing this error: "Both WebGL and wgpu with the "webgl" feature are enabled" because WGPU is enabled via `std`.