### PR TITLE
feat: expose ordered render command prefix

### DIFF
--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -160,7 +160,7 @@ use wgpu_engine::{ExternalResource, WgpuEngine};
 #[cfg(feature = "wgpu")]
 use std::{num::NonZeroUsize, sync::atomic::AtomicBool};
 #[cfg(feature = "wgpu")]
-use wgpu::{Device, Queue, TextureView};
+use wgpu::{CommandBuffer, Device, Queue, TextureView};
 #[cfg(all(feature = "wgpu", feature = "wgpu-profiler"))]
 use wgpu_profiler::{GpuProfiler, GpuProfilerSettings};
 
@@ -479,6 +479,26 @@ impl Renderer {
         texture: &TextureView,
         params: &RenderParams,
     ) -> Result<()> {
+        self.render_to_texture_with_command_buffer(device, queue, scene, texture, params, None)
+    }
+
+    /// Renders a scene to the target texture, optionally after a caller-provided command buffer.
+    ///
+    /// This is an advanced API. When `prefix` is `Some`, Vello consumes the command buffer and
+    /// submits it immediately before its internally encoded render command buffer in the same
+    /// [`wgpu::Queue::submit`] call. The command buffer must have been created from `device` and
+    /// is dropped without submission if recording the Vello render fails.
+    ///
+    /// When `prefix` is `None`, this has the same behavior as [`Self::render_to_texture`].
+    pub fn render_to_texture_with_command_buffer(
+        &mut self,
+        device: &Device,
+        queue: &Queue,
+        scene: &Scene,
+        texture: &TextureView,
+        params: &RenderParams,
+        prefix: Option<CommandBuffer>,
+    ) -> Result<()> {
         let (recording, target) = render::render_full(
             scene,
             &mut self.resolver,
@@ -496,6 +516,7 @@ impl Renderer {
             &recording,
             &external_resources,
             "render_to_texture",
+            prefix,
             #[cfg(feature = "wgpu-profiler")]
             &mut self.profiler,
         )?;
@@ -695,6 +716,7 @@ impl Renderer {
                 &recording,
                 &external_resources,
                 "render_to_texture_async debug layers",
+                None,
                 #[cfg(feature = "wgpu-profiler")]
                 &mut self.profiler,
             )?;
@@ -746,6 +768,7 @@ impl Renderer {
             &recording,
             &[],
             "t_async_coarse",
+            None,
             #[cfg(feature = "wgpu-profiler")]
             &mut self.profiler,
         )?;
@@ -772,6 +795,7 @@ impl Renderer {
             &recording,
             &external_resources,
             "t_async_fine",
+            None,
             #[cfg(feature = "wgpu-profiler")]
             &mut self.profiler,
         )?;

--- a/vello/src/wgpu_engine.rs
+++ b/vello/src/wgpu_engine.rs
@@ -7,9 +7,10 @@ use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 
 use wgpu::{
-    BindGroup, BindGroupLayout, Buffer, BufferUsages, CommandEncoder, CommandEncoderDescriptor,
-    ComputePassDescriptor, ComputePipeline, Device, PipelineCache, PipelineCompilationOptions,
-    Queue, Texture, TextureAspect, TextureUsages, TextureView, TextureViewDimension,
+    BindGroup, BindGroupLayout, Buffer, BufferUsages, CommandBuffer, CommandEncoder,
+    CommandEncoderDescriptor, ComputePassDescriptor, ComputePipeline, Device, PipelineCache,
+    PipelineCompilationOptions, Queue, Texture, TextureAspect, TextureUsages, TextureView,
+    TextureViewDimension,
 };
 
 use crate::{
@@ -138,6 +139,19 @@ struct TransientBindMap<'a> {
 enum TransientBuf<'a> {
     Cpu(&'a [u8]),
     Gpu(&'a Buffer),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum CommandBufferSubmission<T> {
+    Render(T),
+    PrefixAndRender(T, T),
+}
+
+fn command_buffer_submission<T>(prefix: Option<T>, render: T) -> CommandBufferSubmission<T> {
+    match prefix {
+        Some(prefix) => CommandBufferSubmission::PrefixAndRender(prefix, render),
+        None => CommandBufferSubmission::Render(render),
+    }
 }
 
 impl WgpuEngine {
@@ -384,6 +398,7 @@ impl WgpuEngine {
         recording: &Recording,
         external_resources: &[ExternalResource<'_>],
         label: &'static str,
+        prefix: Option<CommandBuffer>,
         #[cfg(feature = "wgpu-profiler")] profiler: &mut wgpu_profiler::GpuProfiler,
     ) -> Result<()> {
         let mut free_bufs: HashSet<ResourceId> = HashSet::default();
@@ -754,7 +769,14 @@ impl WgpuEngine {
         // TODO: This only actually needs to happen once per frame, but run_recording happens two or three times
         #[cfg(feature = "wgpu-profiler")]
         profiler.resolve_queries(&mut encoder);
-        queue.submit(Some(encoder.finish()));
+        match command_buffer_submission(prefix, encoder.finish()) {
+            CommandBufferSubmission::PrefixAndRender(prefix, render) => {
+                queue.submit([prefix, render]);
+            }
+            CommandBufferSubmission::Render(render) => {
+                queue.submit(Some(render));
+            }
+        };
         for id in free_bufs {
             if let Some(buf) = self.bind_map.buf_map.remove(&id)
                 && let MaterializedBuffer::Gpu(gpu_buf) = buf.buffer
@@ -1243,5 +1265,22 @@ impl<'a> TransientBindMap<'a> {
                 ResourceProxy::Image(_) => todo!(),
             })
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CommandBufferSubmission, command_buffer_submission};
+
+    #[test]
+    fn command_buffer_submission_preserves_prefix_order_and_fallback() {
+        assert_eq!(
+            command_buffer_submission(Some("prefix"), "render"),
+            CommandBufferSubmission::PrefixAndRender("prefix", "render")
+        );
+        assert_eq!(
+            command_buffer_submission(None, "render"),
+            CommandBufferSubmission::Render("render")
+        );
     }
 }


### PR DESCRIPTION
## Goal\n\nProvide an additive Vello rendering hook that lets a host place one caller-owned command buffer immediately before Vello internal render work in the same queue submission.\n\n## Scope\n\n- Add Renderer::render_to_texture_with_command_buffer with an optional wgpu CommandBuffer prefix.\n- Keep Renderer::render_to_texture signature-compatible and preserve its existing no-prefix path.\n- Submit prefix then Vello render commands through one Queue::submit call.\n- Add focused deterministic coverage for prefix ordering and the no-prefix fallback.\n- Document ownership and failure behavior.\n\n## Non-goals\n\n- No wgpu-profiler changes.\n- No requirement for TIMESTAMP_QUERY_INSIDE_PASSES.\n- No GPU timing policy, readback, or presentation behavior.\n- No Radiant source changes; this is the dependency prerequisite for a later host integration.\n\n## Definition of done\n\n- Existing callers retain the same API and behavior.\n- A supplied prefix is consumed and submitted exactly once before Vello work.\n- Recording failures never submit the prefix independently.\n- No-prefix callers retain the prior single-buffer submission path.\n- Focused tests and the project checks pass.\n\n## Validation and results\n\n- cargo fmt --all -- --check\n- cargo check -p vello --locked\n- cargo check -p vello --all-features --locked\n- cargo check -p vello --no-default-features --locked\n- cargo check -p vello --features wgpu-profiler --locked\n- cargo test -p vello --all-features --lib --locked\n- cargo test -p vello --doc --locked\n- cargo test -p vello_tests --no-run --locked\n- cargo clippy -p vello --all-targets --all-features --locked\n- git diff --check\n- Existing filled_square_gpu smoke passed.\n\nOnly pre-existing lint warnings were emitted. No GPU runtime integration was added because this hook only establishes queue submission ordering.\n\n## Known limitations\n\nRadiant currently consumes Vello 0.9.0. The follow-up Radiant producer will use this hook after an upstream Vello release containing it.\n\nPlease do not merge until PORTALSURFER explicitly approves the reviewed PR head.