### PR TITLE
Re-export vello_encoding from the low_level module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 This release has an [MSRV][] of 1.88.
 
+### Added
+
+- `vello_encoding` is now re-exported from the `low_level` module. ([#1847][] by [@ChrisJr404][])
+
 ## [0.10.0][] - 2026-08-14
 
 This release has an [MSRV][] of 1.88.
@@ -327,6 +331,7 @@ This release has an [MSRV][] of 1.75.
 [@armansito]: https://github.com/armansito
 [@b0nes164]: https://github.com/b0nes164
 [@cfagot]: https://github.com/cfagot
+[@ChrisJr404]: https://github.com/ChrisJr404
 [@Cupnfish]: https://github.com/Cupnfish
 [@DasLixou]: https://github.com/DasLixou
 [@dfrg]: https://github.com/drfg
@@ -462,6 +467,7 @@ This release has an [MSRV][] of 1.75.
 [#1700]: https://github.com/linebender/vello/pull/1700
 [#1774]: https://github.com/linebender/vello/pull/1774
 [#1777]: https://github.com/linebender/vello/pull/1777
+[#1847]: https://github.com/linebender/vello/pull/1847
 
 [Unreleased]: https://github.com/linebender/vello/compare/v0.10.0...HEAD
 [0.10.0]: https://github.com/linebender/vello/compare/v0.9.0...v0.10.0

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -37,7 +37,9 @@ use scenes::{ExampleScene, ImageCache, SceneParams, SceneSet, SimpleText};
 use vello::kurbo::{Affine, Point, Vec2};
 use vello::peniko::{Color, color::palette};
 use vello::util::{RenderContext, RenderSurface};
-use vello::{AaConfig, Renderer, RendererOptions, Scene, low_level::BumpAllocators};
+use vello::{
+    AaConfig, Renderer, RendererOptions, Scene, low_level::vello_encoding::BumpAllocators,
+};
 
 use winit::dpi::LogicalSize;
 use winit::event_loop::EventLoop;

--- a/examples/with_winit/src/stats.rs
+++ b/examples/with_winit/src/stats.rs
@@ -7,7 +7,7 @@ use std::collections::VecDeque;
 use vello::kurbo::Line;
 use vello::kurbo::{Affine, PathEl, Rect, Stroke};
 use vello::peniko::{Brush, Color, Fill, color::palette};
-use vello::{AaConfig, Scene, low_level::BumpAllocators};
+use vello::{AaConfig, Scene, low_level::vello_encoding::BumpAllocators};
 
 #[cfg(all(feature = "wgpu-profiler", not(target_arch = "wasm32")))]
 use std::time::Duration;

--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -131,6 +131,12 @@ pub mod low_level {
     pub use crate::shaders::FullShaders;
     /// Temporary export, used in `with_winit` for stats
     pub use vello_encoding::BumpAllocators;
+
+    /// The scene encoding layer used to build an alternative renderer.
+    ///
+    /// This is re-exported so that consumers can depend on the same
+    /// `vello_encoding` version that `vello` was built against.
+    pub use vello_encoding;
 }
 /// Styling and composition primitives.
 pub use peniko;

--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -132,10 +132,6 @@ pub mod low_level {
     /// Temporary export, used in `with_winit` for stats
     pub use vello_encoding::BumpAllocators;
 
-    /// The scene encoding layer used to build an alternative renderer.
-    ///
-    /// This is re-exported so that consumers can depend on the same
-    /// `vello_encoding` version that `vello` was built against.
     pub use vello_encoding;
 }
 /// Styling and composition primitives.

--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -129,8 +129,6 @@ pub mod low_level {
     };
     pub use crate::render::Render;
     pub use crate::shaders::FullShaders;
-    /// Temporary export, used in `with_winit` for stats
-    pub use vello_encoding::BumpAllocators;
 
     pub use vello_encoding;
 }
@@ -149,13 +147,13 @@ pub use vello_encoding::{FontEmbolden, Glyph, NormalizedCoord};
 
 use low_level::ShaderId;
 #[cfg(feature = "wgpu")]
-use low_level::{BumpAllocators, FullShaders, Recording, Render};
+use low_level::{FullShaders, Recording, Render};
 use thiserror::Error;
 
 #[cfg(feature = "wgpu")]
 use debug::DebugLayers;
 #[cfg(feature = "wgpu")]
-use vello_encoding::Resolver;
+use vello_encoding::{BumpAllocators, Resolver};
 #[cfg(feature = "wgpu")]
 use wgpu_engine::{ExternalResource, WgpuEngine};
 


### PR DESCRIPTION
Closes #1290. This re-exports the `vello_encoding` crate from `vello::low_level` so consumers building an alternative renderer can reach the encoding types using the same version vello was built against, as suggested in the issue.