### PR TITLE
vello_bench: Add more varied pixmap benchmarks

### DIFF
--- a/sparse_strips/vello_bench/src/pixmap.rs
+++ b/sparse_strips/vello_bench/src/pixmap.rs
@@ -16,6 +16,7 @@ pub fn pixmap(c: &mut Criterion) {
         ("opaque", OPAQUE_BLUE.repeat(pixel_count)),
         ("translucent", TRANSLUCENT_BLUE.repeat(pixel_count)),
         ("interleaved", interleaved_pixels(pixel_count)),
+        ("mixed_lanes", mixed_lane_pixels(pixel_count)),
     ];
 
     let mut group = c.benchmark_group("pixmap/premultiply");
@@ -66,6 +67,19 @@ fn interleaved_pixels(pixel_count: usize) -> Vec<u8> {
     let mut rgba = Vec::with_capacity(pixel_count * 4);
     for index in 0..pixel_count {
         let pixel = if (index / 16).is_multiple_of(2) {
+            TRANSLUCENT_BLUE
+        } else {
+            OPAQUE_BLUE
+        };
+        rgba.extend_from_slice(&pixel);
+    }
+    rgba
+}
+
+fn mixed_lane_pixels(pixel_count: usize) -> Vec<u8> {
+    let mut rgba = Vec::with_capacity(pixel_count * 4);
+    for index in 0..pixel_count {
+        let pixel = if (index / 8).is_multiple_of(2) {
             TRANSLUCENT_BLUE
         } else {
             OPAQUE_BLUE

--- a/sparse_strips/vello_bench/src/pixmap.rs
+++ b/sparse_strips/vello_bench/src/pixmap.rs
@@ -7,43 +7,70 @@ use vello_common::pixmap::{PixelMetadata, Pixmap};
 
 const WIDTH: u16 = 1920;
 const HEIGHT: u16 = 1080;
+const OPAQUE_BLUE: [u8; 4] = [0, 0, 255, 255];
+const TRANSLUCENT_BLUE: [u8; 4] = [0, 0, 255, 128];
 
 pub fn pixmap(c: &mut Criterion) {
     let pixel_count = usize::from(WIDTH) * usize::from(HEIGHT);
+    let inputs = [
+        ("opaque", OPAQUE_BLUE.repeat(pixel_count)),
+        ("translucent", TRANSLUCENT_BLUE.repeat(pixel_count)),
+        ("interleaved", interleaved_pixels(pixel_count)),
+    ];
+
+    let mut group = c.benchmark_group("pixmap/premultiply");
+    for (name, rgba) in &inputs {
+        group.bench_function(*name, |b| {
+            b.iter_batched(
+                || rgba.clone(),
+                |rgba| {
+                    black_box(Pixmap::from_parts(
+                        rgba,
+                        WIDTH,
+                        HEIGHT,
+                        PixelMetadata::new(ImageAlphaType::Alpha, true),
+                    ));
+                },
+                BatchSize::LargeInput,
+            );
+        });
+    }
+    group.finish();
+
+    let pixmaps = inputs.map(|(name, rgba)| {
+        (
+            name,
+            Pixmap::from_parts(
+                rgba,
+                WIDTH,
+                HEIGHT,
+                PixelMetadata::new(ImageAlphaType::Alpha, true),
+            ),
+        )
+    });
+
+    let mut group = c.benchmark_group("pixmap/unpremultiply");
+    for (name, pixmap) in &pixmaps {
+        group.bench_function(*name, |b| {
+            b.iter_batched(
+                || pixmap.clone(),
+                |pixmap| black_box(pixmap.take_unpremultiplied()),
+                BatchSize::LargeInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+fn interleaved_pixels(pixel_count: usize) -> Vec<u8> {
     let mut rgba = Vec::with_capacity(pixel_count * 4);
     for index in 0..pixel_count {
-        let value = index.to_le_bytes()[0];
-        let alpha = if index.is_multiple_of(8) { 128 } else { 255 };
-        rgba.extend_from_slice(&[value, 255 - value, value / 2, alpha]);
+        let pixel = if (index / 16).is_multiple_of(2) {
+            TRANSLUCENT_BLUE
+        } else {
+            OPAQUE_BLUE
+        };
+        rgba.extend_from_slice(&pixel);
     }
-
-    let mut group = c.benchmark_group("pixmap");
-    group.bench_function("new", |b| {
-        b.iter_batched(
-            || rgba.clone(),
-            |rgba| {
-                black_box(Pixmap::from_parts(
-                    rgba,
-                    WIDTH,
-                    HEIGHT,
-                    PixelMetadata::new(ImageAlphaType::Alpha, true),
-                ));
-            },
-            BatchSize::LargeInput,
-        );
-    });
-    let pixmap = Pixmap::from_parts(
-        rgba,
-        WIDTH,
-        HEIGHT,
-        PixelMetadata::new(ImageAlphaType::Alpha, true),
-    );
-    group.bench_function("take_unpremultiplied", |b| {
-        b.iter_batched(
-            || pixmap.clone(),
-            |pixmap| black_box(pixmap.take_unpremultiplied()),
-            BatchSize::LargeInput,
-        );
-    });
-    group.finish();
+    rgba
 }


### PR DESCRIPTION
This PR extend the existing benchmarks to cover three different cases: A fully opaque image, a fully translucent image and an interleaved image, where the two alternate. This is in preparation for a follow-up PR which adds some more optimizations to show that they are worth it.