### PR TITLE
vello_hybrid: Limit the texture sizes of data textures to 4096

### DIFF
--- a/sparse_strips/vello_hybrid/src/filter.rs
+++ b/sparse_strips/vello_hybrid/src/filter.rs
@@ -663,7 +663,7 @@ impl FilterContext {
             return None;
         }
         let height = required_texels.div_ceil(max_texture_dimension_2d);
-        debug_assert!(
+        assert!(
             height <= max_texture_dimension_2d,
             "Filter texture height exceeds max texture dimensions"
         );
@@ -719,6 +719,16 @@ mod tests {
             AlphaColor::new([0.0, 0.0, 0.0, 1.0]),
         ))
         .into()
+    }
+
+    #[test]
+    #[should_panic(expected = "Filter texture height exceeds max texture dimensions")]
+    fn filter_data_height_must_fit_resource_texture_limit() {
+        let context = FilterContext {
+            filters: alloc::vec![gpu_offset()],
+        };
+
+        let _ = context.required_filter_data_height(1);
     }
 
     fn step_layout(plan: &FilterPassPlan) -> Vec<Vec<(u32, u32)>> {

--- a/sparse_strips/vello_hybrid/src/filter.rs
+++ b/sparse_strips/vello_hybrid/src/filter.rs
@@ -656,17 +656,20 @@ impl FilterContext {
 
     /// Calculate the required height for the filter data texture.
     /// Returns `None` if no filters are present.
-    pub(crate) fn required_filter_data_height(&self, max_texture_dimension_2d: u32) -> Option<u32> {
+    pub(crate) fn required_filter_data_height(
+        &self,
+        resource_texture_dimension_2d: u32,
+    ) -> Option<u32> {
         let required_texels = self.total_texels();
 
         if required_texels == 0 {
             return None;
         }
-        let height = required_texels.div_ceil(max_texture_dimension_2d);
+        let height = required_texels.div_ceil(resource_texture_dimension_2d);
         // TODO: Turn into error.
         assert!(
-            height <= max_texture_dimension_2d,
-            "Filter texture height exceeds max texture dimensions"
+            height <= resource_texture_dimension_2d,
+            "Filter texture height exceeds resource texture dimensions"
         );
 
         Some(height)
@@ -723,7 +726,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Filter texture height exceeds max texture dimensions")]
+    #[should_panic(expected = "Filter texture height exceeds resource texture dimensions")]
     fn filter_data_height_must_fit_resource_texture_limit() {
         let context = FilterContext {
             filters: alloc::vec![gpu_offset()],

--- a/sparse_strips/vello_hybrid/src/filter.rs
+++ b/sparse_strips/vello_hybrid/src/filter.rs
@@ -663,6 +663,7 @@ impl FilterContext {
             return None;
         }
         let height = required_texels.div_ceil(max_texture_dimension_2d);
+        // TODO: Turn into error.
         assert!(
             height <= max_texture_dimension_2d,
             "Filter texture height exceeds max texture dimensions"

--- a/sparse_strips/vello_hybrid/src/render/common.rs
+++ b/sparse_strips/vello_hybrid/src/render/common.rs
@@ -41,6 +41,19 @@ pub(crate) struct DeviceLimits {
     pub(crate) max_texture_array_layers: u16,
 }
 
+impl DeviceLimits {
+    pub(crate) fn resource_texture_dimension_2d(self) -> u32 {
+        // See https://github.com/linebender/vello/pull/1830 for why
+        // we enforce an additional limit on intermediate data textures.
+        const MAX_RESOURCE_TEXTURE_DIMENSION_2D: u16 = 4096;
+
+        u32::from(
+            self.max_texture_dimension_2d
+                .min(MAX_RESOURCE_TEXTURE_DIMENSION_2D),
+        )
+    }
+}
+
 // This new type only serves the purpose of documenting the below invariants in a single place.
 /// A scratch texture.
 ///
@@ -210,6 +223,18 @@ mod tests {
         assert_eq!(config.initial_atlas_count, 4);
         assert_eq!(config.max_atlases, 4);
         assert_eq!(config.atlas_size, (4096, 2048));
+    }
+
+    #[test]
+    fn resource_texture_dimension_is_capped_at_4k() {
+        assert_eq!(
+            device_limits(16384, 256).resource_texture_dimension_2d(),
+            4096
+        );
+        assert_eq!(
+            device_limits(2048, 256).resource_texture_dimension_2d(),
+            2048
+        );
     }
 
     #[test]

--- a/sparse_strips/vello_hybrid/src/render/webgl/mod.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl/mod.rs
@@ -1732,17 +1732,17 @@ impl WebGlPrograms {
     }
 
     /// Update the alpha texture size if needed.
-    fn maybe_resize_alphas_tex(&mut self, max_texture_dimension_2d: u32, alphas_len: usize) {
+    fn maybe_resize_alphas_tex(&mut self, resource_texture_dimension_2d: u32, alphas_len: usize) {
         let required_alpha_height = (alphas_len as u32)
             // There are 16 1-byte alpha values per texel.
-            .div_ceil(max_texture_dimension_2d << 4);
+            .div_ceil(resource_texture_dimension_2d << 4);
 
         let current_alpha_height = self.resources.alpha_texture_height;
         if required_alpha_height > current_alpha_height {
             // We need to resize the alpha texture to fit the new alpha data.
             assert!(
-                required_alpha_height <= max_texture_dimension_2d,
-                "Alpha texture height exceeds max texture dimensions"
+                required_alpha_height <= resource_texture_dimension_2d,
+                "Alpha texture height exceeds resource texture dimensions"
             );
 
             // Track the new height.
@@ -1753,20 +1753,21 @@ impl WebGlPrograms {
     /// Update the encoded paints texture size if needed.
     fn maybe_resize_encoded_paints_tex(
         &mut self,
-        max_texture_dimension_2d: u32,
+        resource_texture_dimension_2d: u32,
         paint_idxs: &[u32],
     ) {
         let required_texels = paint_idxs.last().unwrap();
-        let required_encoded_paints_height = required_texels.div_ceil(max_texture_dimension_2d);
+        let required_encoded_paints_height =
+            required_texels.div_ceil(resource_texture_dimension_2d);
         let current_encoded_paints_height = self.resources.encoded_paints_texture_height;
         if required_encoded_paints_height > current_encoded_paints_height {
             assert!(
-                required_encoded_paints_height <= max_texture_dimension_2d,
-                "Encoded paints texture height exceeds max texture dimensions"
+                required_encoded_paints_height <= resource_texture_dimension_2d,
+                "Encoded paints texture height exceeds resource texture dimensions"
             );
 
             let required_encoded_paints_size =
-                (max_texture_dimension_2d * required_encoded_paints_height) << 4;
+                (resource_texture_dimension_2d * required_encoded_paints_height) << 4;
             self.encoded_paints_data
                 .resize(required_encoded_paints_size as usize, 0);
             self.resources.encoded_paints_texture_height = required_encoded_paints_height;
@@ -1777,7 +1778,7 @@ impl WebGlPrograms {
     fn maybe_resize_gradient_tex(
         &mut self,
         _gl: &WebGl2RenderingContext,
-        max_texture_dimension_2d: u32,
+        resource_texture_dimension_2d: u32,
         gradient_cache: &GradientRampCache,
     ) {
         if gradient_cache.is_empty() {
@@ -1787,13 +1788,13 @@ impl WebGlPrograms {
         let gradient_data_size = gradient_cache.luts_size();
         // Each texel is RGBA8, so 4 bytes per texel
         let required_gradient_height =
-            (gradient_data_size as u32).div_ceil(max_texture_dimension_2d * 4);
+            (gradient_data_size as u32).div_ceil(resource_texture_dimension_2d * 4);
 
         let current_gradient_height = self.resources.gradient_texture_height;
         if required_gradient_height > current_gradient_height {
             assert!(
-                required_gradient_height <= max_texture_dimension_2d,
-                "Gradient texture height exceeds max texture dimensions"
+                required_gradient_height <= resource_texture_dimension_2d,
+                "Gradient texture height exceeds resource texture dimensions"
             );
 
             self.resources.gradient_texture_height = required_gradient_height;
@@ -1804,7 +1805,7 @@ impl WebGlPrograms {
     fn maybe_update_config_buffer(
         &mut self,
         gl: &WebGl2RenderingContext,
-        max_texture_dimension_2d: u32,
+        resource_texture_dimension_2d: u32,
         new_render_size: &RenderSize,
     ) {
         // Only negate if we are rendering to the main frame buffer.
@@ -1818,8 +1819,8 @@ impl WebGlPrograms {
                 width: new_render_size.width,
                 height: new_render_size.height,
                 strip_height: u32::from(Tile::HEIGHT),
-                alphas_tex_width_bits: max_texture_dimension_2d.trailing_zeros(),
-                encoded_paints_tex_width_bits: max_texture_dimension_2d.trailing_zeros(),
+                alphas_tex_width_bits: resource_texture_dimension_2d.trailing_zeros(),
+                encoded_paints_tex_width_bits: resource_texture_dimension_2d.trailing_zeros(),
                 strip_offset_x: 0,
                 strip_offset_y: 0,
                 negate_ndc: u32::from(negate_ndc),
@@ -2538,14 +2539,14 @@ fn upload_layer_config_buffer(
     gl: &WebGl2RenderingContext,
     buffer: &Buffer,
     size: SizeU16,
-    max_texture_dimension_2d: u32,
+    resource_texture_dimension_2d: u32,
 ) {
     let config = Config {
         width: u32::from(size.width()),
         height: u32::from(size.height()),
         strip_height: u32::from(Tile::HEIGHT),
-        alphas_tex_width_bits: max_texture_dimension_2d.trailing_zeros(),
-        encoded_paints_tex_width_bits: max_texture_dimension_2d.trailing_zeros(),
+        alphas_tex_width_bits: resource_texture_dimension_2d.trailing_zeros(),
+        encoded_paints_tex_width_bits: resource_texture_dimension_2d.trailing_zeros(),
         strip_offset_x: 0,
         strip_offset_y: 0,
         // Always use y-down when rendering to layer textures.

--- a/sparse_strips/vello_hybrid/src/render/webgl/mod.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl/mod.rs
@@ -379,16 +379,21 @@ impl WebGlRenderer {
             );
         }
         let resources = Resources::new(settings.memory_settings.image_atlas_config);
+        let resource_texture_dimension_2d = device_limits.resource_texture_dimension_2d();
 
-        // Estimate the maximum number of gradient cache entries based on the max texture dimension
-        // and the maximum gradient LUT size - worst case scenario.
-        let max_texture_dimension = u32::from(device_limits.max_texture_dimension_2d);
-        let max_gradient_cache_size =
-            max_texture_dimension * max_texture_dimension / MAX_GRADIENT_LUT_SIZE as u32;
+        // Estimate the maximum number of gradient cache entries based on the resource texture
+        // dimension and the maximum gradient LUT size - worst case scenario.
+        let max_gradient_cache_size = resource_texture_dimension_2d * resource_texture_dimension_2d
+            / MAX_GRADIENT_LUT_SIZE as u32;
         let gradient_cache = GradientRampCache::new(max_gradient_cache_size, settings.level);
         let layer_config = settings.memory_settings.layers_config;
         let init = WebGlRendererInit {
-            programs: PendingWebGlPrograms::new(gl.clone(), &resources.image_cache, layer_config),
+            programs: PendingWebGlPrograms::new(
+                gl.clone(),
+                &resources.image_cache,
+                layer_config,
+                resource_texture_dimension_2d,
+            ),
             gl,
             gradient_cache,
             layers_config: layer_config,
@@ -1174,9 +1179,8 @@ pub(crate) struct WebGlResources {
     /// Pre-allocated JS array for `invalidateFramebuffer` calls.
     depth_attachment_array: js_sys::Array,
 
-    /// Cached result from querying `WebGl2RenderingContext::MAX_TEXTURE_SIZE` which is a blocking
-    /// WebGL call.
-    max_texture_dimension_2d: u32,
+    /// Maximum width or height of packed resource textures.
+    resource_texture_dimension_2d: u32,
 
     /// Dimensions of the intermediate layer and scratch textures.
     texture_size: SizeU16,
@@ -1351,6 +1355,7 @@ impl PendingWebGlPrograms {
         gl: WebGl2RenderingContext,
         image_cache: &ImageCache,
         layer_config: LayersConfig,
+        resource_texture_dimension_2d: u32,
     ) -> Self {
         let parallel_shader_compile = gl
             .get_extension("KHR_parallel_shader_compile")
@@ -1369,14 +1374,19 @@ impl PendingWebGlPrograms {
         let copy_program =
             PendingShaderProgram::new(&gl, copy::VERTEX_SOURCE, copy::FRAGMENT_SOURCE);
 
-        let resources = create_webgl_resources(&gl, image_cache, layer_config);
+        let resources = create_webgl_resources(
+            &gl,
+            image_cache,
+            layer_config,
+            resource_texture_dimension_2d,
+        );
 
         initialize_strip_vao(&gl, &resources);
         initialize_filter_vao(&gl, &resources);
         initialize_blend_vao(&gl, &resources);
         initialize_copy_vao(&gl, &resources);
 
-        let encoded_paints_data = vec![0; (resources.max_texture_dimension_2d << 4) as usize];
+        let encoded_paints_data = vec![0; (resources.resource_texture_dimension_2d << 4) as usize];
 
         Self {
             parallel_shader_compile,
@@ -1453,19 +1463,19 @@ impl WebGlPrograms {
         paint_idxs: &[u32],
         filter_context: &FilterContext,
     ) {
-        let max_texture_dimension_2d = self.resources.max_texture_dimension_2d;
+        let resource_texture_dimension_2d = self.resources.resource_texture_dimension_2d;
 
-        self.maybe_resize_alphas_tex(max_texture_dimension_2d, alphas.len());
-        self.maybe_resize_encoded_paints_tex(max_texture_dimension_2d, paint_idxs);
+        self.maybe_resize_alphas_tex(resource_texture_dimension_2d, alphas.len());
+        self.maybe_resize_encoded_paints_tex(resource_texture_dimension_2d, paint_idxs);
         self.maybe_resize_filter_data_tex(filter_context);
-        self.maybe_update_config_buffer(gl, max_texture_dimension_2d, render_size);
+        self.maybe_update_config_buffer(gl, resource_texture_dimension_2d, render_size);
 
         self.upload_alpha_texture(gl, alphas);
         self.upload_encoded_paints_texture(gl, encoded_paints);
         self.upload_filter_data_texture(gl, filter_context);
 
         if gradient_cache.has_changed() {
-            self.maybe_resize_gradient_tex(gl, max_texture_dimension_2d, gradient_cache);
+            self.maybe_resize_gradient_tex(gl, resource_texture_dimension_2d, gradient_cache);
             self.upload_gradient_texture(gl, gradient_cache);
             gradient_cache.mark_synced();
         }
@@ -1488,7 +1498,7 @@ impl WebGlPrograms {
                 gl,
                 &self.resources.layer_config_buffer,
                 texture_size,
-                self.resources.max_texture_dimension_2d,
+                self.resources.resource_texture_dimension_2d,
             );
         }
 
@@ -1633,16 +1643,16 @@ impl WebGlPrograms {
     }
 
     fn maybe_resize_filter_data_tex(&mut self, filter_context: &FilterContext) {
-        let max_texture_dimension_2d = self.resources.max_texture_dimension_2d;
+        let resource_texture_dimension_2d = self.resources.resource_texture_dimension_2d;
 
         let Some(required_height) =
-            filter_context.required_filter_data_height(max_texture_dimension_2d)
+            filter_context.required_filter_data_height(resource_texture_dimension_2d)
         else {
             return;
         };
 
         if required_height > self.resources.filter_data_texture_height {
-            let required_size = (max_texture_dimension_2d * required_height) << 4;
+            let required_size = (resource_texture_dimension_2d * required_height) << 4;
             self.filter_data.resize(required_size as usize, 0);
             self.resources.filter_data_texture_height = required_height;
         }
@@ -1657,7 +1667,7 @@ impl WebGlPrograms {
             return;
         }
 
-        let width = self.resources.max_texture_dimension_2d;
+        let width = self.resources.resource_texture_dimension_2d;
         let height = self.resources.filter_data_texture_height;
         filter_context.serialize_to_buffer(&mut self.filter_data);
         gl.active_texture(WebGl2RenderingContext::TEXTURE0);
@@ -1836,7 +1846,7 @@ impl WebGlPrograms {
             return;
         }
 
-        let alpha_texture_width = self.resources.max_texture_dimension_2d;
+        let alpha_texture_width = self.resources.resource_texture_dimension_2d;
         let alpha_texture_height = self.resources.alpha_texture_height;
         let total_size = alpha_texture_width as usize * alpha_texture_height as usize * 16;
 
@@ -1864,7 +1874,7 @@ impl WebGlPrograms {
         encoded_paints: &[GpuEncodedPaint],
     ) {
         if !encoded_paints.is_empty() {
-            let encoded_paints_texture_width = self.resources.max_texture_dimension_2d;
+            let encoded_paints_texture_width = self.resources.resource_texture_dimension_2d;
             let encoded_paints_texture_height = self.resources.encoded_paints_texture_height;
 
             GpuEncodedPaint::serialize_to_buffer(encoded_paints, &mut self.encoded_paints_data);
@@ -1889,7 +1899,7 @@ impl WebGlPrograms {
             return;
         }
 
-        let gradient_texture_width = self.resources.max_texture_dimension_2d;
+        let gradient_texture_width = self.resources.resource_texture_dimension_2d;
         let gradient_texture_height = self.resources.gradient_texture_height;
         let total_capacity = (gradient_texture_width * gradient_texture_height * 4) as usize;
 
@@ -2554,6 +2564,7 @@ fn create_webgl_resources(
     gl: &WebGl2RenderingContext,
     image_cache: &ImageCache,
     layer_config: LayersConfig,
+    resource_texture_dimension_2d: u32,
 ) -> WebGlResources {
     let strip_vao = VertexArray::new(gl);
     let filter_vao = VertexArray::new(gl);
@@ -2565,14 +2576,13 @@ fn create_webgl_resources(
 
     let strips_buffer = Buffer::new(gl);
     let view_config_buffer = Buffer::new(gl);
-    let max_texture_dimension_2d = get_max_texture_dimension_2d(gl);
     let texture_size = layer_config.min_texture_size;
     let layer_config_buffer = Buffer::new(gl);
     upload_layer_config_buffer(
         gl,
         &layer_config_buffer,
         texture_size,
-        max_texture_dimension_2d,
+        resource_texture_dimension_2d,
     );
 
     // Create and configure alpha texture.
@@ -2628,7 +2638,7 @@ fn create_webgl_resources(
         // framebuffer. If we ever support non-default framebuffers, this must change
         // to DEPTH_ATTACHMENT.
         depth_attachment_array: js_sys::Array::of1(&WebGl2RenderingContext::DEPTH.into()),
-        max_texture_dimension_2d,
+        resource_texture_dimension_2d,
         texture_size,
         stub_atlas_texture_array,
         atlas_render_framebuffer: None,

--- a/sparse_strips/vello_hybrid/src/render/wgpu/mod.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu/mod.rs
@@ -190,11 +190,11 @@ impl Renderer {
         };
         settings.memory_settings.normalize(&device_limits);
         let resources = Resources::new(settings.memory_settings.image_atlas_config);
-        // Estimate the maximum number of gradient cache entries based on the max texture dimension
-        // and the maximum gradient LUT size - worst case scenario.
-        let max_texture_dimension = u32::from(device_limits.max_texture_dimension_2d);
-        let max_gradient_cache_size =
-            max_texture_dimension * max_texture_dimension / MAX_GRADIENT_LUT_SIZE as u32;
+        let resource_texture_dimension_2d = device_limits.resource_texture_dimension_2d();
+        // Estimate the maximum number of gradient cache entries based on the resource texture
+        // dimension and the maximum gradient LUT size - worst case scenario.
+        let max_gradient_cache_size = resource_texture_dimension_2d * resource_texture_dimension_2d
+            / MAX_GRADIENT_LUT_SIZE as u32;
         let gradient_cache = GradientRampCache::new(max_gradient_cache_size, settings.level);
         let layer_config = settings.memory_settings.layers_config;
 
@@ -204,6 +204,7 @@ impl Renderer {
                 &resources.image_cache,
                 render_target_config,
                 layer_config,
+                resource_texture_dimension_2d,
             ),
             gradient_cache,
             encoded_paints: Vec::new(),
@@ -1024,6 +1025,8 @@ struct GpuResources {
     strips_buffer: Buffer,
     /// Alpha texture.
     alphas_texture: Texture,
+    /// Maximum width or height of packed resource textures.
+    resource_texture_dimension_2d: u32,
     /// Textures for atlas data (multiple atlases supported)
     atlas_texture_array: Texture,
     /// View for atlas texture array
@@ -1119,6 +1122,7 @@ impl Programs {
         image_cache: &ImageCache,
         render_target_config: &RenderTargetConfig,
         layer_config: LayersConfig,
+        resource_texture_dimension_2d: u32,
     ) -> Self {
         let strip_bind_group_layout =
             device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
@@ -1653,25 +1657,24 @@ impl Programs {
             &filter_input_bind_group_layouts[1],
             &placeholder_external_texture_view,
         );
-        let max_texture_dimension_2d = device.limits().max_texture_dimension_2d;
         let layer_config_buffer = Self::create_config_buffer(
             device,
             u32::from(texture_size.width()),
             u32::from(texture_size.height()),
-            max_texture_dimension_2d,
+            resource_texture_dimension_2d,
         );
 
         const INITIAL_ALPHA_TEXTURE_HEIGHT: u32 = 1;
         let alphas_texture = Self::create_alphas_texture(
             device,
-            max_texture_dimension_2d,
+            resource_texture_dimension_2d,
             INITIAL_ALPHA_TEXTURE_HEIGHT,
         );
         let view_config_buffer = Self::create_config_buffer(
             device,
             render_target_config.width,
             render_target_config.height,
-            max_texture_dimension_2d,
+            resource_texture_dimension_2d,
         );
 
         let AtlasConfig {
@@ -1710,12 +1713,12 @@ impl Programs {
         const INITIAL_ENCODED_PAINTS_TEXTURE_HEIGHT: u32 = 1;
         let encoded_paints_data = vec![
             0;
-            ((max_texture_dimension_2d * INITIAL_ENCODED_PAINTS_TEXTURE_HEIGHT) << 4)
+            ((resource_texture_dimension_2d * INITIAL_ENCODED_PAINTS_TEXTURE_HEIGHT) << 4)
                 as usize
         ];
         let encoded_paints_texture = Self::create_encoded_paints_texture(
             device,
-            max_texture_dimension_2d,
+            resource_texture_dimension_2d,
             INITIAL_ENCODED_PAINTS_TEXTURE_HEIGHT,
         );
         let encoded_paints_bind_group = Self::create_encoded_paints_bind_group(
@@ -1727,7 +1730,7 @@ impl Programs {
         const INITIAL_GRADIENT_TEXTURE_HEIGHT: u32 = 1;
         let gradient_texture = Self::create_gradient_texture(
             device,
-            max_texture_dimension_2d,
+            resource_texture_dimension_2d,
             INITIAL_GRADIENT_TEXTURE_HEIGHT,
         );
         let gradient_bind_group = Self::create_gradient_bind_group(
@@ -1738,11 +1741,14 @@ impl Programs {
 
         // TODO: We really should deduplicate handling of this this with encoded paints texture.
         const INITIAL_FILTER_TEXTURE_HEIGHT: u32 = 1;
-        let filter_data =
-            vec![0_u8; ((max_texture_dimension_2d * INITIAL_FILTER_TEXTURE_HEIGHT) << 4) as usize];
+        let filter_data = vec![
+            0_u8;
+            ((resource_texture_dimension_2d * INITIAL_FILTER_TEXTURE_HEIGHT) << 4)
+                as usize
+        ];
         let filter_data_texture = Self::create_filter_data_texture(
             device,
-            max_texture_dimension_2d,
+            resource_texture_dimension_2d,
             INITIAL_FILTER_TEXTURE_HEIGHT,
         );
         let filter_base_bind_group = Self::create_filter_base_bind_group(
@@ -1764,6 +1770,7 @@ impl Programs {
             scratch_copy_bind_group,
             layer_config_buffer,
             alphas_texture,
+            resource_texture_dimension_2d,
             atlas_texture_array,
             atlas_texture_array_view,
             atlas_size,
@@ -1860,7 +1867,7 @@ impl Programs {
                 device,
                 u32::from(texture_size.width()),
                 u32::from(texture_size.height()),
-                device.limits().max_texture_dimension_2d,
+                self.resources.resource_texture_dimension_2d,
             );
         }
 
@@ -2244,18 +2251,18 @@ impl Programs {
         paint_idxs: &[u32],
         filter_context: &FilterContext,
     ) {
-        let max_texture_dimension_2d = device.limits().max_texture_dimension_2d;
-        self.maybe_resize_alphas_tex(device, max_texture_dimension_2d, alphas.len());
-        self.maybe_resize_encoded_paints_tex(device, max_texture_dimension_2d, paint_idxs);
-        self.maybe_resize_filter_tex(device, max_texture_dimension_2d, filter_context);
-        self.maybe_update_config_buffer(queue, max_texture_dimension_2d, new_render_size);
+        let resource_texture_dimension_2d = self.resources.resource_texture_dimension_2d;
+        self.maybe_resize_alphas_tex(device, resource_texture_dimension_2d, alphas.len());
+        self.maybe_resize_encoded_paints_tex(device, resource_texture_dimension_2d, paint_idxs);
+        self.maybe_resize_filter_tex(device, resource_texture_dimension_2d, filter_context);
+        self.maybe_update_config_buffer(queue, resource_texture_dimension_2d, new_render_size);
 
         self.upload_alpha_texture(queue, alphas);
         self.upload_encoded_paints_texture(queue, encoded_paints);
         self.upload_filter_texture(queue, filter_context);
 
         if gradient_cache.has_changed() {
-            self.maybe_resize_gradient_tex(device, max_texture_dimension_2d, gradient_cache);
+            self.maybe_resize_gradient_tex(device, resource_texture_dimension_2d, gradient_cache);
             self.upload_gradient_texture(queue, gradient_cache);
             gradient_cache.mark_synced();
         }

--- a/sparse_strips/vello_hybrid/src/render/wgpu/mod.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu/mod.rs
@@ -2271,26 +2271,27 @@ impl Programs {
     fn maybe_resize_filter_tex(
         &mut self,
         device: &Device,
-        max_texture_dimension_2d: u32,
+        resource_texture_dimension_2d: u32,
         filter_context: &FilterContext,
     ) {
         let Some(required_filter_height) =
-            filter_context.required_filter_data_height(max_texture_dimension_2d)
+            filter_context.required_filter_data_height(resource_texture_dimension_2d)
         else {
             return;
         };
         debug_assert!(
-            self.resources.filter_data_texture.width() == max_texture_dimension_2d,
-            "Filter texture width must match max texture dimensions"
+            self.resources.filter_data_texture.width() == resource_texture_dimension_2d,
+            "Filter texture width must match resource texture dimensions"
         );
         let current_filter_height = self.resources.filter_data_texture.height();
         if required_filter_height > current_filter_height {
-            let required_filter_size = (max_texture_dimension_2d * required_filter_height) << 4;
+            let required_filter_size =
+                (resource_texture_dimension_2d * required_filter_height) << 4;
             self.filter_data.resize(required_filter_size as usize, 0);
 
             let filter_texture = Self::create_filter_data_texture(
                 device,
-                max_texture_dimension_2d,
+                resource_texture_dimension_2d,
                 required_filter_height,
             );
             self.resources.filter_data_texture = filter_texture;
@@ -2309,29 +2310,29 @@ impl Programs {
     fn maybe_resize_alphas_tex(
         &mut self,
         device: &Device,
-        max_texture_dimension_2d: u32,
+        resource_texture_dimension_2d: u32,
         alphas_len: usize,
     ) {
         let required_alpha_height = u32::try_from(alphas_len)
             .unwrap()
             // There are 16 1-byte alpha values per texel.
-            .div_ceil(max_texture_dimension_2d << 4);
+            .div_ceil(resource_texture_dimension_2d << 4);
         debug_assert!(
-            self.resources.alphas_texture.width() == max_texture_dimension_2d,
-            "Alpha texture width must match max texture dimensions"
+            self.resources.alphas_texture.width() == resource_texture_dimension_2d,
+            "Alpha texture width must match resource texture dimensions"
         );
         let current_alpha_height = self.resources.alphas_texture.height();
         if required_alpha_height > current_alpha_height {
             // We need to resize the alpha texture to fit the new alpha data.
             assert!(
-                required_alpha_height <= max_texture_dimension_2d,
-                "Alpha texture height exceeds max texture dimensions"
+                required_alpha_height <= resource_texture_dimension_2d,
+                "Alpha texture height exceeds resource texture dimensions"
             );
 
             // The alpha texture encodes 16 1-byte alpha values per texel, with 4 alpha values packed in each channel
             let alphas_texture = Self::create_alphas_texture(
                 device,
-                max_texture_dimension_2d,
+                resource_texture_dimension_2d,
                 required_alpha_height,
             );
             self.resources.alphas_texture = alphas_texture;
@@ -2344,28 +2345,29 @@ impl Programs {
     fn maybe_resize_encoded_paints_tex(
         &mut self,
         device: &Device,
-        max_texture_dimension_2d: u32,
+        resource_texture_dimension_2d: u32,
         paint_idxs: &[u32],
     ) {
         let required_texels = paint_idxs.last().unwrap();
-        let required_encoded_paints_height = required_texels.div_ceil(max_texture_dimension_2d);
+        let required_encoded_paints_height =
+            required_texels.div_ceil(resource_texture_dimension_2d);
         debug_assert!(
-            self.resources.encoded_paints_texture.width() == max_texture_dimension_2d,
-            "Encoded paints texture width must match max texture dimensions"
+            self.resources.encoded_paints_texture.width() == resource_texture_dimension_2d,
+            "Encoded paints texture width must match resource texture dimensions"
         );
         let current_encoded_paints_height = self.resources.encoded_paints_texture.height();
         if required_encoded_paints_height > current_encoded_paints_height {
             assert!(
-                required_encoded_paints_height <= max_texture_dimension_2d,
-                "Encoded paints texture height exceeds max texture dimensions"
+                required_encoded_paints_height <= resource_texture_dimension_2d,
+                "Encoded paints texture height exceeds resource texture dimensions"
             );
             let required_encoded_paints_size =
-                (max_texture_dimension_2d * required_encoded_paints_height) << 4;
+                (resource_texture_dimension_2d * required_encoded_paints_height) << 4;
             self.encoded_paints_data
                 .resize(required_encoded_paints_size as usize, 0);
             let encoded_paints_texture = Self::create_encoded_paints_texture(
                 device,
-                max_texture_dimension_2d,
+                resource_texture_dimension_2d,
                 required_encoded_paints_height,
             );
             self.resources.encoded_paints_texture = encoded_paints_texture;
@@ -2386,24 +2388,24 @@ impl Programs {
     fn maybe_resize_gradient_tex(
         &mut self,
         device: &Device,
-        max_texture_dimension_2d: u32,
+        resource_texture_dimension_2d: u32,
         gradient_cache: &GradientRampCache,
     ) {
         let gradient_pixels = (gradient_cache.luts_size() / 4) as u32; // 4 bytes per RGBA8 pixel
-        let required_gradient_height = gradient_pixels.div_ceil(max_texture_dimension_2d);
+        let required_gradient_height = gradient_pixels.div_ceil(resource_texture_dimension_2d);
         debug_assert!(
-            self.resources.gradient_texture.width() == max_texture_dimension_2d,
-            "Gradient texture width must match max texture dimensions"
+            self.resources.gradient_texture.width() == resource_texture_dimension_2d,
+            "Gradient texture width must match resource texture dimensions"
         );
         let current_gradient_height = self.resources.gradient_texture.height();
         if required_gradient_height > current_gradient_height {
             assert!(
-                required_gradient_height <= max_texture_dimension_2d,
-                "Gradient texture height exceeds max texture dimensions"
+                required_gradient_height <= resource_texture_dimension_2d,
+                "Gradient texture height exceeds resource texture dimensions"
             );
             let gradient_texture = Self::create_gradient_texture(
                 device,
-                max_texture_dimension_2d,
+                resource_texture_dimension_2d,
                 required_gradient_height,
             );
             self.resources.gradient_texture = gradient_texture;
@@ -2424,7 +2426,7 @@ impl Programs {
     fn maybe_update_config_buffer(
         &mut self,
         queue: &Queue,
-        max_texture_dimension_2d: u32,
+        resource_texture_dimension_2d: u32,
         new_render_size: &RenderSize,
     ) {
         if self.render_size != *new_render_size {
@@ -2432,8 +2434,8 @@ impl Programs {
                 width: new_render_size.width,
                 height: new_render_size.height,
                 strip_height: Tile::HEIGHT.into(),
-                alphas_tex_width_bits: max_texture_dimension_2d.trailing_zeros(),
-                encoded_paints_tex_width_bits: max_texture_dimension_2d.trailing_zeros(),
+                alphas_tex_width_bits: resource_texture_dimension_2d.trailing_zeros(),
+                encoded_paints_tex_width_bits: resource_texture_dimension_2d.trailing_zeros(),
                 strip_offset_x: 0,
                 strip_offset_y: 0,
                 negate_ndc: 0,


### PR DESCRIPTION
The issue I've been encountering is encapsulated in the following simplified example:

```html
<!doctype html>

<canvas></canvas>

<style>
  html,
  body,
  canvas {
    width: 100%;
    height: 100%;
    margin: 0;
    display: block;
  }
</style>

<script>
  const gl = document.querySelector("canvas").getContext("webgl2");

  // The exact cutoff doesn't seem fully reproducible, but this width seems to
  // fail consistently.
  const width = 16365;

  function compile(type, source) {
    const shader = gl.createShader(type);

    gl.shaderSource(shader, source);
    gl.compileShader(shader);

    return shader;
  }

  const program = gl.createProgram();

  gl.attachShader(
    program,
    compile(
      gl.VERTEX_SHADER,
      `#version 300 es

void main() {
  vec2 p = vec2(
    gl_VertexID == 1 ? 3.0 : -1.0,
    gl_VertexID == 2 ? 3.0 : -1.0
  );
  gl_Position = vec4(p, 0.0, 1.0);
}
`,
    ),
  );

  gl.attachShader(
    program,
    compile(
      gl.FRAGMENT_SHADER,
      `#version 300 es

precision highp float;
precision highp int;

uniform highp usampler2D texture_;
uniform int frame_;

out vec4 color;

void main() {
  float value = float(texelFetch(texture_, ivec2(0), 0).r & 255u) / 255.0;

  color = frame_ == 0
    ? vec4(value, 0.0, 0.0, 1.0)
    : vec4(0.0, value, 0.0, 1.0);
}
`,
    ),
  );

  gl.linkProgram(program);
  gl.useProgram(program);

  const frameUniform = gl.getUniformLocation(program, "frame_");

  gl.bindTexture(gl.TEXTURE_2D, gl.createTexture());

  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);

  gl.texImage2D(
    gl.TEXTURE_2D,
    0,
    gl.RGBA32UI,
    width,
    1,
    0,
    gl.RGBA_INTEGER,
    gl.UNSIGNED_INT,
    null,
  );

  let frames = 0;

  function frame() {
    const pixels = new Uint32Array(width * 4);
    pixels[0] = 255;

    gl.texSubImage2D(
      gl.TEXTURE_2D,
      0,
      0,
      0,
      width,
      1,
      gl.RGBA_INTEGER,
      gl.UNSIGNED_INT,
      pixels,
    );

    gl.uniform1i(frameUniform, frames);
    gl.drawArrays(gl.TRIANGLES, 0, 3);

    frames++;

    if (frames < 2) {
      requestAnimationFrame(frame);
    }
  }

  requestAnimationFrame(frame);
</script>
```

On working machines, this should show red briefly but then go to green. However, on the affected machines, this will show red **and then the browser will completely freeze for ~30 seconds**, after which the WebGL context becomes lost. I have tested this on a Big Sur machine with Chrome 138 and a Monterey machine with Chrome 151. However, it's more likely that it has to do with the GPU and the driver version instead of the OS version. 

Basically, it seems that for unknown reasons, using textures close to the 16k limit (even with just a height and uploading to them repeatedly over at least 2 frames causes this hang. This issue does not seem to be about the overall amount of data uploaded (for example uploading a 4kx4k texture works fine), but instead really about the maximum width of the texture. If I set the width to 8k or even lower, it seems to work fine (even 13k or 14k seem so to have worked most of the time). I know it would be interesting to do more digging, but this is very frustrating to debug (you always need to wait until the freeze is over, you need to restart regularly because at some point Chrome just falls back to the software rasterizer, etc.), so I hope we can just leave it at that for now in the short term.

Setting the maximum limit to 4k gives us storage for 268MB of alpha values, which should be more than sufficient for any sane scene, let alone any of the other data textures. We could do 8k instead since at least the affected machines, but I feel like it's better to stick to a lower number for now. I confirmed that with rhese changes, vello bench works fine on those devices!

This PR was done with assistance of GPT 5.6 Sol.