### PR TITLE
vello_hybrid: Use `u16` consistently throughout the codebase

### DIFF
--- a/glifo/src/atlas/cache.rs
+++ b/glifo/src/atlas/cache.rs
@@ -216,8 +216,9 @@ impl GlyphAtlas {
         key: GlyphCacheKey,
         raster_metrics: RasterMetrics,
     ) -> Option<AtlasSlot> {
-        let padded_w = u32::from(raster_metrics.width) + u32::from(GLYPH_PADDING) * 2;
-        let padded_h = u32::from(raster_metrics.height) + u32::from(GLYPH_PADDING) * 2;
+        let padding = GLYPH_PADDING.checked_mul(2)?;
+        let padded_w = raster_metrics.width.checked_add(padding)?;
+        let padded_h = raster_metrics.height.checked_add(padding)?;
 
         let image_id = image_cache.allocate(padded_w, padded_h, 0).ok()?;
         let resource = image_cache.get(image_id)?;
@@ -262,10 +263,6 @@ impl GlyphAtlas {
     }
 
     /// Allocate atlas space, insert a cache entry, and return the page recorder.
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "atlas dimensions are configured to fit in u16"
-    )]
     pub fn insert(
         &mut self,
         image_cache: &mut ImageCache,
@@ -273,10 +270,7 @@ impl GlyphAtlas {
         raster_metrics: RasterMetrics,
     ) -> Option<(AtlasSlot, &mut AtlasCommandRecorder)> {
         let atlas_slot = self.insert_entry(image_cache, key, raster_metrics)?;
-        let (atlas_w, atlas_h) = {
-            let (w, h) = image_cache.atlas_manager().config().atlas_size;
-            (w as u16, h as u16)
-        };
+        let (atlas_w, atlas_h) = image_cache.atlas_manager().config().atlas_size;
         let recorder = self.recorder_for_page(atlas_slot.page_index, atlas_w, atlas_h);
         Some((atlas_slot, recorder))
     }

--- a/sparse_strips/vello_bench/src/allocator.rs
+++ b/sparse_strips/vello_bench/src/allocator.rs
@@ -9,7 +9,7 @@ use vello_common::multi_atlas::AtlasId;
 
 use crate::SEED;
 
-const ATLAS_SIZE: u32 = 4096;
+const ATLAS_SIZE: u16 = 4096;
 
 fn make_atlas() -> Atlas {
     Atlas::new(AtlasId::new(0), ATLAS_SIZE, ATLAS_SIZE)
@@ -24,7 +24,7 @@ pub fn allocator(c: &mut Criterion) {
 /// Allocate 1000 rectangles with random sizes between 8x8 and 128x128.
 fn allocate_varied(c: &mut Criterion) {
     let mut rng = SmallRng::from_seed(SEED);
-    let sizes: Vec<(u32, u32)> = (0..1000)
+    let sizes: Vec<(u16, u16)> = (0..1000)
         .map(|_| (rng.random_range(8..=128), rng.random_range(8..=128)))
         .collect();
 
@@ -60,7 +60,7 @@ fn allocate_until_full(c: &mut Criterion) {
 /// (500 cycles). Measures reuse / merge performance under typical glyph-cache turnover.
 fn alloc_dealloc_churn(c: &mut Criterion) {
     let mut rng = SmallRng::from_seed(SEED);
-    let sizes: Vec<(u32, u32)> = (0..1000)
+    let sizes: Vec<(u16, u16)> = (0..1000)
         .map(|_| (rng.random_range(16..=64), rng.random_range(16..=64)))
         .collect();
 
@@ -68,7 +68,7 @@ fn alloc_dealloc_churn(c: &mut Criterion) {
     g.bench_function("churn_500_steady_state", |b| {
         b.iter(|| {
             let mut atlas = make_atlas();
-            let mut live: Vec<(vello_common::multi_atlas::AllocId, u32, u32)> = Vec::new();
+            let mut live: Vec<(vello_common::multi_atlas::AllocId, u16, u16)> = Vec::new();
 
             for &(w, h) in sizes.iter().take(500) {
                 if let Some(a) = atlas.allocate(w, h) {

--- a/sparse_strips/vello_common/src/geometry.rs
+++ b/sparse_strips/vello_common/src/geometry.rs
@@ -5,7 +5,6 @@
 
 use crate::kurbo::Rect;
 use bytemuck::{Pod, Zeroable};
-use core::num::TryFromIntError;
 use core::ops::Add;
 
 /// A size represented by two 16-bit unsigned integers.
@@ -57,11 +56,31 @@ impl SizeU16 {
     pub fn clamp(self, min: u16, max: u16) -> Self {
         Self::from_wh(self.width().clamp(min, max), self.height().clamp(min, max))
     }
+
+    /// Add the same value to both dimensions, returning `None` on overflow.
+    pub fn checked_add(self, value: u16) -> Option<Self> {
+        Some(Self::from_wh(
+            self.width().checked_add(value)?,
+            self.height().checked_add(value)?,
+        ))
+    }
 }
 
 impl From<[u16; 2]> for SizeU16 {
     fn from(value: [u16; 2]) -> Self {
         Self(value)
+    }
+}
+
+impl From<(u16, u16)> for SizeU16 {
+    fn from((width, height): (u16, u16)) -> Self {
+        Self::from_wh(width, height)
+    }
+}
+
+impl From<SizeU16> for (u16, u16) {
+    fn from(size: SizeU16) -> Self {
+        (size.width(), size.height())
     }
 }
 
@@ -256,177 +275,6 @@ impl RectU16 {
 impl From<RectU16> for SizeU16 {
     fn from(rect: RectU16) -> Self {
         Self::from_wh(rect.width(), rect.height())
-    }
-}
-
-// TODO: Remove these types once we've completely moved to u16 everywhere in Vello Hybrid.
-
-/// An offset represented by two 32-bit unsigned integers.
-#[repr(C)]
-#[derive(Copy, Clone, Debug, Pod, Zeroable, PartialEq, Eq)]
-pub struct OffsetU32(pub [u32; 2]);
-
-impl OffsetU32 {
-    /// A zero offset.
-    pub const ZERO: Self = Self::new(0);
-
-    /// Create a new offset with equal x and y coordinates.
-    pub const fn new(offset: u32) -> Self {
-        Self([offset; 2])
-    }
-
-    /// Create a new offset from its x and y coordinates.
-    pub const fn from_xy(x: u32, y: u32) -> Self {
-        Self([x, y])
-    }
-
-    /// The x coordinate of this offset.
-    pub const fn x(self) -> u32 {
-        self.0[0]
-    }
-
-    /// The y coordinate of this offset.
-    pub const fn y(self) -> u32 {
-        self.0[1]
-    }
-}
-
-impl From<[u32; 2]> for OffsetU32 {
-    fn from(value: [u32; 2]) -> Self {
-        Self(value)
-    }
-}
-
-/// A size represented by two 32-bit unsigned integers.
-#[repr(C)]
-#[derive(Copy, Clone, Debug, Pod, Zeroable, PartialEq, Eq)]
-pub struct SizeU32(pub [u32; 2]);
-
-impl SizeU32 {
-    /// A zero size.
-    pub const ZERO: Self = Self::new(0);
-
-    /// Create a new square size.
-    pub const fn new(size: u32) -> Self {
-        Self([size; 2])
-    }
-
-    /// Create a new size from its width and height.
-    pub const fn from_wh(width: u32, height: u32) -> Self {
-        Self([width, height])
-    }
-
-    /// The width of this size.
-    pub const fn width(self) -> u32 {
-        self.0[0]
-    }
-
-    /// The height of this size.
-    pub const fn height(self) -> u32 {
-        self.0[1]
-    }
-
-    /// Return the maximum of the two sizes.
-    pub fn max(self, other: Self) -> Self {
-        Self::from_wh(
-            self.width().max(other.width()),
-            self.height().max(other.height()),
-        )
-    }
-
-    /// Return the minimum of the two sizes.
-    pub fn min(self, other: Self) -> Self {
-        Self::from_wh(
-            self.width().min(other.width()),
-            self.height().min(other.height()),
-        )
-    }
-
-    /// Clamp both dimensions to the given range.
-    pub fn clamp(self, min: u32, max: u32) -> Self {
-        Self::from_wh(self.width().clamp(min, max), self.height().clamp(min, max))
-    }
-}
-
-impl From<[u32; 2]> for SizeU32 {
-    fn from(value: [u32; 2]) -> Self {
-        Self(value)
-    }
-}
-
-impl From<(u32, u32)> for SizeU32 {
-    fn from((width, height): (u32, u32)) -> Self {
-        Self::from_wh(width, height)
-    }
-}
-
-impl From<SizeU32> for (u32, u32) {
-    fn from(size: SizeU32) -> Self {
-        (size.width(), size.height())
-    }
-}
-
-impl From<SizeU16> for SizeU32 {
-    fn from(size: SizeU16) -> Self {
-        Self::from_wh(u32::from(size.width()), u32::from(size.height()))
-    }
-}
-
-impl TryFrom<SizeU32> for SizeU16 {
-    type Error = TryFromIntError;
-
-    fn try_from(size: SizeU32) -> Result<Self, Self::Error> {
-        Ok(Self::from_wh(
-            u16::try_from(size.width())?,
-            u16::try_from(size.height())?,
-        ))
-    }
-}
-
-impl Add for SizeU32 {
-    type Output = Self;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        Self::from_wh(self.width() + rhs.width(), self.height() + rhs.height())
-    }
-}
-
-impl Add<u32> for SizeU32 {
-    type Output = Self;
-
-    fn add(self, rhs: u32) -> Self::Output {
-        self + Self::new(rhs)
-    }
-}
-
-/// An axis-aligned rectangle with `u32` coordinates.
-#[repr(C)]
-#[derive(Copy, Clone, Debug, Pod, Zeroable, PartialEq, Eq)]
-pub struct RectU32 {
-    /// The minimum x coordinate.
-    pub x0: u32,
-    /// The minimum y coordinate.
-    pub y0: u32,
-    /// The exclusive maximum x coordinate.
-    pub x1: u32,
-    /// The exclusive maximum y coordinate.
-    pub y1: u32,
-}
-
-impl RectU32 {
-    /// Create a new rectangle from its corner coordinates.
-    pub const fn new(x0: u32, y0: u32, x1: u32, y1: u32) -> Self {
-        Self { x0, y0, x1, y1 }
-    }
-
-    /// The width of this rectangle.
-    pub const fn width(self) -> u32 {
-        self.x1.saturating_sub(self.x0)
-    }
-
-    /// The height of this rectangle.
-    pub const fn height(self) -> u32 {
-        self.y1.saturating_sub(self.y0)
     }
 }
 

--- a/sparse_strips/vello_common/src/image_cache.rs
+++ b/sparse_strips/vello_common/src/image_cache.rs
@@ -31,14 +31,14 @@ pub struct ImageResource {
 }
 
 impl ImageResource {
-    /// Returns the offset as `[u32; 2]`.
-    pub fn offsets(&self) -> [u32; 2] {
-        [self.offset[0] as u32, self.offset[1] as u32]
+    /// Returns the offset as `[u16; 2]`.
+    pub fn offsets(&self) -> [u16; 2] {
+        self.offset
     }
 
-    /// Returns the size as `[u32; 2]`.
-    pub fn size(&self) -> [u32; 2] {
-        [self.width as u32, self.height as u32]
+    /// Returns the size as `[u16; 2]`.
+    pub fn size(&self) -> [u16; 2] {
+        [self.width, self.height]
     }
 }
 
@@ -94,8 +94,8 @@ impl ImageCache {
     /// Allocate an image in the cache, with optional transparent padding.
     pub fn allocate(
         &mut self,
-        width: u32,
-        height: u32,
+        width: u16,
+        height: u16,
         padding: u16,
     ) -> Result<ImageId, AtlasError> {
         self.allocate_excluding(width, height, padding, None)
@@ -103,19 +103,27 @@ impl ImageCache {
 
     /// Allocate an image in the cache, with optional transparency padding
     /// and optionally excluding a specific atlas.
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "u16 is enough for the offset and width/height"
-    )]
     pub fn allocate_excluding(
         &mut self,
-        width: u32,
-        height: u32,
+        width: u16,
+        height: u16,
         padding: u16,
         exclude_atlas_id: Option<AtlasId>,
     ) -> Result<ImageId, AtlasError> {
-        let padded_width = width + u32::from(padding) * 2;
-        let padded_height = height + u32::from(padding) * 2;
+        let doubled_padding = u32::from(padding) * 2;
+        let padded_width = u32::from(width) + doubled_padding;
+        let padded_height = u32::from(height) + doubled_padding;
+        let (max_width, max_height) = self.atlas_manager.config().atlas_size;
+        let (Ok(padded_width), Ok(padded_height)) =
+            (u16::try_from(padded_width), u16::try_from(padded_height))
+        else {
+            return Err(AtlasError::TextureTooLarge {
+                width: padded_width,
+                height: padded_height,
+                max_width,
+                max_height,
+            });
+        };
         let atlas_alloc = self.atlas_manager.try_allocate_excluding(
             padded_width,
             padded_height,
@@ -132,12 +140,12 @@ impl ImageCache {
 
         let image_id = ImageId::new(slot_idx as u32);
         let image_resource = ImageResource {
-            width: width as u16,
-            height: height as u16,
+            width,
+            height,
             atlas_id: atlas_alloc.atlas_id,
             offset: [
-                atlas_alloc.allocation.x as u16 + padding,
-                atlas_alloc.allocation.y as u16 + padding,
+                atlas_alloc.allocation.x + padding,
+                atlas_alloc.allocation.y + padding,
             ],
             padding,
             atlas_alloc_id: atlas_alloc.allocation.id,
@@ -152,9 +160,8 @@ impl ImageCache {
         let index = id.as_u32() as usize;
         if let Some(image_resource) = self.slots.get_mut(index).and_then(Option::take) {
             // Deallocate from the appropriate atlas
-            let padded_width = image_resource.width as u32 + u32::from(image_resource.padding) * 2;
-            let padded_height =
-                image_resource.height as u32 + u32::from(image_resource.padding) * 2;
+            let padded_width = image_resource.width + image_resource.padding * 2;
+            let padded_height = image_resource.height + image_resource.padding * 2;
             self.atlas_manager
                 .deallocate(
                     image_resource.atlas_id,
@@ -185,7 +192,7 @@ impl ImageCache {
 mod tests {
     use super::*;
 
-    const ATLAS_SIZE: u32 = 1024;
+    const ATLAS_SIZE: u16 = 1024;
 
     #[test]
     fn test_insert_single_image() {
@@ -220,6 +227,24 @@ mod tests {
         assert_eq!(resource.padding, 4);
         // Offset should be shifted inward by padding.
         assert_eq!(resource.offset, [4, 4]);
+    }
+
+    #[test]
+    fn test_rejects_padded_dimensions_outside_u16_atlas_domain() {
+        let mut cache = ImageCache::new_with_config(AtlasConfig {
+            atlas_size: (u16::MAX, u16::MAX),
+            ..Default::default()
+        });
+
+        assert!(matches!(
+            cache.allocate(u16::MAX, 100, 1),
+            Err(AtlasError::TextureTooLarge {
+                width: 65_537,
+                height: 102,
+                max_width: u16::MAX,
+                max_height: u16::MAX,
+            })
+        ));
     }
 
     #[test]

--- a/sparse_strips/vello_common/src/multi_atlas.rs
+++ b/sparse_strips/vello_common/src/multi_atlas.rs
@@ -21,9 +21,9 @@ pub struct Allocation {
     /// Opaque handle used for deallocation.
     pub id: AllocId,
     /// X coordinate of the top-left corner of the allocated rectangle.
-    pub x: u32,
+    pub x: u16,
     /// Y coordinate of the top-left corner of the allocated rectangle.
-    pub y: u32,
+    pub y: u16,
 }
 
 // ---------------------------------------------------------------------------
@@ -44,13 +44,13 @@ pub struct Atlas {
 
 impl Atlas {
     /// Create a new atlas with the given ID and size.
-    pub fn new(id: AtlasId, width: u32, height: u32) -> Self {
+    pub fn new(id: AtlasId, width: u16, height: u16) -> Self {
         Self {
             id,
-            allocator: AtlasAllocator::new(guillotiere::size2(width as i32, height as i32)),
+            allocator: AtlasAllocator::new(guillotiere::size2(i32::from(width), i32::from(height))),
             stats: AtlasUsageStats {
                 allocated_area: 0,
-                total_area: width * height,
+                total_area: u32::from(width) * u32::from(height),
                 allocated_count: 0,
             },
             allocation_counter: 0,
@@ -58,28 +58,29 @@ impl Atlas {
     }
 
     /// Try to allocate an image in this atlas.
-    #[expect(
-        clippy::cast_sign_loss,
-        reason = "coordinates are always non-negative for valid allocations"
-    )]
-    pub fn allocate(&mut self, width: u32, height: u32) -> Option<Allocation> {
+    pub fn allocate(&mut self, width: u16, height: u16) -> Option<Allocation> {
         let alloc = self
             .allocator
-            .allocate(guillotiere::size2(width as i32, height as i32))?;
-        self.stats.allocated_area += width * height;
+            .allocate(guillotiere::size2(i32::from(width), i32::from(height)))?;
+        self.stats.allocated_area += u32::from(width) * u32::from(height);
         self.stats.allocated_count += 1;
         self.allocation_counter += 1;
         Some(Allocation {
             id: alloc.id,
-            x: alloc.rectangle.min.x as u32,
-            y: alloc.rectangle.min.y as u32,
+            x: u16::try_from(alloc.rectangle.min.x)
+                .expect("guillotiere returned an out-of-range x coordinate"),
+            y: u16::try_from(alloc.rectangle.min.y)
+                .expect("guillotiere returned an out-of-range y coordinate"),
         })
     }
 
     /// Deallocate an image from this atlas.
-    pub fn deallocate(&mut self, alloc_id: AllocId, width: u32, height: u32) {
+    pub fn deallocate(&mut self, alloc_id: AllocId, width: u16, height: u16) {
         self.allocator.deallocate(alloc_id);
-        self.stats.allocated_area = self.stats.allocated_area.saturating_sub(width * height);
+        self.stats.allocated_area = self
+            .stats
+            .allocated_area
+            .saturating_sub(u32::from(width) * u32::from(height));
         self.stats.allocated_count = self.stats.allocated_count.saturating_sub(1);
     }
 
@@ -159,7 +160,7 @@ impl MultiAtlasManager {
     }
 
     /// Try to allocate space for an image with the given dimensions.
-    pub fn try_allocate(&mut self, width: u32, height: u32) -> Result<AtlasAllocation, AtlasError> {
+    pub fn try_allocate(&mut self, width: u16, height: u16) -> Result<AtlasAllocation, AtlasError> {
         self.try_allocate_excluding(width, height, None)
     }
 
@@ -167,15 +168,15 @@ impl MultiAtlasManager {
     /// optionally excluding a specific atlas.
     pub fn try_allocate_excluding(
         &mut self,
-        width: u32,
-        height: u32,
+        width: u16,
+        height: u16,
         exclude_atlas_id: Option<AtlasId>,
     ) -> Result<AtlasAllocation, AtlasError> {
         // Check if the image is too large for any atlas
         if width > self.config.atlas_size.0 || height > self.config.atlas_size.1 {
             return Err(AtlasError::TextureTooLarge {
-                width,
-                height,
+                width: u32::from(width),
+                height: u32::from(height),
                 max_width: self.config.atlas_size.0,
                 max_height: self.config.atlas_size.1,
             });
@@ -196,7 +197,7 @@ impl MultiAtlasManager {
         }
     }
 
-    fn space_diagnostics(&self, width: u32, height: u32) -> AtlasSpaceDiagnostics {
+    fn space_diagnostics(&self, width: u16, height: u16) -> AtlasSpaceDiagnostics {
         let mut atlases = Vec::new();
 
         for atlas in &self.atlases {
@@ -206,8 +207,10 @@ impl MultiAtlasManager {
             let mut largest_free_height = 0;
             let mut largest_free_area = 0_u64;
             atlas.allocator.for_each_free_rectangle(|rect| {
-                let rect_width = rect.width() as u32;
-                let rect_height = rect.height() as u32;
+                let rect_width = u16::try_from(rect.width())
+                    .expect("guillotiere returned an out-of-range rectangle width");
+                let rect_height = u16::try_from(rect.height())
+                    .expect("guillotiere returned an out-of-range rectangle height");
                 let rect_area = u64::from(rect_width) * u64::from(rect_height);
                 free_area += rect_area;
                 free_rectangle_count += 1;
@@ -239,11 +242,11 @@ impl MultiAtlasManager {
         }
     }
 
-    fn no_space_available(&self, width: u32, height: u32) -> AtlasError {
+    fn no_space_available(&self, width: u16, height: u16) -> AtlasError {
         AtlasError::NoSpaceAvailable(self.space_diagnostics(width, height))
     }
 
-    fn atlas_limit_reached(&self, width: u32, height: u32) -> AtlasError {
+    fn atlas_limit_reached(&self, width: u16, height: u16) -> AtlasError {
         AtlasError::AtlasLimitReached {
             max_atlases: self.config.max_atlases,
             diagnostics: self.space_diagnostics(width, height),
@@ -253,8 +256,8 @@ impl MultiAtlasManager {
     /// Allocate using first-fit strategy: try atlases in order until one has space.
     fn allocate_first_fit(
         &mut self,
-        width: u32,
-        height: u32,
+        width: u16,
+        height: u16,
         exclude_atlas_id: Option<AtlasId>,
     ) -> Result<AtlasAllocation, AtlasError> {
         for atlas in &mut self.atlases {
@@ -291,8 +294,8 @@ impl MultiAtlasManager {
     /// can fit the image.
     fn allocate_best_fit(
         &mut self,
-        width: u32,
-        height: u32,
+        width: u16,
+        height: u16,
         exclude_atlas_id: Option<AtlasId>,
     ) -> Result<AtlasAllocation, AtlasError> {
         let mut best_atlas_idx = None;
@@ -307,7 +310,9 @@ impl MultiAtlasManager {
             let stats = atlas.stats();
             let remaining_space = stats.total_area - stats.allocated_area;
 
-            if remaining_space >= width * height && remaining_space < best_remaining_space {
+            if remaining_space >= u32::from(width) * u32::from(height)
+                && remaining_space < best_remaining_space
+            {
                 best_remaining_space = remaining_space;
                 best_atlas_idx = Some(idx);
             }
@@ -330,8 +335,8 @@ impl MultiAtlasManager {
     /// Allocate using least-used strategy: prefer the atlas with the lowest usage percentage.
     fn allocate_least_used(
         &mut self,
-        width: u32,
-        height: u32,
+        width: u16,
+        height: u16,
         exclude_atlas_id: Option<AtlasId>,
     ) -> Result<AtlasAllocation, AtlasError> {
         let mut best_atlas_idx = None;
@@ -367,8 +372,8 @@ impl MultiAtlasManager {
     /// Allocate using round-robin strategy: cycle through atlases using a round-robin counter.
     fn allocate_round_robin(
         &mut self,
-        width: u32,
-        height: u32,
+        width: u16,
+        height: u16,
         exclude_atlas_id: Option<AtlasId>,
     ) -> Result<AtlasAllocation, AtlasError> {
         if self.atlases.is_empty() {
@@ -418,8 +423,8 @@ impl MultiAtlasManager {
         &mut self,
         atlas_id: AtlasId,
         alloc_id: AllocId,
-        width: u32,
-        height: u32,
+        width: u16,
+        height: u16,
     ) -> Result<(), AtlasError> {
         // Since atlases only grow (never deallocate) and id is the index into the atlases vec,
         // we can do a lookup instead of a linear search
@@ -479,9 +484,9 @@ pub enum AtlasError {
         /// The height of the requested texture.
         height: u32,
         /// The maximum texture width supported by the atlas.
-        max_width: u32,
+        max_width: u16,
         /// The maximum texture height supported by the atlas.
-        max_height: u32,
+        max_height: u16,
     },
     /// The specified atlas was not found.
     #[error("Atlas with Id {0:?} not found")]
@@ -496,13 +501,13 @@ pub enum AtlasSpaceDiagnostics {
     /// Details about the requested allocation and available atlas space.
     Allocation {
         /// The requested allocation width.
-        width: u32,
+        width: u16,
         /// The requested allocation height.
-        height: u32,
+        height: u16,
         /// The width shared by all atlas layers.
-        atlas_width: u32,
+        atlas_width: u16,
         /// The height shared by all atlas layers.
-        atlas_height: u32,
+        atlas_height: u16,
         /// The configured maximum number of atlas layers.
         max_atlases: usize,
         /// Per-layer details for each atlas considered for the allocation.
@@ -575,9 +580,9 @@ pub struct AtlasLayerDiagnostics {
     /// The number of disjoint free rectangles in the layer.
     pub free_rectangle_count: usize,
     /// The width of the largest free rectangle by area.
-    pub largest_free_width: u32,
+    pub largest_free_width: u16,
     /// The height of the largest free rectangle by area.
-    pub largest_free_height: u32,
+    pub largest_free_height: u16,
 }
 
 impl AtlasLayerDiagnostics {
@@ -622,7 +627,7 @@ impl core::fmt::Debug for AtlasLayerDiagnostics {
     }
 }
 
-struct Dimensions(u32, u32);
+struct Dimensions(u16, u16);
 
 impl core::fmt::Debug for Dimensions {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -699,9 +704,8 @@ pub struct AtlasConfig {
     pub initial_atlas_count: usize,
     /// Maximum number of atlases to create.
     pub max_atlases: usize,
-    // TODO: Make those u16 instead?
     /// Size of each atlas texture.
-    pub atlas_size: (u32, u32),
+    pub atlas_size: (u16, u16),
     /// Whether to automatically create new atlases when needed.
     pub auto_grow: bool,
     /// Strategy for allocating images across atlases.

--- a/sparse_strips/vello_hybrid/examples/native_webgl/src/lib.rs
+++ b/sparse_strips/vello_hybrid/examples/native_webgl/src/lib.rs
@@ -268,8 +268,8 @@ impl AppState {
         &self,
         pixmap: &vello_hybrid::Pixmap,
     ) -> vello_hybrid::WebGlTextureWithDimensions {
-        let width = pixmap.width() as u32;
-        let height = pixmap.height() as u32;
+        let width = pixmap.width();
+        let height = pixmap.height();
         let rgba_data = pixmap.data_as_u8_slice();
 
         let gl = &self.renderer_wrapper.renderer.gl_context();

--- a/sparse_strips/vello_hybrid/src/lib.rs
+++ b/sparse_strips/vello_hybrid/src/lib.rs
@@ -149,9 +149,9 @@ pub enum IntermediateTextureError {
         /// The requested allocation height.
         height: u32,
         /// The maximum intermediate texture width.
-        max_width: u32,
+        max_width: u16,
         /// The maximum intermediate texture height.
-        max_height: u32,
+        max_height: u16,
     },
     /// A render requires more intermediate textures than configured.
     #[error(

--- a/sparse_strips/vello_hybrid/src/render/common.rs
+++ b/sparse_strips/vello_hybrid/src/render/common.rs
@@ -15,7 +15,7 @@ use crate::filter::FILTER_ATLAS_PADDING;
 use crate::scene::{LayersConfig, MemorySettings, RecordedDraw};
 use alloc::vec::Vec;
 use bytemuck::{Pod, Zeroable};
-use vello_common::geometry::{SizeU16, SizeU32};
+use vello_common::geometry::SizeU16;
 use vello_common::record::CommandRecorder;
 
 // GPU paint structure sizes in texels (1 texel = 16 bytes for RGBA32Uint texture format).
@@ -36,9 +36,9 @@ pub(crate) const IMAGE_PADDING: u16 = 0;
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct DeviceLimits {
     /// Maximum width or height of a two-dimensional texture.
-    pub(crate) max_texture_dimension_2d: u32,
+    pub(crate) max_texture_dimension_2d: u16,
     /// Maximum number of layers in an image atlas texture array.
-    pub(crate) max_texture_array_layers: u32,
+    pub(crate) max_texture_array_layers: u16,
 }
 
 // This new type only serves the purpose of documenting the below invariants in a single place.
@@ -102,27 +102,24 @@ impl MemorySettings {
             layers_config,
         } = self;
 
-        image_atlas_config.atlas_size = SizeU32::from(image_atlas_config.atlas_size)
+        image_atlas_config.atlas_size = SizeU16::from(image_atlas_config.atlas_size)
             .clamp(1, device_limits.max_texture_dimension_2d)
             .into();
 
-        let supported_max_atlases = device_limits.max_texture_array_layers as usize;
+        let supported_max_atlases = usize::from(device_limits.max_texture_array_layers);
         image_atlas_config.max_atlases = image_atlas_config.max_atlases.min(supported_max_atlases);
         image_atlas_config.initial_atlas_count = image_atlas_config
             .initial_atlas_count
             .min(image_atlas_config.max_atlases);
 
-        let max_intermediate_texture_dimension =
-            u16::try_from(device_limits.max_texture_dimension_2d).unwrap();
-
         layers_config.min_texture_size = layers_config
             .min_texture_size
-            .clamp(1, max_intermediate_texture_dimension)
+            .clamp(1, device_limits.max_texture_dimension_2d)
             // In case the user erroneously provided a smaller max size than min size.
             .min(layers_config.max_texture_size);
         layers_config.max_texture_size = layers_config
             .max_texture_size
-            .clamp(1, max_intermediate_texture_dimension);
+            .clamp(1, device_limits.max_texture_dimension_2d);
     }
 }
 
@@ -134,39 +131,49 @@ impl LayersConfig {
         let min_size = self.min_texture_size;
         let max_size = self.max_texture_size;
 
-        let checked_size = |size: SizeU32| {
-            if size.width() > u32::from(max_size.width())
-                || size.height() > u32::from(max_size.height())
-            {
+        let checked_size = |width: u32, height: u32| {
+            if width > u32::from(max_size.width()) || height > u32::from(max_size.height()) {
                 return Err(IntermediateTextureError::TooLarge {
-                    width: size.width(),
-                    height: size.height(),
-                    max_width: u32::from(max_size.width()),
-                    max_height: u32::from(max_size.height()),
+                    width,
+                    height,
+                    max_width: max_size.width(),
+                    max_height: max_size.height(),
                 });
             }
 
-            Ok(SizeU16::try_from(size).unwrap())
+            Ok(SizeU16::from_wh(
+                u16::try_from(width).unwrap(),
+                u16::try_from(height).unwrap(),
+            ))
         };
 
         let filter_padding = u32::from(FILTER_ATLAS_PADDING) * 2;
-        let filter_size = recorder
-            .largest_filter_layer_size
-            .map_or(SizeU32::ZERO, |size| SizeU32::from(size) + filter_padding);
+        let filter_size = if let Some(size) = recorder.largest_filter_layer_size {
+            checked_size(
+                u32::from(size.width()) + filter_padding,
+                u32::from(size.height()) + filter_padding,
+            )?
+        } else {
+            SizeU16::ZERO
+        };
 
         let mut layer_size = recorder
             .largest_layer_size
-            .map_or(SizeU32::ZERO, SizeU32::from)
+            .unwrap_or(SizeU16::ZERO)
             .max(filter_size);
 
         // If we are blending into the root we will render the whole root into an
         // layer texture. Since we don't track the bbox of root draw commands, we need
         // to reserve space for the full size of the scene.
         if recorder.root_is_blend_target {
-            layer_size = layer_size.max(SizeU32::from(recorder.scene_size));
+            layer_size = layer_size.max(recorder.scene_size);
         }
 
-        Ok(checked_size(layer_size)?.max(min_size))
+        Ok(checked_size(
+            u32::from(layer_size.width()),
+            u32::from(layer_size.height()),
+        )?
+        .max(min_size))
     }
 }
 
@@ -178,7 +185,7 @@ mod tests {
     use vello_common::multi_atlas::AtlasConfig;
     use vello_common::record::CommandRecorder;
 
-    fn device_limits(max_texture_dimension_2d: u32, max_texture_array_layers: u32) -> DeviceLimits {
+    fn device_limits(max_texture_dimension_2d: u16, max_texture_array_layers: u16) -> DeviceLimits {
         DeviceLimits {
             max_texture_dimension_2d,
             max_texture_array_layers,
@@ -304,6 +311,38 @@ mod tests {
                 max_height: 512,
             })
         ));
+    }
+
+    #[test]
+    fn required_intermediate_texture_size_rejects_filter_padding_overflow() {
+        let mut recorder = CommandRecorder::<RecordedDraw>::new(10, 10);
+        recorder.largest_filter_layer_size = Some(SizeU16::from_wh(u16::MAX, 10));
+
+        let config = LayersConfig {
+            min_texture_size: SizeU16::new(1),
+            max_texture_size: SizeU16::new(u16::MAX),
+            ..Default::default()
+        };
+
+        let padding = u32::from(crate::filter::FILTER_ATLAS_PADDING) * 2;
+        let error = config
+            .required_intermediate_texture_size(&recorder)
+            .unwrap_err();
+
+        match error {
+            IntermediateTextureError::TooLarge {
+                width,
+                height,
+                max_width,
+                max_height,
+            } => {
+                assert_eq!(width, u32::from(u16::MAX) + padding);
+                assert_eq!(height, 10 + padding);
+                assert_eq!(max_width, u16::MAX);
+                assert_eq!(max_height, u16::MAX);
+            }
+            _ => panic!("expected TooLarge"),
+        }
     }
 }
 

--- a/sparse_strips/vello_hybrid/src/render/webgl/mod.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl/mod.rs
@@ -178,9 +178,9 @@ impl WebGlTextureBindings {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AtlasTextureInfo {
     /// Width of the currently bound texture array.
-    pub width: u32,
+    pub width: u16,
     /// Height of the currently bound texture array.
-    pub height: u32,
+    pub height: u16,
     /// Number of real atlas layers available to the image cache.
     pub layer_count: u32,
 }
@@ -308,8 +308,10 @@ impl WebGlRenderer {
         }
 
         let device_limits = DeviceLimits {
-            max_texture_dimension_2d: get_max_texture_dimension_2d(&gl),
-            max_texture_array_layers: get_max_texture_array_layers(&gl),
+            max_texture_dimension_2d: u16::try_from(get_max_texture_dimension_2d(&gl))
+                .unwrap_or(u16::MAX),
+            max_texture_array_layers: u16::try_from(get_max_texture_array_layers(&gl))
+                .unwrap_or(u16::MAX),
         };
         settings.memory_settings.normalize(&device_limits);
         if use_depth_buffer {
@@ -323,12 +325,12 @@ impl WebGlRenderer {
             );
         }
         let resources = Resources::new(settings.memory_settings.image_atlas_config);
-        let max_texture_dimension_2d = device_limits.max_texture_dimension_2d;
 
         // Estimate the maximum number of gradient cache entries based on the max texture dimension
         // and the maximum gradient LUT size - worst case scenario.
+        let max_texture_dimension = u32::from(device_limits.max_texture_dimension_2d);
         let max_gradient_cache_size =
-            max_texture_dimension_2d * max_texture_dimension_2d / MAX_GRADIENT_LUT_SIZE as u32;
+            max_texture_dimension * max_texture_dimension / MAX_GRADIENT_LUT_SIZE as u32;
         let gradient_cache = GradientRampCache::new(max_gradient_cache_size, settings.level);
         let layer_config = settings.memory_settings.layers_config;
         let renderer = Self {
@@ -451,8 +453,8 @@ impl WebGlRenderer {
 
         let (atlas_width, atlas_height) = atlas_config.atlas_size;
         let atlas_render_size = RenderSize {
-            width: atlas_width,
-            height: atlas_height,
+            width: u32::from(atlas_width),
+            height: u32::from(atlas_height),
         };
 
         let atlas_framebuffer = self
@@ -671,16 +673,13 @@ impl WebGlRenderer {
         image_cache: &ImageCache,
         image_id: ImageId,
         writer: &T,
-        offset_override: Option<[u32; 2]>,
+        offset_override: Option<[u16; 2]>,
     ) {
         let image_resource = image_cache.get(image_id).expect("Image resource not found");
 
         self.programs
             .maybe_resize_atlas_texture_array(&self.gl, image_cache.atlas_count() as u32);
-        let offset = offset_override.unwrap_or([
-            image_resource.offset[0] as u32,
-            image_resource.offset[1] as u32,
-        ]);
+        let offset = offset_override.unwrap_or(image_resource.offset);
         writer.write_to_atlas_layer(
             &self.gl,
             &self.programs.resources.atlas_texture_array.texture,
@@ -694,15 +693,15 @@ impl WebGlRenderer {
     /// Destroy an image from the cache and clear the allocated slot in the atlas.
     pub fn destroy_image(&mut self, resources: &mut Resources, image_id: ImageId) {
         if let Some(image_resource) = resources.image_cache.deallocate(image_id) {
-            let padding = image_resource.padding as u32;
+            let padding = image_resource.padding;
             self.clear_atlas_region(
                 image_resource.atlas_id,
                 [
-                    image_resource.offset[0] as u32 - padding,
-                    image_resource.offset[1] as u32 - padding,
+                    image_resource.offset[0] - padding,
+                    image_resource.offset[1] - padding,
                 ],
-                image_resource.width as u32 + padding * 2,
-                image_resource.height as u32 + padding * 2,
+                image_resource.width + padding * 2,
+                image_resource.height + padding * 2,
             );
         }
     }
@@ -721,14 +720,16 @@ impl WebGlRenderer {
     pub fn atlas_info(&self) -> AtlasTextureInfo {
         let resources = &self.programs.resources;
         AtlasTextureInfo {
-            width: resources.atlas_texture_array.size.width,
-            height: resources.atlas_texture_array.size.height,
+            width: u16::try_from(resources.atlas_texture_array.size.width)
+                .expect("atlas texture width exceeds the u16 renderer domain"),
+            height: u16::try_from(resources.atlas_texture_array.size.height)
+                .expect("atlas texture height exceeds the u16 renderer domain"),
             layer_count: resources.atlas_layer_count,
         }
     }
 
     /// Clear a specific region of the atlas texture array.
-    fn clear_atlas_region(&mut self, atlas_id: AtlasId, offset: [u32; 2], width: u32, height: u32) {
+    fn clear_atlas_region(&mut self, atlas_id: AtlasId, offset: [u16; 2], width: u16, height: u16) {
         let _state_guard = WebGlStateGuard::for_clear_atlas_region(&self.gl);
         let temp_framebuffer = Framebuffer::new(&self.gl);
 
@@ -967,13 +968,13 @@ impl WebGlRenderer {
 fn clear_atlas_region(renderer: &mut WebGlRenderer, rect: &PendingClearRect) {
     // TODO: Similarly to wgpu, maybe this can be done in a more effective
     // way?
-    let padding = u32::from(GLYPH_PADDING);
+    let padding = GLYPH_PADDING;
     let offset = [
-        u32::from(rect.x).saturating_sub(padding),
-        u32::from(rect.y).saturating_sub(padding),
+        rect.x.saturating_sub(padding),
+        rect.y.saturating_sub(padding),
     ];
-    let width = u32::from(rect.width) + padding * 2;
-    let height = u32::from(rect.height) + padding * 2;
+    let width = rect.width + padding * 2;
+    let height = rect.height + padding * 2;
     renderer.clear_atlas_region(AtlasId::new(rect.page_index), offset, width, height);
 }
 
@@ -1064,7 +1065,7 @@ pub(crate) struct WebGlResources {
     /// Texture array for atlas data (multiple atlases supported)
     pub(crate) atlas_texture_array: WebGlTextureArray,
     /// Configured dimensions used when promoting the placeholder to a real atlas.
-    pub(crate) atlas_size: (u32, u32),
+    pub(crate) atlas_size: (u16, u16),
     /// Number of real atlas layers currently allocated.
     pub(crate) atlas_layer_count: u32,
     /// Encoded paints texture for image metadata.
@@ -1350,7 +1351,10 @@ impl WebGlPrograms {
                 None,
             )
             .unwrap();
-            self.resources.atlas_texture_array.size = WebGlTextureSize { width, height };
+            self.resources.atlas_texture_array.size = WebGlTextureSize {
+                width: u32::from(width),
+                height: u32::from(height),
+            };
         } else {
             // Growing an atlas that already holds data: allocate a new, larger `TEXTURE_2D_ARRAY`,
             // copy the existing layers across, then swap. On Mali-G52 under the Android WebView GL
@@ -2514,8 +2518,8 @@ fn create_intermediate_texture(
 /// Create an atlas texture array.
 pub(crate) fn create_atlas_texture_array(
     gl: &WebGl2RenderingContext,
-    width: u32,
-    height: u32,
+    width: u16,
+    height: u16,
     layer_count: u32,
 ) -> WebGlTextureArray {
     debug_assert!(
@@ -2543,7 +2547,7 @@ pub(crate) fn create_atlas_texture_array(
     )
     .unwrap();
 
-    WebGlTextureArray::new(atlas_texture, width, height)
+    WebGlTextureArray::new(atlas_texture, u32::from(width), u32::from(height))
 }
 
 /// Create a framebuffer for a texture.
@@ -3185,9 +3189,9 @@ impl Backend for WebGlRendererContext<'_> {
 /// - Custom implementations for other image sources
 pub trait WebGlAtlasWriter {
     /// Get the width of the image.
-    fn width(&self) -> u32;
+    fn width(&self) -> u16;
     /// Get the height of the image.
-    fn height(&self) -> u32;
+    fn height(&self) -> u16;
 
     /// Write image data to a specific layer of an atlas texture array at the specified offset.
     fn write_to_atlas_layer(
@@ -3195,20 +3199,20 @@ pub trait WebGlAtlasWriter {
         gl: &WebGl2RenderingContext,
         atlas_texture_array: &WebGlTexture,
         layer: u32,
-        offset: [u32; 2],
-        width: u32,
-        height: u32,
+        offset: [u16; 2],
+        width: u16,
+        height: u16,
     );
 }
 
 /// Implementation for `Pixmap` - direct upload using raw pixel data.
 impl WebGlAtlasWriter for Pixmap {
-    fn width(&self) -> u32 {
-        self.width() as u32
+    fn width(&self) -> u16 {
+        self.width()
     }
 
-    fn height(&self) -> u32 {
-        self.height() as u32
+    fn height(&self) -> u16 {
+        self.height()
     }
 
     fn write_to_atlas_layer(
@@ -3216,9 +3220,9 @@ impl WebGlAtlasWriter for Pixmap {
         gl: &WebGl2RenderingContext,
         atlas_texture_array: &WebGlTexture,
         layer: u32,
-        offset: [u32; 2],
-        width: u32,
-        height: u32,
+        offset: [u16; 2],
+        width: u16,
+        height: u16,
     ) {
         // Bind the atlas texture array
         gl.active_texture(WebGl2RenderingContext::TEXTURE0);
@@ -3250,12 +3254,12 @@ impl WebGlAtlasWriter for Pixmap {
 
 /// Implementation for `Arc<Pixmap>`.
 impl WebGlAtlasWriter for Arc<Pixmap> {
-    fn width(&self) -> u32 {
-        self.as_ref().width() as u32
+    fn width(&self) -> u16 {
+        self.as_ref().width()
     }
 
-    fn height(&self) -> u32 {
-        self.as_ref().height() as u32
+    fn height(&self) -> u16 {
+        self.as_ref().height()
     }
 
     fn write_to_atlas_layer(
@@ -3263,9 +3267,9 @@ impl WebGlAtlasWriter for Arc<Pixmap> {
         gl: &WebGl2RenderingContext,
         atlas_texture_array: &WebGlTexture,
         layer: u32,
-        offset: [u32; 2],
-        width: u32,
-        height: u32,
+        offset: [u16; 2],
+        width: u16,
+        height: u16,
     ) {
         self.as_ref()
             .write_to_atlas_layer(gl, atlas_texture_array, layer, offset, width, height);
@@ -3274,14 +3278,14 @@ impl WebGlAtlasWriter for Arc<Pixmap> {
 
 /// Implementation for `WebGlTexture` - texture-to-texture copy.
 impl WebGlAtlasWriter for WebGlTexture {
-    fn width(&self) -> u32 {
+    fn width(&self) -> u16 {
         // WebGL textures don't expose their dimensions directly
         // This is a limitation - in practice, you'd need to track dimensions separately
         // For now, we'll require the caller to provide correct width/height parameters
         unreachable!("WebGlTexture width must be provided by caller")
     }
 
-    fn height(&self) -> u32 {
+    fn height(&self) -> u16 {
         // WebGL textures don't expose their dimensions directly
         // This is a limitation - in practice, you'd need to track dimensions separately
         // For now, we'll require the caller to provide correct width/height parameters
@@ -3293,9 +3297,9 @@ impl WebGlAtlasWriter for WebGlTexture {
         gl: &WebGl2RenderingContext,
         atlas_texture_array: &WebGlTexture,
         layer: u32,
-        offset: [u32; 2],
-        width: u32,
-        height: u32,
+        offset: [u16; 2],
+        width: u16,
+        height: u16,
     ) {
         copy_to_texture_array_layer(
             gl,
@@ -3311,8 +3315,8 @@ impl WebGlAtlasWriter for WebGlTexture {
             },
             atlas_texture_array,
             layer,
-            offset,
-            [width, height],
+            [u32::from(offset[0]), u32::from(offset[1])],
+            [u32::from(width), u32::from(height)],
         );
     }
 }
@@ -3323,17 +3327,17 @@ pub struct WebGlTextureWithDimensions {
     /// The WebGL texture.
     pub texture: WebGlTexture,
     /// The width of the texture.
-    pub width: u32,
+    pub width: u16,
     /// The height of the texture.
-    pub height: u32,
+    pub height: u16,
 }
 
 impl WebGlAtlasWriter for WebGlTextureWithDimensions {
-    fn width(&self) -> u32 {
+    fn width(&self) -> u16 {
         self.width
     }
 
-    fn height(&self) -> u32 {
+    fn height(&self) -> u16 {
         self.height
     }
 
@@ -3342,9 +3346,9 @@ impl WebGlAtlasWriter for WebGlTextureWithDimensions {
         gl: &WebGl2RenderingContext,
         atlas_texture_array: &WebGlTexture,
         layer: u32,
-        offset: [u32; 2],
-        width: u32,
-        height: u32,
+        offset: [u16; 2],
+        width: u16,
+        height: u16,
     ) {
         self.texture
             .write_to_atlas_layer(gl, atlas_texture_array, layer, offset, width, height);

--- a/sparse_strips/vello_hybrid/src/render/webgl/mod.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl/mod.rs
@@ -59,7 +59,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::fmt::Debug;
 #[cfg(feature = "text")]
-use glifo::{GLYPH_PADDING, PendingClearRect};
+use glifo::PendingClearRect;
 use hashbrown::HashMap;
 use resource::{Buffer, FragmentShader, Framebuffer, Program, Texture, VertexArray, VertexShader};
 use vello_common::image_cache::{ImageCache, ImageResource};
@@ -968,14 +968,12 @@ impl WebGlRenderer {
 fn clear_atlas_region(renderer: &mut WebGlRenderer, rect: &PendingClearRect) {
     // TODO: Similarly to wgpu, maybe this can be done in a more effective
     // way?
-    let padding = GLYPH_PADDING;
-    let offset = [
-        rect.x.saturating_sub(padding),
-        rect.y.saturating_sub(padding),
-    ];
-    let width = rect.width + padding * 2;
-    let height = rect.height + padding * 2;
-    renderer.clear_atlas_region(AtlasId::new(rect.page_index), offset, width, height);
+    renderer.clear_atlas_region(
+        AtlasId::new(rect.page_index),
+        [rect.x, rect.y],
+        rect.width,
+        rect.height,
+    );
 }
 
 /// Contains the WebGL programs and resources for rendering.

--- a/sparse_strips/vello_hybrid/src/render/wgpu/mod.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu/mod.rs
@@ -183,16 +183,18 @@ impl Renderer {
         let mut settings = settings;
         let limits = device.limits();
         let device_limits = DeviceLimits {
-            max_texture_dimension_2d: limits.max_texture_dimension_2d,
-            max_texture_array_layers: limits.max_texture_array_layers,
+            max_texture_dimension_2d: u16::try_from(limits.max_texture_dimension_2d)
+                .unwrap_or(u16::MAX),
+            max_texture_array_layers: u16::try_from(limits.max_texture_array_layers)
+                .unwrap_or(u16::MAX),
         };
         settings.memory_settings.normalize(&device_limits);
         let resources = Resources::new(settings.memory_settings.image_atlas_config);
-        let max_texture_dimension_2d = device_limits.max_texture_dimension_2d;
         // Estimate the maximum number of gradient cache entries based on the max texture dimension
         // and the maximum gradient LUT size - worst case scenario.
+        let max_texture_dimension = u32::from(device_limits.max_texture_dimension_2d);
         let max_gradient_cache_size =
-            max_texture_dimension_2d * max_texture_dimension_2d / MAX_GRADIENT_LUT_SIZE as u32;
+            max_texture_dimension * max_texture_dimension / MAX_GRADIENT_LUT_SIZE as u32;
         let gradient_cache = GradientRampCache::new(max_gradient_cache_size, settings.level);
         let layer_config = settings.memory_settings.layers_config;
 
@@ -367,8 +369,8 @@ impl Renderer {
 
         let (atlas_width, atlas_height) = atlas_config.atlas_size;
         let atlas_render_size = RenderSize {
-            width: atlas_width,
-            height: atlas_height,
+            width: u32::from(atlas_width),
+            height: u32::from(atlas_height),
         };
 
         let layer_view =
@@ -609,7 +611,7 @@ impl Renderer {
         encoder: &mut CommandEncoder,
         image_id: vello_common::paint::ImageId,
         writer: &T,
-        offset_override: Option<[u32; 2]>,
+        offset_override: Option<[u16; 2]>,
     ) {
         let image_resource = image_cache.get(image_id).expect("Image resource not found");
 
@@ -620,10 +622,7 @@ impl Renderer {
             &self.programs.atlas_bind_group_layout,
             image_cache.atlas_count() as u32,
         );
-        let offset = offset_override.unwrap_or([
-            image_resource.offset[0] as u32,
-            image_resource.offset[1] as u32,
-        ]);
+        let offset = offset_override.unwrap_or(image_resource.offset);
         writer.write_to_atlas_layer(
             device,
             queue,
@@ -644,17 +643,17 @@ impl Renderer {
         image_id: vello_common::paint::ImageId,
     ) {
         if let Some(image_resource) = resources.image_cache.deallocate(image_id) {
-            let padding = image_resource.padding as u32;
+            let padding = image_resource.padding;
 
             self.clear_atlas_region(
                 encoder,
                 image_resource.atlas_id,
                 [
-                    image_resource.offset[0] as u32 - padding,
-                    image_resource.offset[1] as u32 - padding,
+                    image_resource.offset[0] - padding,
+                    image_resource.offset[1] - padding,
                 ],
-                image_resource.width as u32 + padding * 2,
-                image_resource.height as u32 + padding * 2,
+                image_resource.width + padding * 2,
+                image_resource.height + padding * 2,
             );
         }
     }
@@ -673,9 +672,9 @@ impl Renderer {
         &mut self,
         encoder: &mut CommandEncoder,
         atlas_id: AtlasId,
-        offset: [u32; 2],
-        width: u32,
-        height: u32,
+        offset: [u16; 2],
+        width: u16,
+        height: u16,
     ) {
         // Create a texture view for the specific atlas layer
         let layer_view =
@@ -714,7 +713,12 @@ impl Renderer {
         });
 
         // Set scissor rectangle to limit clearing to specific region
-        render_pass.set_scissor_rect(offset[0], offset[1], width, height);
+        render_pass.set_scissor_rect(
+            u32::from(offset[0]),
+            u32::from(offset[1]),
+            u32::from(width),
+            u32::from(height),
+        );
         // Use atlas clear pipeline to render transparent pixels
         render_pass.set_pipeline(&self.programs.atlas_clear_pipeline);
         // Draw fullscreen quad
@@ -1019,7 +1023,7 @@ struct GpuResources {
     /// View for atlas texture array
     atlas_texture_array_view: TextureView,
     /// Configured dimensions used when promoting the placeholder to a real atlas.
-    atlas_size: (u32, u32),
+    atlas_size: (u16, u16),
     /// Number of real atlas layers currently exposed by the texture view.
     atlas_layer_count: u32,
     /// Bind group for paint sources: an atlas textures as texture array plus an external texture.
@@ -1997,8 +2001,8 @@ impl Programs {
 
     fn create_atlas_texture_array(
         device: &Device,
-        width: u32,
-        height: u32,
+        width: u16,
+        height: u16,
         atlas_count: u32,
     ) -> (Texture, TextureView) {
         debug_assert!(
@@ -2017,8 +2021,8 @@ impl Programs {
         let atlas_texture_array = device.create_texture(&wgpu::TextureDescriptor {
             label: Some("Atlas Texture Array"),
             size: Extent3d {
-                width,
-                height,
+                width: u32::from(width),
+                height: u32::from(height),
                 depth_or_array_layers,
             },
             mip_level_count: 1,
@@ -2517,8 +2521,8 @@ impl Programs {
         old_atlas_texture_array: &Texture,
         new_atlas_texture_array: &Texture,
         layer_count_to_copy: u32,
-        width: u32,
-        height: u32,
+        width: u16,
+        height: u16,
     ) {
         // Copy all layers from old texture array to new texture array
         encoder.copy_texture_to_texture(
@@ -2535,8 +2539,8 @@ impl Programs {
                 aspect: wgpu::TextureAspect::All,
             },
             Extent3d {
-                width,
-                height,
+                width: u32::from(width),
+                height: u32::from(height),
                 depth_or_array_layers: layer_count_to_copy,
             },
         );
@@ -3301,9 +3305,9 @@ fn create_filter_original_texture_bind_group(
 /// - Custom implementations for other image sources
 pub trait AtlasWriter {
     /// Get the width of the image.
-    fn width(&self) -> u32;
+    fn width(&self) -> u16;
     /// Get the height of the image.
-    fn height(&self) -> u32;
+    fn height(&self) -> u16;
 
     /// Write image data to a specific layer of an atlas texture array at the specified offset.
     fn write_to_atlas_layer(
@@ -3313,20 +3317,20 @@ pub trait AtlasWriter {
         encoder: &mut CommandEncoder,
         atlas_texture: &Texture,
         layer: u32,
-        offset: [u32; 2],
-        width: u32,
-        height: u32,
+        offset: [u16; 2],
+        width: u16,
+        height: u16,
     );
 }
 
 /// Implementation for `wgpu::Texture` - uses texture-to-texture copy
 impl AtlasWriter for Texture {
-    fn width(&self) -> u32 {
-        self.width()
+    fn width(&self) -> u16 {
+        u16::try_from(self.width()).expect("texture width exceeds the u16 atlas domain")
     }
 
-    fn height(&self) -> u32 {
-        self.height()
+    fn height(&self) -> u16 {
+        u16::try_from(self.height()).expect("texture height exceeds the u16 atlas domain")
     }
 
     fn write_to_atlas_layer(
@@ -3336,9 +3340,9 @@ impl AtlasWriter for Texture {
         encoder: &mut CommandEncoder,
         atlas_texture: &Texture,
         layer: u32,
-        offset: [u32; 2],
-        width: u32,
-        height: u32,
+        offset: [u16; 2],
+        width: u16,
+        height: u16,
     ) {
         encoder.copy_texture_to_texture(
             wgpu::TexelCopyTextureInfo {
@@ -3351,15 +3355,15 @@ impl AtlasWriter for Texture {
                 texture: atlas_texture,
                 mip_level: 0,
                 origin: wgpu::Origin3d {
-                    x: offset[0],
-                    y: offset[1],
+                    x: u32::from(offset[0]),
+                    y: u32::from(offset[1]),
                     z: layer,
                 },
                 aspect: wgpu::TextureAspect::All,
             },
             Extent3d {
-                width,
-                height,
+                width: u32::from(width),
+                height: u32::from(height),
                 depth_or_array_layers: 1,
             },
         );
@@ -3368,12 +3372,12 @@ impl AtlasWriter for Texture {
 
 /// Implementation for `Pixmap` - direct upload to atlas
 impl AtlasWriter for Pixmap {
-    fn width(&self) -> u32 {
-        self.width() as u32
+    fn width(&self) -> u16 {
+        self.width()
     }
 
-    fn height(&self) -> u32 {
-        self.height() as u32
+    fn height(&self) -> u16 {
+        self.height()
     }
 
     fn write_to_atlas_layer(
@@ -3383,17 +3387,19 @@ impl AtlasWriter for Pixmap {
         _encoder: &mut CommandEncoder,
         atlas_texture: &Texture,
         layer: u32,
-        offset: [u32; 2],
-        width: u32,
-        height: u32,
+        offset: [u16; 2],
+        width: u16,
+        height: u16,
     ) {
+        let width = u32::from(width);
+        let height = u32::from(height);
         queue.write_texture(
             wgpu::TexelCopyTextureInfo {
                 texture: atlas_texture,
                 mip_level: 0,
                 origin: wgpu::Origin3d {
-                    x: offset[0],
-                    y: offset[1],
+                    x: u32::from(offset[0]),
+                    y: u32::from(offset[1]),
                     z: layer,
                 },
                 aspect: wgpu::TextureAspect::All,
@@ -3415,12 +3421,12 @@ impl AtlasWriter for Pixmap {
 
 /// Implementation for `Arc<Pixmap>`
 impl AtlasWriter for Arc<Pixmap> {
-    fn width(&self) -> u32 {
-        self.as_ref().width() as u32
+    fn width(&self) -> u16 {
+        self.as_ref().width()
     }
 
-    fn height(&self) -> u32 {
-        self.as_ref().height() as u32
+    fn height(&self) -> u16 {
+        self.as_ref().height()
     }
 
     fn write_to_atlas_layer(
@@ -3430,9 +3436,9 @@ impl AtlasWriter for Arc<Pixmap> {
         encoder: &mut CommandEncoder,
         atlas_texture: &Texture,
         layer: u32,
-        offset: [u32; 2],
-        width: u32,
-        height: u32,
+        offset: [u16; 2],
+        width: u16,
+        height: u16,
     ) {
         self.as_ref().write_to_atlas_layer(
             device,

--- a/sparse_strips/vello_hybrid/src/schedule/allocate.rs
+++ b/sparse_strips/vello_hybrid/src/schedule/allocate.rs
@@ -6,7 +6,7 @@
 use crate::filter::FILTER_ATLAS_PADDING;
 use crate::target::{LayerTextureId, TextureParity, TextureRegion};
 use alloc::vec::Vec;
-use vello_common::geometry::{RectU16, SizeU16, SizeU32};
+use vello_common::geometry::{RectU16, SizeU16};
 use vello_common::multi_atlas::{AllocId, Atlas, AtlasId};
 use vello_common::record::RecordedLayerKind;
 
@@ -91,8 +91,8 @@ impl Atlases {
         let size = self.texture_size;
         let atlas = Atlas::new(
             AtlasId::new(u32::from(page_index)),
-            u32::from(size.width()),
-            u32::from(size.height()),
+            size.width(),
+            size.height(),
         );
 
         self.layer_atlases[parity].push(atlas);
@@ -133,7 +133,7 @@ impl LayerAllocationRequest {
         }
     }
 
-    pub(super) fn allocation_size(self) -> SizeU32 {
+    pub(super) fn allocation_size(self) -> SizeU16 {
         self.region.allocation_size()
     }
 }
@@ -149,8 +149,11 @@ struct RegionProps {
 
 impl RegionProps {
     /// Size of the atlas allocation needed to hold the region and its padding.
-    fn allocation_size(self) -> SizeU32 {
-        SizeU32::from(self.size) + u32::from(self.padding) * 2
+    fn allocation_size(self) -> SizeU16 {
+        self.padding
+            .checked_mul(2)
+            .and_then(|padding| self.size.checked_add(padding))
+            .expect("layer allocation size exceeds the u16 atlas domain")
     }
 }
 
@@ -205,13 +208,13 @@ impl AtlasExt for Atlas {
         target: LayerTextureId,
         props: RegionProps,
     ) -> Option<AllocatedTextureRegion> {
-        let padding = u32::from(props.padding);
+        let padding = props.padding;
         let width = props.size.width();
         let height = props.size.height();
         let allocation_size = props.allocation_size();
         let allocation = self.allocate(allocation_size.width(), allocation_size.height())?;
-        let x = u16::try_from(allocation.x + padding).unwrap();
-        let y = u16::try_from(allocation.y + padding).unwrap();
+        let x = allocation.x + padding;
+        let y = allocation.y + padding;
         let region = AllocatedTextureRegion::new(
             TextureRegion {
                 target,
@@ -231,8 +234,8 @@ impl AtlasExt for Atlas {
             texture.alloc_id,
             // TODO: Change the atlas API to not require passing in the width/height again.
             // This should somehow be tracked internally in the atlas based on the allocation ID.
-            u32::from(allocation_region.width()),
-            u32::from(allocation_region.height()),
+            allocation_region.width(),
+            allocation_region.height(),
         );
     }
 }

--- a/sparse_strips/vello_hybrid/src/schedule/cursor.rs
+++ b/sparse_strips/vello_hybrid/src/schedule/cursor.rs
@@ -68,18 +68,18 @@ impl Cursor {
         // Therefore, we need to attempt to create a new one.
         self.atlases.add_layer_atlas(request.texture_parity);
 
-        let requested_size = request.allocation_size();
         let texture_size = self.atlases.texture_size();
+        let requested_size = request.allocation_size();
         let allocation = self
             .atlases
             .allocate_layer(&request)
             // If we successfully added a new texture but allocation still fails, it means the layer
             // itself is larger than the maximum texture size, so it cannot possibly fit.
             .ok_or(IntermediateTextureError::TooLarge {
-                width: requested_size.width(),
-                height: requested_size.height(),
-                max_width: u32::from(texture_size.width()),
-                max_height: u32::from(texture_size.height()),
+                width: u32::from(requested_size.width()),
+                height: u32::from(requested_size.height()),
+                max_width: texture_size.width(),
+                max_height: texture_size.height(),
             })?;
 
         Ok(Allocation {

--- a/sparse_strips/vello_hybrid/src/text.rs
+++ b/sparse_strips/vello_hybrid/src/text.rs
@@ -54,14 +54,7 @@ impl GlyphAtlasResources {
 impl Resources {
     fn ensure_glyph_resources(&mut self) {
         if self.glyph_resources.is_none() {
-            #[expect(
-                clippy::cast_possible_truncation,
-                reason = "atlas dimensions are configured to fit in u16"
-            )]
-            let (atlas_width, atlas_height) = {
-                let (width, height) = self.image_cache.atlas_manager().config().atlas_size;
-                (width as u16, height as u16)
-            };
+            let (atlas_width, atlas_height) = self.image_cache.atlas_manager().config().atlas_size;
             // TODO: Use a config optionally provided by the user!
             self.glyph_resources = Some(GlyphAtlasResources::with_config(
                 atlas_width,
@@ -101,7 +94,7 @@ impl Resources {
         &mut self,
         backend: &mut T,
         mut render_to_atlas: impl FnMut(&mut T, &Scene, u32, AtlasConfig, AtlasId),
-        mut upload_to_atlas: impl FnMut(&mut T, &ImageCache, &PendingBitmapUpload, u32, u32),
+        mut upload_to_atlas: impl FnMut(&mut T, &ImageCache, &PendingBitmapUpload, u16, u16),
     ) {
         let atlas_count = self.atlas_count();
         let atlas_config = self.atlas_config();
@@ -109,13 +102,13 @@ impl Resources {
             render_to_atlas(backend, glyph_renderer, atlas_count, atlas_config, atlas_id);
         });
 
-        const PADDING: u32 = GLYPH_PADDING as u32;
+        const PADDING: u16 = GLYPH_PADDING;
 
         if let Some(glyph_resources) = self.glyph_resources.as_mut() {
             for upload in glyph_resources.glyph_atlas.drain_pending_uploads() {
                 let resource = self.image_cache.get(upload.image_id).unwrap();
-                let dst_x = resource.offset[0] as u32 + PADDING;
-                let dst_y = resource.offset[1] as u32 + PADDING;
+                let dst_x = resource.offset[0] + PADDING;
+                let dst_y = resource.offset[1] + PADDING;
                 upload_to_atlas(backend, &self.image_cache, &upload, dst_x, dst_y);
             }
         }


### PR DESCRIPTION
Currently, Vello Hybrid is very inconsistent in its use of data types for storing sizes and various rectangles. Because of this, there's a lot of code that converts between the two, and we essentially have to duplicate each data structure for both, u16 and u32.

The current sparse strips architecture (in `vello_common`) does not support targets larger than u16, due to coordinates being stored this way to improve performance and reduce memory consumption. In addition to that, most GPUs don't support render targets larger than 16k anyway. Therefore, I propose that we use u16 consistently throughout the code and only switch to u32 on demand 1) in the WebGL/WebGPU backend because it's required by them and 2) at the boundary between Vello and guillotierre, since the crate also uses u32 coordinates. In all other parts of the codebase, we stick to u16.

This PR was done with assistence of GPT 5.6 Sol.