### PR TITLE
vello_hybrid: Compact shaders

### DIFF
--- a/sparse_strips/vello_sparse_shaders/build.rs
+++ b/sparse_strips/vello_sparse_shaders/build.rs
@@ -47,8 +47,7 @@ fn load_shader_infos(shader_dir: &Path) -> Vec<ShaderInfo> {
     let shader_names = load_shader_names(shader_dir);
     let mut compiler = Wesl::new(shader_dir);
 
-    // Keep the initial migration behavior-preserving.
-    compiler.use_stripping(false);
+    compiler.use_stripping(true);
 
     shader_names
         .into_iter()

--- a/sparse_strips/vello_sparse_shaders/src/compile.rs
+++ b/sparse_strips/vello_sparse_shaders/src/compile.rs
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use naga::{
-    ShaderStage,
+    Module, ShaderStage,
     back::glsl::{self, PipelineOptions, Version},
+    compact::KeepUnused,
     front::wgsl,
-    valid::{Capabilities, ValidationFlags, Validator},
+    valid::{Capabilities, ModuleInfo, ValidationFlags, Validator},
 };
 
 use crate::lint::lint;
@@ -26,11 +27,7 @@ pub(crate) fn compile_wgsl_shader(
 
     lint(shader_name, &module);
 
-    let info = Validator::new(ValidationFlags::all(), Capabilities::default())
-        .subgroup_stages(naga::valid::ShaderStages::all())
-        .subgroup_operations(naga::valid::SubgroupOperationSet::all())
-        .validate(&module)
-        .unwrap();
+    validate(&module);
 
     let options = glsl::Options {
         version: Version::Embedded {
@@ -40,45 +37,36 @@ pub(crate) fn compile_wgsl_shader(
         ..Default::default()
     };
 
-    let mut glsl_vs = String::new();
-    let reflection_vs = {
-        let pipeline_options = PipelineOptions {
-            entry_point: vertex_entry.into(),
-            shader_stage: ShaderStage::Vertex,
-            multiview: None,
-        };
+    CompiledGlsl {
+        vertex: compile_stage(&module, vertex_entry, ShaderStage::Vertex, &options),
+        fragment: compile_stage(&module, fragment_entry, ShaderStage::Fragment, &options),
+    }
+}
 
-        let mut w_vs = glsl::Writer::new(
-            &mut glsl_vs,
-            &module,
-            &info,
-            &options,
-            &pipeline_options,
-            naga::proc::BoundsCheckPolicies {
-                index: naga::proc::BoundsCheckPolicy::Unchecked,
-                buffer: naga::proc::BoundsCheckPolicy::Unchecked,
-                image_load: naga::proc::BoundsCheckPolicy::Unchecked,
-                binding_array: naga::proc::BoundsCheckPolicy::Unchecked,
-            },
-        )
-        .unwrap();
-        ReflectionMap::new(
-            w_vs.write().expect("failed to write vertex."),
-            &module.global_variables,
-        )
-    };
+fn compile_stage(
+    module: &Module,
+    entry_point: &str,
+    shader_stage: ShaderStage,
+    options: &glsl::Options,
+) -> Stage {
+    let mut module = module.clone();
+    module
+        .entry_points
+        .retain(|entry| entry.stage == shader_stage && entry.name == entry_point);
+    naga::compact::compact(&mut module, KeepUnused::No);
+    let info = validate(&module);
 
     let pipeline_options = PipelineOptions {
-        entry_point: fragment_entry.into(),
-        shader_stage: ShaderStage::Fragment,
+        entry_point: entry_point.into(),
+        shader_stage,
         multiview: None,
     };
-    let mut glsl_fs = String::new();
-    let mut w_fs = glsl::Writer::new(
-        &mut glsl_fs,
+    let mut source = String::new();
+    let mut writer = glsl::Writer::new(
+        &mut source,
         &module,
         &info,
-        &options,
+        options,
         &pipeline_options,
         naga::proc::BoundsCheckPolicies {
             index: naga::proc::BoundsCheckPolicy::Unchecked,
@@ -88,19 +76,21 @@ pub(crate) fn compile_wgsl_shader(
         },
     )
     .unwrap();
-    let reflection_fs = ReflectionMap::new(
-        w_fs.write().expect("failed to write fragment."),
+    let reflection_map = ReflectionMap::new(
+        writer.write().expect("failed to write shader stage."),
         &module.global_variables,
     );
 
-    CompiledGlsl {
-        vertex: Stage {
-            source: glsl_vs,
-            reflection_map: reflection_vs,
-        },
-        fragment: Stage {
-            source: glsl_fs,
-            reflection_map: reflection_fs,
-        },
+    Stage {
+        source,
+        reflection_map,
     }
+}
+
+fn validate(module: &Module) -> ModuleInfo {
+    Validator::new(ValidationFlags::all(), Capabilities::default())
+        .subgroup_stages(naga::valid::ShaderStages::all())
+        .subgroup_operations(naga::valid::SubgroupOperationSet::all())
+        .validate(module)
+        .unwrap()
 }


### PR DESCRIPTION
Currently, functions are duplicated across both, vertex and fragment shader in the GLSL files, even if they are only needed in one stage. We can easily prune them by calling `naga::compact::compact`. This reduces the file size of `compiled_shaders.rs` from 209KB to 164KB.

I manually checked the resulting diff from the GLSL files and they look reasonable.

This PR was done with assistance of GPT 5.6 Sol.