### PR TITLE
vello_common: Optimize pixmap unpremultiplication

### DIFF
--- a/sparse_strips/vello_common/src/pixmap.rs
+++ b/sparse_strips/vello_common/src/pixmap.rs
@@ -398,7 +398,7 @@ impl Pixmap {
     /// The pixels are in row-major order.
     pub fn take_unpremultiplied(mut self) -> Vec<Rgba8> {
         unpremultiply_rgba8(bytemuck::cast_slice_mut(&mut self.buf));
-        
+
         bytemuck::cast_vec(self.buf)
     }
 }
@@ -448,7 +448,7 @@ fn premultiply_rgba8(data: &mut [u8]) -> bool {
 /// Unpremultiplies each RGBA8 pixel in `data`.
 fn unpremultiply_rgba8(data: &mut [u8]) {
     let level = Level::try_detect().unwrap_or(Level::baseline());
-    
+
     dispatch!(level, simd => unpremultiply_rgba8_impl(simd, data));
 }
 

--- a/sparse_strips/vello_common/src/pixmap.rs
+++ b/sparse_strips/vello_common/src/pixmap.rs
@@ -400,7 +400,9 @@ impl Pixmap {
     ///
     /// The pixels are in row-major order.
     pub fn take_unpremultiplied(mut self) -> Vec<Rgba8> {
-        unpremultiply_rgba8(bytemuck::cast_slice_mut(&mut self.buf));
+        if self.may_have_transparency {
+            unpremultiply_rgba8(bytemuck::cast_slice_mut(&mut self.buf));
+        }
 
         bytemuck::cast_vec(self.buf)
     }

--- a/sparse_strips/vello_common/src/pixmap.rs
+++ b/sparse_strips/vello_common/src/pixmap.rs
@@ -95,6 +95,9 @@ impl Pixmap {
 
     /// Create a new pixmap from the given buffer of bytes, representing pixel data.
     ///
+    /// When passing premultiplied pixels, the data must be correctly premultiplied, i.e. each RGB
+    /// component must be less than or equal to its pixel's alpha component.
+    ///
     /// # Panics
     ///
     /// - Panics if `data` is not exactly `width * height * 4` bytes long.

--- a/sparse_strips/vello_common/src/pixmap.rs
+++ b/sparse_strips/vello_common/src/pixmap.rs
@@ -8,12 +8,12 @@ use alloc::vec::Vec;
 #[cfg(feature = "png")]
 use std::io::{BufRead, Seek};
 
-use crate::fearless_simd::{Level, Simd, SimdBase, SimdInt, SimdMask, dispatch, mask8x16};
+use crate::fearless_simd::{Level, Simd, SimdBase, SimdInt, SimdMask, dispatch, mask8x16, u16x16};
 use crate::peniko::{
     ImageAlphaType,
     color::{PremulRgba8, Rgba8},
 };
-use crate::util::Div255Ext;
+use crate::util::{Div255Ext, unpremultiply};
 
 #[cfg(feature = "png")]
 extern crate std;
@@ -395,28 +395,11 @@ impl Pixmap {
 
     /// Consume the pixmap, returning the data as (unpremultiplied) RGBA8.
     ///
-    /// Not fast, but useful for saving to PNG etc.
-    ///
     /// The pixels are in row-major order.
-    pub fn take_unpremultiplied(self) -> Vec<Rgba8> {
-        self.buf
-            .into_iter()
-            .map(|PremulRgba8 { r, g, b, a }| {
-                let alpha = 255.0 / f32::from(a);
-                if a != 0 {
-                    #[expect(clippy::cast_possible_truncation, reason = "deliberate quantization")]
-                    let unpremultiply = |component| (f32::from(component) * alpha + 0.5) as u8;
-                    Rgba8 {
-                        r: unpremultiply(r),
-                        g: unpremultiply(g),
-                        b: unpremultiply(b),
-                        a,
-                    }
-                } else {
-                    Rgba8 { r, g, b, a }
-                }
-            })
-            .collect()
+    pub fn take_unpremultiplied(mut self) -> Vec<Rgba8> {
+        unpremultiply_rgba8(bytemuck::cast_slice_mut(&mut self.buf));
+        
+        bytemuck::cast_vec(self.buf)
     }
 }
 
@@ -460,6 +443,39 @@ fn premultiply_rgba8(data: &mut [u8]) -> bool {
     let level = Level::try_detect().unwrap_or(Level::baseline());
 
     dispatch!(level, simd => premultiply_rgba8_impl(simd, data))
+}
+
+/// Unpremultiplies each RGBA8 pixel in `data`.
+fn unpremultiply_rgba8(data: &mut [u8]) {
+    let level = Level::try_detect().unwrap_or(Level::baseline());
+    
+    dispatch!(level, simd => unpremultiply_rgba8_impl(simd, data));
+}
+
+#[inline(always)]
+fn unpremultiply_rgba8_impl<S: Simd>(simd: S, data: &mut [u8]) {
+    let (body, tail) = data.as_chunks_mut::<64>();
+
+    for chunk in body {
+        let rgba = simd.load_interleaved_128_u8x64(chunk);
+        let (rg, ba) = simd.split_u8x64(rgba);
+        let (r, g) = simd.split_u8x32(rg);
+        let (b, a) = simd.split_u8x32(ba);
+        let reciprocal = u16x16::from_fn(simd, |lane| unpremultiply::reciprocal(a[lane]));
+        let r = unpremultiply::simd(simd, r, reciprocal);
+        let g = unpremultiply::simd(simd, g, reciprocal);
+        let b = unpremultiply::simd(simd, b, reciprocal);
+
+        let rgba = simd.combine_u8x32(simd.combine_u8x16(r, g), simd.combine_u8x16(b, a));
+        simd.store_interleaved_128_u8x64(rgba, chunk);
+    }
+
+    for pixel in tail.chunks_exact_mut(4) {
+        let reciprocal = unpremultiply::reciprocal(pixel[3]);
+        for component in &mut pixel[..3] {
+            *component = unpremultiply::scalar(*component, reciprocal);
+        }
+    }
 }
 
 #[inline(always)]

--- a/sparse_strips/vello_common/src/util.rs
+++ b/sparse_strips/vello_common/src/util.rs
@@ -369,6 +369,139 @@ pub fn strip_bbox(strips: &[Strip]) -> Option<RectU16> {
     }
 }
 
+pub(crate) mod unpremultiply {
+    use fearless_simd::{Simd, SimdBase, u8x16, u16x16};
+
+    trait Div256Ext {
+        /// Divide by 256, rounding to the nearest integer.
+        ///
+        /// Values must not exceed `u16::MAX - 128`.
+        fn div_256(self) -> Self;
+    }
+
+    impl Div256Ext for u16 {
+        #[inline(always)]
+        fn div_256(self) -> Self {
+            (self + 128) >> 8
+        }
+    }
+
+    impl<S: Simd> Div256Ext for u16x16<S> {
+        #[inline(always)]
+        fn div_256(self) -> Self {
+            (self + Self::splat(self.simd, 128)) >> 8
+        }
+    }
+
+    // Unlike premultiplication, unpremultiplication is difficult to perform
+    // efficiently with SIMD because the divisor varies for each pixel.
+    // Premultiplication computes `rgb * alpha / 255`, while
+    // unpremultiplication computes `rgb * 255 / alpha`.
+    //
+    // Therefore, what we do instead is that we precompute the reciprocal
+    // 255 / alpha for each possible alpha value such that the
+    // computation simply becomes rgb * reciprocal. We do this using fixed-point
+    // artithmetic with 8 fractional digits, hence why we need to multiply and
+    // divide by 256.
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "all generated reciprocals fit into a u16"
+    )]
+    const fn reciprocals() -> [u16; 256] {
+        let mut values = [0; 256];
+
+        // When alpha is 0, so are the RGB channels so it just stays
+        // 0.
+        let mut alpha = 1;
+
+        while alpha < 256 {
+            let round_factor = alpha / 2;
+            values[alpha] = ((255 * 256 + round_factor) / alpha) as u16;
+            alpha += 1;
+        }
+
+        values
+    }
+
+    const RECIPROCALS: [u16; 256] = reciprocals();
+
+    #[inline(always)]
+    pub(crate) const fn reciprocal(alpha: u8) -> u16 {
+        RECIPROCALS[alpha as usize]
+    }
+
+    #[inline(always)]
+    pub(crate) fn scalar(component: u8, reciprocal: u16) -> u8 {
+        (u16::from(component) * reciprocal).div_256() as u8
+    }
+
+    #[inline(always)]
+    pub(crate) fn simd<S: Simd>(simd: S, component: u8x16<S>, reciprocal: u16x16<S>) -> u8x16<S> {
+        let product = simd.widen_u8x16(component) * reciprocal;
+        simd.narrow_u16x16(product.div_256())
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use fearless_simd::{Level, SimdBase, dispatch, u8x16, u16x16};
+
+        use super::{reciprocal, scalar, simd as unpremultiply_simd};
+
+        fn assert_accurate(component: u8, alpha: u8, actual: u8) {
+            // For 0 and 255 we want exact matches, otherwise we tolerate
+            // a delta of at most 1 compared to f32.
+
+            if component == 0 || alpha == 0 || alpha == 255 {
+                assert_eq!(actual, component);
+            } else if component == alpha {
+                assert_eq!(actual, 255);
+            } else {
+                let expected = (f32::from(component) * 255.0 / f32::from(alpha) + 0.5) as u8;
+
+                assert!(
+                    actual.abs_diff(expected) <= 1,
+                    "component {component} with alpha {alpha} produced {actual} instead of {expected}"
+                );
+            }
+        }
+
+        #[test]
+        fn scalar_exhaustive() {
+            for alpha in 0_u8..=255 {
+                for component in 0_u8..=alpha {
+                    assert_accurate(component, alpha, scalar(component, reciprocal(alpha)));
+                }
+            }
+        }
+
+        #[test]
+        fn simd_exhaustive() {
+            let level = Level::try_detect().unwrap_or(Level::baseline());
+
+            dispatch!(level, simd => {
+                for alpha in 0_u8..=255 {
+                    let alpha_simd = u8x16::splat(simd, alpha);
+                    let reciprocal =
+                        u16x16::from_fn(simd, |lane| reciprocal(alpha_simd[lane]));
+
+                    for component_start in (0_u16..=u16::from(alpha)).step_by(16) {
+                        let component = u8x16::from_fn(simd, |lane| {
+                            (component_start + lane as u16).min(u16::from(alpha)) as u8
+                        });
+                        let actual = unpremultiply_simd(simd, component, reciprocal);
+
+                        for lane in 0..16 {
+                            let component = component[lane];
+                            assert_accurate(component, alpha, actual[lane]);
+                        }
+                    }
+                }
+            });
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::RectU16;

--- a/sparse_strips/vello_common/src/util.rs
+++ b/sparse_strips/vello_common/src/util.rs
@@ -433,7 +433,7 @@ pub(crate) mod unpremultiply {
 
     #[inline(always)]
     pub(crate) fn scalar(component: u8, reciprocal: u16) -> u8 {
-        (u16::from(component) * reciprocal).div_256() as u8
+        u16::from(component).wrapping_mul(reciprocal).div_256() as u8
     }
 
     #[inline(always)]

--- a/sparse_strips/vello_sparse_tests/snapshots/gradient_color_alpha_unmul.png
+++ b/sparse_strips/vello_sparse_tests/snapshots/gradient_color_alpha_unmul.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:abdcde1d89e80b4b9f07e4834b6d1883e976404b95522e206595f4394c16815a
-size 299
+oid sha256:1de2c56a4c18c764659939d678595fe6437db5da4420b271d7db038966c19ee2
+size 314


### PR DESCRIPTION
Builds on top of #1838. This PR adds SIMD acceleration for the pixmap unpremultiplication method. Unfortunately, unpremultiplying is fundamentally harder than premutiplying because we need to divide by (a non-constant) integer, which isn't well supported in SIMD. I experimented with various different approaches, such as using SIMD but with f32 instead, but this one seemed to be by far the fastest.

I also tested this in my PDF library and didn't see any regressions.

## NEON
Before:
``` 
pixmap/take_unpremultiplied
                        time:   [2.2905 ms 2.3092 ms 2.3296 ms]
                        change: [+156.03% +161.53% +166.71%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
``` 

After:
``` 
pixmap/take_unpremultiplied
                        time:   [920.59 µs 944.89 µs 969.06 µs]
                        change: [-61.151% -60.308% -59.391%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
``` 

It's still 2-3 times slower than premultiplying, but at least it's faster than before! The gather for the reciprocals is unfortunately pretty expensive.

## AVX2
I can't check currently, unfortunately, but will test this as soon as I have access to my device again.