### PR TITLE
sparse_strips: Fix issues on big-endian targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,40 +346,6 @@ jobs:
       - name: cargo test --doc
         run: cargo test --doc --workspace --locked --all-features --no-fail-fast
 
-  test-stable-big-endian:
-    name: cargo test (big-endian, powerpc64)
-    needs: prime-lfs-cache
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Restore lfs cache
-        id: lfs-cache
-        uses: actions/cache/restore@v4
-        with:
-          path: .git/lfs
-          key: vello-lfs-${{ needs.prime-lfs-cache.outputs.lfs-hash }}
-          enableCrossOsArchive: true
-
-      - name: Checkout LFS files
-        run: git lfs checkout '${{ join(fromJson(env.LFS_FILES), ''' ''') }}'
-        continue-on-error: true
-
-      - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUST_STABLE_VER }}
-
-      - name: install cross
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cross
-
-      - name: cargo test
-        run: cross test -p vello_sparse_tests --test tests --locked --release --target powerpc64-unknown-linux-gnu _scalar
-        env:
-          CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS: "true"
-
   test-stable-wasm:
     name: cargo test (wasm32, ${{ matrix.name }})
     needs: prime-lfs-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,6 +346,40 @@ jobs:
       - name: cargo test --doc
         run: cargo test --doc --workspace --locked --all-features --no-fail-fast
 
+  test-stable-big-endian:
+    name: cargo test (big-endian, powerpc64)
+    needs: prime-lfs-cache
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Restore lfs cache
+        id: lfs-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .git/lfs
+          key: vello-lfs-${{ needs.prime-lfs-cache.outputs.lfs-hash }}
+          enableCrossOsArchive: true
+
+      - name: Checkout LFS files
+        run: git lfs checkout '${{ join(fromJson(env.LFS_FILES), ''' ''') }}'
+        continue-on-error: true
+
+      - name: install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE_VER }}
+
+      - name: install cross
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+
+      - name: cargo test
+        run: cross test -p vello_sparse_tests --test tests --locked --release --target powerpc64-unknown-linux-gnu _scalar
+        env:
+          CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS: "true"
+
   test-stable-wasm:
     name: cargo test (wasm32, ${{ matrix.name }})
     needs: prime-lfs-cache

--- a/sparse_strips/vello_common/src/util.rs
+++ b/sparse_strips/vello_common/src/util.rs
@@ -31,9 +31,23 @@ pub fn f32_to_u8<S: Simd>(val: f32x16<S>) -> u8x16<S> {
     let (p1, p2) = simd.split_u8x32(x8_1);
     let (p3, p4) = simd.split_u8x32(x8_2);
 
-    let uzp1 = simd.unzip_low_u8x16(p1, p2);
-    let uzp2 = simd.unzip_low_u8x16(p3, p4);
-    simd.unzip_low_u8x16(uzp1, uzp2)
+    #[cfg(target_endian = "little")]
+    let result = {
+        let uzp1 = simd.unzip_low_u8x16(p1, p2);
+        let uzp2 = simd.unzip_low_u8x16(p3, p4);
+
+        simd.unzip_low_u8x16(uzp1, uzp2)
+    };
+
+    #[cfg(target_endian = "big")]
+    let result = {
+        let uzp1 = simd.unzip_high_u8x16(p1, p2);
+        let uzp2 = simd.unzip_high_u8x16(p3, p4);
+
+        simd.unzip_high_u8x16(uzp1, uzp2)
+    };
+
+    result
 }
 
 /// A trait for implementing a fast approximal division by 255 for integers.

--- a/sparse_strips/vello_cpu/src/fine/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/mod.rs
@@ -134,25 +134,36 @@ pub(crate) fn u8_to_f32<S: Simd>(val: u8x16<S>) -> f32x16<S> {
     let simd = val.simd;
     let zeroes = u8x16::splat(simd, 0);
 
-    let zip1 = simd.zip_high_u8x16(val, zeroes);
-    let zip2 = simd.zip_low_u8x16(val, zeroes);
+    #[cfg(target_endian = "little")]
+    let (p1, p2, p3, p4) = {
+        let lo = simd.zip_low_u8x16(val, zeroes);
+        let hi = simd.zip_high_u8x16(val, zeroes);
 
-    let p1 = simd
-        .zip_low_u8x16(zip2, zeroes)
-        .bitcast::<u32x4<S>>()
-        .to_float::<f32x4<S>>();
-    let p2 = simd
-        .zip_high_u8x16(zip2, zeroes)
-        .bitcast::<u32x4<S>>()
-        .to_float::<f32x4<S>>();
-    let p3 = simd
-        .zip_low_u8x16(zip1, zeroes)
-        .bitcast::<u32x4<S>>()
-        .to_float::<f32x4<S>>();
-    let p4 = simd
-        .zip_high_u8x16(zip1, zeroes)
-        .bitcast::<u32x4<S>>()
-        .to_float::<f32x4<S>>();
+        (
+            simd.zip_low_u8x16(lo, zeroes),
+            simd.zip_high_u8x16(lo, zeroes),
+            simd.zip_low_u8x16(hi, zeroes),
+            simd.zip_high_u8x16(hi, zeroes),
+        )
+    };
+
+    #[cfg(target_endian = "big")]
+    let (p1, p2, p3, p4) = {
+        let lo = simd.zip_low_u8x16(zeroes, val);
+        let hi = simd.zip_high_u8x16(zeroes, val);
+
+        (
+            simd.zip_low_u8x16(zeroes, lo),
+            simd.zip_high_u8x16(zeroes, lo),
+            simd.zip_low_u8x16(zeroes, hi),
+            simd.zip_high_u8x16(zeroes, hi),
+        )
+    };
+
+    let p1 = p1.bitcast::<u32x4<S>>().to_float::<f32x4<S>>();
+    let p2 = p2.bitcast::<u32x4<S>>().to_float::<f32x4<S>>();
+    let p3 = p3.bitcast::<u32x4<S>>().to_float::<f32x4<S>>();
+    let p4 = p4.bitcast::<u32x4<S>>().to_float::<f32x4<S>>();
 
     simd.combine_f32x8(simd.combine_f32x4(p1, p2), simd.combine_f32x4(p3, p4))
 }


### PR DESCRIPTION
First commit adds a CI step that runs (only scalar) tests from `vello_sparse_tests` on a big-endian target. As you can see, it's completetly broken.

Second commit fixes this by making the `u8_to_f32` and `f32_to_u8` methods aware of endianness