### PR TITLE
perf: use immutable storage for WebGL data textures

### DIFF
--- a/sparse_strips/vello_hybrid/src/render/webgl/mod.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl/mod.rs
@@ -1467,13 +1467,13 @@ impl WebGlPrograms {
     ) {
         let resource_texture_dimension_2d = self.resources.resource_texture_dimension_2d;
 
-        self.maybe_resize_alphas_tex(resource_texture_dimension_2d, alphas.len());
-        self.maybe_resize_encoded_paints_tex(resource_texture_dimension_2d, paint_idxs);
-        self.maybe_resize_filter_data_tex(filter_context);
+        self.maybe_resize_alphas_tex(gl, resource_texture_dimension_2d, alphas.len());
+        self.maybe_resize_encoded_paints_tex(gl, resource_texture_dimension_2d, paint_idxs);
+        self.maybe_resize_filter_data_tex(gl, filter_context);
         self.maybe_update_config_buffer(gl, resource_texture_dimension_2d, render_size);
 
         self.upload_alpha_texture(gl, alphas);
-        self.upload_encoded_paints_texture(gl, encoded_paints);
+        self.upload_encoded_paints_texture(gl, encoded_paints, paint_idxs);
         self.upload_filter_data_texture(gl, filter_context);
 
         if gradient_cache.has_changed() {
@@ -1644,7 +1644,14 @@ impl WebGlPrograms {
         }
     }
 
-    fn maybe_resize_filter_data_tex(&mut self, filter_context: &FilterContext) {
+    /// Grow the filter data texture if needed.
+    ///
+    /// See [`maybe_resize_alphas_tex`](Self::maybe_resize_alphas_tex) for the storage strategy.
+    fn maybe_resize_filter_data_tex(
+        &mut self,
+        gl: &WebGl2RenderingContext,
+        filter_context: &FilterContext,
+    ) {
         let resource_texture_dimension_2d = self.resources.resource_texture_dimension_2d;
 
         let Some(required_height) =
@@ -1656,10 +1663,20 @@ impl WebGlPrograms {
         if required_height > self.resources.filter_data_texture_height {
             let required_size = (resource_texture_dimension_2d * required_height) << 4;
             self.filter_data.resize(required_size as usize, 0);
+            self.resources.filter_data_texture = create_data_texture_storage(
+                gl,
+                WebGl2RenderingContext::RGBA32UI,
+                resource_texture_dimension_2d,
+                required_height,
+            );
             self.resources.filter_data_texture_height = required_height;
         }
     }
 
+    /// Upload filter data to the texture.
+    ///
+    /// Only the rows covering this frame's filter data are uploaded; see
+    /// [`upload_alpha_texture`](Self::upload_alpha_texture).
     fn upload_filter_data_texture(
         &mut self,
         gl: &WebGl2RenderingContext,
@@ -1670,27 +1687,18 @@ impl WebGlPrograms {
         }
 
         let width = self.resources.resource_texture_dimension_2d;
-        let height = self.resources.filter_data_texture_height;
+        let used_height = filter_context
+            .required_filter_data_height(width)
+            .expect("non-empty filter context must have a data height");
+        let used_size = ((width * used_height) << 4) as usize;
         filter_context.serialize_to_buffer(&mut self.filter_data);
-        gl.active_texture(WebGl2RenderingContext::TEXTURE0);
-        gl.bind_texture(
-            WebGl2RenderingContext::TEXTURE_2D,
-            Some(&self.resources.filter_data_texture),
+        upload_rgba32ui_rows(
+            gl,
+            &self.resources.filter_data_texture,
+            bytemuck::cast_slice::<u8, u32>(&self.filter_data[..used_size]),
+            width,
+            used_height,
         );
-        let data_as_u32 = bytemuck::cast_slice::<u8, u32>(&self.filter_data);
-        let packed_array = js_sys::Uint32Array::from(data_as_u32);
-        gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_array_buffer_view(
-            WebGl2RenderingContext::TEXTURE_2D,
-            0,
-            WebGl2RenderingContext::RGBA32UI as i32,
-            width as i32,
-            height as i32,
-            0,
-            WebGl2RenderingContext::RGBA_INTEGER,
-            WebGl2RenderingContext::UNSIGNED_INT,
-            Some(&packed_array),
-        )
-        .unwrap();
     }
 
     fn upload_filter_instances(
@@ -1733,8 +1741,17 @@ impl WebGlPrograms {
         );
     }
 
-    /// Update the alpha texture size if needed.
-    fn maybe_resize_alphas_tex(&mut self, resource_texture_dimension_2d: u32, alphas_len: usize) {
+    /// Grow the alpha texture if needed.
+    ///
+    /// The texture uses immutable storage, so growing allocates a new texture. No contents need
+    /// copying: the alpha data is fully rewritten every frame. The allocated height only ever
+    /// grows; frames upload just the rows they use.
+    fn maybe_resize_alphas_tex(
+        &mut self,
+        gl: &WebGl2RenderingContext,
+        resource_texture_dimension_2d: u32,
+        alphas_len: usize,
+    ) {
         let required_alpha_height = (alphas_len as u32)
             // There are 16 1-byte alpha values per texel.
             .div_ceil(resource_texture_dimension_2d << 4);
@@ -1747,14 +1764,22 @@ impl WebGlPrograms {
                 "Alpha texture height exceeds resource texture dimensions"
             );
 
-            // Track the new height.
+            self.resources.alphas_texture = create_data_texture_storage(
+                gl,
+                WebGl2RenderingContext::RGBA32UI,
+                resource_texture_dimension_2d,
+                required_alpha_height,
+            );
             self.resources.alpha_texture_height = required_alpha_height;
         }
     }
 
-    /// Update the encoded paints texture size if needed.
+    /// Grow the encoded paints texture if needed.
+    ///
+    /// See [`maybe_resize_alphas_tex`](Self::maybe_resize_alphas_tex) for the storage strategy.
     fn maybe_resize_encoded_paints_tex(
         &mut self,
+        gl: &WebGl2RenderingContext,
         resource_texture_dimension_2d: u32,
         paint_idxs: &[u32],
     ) {
@@ -1772,14 +1797,25 @@ impl WebGlPrograms {
                 (resource_texture_dimension_2d * required_encoded_paints_height) << 4;
             self.encoded_paints_data
                 .resize(required_encoded_paints_size as usize, 0);
+            self.resources.encoded_paints_texture = create_data_texture_storage(
+                gl,
+                WebGl2RenderingContext::RGBA32UI,
+                resource_texture_dimension_2d,
+                required_encoded_paints_height,
+            );
             self.resources.encoded_paints_texture_height = required_encoded_paints_height;
         }
     }
 
-    /// Update the gradient texture size if needed.
+    /// Grow the gradient texture if needed.
+    ///
+    /// See [`maybe_resize_alphas_tex`](Self::maybe_resize_alphas_tex) for the storage strategy.
+    /// No contents need copying on growth: this is only called when the gradient cache has
+    /// changed, and [`upload_gradient_texture`](Self::upload_gradient_texture) then re-uploads
+    /// the entire LUT cache.
     fn maybe_resize_gradient_tex(
         &mut self,
-        _gl: &WebGl2RenderingContext,
+        gl: &WebGl2RenderingContext,
         resource_texture_dimension_2d: u32,
         gradient_cache: &GradientRampCache,
     ) {
@@ -1799,6 +1835,12 @@ impl WebGlPrograms {
                 "Gradient texture height exceeds resource texture dimensions"
             );
 
+            self.resources.gradient_texture = create_data_texture_storage(
+                gl,
+                WebGl2RenderingContext::RGBA8,
+                resource_texture_dimension_2d,
+                required_gradient_height,
+            );
             self.resources.gradient_texture_height = required_gradient_height;
         }
     }
@@ -1844,26 +1886,31 @@ impl WebGlPrograms {
     }
 
     /// Upload alpha data to the texture.
+    ///
+    /// Only the rows used by this frame's alpha data are uploaded, not the full (peak-sized)
+    /// texture. Rows above keep stale contents from previous frames, which is fine because the
+    /// shader only reads alpha indices produced by the current frame.
     fn upload_alpha_texture(&mut self, gl: &WebGl2RenderingContext, alphas: &mut Vec<u8>) {
         if alphas.is_empty() {
             return;
         }
 
         let alpha_texture_width = self.resources.resource_texture_dimension_2d;
-        let alpha_texture_height = self.resources.alpha_texture_height;
-        let total_size = alpha_texture_width as usize * alpha_texture_height as usize * 16;
+        // There are 16 1-byte alpha values per texel.
+        let used_height = (alphas.len() as u32).div_ceil(alpha_texture_width << 4);
+        let used_size = (alpha_texture_width as usize) * (used_height as usize) * 16;
 
         let original_len = alphas.len();
 
-        // Temporarily pad the length of the alphas to the texture size before uploading.
-        alphas.resize(total_size, 0);
+        // Temporarily pad the length of the alphas to the end of the last used row.
+        alphas.resize(used_size, 0);
 
-        upload_data_to_rgba32_texture(
+        upload_rgba32ui_rows(
             gl,
             &self.resources.alphas_texture,
             bytemuck::cast_slice::<u8, u32>(alphas),
             alpha_texture_width,
-            alpha_texture_height,
+            used_height,
         );
 
         // Truncate back to the original size.
@@ -1871,23 +1918,29 @@ impl WebGlPrograms {
     }
 
     /// Upload encoded paints to the texture.
+    ///
+    /// Only the rows covering this frame's paints are uploaded; see
+    /// [`upload_alpha_texture`](Self::upload_alpha_texture).
     fn upload_encoded_paints_texture(
         &mut self,
         gl: &WebGl2RenderingContext,
         encoded_paints: &[GpuEncodedPaint],
+        paint_idxs: &[u32],
     ) {
         if !encoded_paints.is_empty() {
             let encoded_paints_texture_width = self.resources.resource_texture_dimension_2d;
-            let encoded_paints_texture_height = self.resources.encoded_paints_texture_height;
+            let used_texels = *paint_idxs.last().unwrap();
+            let used_height = used_texels.div_ceil(encoded_paints_texture_width);
+            let used_size = ((encoded_paints_texture_width * used_height) << 4) as usize;
 
             GpuEncodedPaint::serialize_to_buffer(encoded_paints, &mut self.encoded_paints_data);
 
-            upload_data_to_rgba32_texture(
+            upload_rgba32ui_rows(
                 gl,
                 &self.resources.encoded_paints_texture,
-                bytemuck::cast_slice::<u8, u32>(&self.encoded_paints_data),
+                bytemuck::cast_slice::<u8, u32>(&self.encoded_paints_data[..used_size]),
                 encoded_paints_texture_width,
-                encoded_paints_texture_height,
+                used_height,
             );
         }
     }
@@ -1903,13 +1956,15 @@ impl WebGlPrograms {
         }
 
         let gradient_texture_width = self.resources.resource_texture_dimension_2d;
-        let gradient_texture_height = self.resources.gradient_texture_height;
-        let total_capacity = (gradient_texture_width * gradient_texture_height * 4) as usize;
+        // Each texel is RGBA8, so 4 bytes per texel. Only the rows covering the LUT cache are
+        // uploaded; see `upload_alpha_texture`.
+        let used_height = (gradient_cache.luts_size() as u32).div_ceil(gradient_texture_width * 4);
+        let used_size = (gradient_texture_width * used_height * 4) as usize;
 
-        // Take ownership of the luts to avoid copying, then resize for texture padding.
+        // Take ownership of the luts to avoid copying, then pad to the end of the last used row.
         let mut luts = gradient_cache.take_luts();
         let old_luts_len = luts.len();
-        luts.resize(total_capacity, 0);
+        luts.resize(used_size, 0);
 
         gl.active_texture(WebGl2RenderingContext::TEXTURE0);
         gl.bind_texture(
@@ -1917,13 +1972,13 @@ impl WebGlPrograms {
             Some(&self.resources.gradient_texture),
         );
 
-        gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_u8_array(
+        gl.tex_sub_image_2d_with_i32_and_i32_and_u32_and_type_and_opt_u8_array(
             WebGl2RenderingContext::TEXTURE_2D,
             0,
-            WebGl2RenderingContext::RGBA8 as i32,
-            gradient_texture_width as i32,
-            gradient_texture_height as i32,
             0,
+            0,
+            gradient_texture_width as i32,
+            used_height as i32,
             WebGl2RenderingContext::RGBA,
             WebGl2RenderingContext::UNSIGNED_BYTE,
             Some(&luts),
@@ -2497,16 +2552,42 @@ fn create_texture_inner(
     texture
 }
 
-/// Create a 1x1 RGBA32UI placeholder texture.
-fn create_placeholder_rgba32ui_texture(gl: &WebGl2RenderingContext) -> Texture {
+/// Create a data texture backed by immutable storage (`texStorage2D`).
+///
+/// Immutable storage is preferred over `texImage2D` for the per-frame data textures: the driver
+/// allocates and validates the texture once at creation instead of re-specifying (and
+/// re-validating) the backing store on every upload, and contents can then be streamed with
+/// `texSubImage2D` covering only the region that changed. See
+/// <https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices#use_texstorage_to_create_textures>.
+///
+/// The size and format are fixed for the lifetime of the texture; growing requires creating a
+/// new texture. WebGL guarantees the storage is zero-initialized.
+fn create_data_texture_storage(
+    gl: &WebGl2RenderingContext,
+    internal_format: u32,
+    width: u32,
+    height: u32,
+) -> Texture {
     let texture = create_texture(
         gl,
         WebGl2RenderingContext::NEAREST,
         WebGl2RenderingContext::NEAREST,
     );
-    // See `create_placeholder_rgba8_texture` for why the initial allocation matters.
-    upload_data_to_rgba32_texture(gl, &texture, &[0; 4], 1, 1);
+    // `create_texture` leaves the new texture bound on the active texture unit.
+    gl.tex_storage_2d(
+        WebGl2RenderingContext::TEXTURE_2D,
+        1,
+        internal_format,
+        width as i32,
+        height as i32,
+    );
     texture
+}
+
+/// Create a 1x1 RGBA32UI placeholder texture.
+fn create_placeholder_rgba32ui_texture(gl: &WebGl2RenderingContext) -> Texture {
+    // See `create_placeholder_rgba8_texture` for why the initial allocation matters.
+    create_data_texture_storage(gl, WebGl2RenderingContext::RGBA32UI, 1, 1)
 }
 
 /// Create a 1x1 RGBA8 placeholder texture.
@@ -2515,26 +2596,9 @@ fn create_placeholder_rgba32ui_texture(gl: &WebGl2RenderingContext) -> Texture {
 /// makes the draw call non-renderable: the driver substitutes a black texture for every draw and
 /// browsers log a render warning for each one. Data textures are only uploaded when a scene has
 /// data for them, so allocate a minimal level 0 up front to keep them complete for scenes that
-/// don't.
+/// don't. WebGL zero-initializes the storage, so these sample as transparent black.
 fn create_placeholder_rgba8_texture(gl: &WebGl2RenderingContext) -> Texture {
-    let texture = create_texture(
-        gl,
-        WebGl2RenderingContext::NEAREST,
-        WebGl2RenderingContext::NEAREST,
-    );
-    gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_u8_array(
-        WebGl2RenderingContext::TEXTURE_2D,
-        0,
-        WebGl2RenderingContext::RGBA8 as i32,
-        1,
-        1,
-        0,
-        WebGl2RenderingContext::RGBA,
-        WebGl2RenderingContext::UNSIGNED_BYTE,
-        Some(&[0, 0, 0, 0]),
-    )
-    .unwrap();
-    texture
+    create_data_texture_storage(gl, WebGl2RenderingContext::RGBA8, 1, 1)
 }
 
 fn upload_layer_config_buffer(
@@ -3627,14 +3691,24 @@ fn copy_to_texture_array_layer(
     );
 }
 
-// Upload the data to the currently bound texture assuming a RGBA32UI format.
-fn upload_data_to_rgba32_texture(
+/// Upload `rows` full rows of RGBA32UI texel data into the given texture's existing
+/// (immutable) storage via `texSubImage2D`.
+///
+/// `data` must contain exactly `width * rows` RGBA32UI texels (4 `u32`s per texel). Only the
+/// uploaded rows are modified; rows above `rows` keep their previous contents, which is fine
+/// because shaders only read texels referenced by the current frame's data.
+fn upload_rgba32ui_rows(
     gl: &WebGl2RenderingContext,
     texture: &WebGlTexture,
     data: &[u32],
-    texture_width: u32,
-    texture_height: u32,
+    width: u32,
+    rows: u32,
 ) {
+    debug_assert_eq!(
+        data.len(),
+        (width * rows * 4) as usize,
+        "row upload data must cover exactly the uploaded region"
+    );
     gl.active_texture(WebGl2RenderingContext::TEXTURE0);
     gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, Some(texture));
 
@@ -3642,8 +3716,8 @@ fn upload_data_to_rgba32_texture(
     // WASM linear memory, and any additional allocations might invalidate that view.
     // In our case, this is not an issue because we only use this view once for uploading
     // data to the GPU below, and no allocations happen between that.
-    // The `tex_image_2d` method is synchronous in the sense that once it returns, it is guaranteed
-    // that all necessary data has already been read, so any allocations that happen
+    // The `tex_sub_image_2d` method is synchronous in the sense that once it returns, it is
+    // guaranteed that all necessary data has already been read, so any allocations that happen
     // after this block don't affect this anymore.
     //
     // See also: https://wikis.khronos.org/opengl/Synchronization
@@ -3658,13 +3732,13 @@ fn upload_data_to_rgba32_texture(
     // >> pointer you gave it, as OpenGL has already read as much as it wants.
     let packed_array = unsafe { js_sys::Uint32Array::view(data) };
 
-    gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_array_buffer_view(
+    gl.tex_sub_image_2d_with_i32_and_i32_and_u32_and_type_and_opt_array_buffer_view(
         WebGl2RenderingContext::TEXTURE_2D,
         0,
-        WebGl2RenderingContext::RGBA32UI as i32,
-        texture_width as i32,
-        texture_height as i32,
         0,
+        0,
+        width as i32,
+        rows as i32,
         WebGl2RenderingContext::RGBA_INTEGER,
         WebGl2RenderingContext::UNSIGNED_INT,
         Some(&packed_array),

--- a/sparse_strips/vello_hybrid/src/render/webgl/mod.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl/mod.rs
@@ -1645,8 +1645,6 @@ impl WebGlPrograms {
     }
 
     /// Grow the filter data texture if needed.
-    ///
-    /// See [`maybe_resize_alphas_tex`](Self::maybe_resize_alphas_tex) for the storage strategy.
     fn maybe_resize_filter_data_tex(
         &mut self,
         gl: &WebGl2RenderingContext,
@@ -1674,9 +1672,6 @@ impl WebGlPrograms {
     }
 
     /// Upload filter data to the texture.
-    ///
-    /// Only the rows covering this frame's filter data are uploaded; see
-    /// [`upload_alpha_texture`](Self::upload_alpha_texture).
     fn upload_filter_data_texture(
         &mut self,
         gl: &WebGl2RenderingContext,
@@ -1742,10 +1737,6 @@ impl WebGlPrograms {
     }
 
     /// Grow the alpha texture if needed.
-    ///
-    /// The texture uses immutable storage, so growing allocates a new texture. No contents need
-    /// copying: the alpha data is fully rewritten every frame. The allocated height only ever
-    /// grows; frames upload just the rows they use.
     fn maybe_resize_alphas_tex(
         &mut self,
         gl: &WebGl2RenderingContext,
@@ -1775,8 +1766,6 @@ impl WebGlPrograms {
     }
 
     /// Grow the encoded paints texture if needed.
-    ///
-    /// See [`maybe_resize_alphas_tex`](Self::maybe_resize_alphas_tex) for the storage strategy.
     fn maybe_resize_encoded_paints_tex(
         &mut self,
         gl: &WebGl2RenderingContext,
@@ -1808,11 +1797,6 @@ impl WebGlPrograms {
     }
 
     /// Grow the gradient texture if needed.
-    ///
-    /// See [`maybe_resize_alphas_tex`](Self::maybe_resize_alphas_tex) for the storage strategy.
-    /// No contents need copying on growth: this is only called when the gradient cache has
-    /// changed, and [`upload_gradient_texture`](Self::upload_gradient_texture) then re-uploads
-    /// the entire LUT cache.
     fn maybe_resize_gradient_tex(
         &mut self,
         gl: &WebGl2RenderingContext,
@@ -1886,10 +1870,6 @@ impl WebGlPrograms {
     }
 
     /// Upload alpha data to the texture.
-    ///
-    /// Only the rows used by this frame's alpha data are uploaded, not the full (peak-sized)
-    /// texture. Rows above keep stale contents from previous frames, which is fine because the
-    /// shader only reads alpha indices produced by the current frame.
     fn upload_alpha_texture(&mut self, gl: &WebGl2RenderingContext, alphas: &mut Vec<u8>) {
         if alphas.is_empty() {
             return;
@@ -1918,9 +1898,6 @@ impl WebGlPrograms {
     }
 
     /// Upload encoded paints to the texture.
-    ///
-    /// Only the rows covering this frame's paints are uploaded; see
-    /// [`upload_alpha_texture`](Self::upload_alpha_texture).
     fn upload_encoded_paints_texture(
         &mut self,
         gl: &WebGl2RenderingContext,
@@ -2552,16 +2529,7 @@ fn create_texture_inner(
     texture
 }
 
-/// Create a data texture backed by immutable storage (`texStorage2D`).
-///
-/// Immutable storage is preferred over `texImage2D` for the per-frame data textures: the driver
-/// allocates and validates the texture once at creation instead of re-specifying (and
-/// re-validating) the backing store on every upload, and contents can then be streamed with
-/// `texSubImage2D` covering only the region that changed. See
-/// <https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices#use_texstorage_to_create_textures>.
-///
-/// The size and format are fixed for the lifetime of the texture; growing requires creating a
-/// new texture. WebGL guarantees the storage is zero-initialized.
+/// Create a zero-initialized data texture backed by immutable storage (`texStorage2D`).
 fn create_data_texture_storage(
     gl: &WebGl2RenderingContext,
     internal_format: u32,
@@ -2574,6 +2542,8 @@ fn create_data_texture_storage(
         WebGl2RenderingContext::NEAREST,
     );
     // `create_texture` leaves the new texture bound on the active texture unit.
+    // Prefer `texStorage2D` over `texImage2D` for potentially better performance; see
+    // <https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices#use_texstorage_to_create_textures>.
     gl.tex_storage_2d(
         WebGl2RenderingContext::TEXTURE_2D,
         1,
@@ -2586,7 +2556,7 @@ fn create_data_texture_storage(
 
 /// Create a 1x1 RGBA32UI placeholder texture.
 fn create_placeholder_rgba32ui_texture(gl: &WebGl2RenderingContext) -> Texture {
-    // See `create_placeholder_rgba8_texture` for why the initial allocation matters.
+    // Allocated storage keeps the placeholder texture complete when no data is available.
     create_data_texture_storage(gl, WebGl2RenderingContext::RGBA32UI, 1, 1)
 }
 
@@ -2596,7 +2566,7 @@ fn create_placeholder_rgba32ui_texture(gl: &WebGl2RenderingContext) -> Texture {
 /// makes the draw call non-renderable: the driver substitutes a black texture for every draw and
 /// browsers log a render warning for each one. Data textures are only uploaded when a scene has
 /// data for them, so allocate a minimal level 0 up front to keep them complete for scenes that
-/// don't. WebGL zero-initializes the storage, so these sample as transparent black.
+/// don't.
 fn create_placeholder_rgba8_texture(gl: &WebGl2RenderingContext) -> Texture {
     create_data_texture_storage(gl, WebGl2RenderingContext::RGBA8, 1, 1)
 }
@@ -3691,12 +3661,10 @@ fn copy_to_texture_array_layer(
     );
 }
 
-/// Upload `rows` full rows of RGBA32UI texel data into the given texture's existing
-/// (immutable) storage via `texSubImage2D`.
+/// Upload full rows of RGBA32UI data into immutable texture storage.
 ///
-/// `data` must contain exactly `width * rows` RGBA32UI texels (4 `u32`s per texel). Only the
-/// uploaded rows are modified; rows above `rows` keep their previous contents, which is fine
-/// because shaders only read texels referenced by the current frame's data.
+/// `data` must contain exactly `width * rows * 4` `u32` values.
+/// Texels outside the uploaded rows remain unchanged.
 fn upload_rgba32ui_rows(
     gl: &WebGl2RenderingContext,
     texture: &WebGlTexture,


### PR DESCRIPTION
## Problem

The WebGL renderer calls `texImage2D` every frame for alpha, encoded-paint, gradient, and filter-data textures. This uploads the texture’s full peak allocation even when the current frame only uses a few rows.

After one large frame grows a texture, subsequent small frames continue paying the peak-sized upload cost.

## Root Cause

`texImage2D` does more than copy pixels: it **specifies the texture storage** for a mip level, including its dimensions and internal format.

**respecification**: the call tells WebGL that the existing storage may be replaced with a differently sized or formatted allocation. Even when the arguments remain unchanged, the API permits a storage change, so the browser and driver may need to:

- validate the dimensions, format, and texture completeness again;
- allocate, replace, or orphan the backing GPU storage;
- update internal texture metadata;
- synchronize or defer allocation until the texture is used.

By contrast, `texSubImage2D` cannot change the allocation. It only writes pixels into storage whose size and format are already fixed, giving the implementation stronger guarantees.

The renderer’s CPU buffers and texture heights only grow, so the old `texImage2D` calls also upload the largest allocation observed rather than the rows required by the current frame.

## Solution

Allocate these data textures with immutable `texStorage2D` storage and update their contents using `texSubImage2D`.

- Recreate immutable storage only when a texture must grow.
- Upload only the full-width rows containing current-frame data.
- Leave unused rows untouched because current-frame shader indices cannot reference them.
- Allocate one mip level because these data textures do not use mipmapping.

## Expected Performance Impact

The improvement should primarily appear in CPU time inside `WebGlRenderer::render`, specifically during per-frame texture uploads:

- less browser/driver allocation and validation work;
- fewer opportunities for allocation-related stalls or pipeline flushes;
- lower CPU-to-GPU transfer volume when the current frame is smaller than the historical peak;
- more stable frame times after temporary workload spikes grow the textures.

The largest improvement should occur when a heavy frame is followed by smaller frames. Previously, every smaller frame continued re-specifying and uploading the peak-sized texture; now it uploads only its active rows.

Frames that grow a texture still require a new allocation, but growth is infrequent because capacity only increases. Frames that genuinely use the full peak allocation will transfer approximately the same amount of data as before.

## References

- [MDN: WebGL best practices — Use `texStorage` to create textures](https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices#use_texstorage_to_create_textures) explains that independently specified `texImage` mip levels prevent drivers from preparing texture memory until draw time. It recommends `texStorage` + `texSubImage` for WebGL 2 and notes that some drivers may otherwise allocate an unnecessary full mip chain, adding approximately 30% memory.
- [MDN: `texStorage2D`](https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext/texStorage2D) documents allocating texture levels with fixed dimensions and format.

- [Khronos: Texture Storage](https://wikis.khronos.org/opengl/Texture_Storage) explains the fundamental difference between mutable and immutable allocation. Mutable storage is defined one mip level at a time with `glTexImage*`, and those levels can later be replaced with different dimensions or formats. This leaves the application responsible for maintaining texture completeness. Immutable storage allocates all requested levels together with fixed dimensions and formats. Importantly, “immutable” applies only to the allocation — not its pixel contents. The contents can still be replaced repeatedly with `glTexSubImage*`. For Vello, this means the backing allocation remains stable between frames while frame-specific data can still be uploaded normally.
- [Khronos: Pixel Transfer](https://wikis.khronos.org/opengl/Pixel_Transfer) explicitly separates allocation from updating:
  - `glTexImage*` **allocates mutable storage** for a mip level and optionally writes pixel data.
  - `glTexSubImage*` only **writes pixel data into existing storage**.

  This distinction is directly relevant to Vello. The old code used the allocation-capable `texImage2D` operation for every frame update, even when the texture dimensions and format had not changed. The new code uses `texStorage2D` only when creating or growing a texture, then uses the update-only `texSubImage2D` path during normal frames. That communicates to the driver that no allocation or format change is possible during routine uploads.

These Khronos pages describe OpenGL, but the same storage-versus-content model underlies the equivalent WebGL 2 APIs. They establish the semantic reason for using `texStorage2D`; they do not by themselves guarantee a particular performance improvement.

Created with assistance from GPT-5.6 Sol.