### PR TITLE
vello_bench: Add a benchmark for ` take_unpremultiplied` 

### DIFF
--- a/sparse_strips/vello_bench/src/pixmap.rs
+++ b/sparse_strips/vello_bench/src/pixmap.rs
@@ -32,5 +32,18 @@ pub fn pixmap(c: &mut Criterion) {
             BatchSize::LargeInput,
         );
     });
+    let pixmap = Pixmap::from_parts(
+        rgba,
+        WIDTH,
+        HEIGHT,
+        PixelMetadata::new(ImageAlphaType::Alpha, true),
+    );
+    group.bench_function("take_unpremultiplied", |b| {
+        b.iter_batched(
+            || pixmap.clone(),
+            |pixmap| black_box(pixmap.take_unpremultiplied()),
+            BatchSize::LargeInput,
+        );
+    });
     group.finish();
 }


### PR DESCRIPTION
Currently pretty slow:

``` 
pixmap/take_unpremultiplied
                        time:   [2.5064 ms 2.5929 ms 2.6989 ms]
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) high mild
  7 (7.00%) high severe
``` 