### PR TITLE
 feat: add browser performance panels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4553,6 +4553,8 @@ dependencies = [
  "vello_common",
  "vello_cpu",
  "vello_hybrid",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/sparse_strips/vello_cpu/examples/wasm_cpu/src/lib.rs
+++ b/sparse_strips/vello_cpu/examples/wasm_cpu/src/lib.rs
@@ -14,7 +14,11 @@ use std::{cell::RefCell, sync::Arc};
 use vello_common::kurbo::{Affine, Vec2};
 use vello_common::paint::ImageSource;
 use vello_cpu::RenderContext;
-use vello_example_scenes::{AnyScene, image::ImageScene};
+use vello_example_scenes::{
+    AnyScene,
+    image::ImageScene,
+    performance::{FrameTiming, PerformancePanel, PerformanceStage, now},
+};
 use wasm_bindgen::prelude::*;
 use web_sys::{Event, HtmlCanvasElement, KeyboardEvent, MouseEvent, WheelEvent};
 
@@ -30,7 +34,7 @@ struct AppState {
     renderer: RenderContext,
     resources: vello_cpu::Resources,
     pixmap: vello_common::pixmap::Pixmap,
-    need_render: bool,
+    performance: PerformancePanel<3>,
     canvas: HtmlCanvasElement,
 }
 
@@ -61,24 +65,44 @@ impl AppState {
             renderer,
             resources: vello_cpu::Resources::new(),
             pixmap,
-            need_render: true,
+            performance: PerformancePanel::new(
+                "Vello CPU · WASM",
+                [
+                    PerformanceStage {
+                        label: "Scene build",
+                        description: "CPU time to reset and populate the scene.",
+                        color: "#ef4444",
+                    },
+                    PerformanceStage {
+                        label: "Rasterize",
+                        description: "CPU time to rasterize the scene into the output pixmap.",
+                        color: "#f59e0b",
+                    },
+                    PerformanceStage {
+                        label: "Canvas upload",
+                        description: "CPU time to create ImageData and copy the pixels into the browser canvas.",
+                        color: "#3b82f6",
+                    },
+                ],
+                "Vello rendering is CPU-timed; browser canvas compositing is not timed",
+            ),
             canvas,
         }
     }
 
-    fn render(&mut self) {
-        if !self.need_render {
-            return;
-        }
+    fn render(&mut self) -> FrameTiming<3> {
+        let frame_start = now();
         self.renderer.reset();
         self.scenes[self.current_scene].render(
             &mut self.renderer,
             &mut self.resources,
             self.transform,
         );
+        let scene_end = now();
 
         // Render the current scene with transform
         self.renderer.render(&mut self.pixmap, &mut self.resources);
+        let raster_end = now();
         let rgba_bytes = self.pixmap.data_as_u8_slice();
         let image_data = web_sys::ImageData::new_with_u8_clamped_array_and_sh(
             wasm_bindgen::Clamped(rgba_bytes),
@@ -97,7 +121,30 @@ impl AppState {
         ctx_2d
             .put_image_data(&image_data, 0., 0.)
             .expect("Failed to put image data");
-        self.need_render = false;
+        let frame_end = now();
+
+        FrameTiming {
+            stages_ms: [
+                scene_end - frame_start,
+                raster_end - scene_end,
+                frame_end - raster_end,
+            ],
+            total_ms: frame_end - frame_start,
+        }
+    }
+
+    fn frame(&mut self, timestamp: f64) {
+        let timing = self.render();
+        let scene = self.current_scene + 1;
+        let scene_count = self.scenes.len();
+        self.performance.record(
+            timestamp,
+            Some(timing),
+            scene,
+            scene_count,
+            self.width,
+            self.height,
+        );
     }
 
     fn resize(&mut self, width: u32, height: u32) {
@@ -115,14 +162,13 @@ impl AppState {
                 ..Default::default()
             },
         );
-
-        self.need_render = true;
+        self.performance.reset();
     }
 
     fn next_scene(&mut self) {
         self.current_scene = (self.current_scene + 1) % self.scenes.len();
         self.transform = Affine::IDENTITY;
-        self.need_render = true;
+        self.performance.reset();
     }
 
     fn prev_scene(&mut self) {
@@ -132,19 +178,16 @@ impl AppState {
             self.current_scene - 1
         };
         self.transform = Affine::IDENTITY;
-        self.need_render = true;
+        self.performance.reset();
     }
 
     fn reset_transform(&mut self) {
         self.transform = Affine::IDENTITY;
-        self.need_render = true;
     }
 
     fn handle_key(&mut self, key: &str) {
-        if let Some(scene) = self.scenes.get_mut(self.current_scene)
-            && scene.handle_key(key)
-        {
-            self.need_render = true;
+        if let Some(scene) = self.scenes.get_mut(self.current_scene) {
+            scene.handle_key(key);
         }
     }
 
@@ -166,7 +209,6 @@ impl AppState {
         {
             let delta = current_pos - last_pos;
             self.transform = Affine::translate(delta) * self.transform;
-            self.need_render = true;
         }
 
         self.last_cursor_position = Some(current_pos);
@@ -183,8 +225,6 @@ impl AppState {
                 * Affine::scale(zoom_factor)
                 * Affine::translate(-cursor_pos)
                 * self.transform;
-
-            self.need_render = true;
         } else {
             // If no cursor position is known, zoom centered on screen
             let center = Vec2::new(self.width as f64 / 2.0, self.height as f64 / 2.0);
@@ -195,8 +235,6 @@ impl AppState {
                 * Affine::scale(zoom_factor)
                 * Affine::translate(-center)
                 * self.transform;
-
-            self.need_render = true;
         }
     }
 }
@@ -204,7 +242,7 @@ impl AppState {
 #[wasm_bindgen]
 extern "C" {
     #[wasm_bindgen(js_name = requestAnimationFrame)]
-    fn request_animation_frame(f: &Closure<dyn FnMut()>);
+    fn request_animation_frame(f: &Closure<dyn FnMut(f64)>);
 }
 
 /// Creates a `HTMLCanvasElement` of the given dimensions and renders the given scenes into it,
@@ -247,14 +285,14 @@ pub async fn run_interactive(canvas_width: u16, canvas_height: u16) {
 
     // Set up animation frame loop
     {
-        let f = Rc::new(RefCell::new(None));
+        let f = Rc::new(RefCell::new(None::<Closure<dyn FnMut(f64)>>));
         let g = f.clone();
         let app_state = app_state.clone();
 
-        *g.borrow_mut() = Some(Closure::wrap(Box::new(move || {
-            app_state.borrow_mut().render();
+        *g.borrow_mut() = Some(Closure::wrap(Box::new(move |timestamp: f64| {
+            app_state.borrow_mut().frame(timestamp);
             request_animation_frame(f.borrow().as_ref().unwrap());
-        }) as Box<dyn FnMut()>));
+        }) as Box<dyn FnMut(f64)>));
 
         request_animation_frame(g.borrow().as_ref().unwrap());
     }

--- a/sparse_strips/vello_example_scenes/Cargo.toml
+++ b/sparse_strips/vello_example_scenes/Cargo.toml
@@ -28,6 +28,16 @@ log = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 parley = { version = "0.11.0", default-features = false, features = ["std"] }
+wasm-bindgen = { workspace = true }
+web-sys = { workspace = true, features = [
+    "Window",
+    "Performance",
+    "Document",
+    "Node",
+    "Element",
+    "HtmlElement",
+    "CssStyleDeclaration",
+] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 parley = { version = "0.11.0", default-features = true }

--- a/sparse_strips/vello_example_scenes/src/lib.rs
+++ b/sparse_strips/vello_example_scenes/src/lib.rs
@@ -14,6 +14,8 @@ pub mod gradient;
 pub mod image;
 pub mod multi_image;
 pub mod path;
+#[cfg(target_arch = "wasm32")]
+pub mod performance;
 pub mod random_text;
 pub mod simple;
 pub mod spritesheet;

--- a/sparse_strips/vello_example_scenes/src/performance.rs
+++ b/sparse_strips/vello_example_scenes/src/performance.rs
@@ -1,0 +1,327 @@
+// Copyright 2025 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#![allow(missing_docs, reason = "Internal support for browser examples")]
+#![allow(
+    clippy::cast_possible_truncation,
+    reason = "Sample windows are bounded to 120 entries"
+)]
+
+use std::fmt::Write as _;
+use wasm_bindgen::JsCast;
+use web_sys::HtmlElement;
+
+const MAX_SAMPLES: usize = 120;
+const PANEL_UPDATE_INTERVAL_MS: f64 = 250.0;
+const SUSPENDED_FRAME_THRESHOLD_MS: f64 = 250.0;
+
+#[derive(Clone, Copy, Debug)]
+pub struct PerformanceStage {
+    pub label: &'static str,
+    pub description: &'static str,
+    pub color: &'static str,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct FrameTiming<const N: usize> {
+    pub stages_ms: [f64; N],
+    pub total_ms: f64,
+}
+
+#[derive(Debug)]
+pub struct PerformancePanel<const N: usize> {
+    backend: &'static str,
+    stages: [PerformanceStage; N],
+    timing_note: &'static str,
+    element: HtmlElement,
+    last_frame_timestamp: Option<f64>,
+    last_panel_update: f64,
+    frame_intervals: Vec<f64>,
+    stage_times: [Vec<f64>; N],
+    total_times: Vec<f64>,
+}
+
+impl<const N: usize> PerformancePanel<N> {
+    pub fn new(
+        backend: &'static str,
+        stages: [PerformanceStage; N],
+        timing_note: &'static str,
+    ) -> Self {
+        let document = web_sys::window().unwrap().document().unwrap();
+        let element: HtmlElement = document
+            .create_element("div")
+            .unwrap()
+            .dyn_into::<HtmlElement>()
+            .unwrap();
+        let style = element.style();
+        style.set_property("position", "fixed").unwrap();
+        style.set_property("right", "10px").unwrap();
+        style.set_property("bottom", "10px").unwrap();
+        style.set_property("z-index", "1").unwrap();
+        style
+            .set_property("background", "rgba(0, 0, 0, 0.75)")
+            .unwrap();
+        style.set_property("color", "white").unwrap();
+        style.set_property("padding", "8px 10px").unwrap();
+        style.set_property("border-radius", "5px").unwrap();
+        style
+            .set_property(
+                "font-family",
+                "ui-monospace, SFMono-Regular, Menlo, monospace",
+            )
+            .unwrap();
+        style.set_property("font-size", "12px").unwrap();
+        style.set_property("line-height", "1.45").unwrap();
+        style
+            .set_property("width", "min(420px, calc(100vw - 20px))")
+            .unwrap();
+        style
+            .set_property("max-width", "calc(100vw - 20px)")
+            .unwrap();
+        style.set_property("box-sizing", "border-box").unwrap();
+        style
+            .set_property("font-variant-numeric", "tabular-nums")
+            .unwrap();
+        style.set_property("pointer-events", "auto").unwrap();
+        element.set_inner_text("Collecting performance samples…");
+        document.body().unwrap().append_child(&element).unwrap();
+
+        Self {
+            backend,
+            stages,
+            timing_note,
+            element,
+            last_frame_timestamp: None,
+            last_panel_update: 0.0,
+            frame_intervals: Vec::with_capacity(MAX_SAMPLES),
+            stage_times: std::array::from_fn(|_| Vec::with_capacity(MAX_SAMPLES)),
+            total_times: Vec::with_capacity(MAX_SAMPLES),
+        }
+    }
+
+    pub fn record(
+        &mut self,
+        timestamp: f64,
+        timing: Option<FrameTiming<N>>,
+        scene: usize,
+        scene_count: usize,
+        width: u32,
+        height: u32,
+    ) {
+        if let Some(last_timestamp) = self.last_frame_timestamp {
+            let interval = timestamp - last_timestamp;
+            if interval > SUSPENDED_FRAME_THRESHOLD_MS {
+                self.clear_samples();
+            } else if interval > 0.0 {
+                push_sample(&mut self.frame_intervals, interval);
+            }
+        }
+        self.last_frame_timestamp = Some(timestamp);
+
+        if let Some(timing) = timing {
+            for (samples, duration) in self.stage_times.iter_mut().zip(timing.stages_ms) {
+                push_sample(samples, duration);
+            }
+            push_sample(&mut self.total_times, timing.total_ms);
+        }
+
+        if timestamp - self.last_panel_update < PANEL_UPDATE_INTERVAL_MS
+            && self.last_panel_update != 0.0
+        {
+            return;
+        }
+        if self.element.matches(":hover").unwrap_or(false) {
+            return;
+        }
+        self.last_panel_update = timestamp;
+        self.update_text(scene, scene_count, width, height);
+    }
+
+    pub fn reset(&mut self) {
+        self.clear_samples();
+        self.last_frame_timestamp = None;
+        self.last_panel_update = 0.0;
+    }
+
+    fn clear_samples(&mut self) {
+        self.frame_intervals.clear();
+        for samples in &mut self.stage_times {
+            samples.clear();
+        }
+        self.total_times.clear();
+    }
+
+    fn update_text(&self, scene: usize, scene_count: usize, width: u32, height: u32) {
+        let Some(frame) = SampleStats::from_samples(&self.frame_intervals) else {
+            return;
+        };
+        let Some(total) = SampleStats::from_samples(&self.total_times) else {
+            return;
+        };
+        let stage_stats = std::array::from_fn(|index| {
+            SampleStats::from_samples(&self.stage_times[index]).unwrap()
+        });
+
+        let html = format_panel_html(&PanelSnapshot {
+            backend: self.backend,
+            stages: &self.stages,
+            timing_note: self.timing_note,
+            scene,
+            scene_count,
+            width,
+            height,
+            frame: &frame,
+            total: &total,
+            stage_stats: &stage_stats,
+            sample_count: self.total_times.len(),
+        });
+        self.element.set_inner_html(&html);
+    }
+}
+
+struct PanelSnapshot<'a, const N: usize> {
+    backend: &'a str,
+    stages: &'a [PerformanceStage; N],
+    timing_note: &'a str,
+    scene: usize,
+    scene_count: usize,
+    width: u32,
+    height: u32,
+    frame: &'a SampleStats,
+    total: &'a SampleStats,
+    stage_stats: &'a [SampleStats; N],
+    sample_count: usize,
+}
+
+fn format_panel_html<const N: usize>(panel: &PanelSnapshot<'_, N>) -> String {
+    let fps = 1_000.0 / panel.frame.average;
+    let timeline_duration = panel.frame.average.max(panel.total.average);
+    let other_percent = (100.0 - 100.0 * panel.total.average / timeline_duration).max(0.0);
+    let other_average = (panel.frame.average - panel.total.average).max(0.0);
+
+    let mut html = String::with_capacity(4096);
+    html.push_str(
+        r#"<style>
+.vello-perf-info { position:relative;cursor:help;opacity:.7 }
+.vello-perf-tooltip { display:none;position:absolute;right:0;bottom:calc(100% + 6px);width:min(360px, calc(100vw - 40px));padding:9px 11px;background:#222;color:white;border:1px solid rgba(255,255,255,.35);border-radius:4px;box-shadow:0 4px 14px rgba(0,0,0,.45);font-size:12px;font-weight:400;line-height:1.35;text-align:left;z-index:2;pointer-events:none }
+.vello-perf-info:hover .vello-perf-tooltip { display:block }
+.vello-perf-tooltip-row { display:grid;grid-template-columns:105px 1fr;column-gap:10px;margin:3px 0 }
+</style>"#,
+    );
+    write!(
+        html,
+        r#"<div style="font-size:14px;font-weight:700">{} <span class="vello-perf-info" aria-label="Performance metric definitions">ⓘ<span class="vello-perf-tooltip">
+  <span class="vello-perf-tooltip-row"><strong>Frame</strong><span>Elapsed time between rAF callbacks.</span></span>"#,
+        panel.backend,
+    )
+    .unwrap();
+    for stage in panel.stages {
+        write!(
+            html,
+            r#"<span class="vello-perf-tooltip-row"><strong>{}</strong><span>{}</span></span>"#,
+            stage.label, stage.description,
+        )
+        .unwrap();
+    }
+    html.push_str(
+        r#"<span class="vello-perf-tooltip-row"><strong>Browser/rAF</strong><span>Browser work, scheduling, and display wait.</span></span>
+  <span class="vello-perf-tooltip-row"><strong>Full render</strong><span>Sum of measured stages, on the CPU.</span></span>
+  <span class="vello-perf-tooltip-row"><strong>Statistics</strong><span>Rolling average, p95, and maximum.</span></span>
+</span></span></div>"#,
+    );
+    write!(
+        html,
+        r#"<div style="margin-bottom:9px;opacity:.8">Scene {}/{} · {}×{}px · {fps:.1} FPS</div>
+<div style="display:flex;justify-content:space-between;margin-bottom:4px">
+  <span>Average rAF frame</span><strong>{:.2} ms</strong>
+</div>
+<div style="display:flex;height:20px;overflow:hidden;border:1px solid rgba(255,255,255,.45);border-radius:3px">"#,
+        panel.scene, panel.scene_count, panel.width, panel.height, panel.frame.average,
+    )
+    .unwrap();
+    for (stage, stats) in panel.stages.iter().zip(panel.stage_stats) {
+        let percent = 100.0 * stats.average / timeline_duration;
+        write!(
+            html,
+            r#"<div style="width:{percent:.3}%;background:{}"></div>"#,
+            stage.color,
+        )
+        .unwrap();
+    }
+    write!(
+        html,
+        r#"<div style="width:{other_percent:.3}%;background:rgba(255,255,255,.16)"></div>
+</div>
+<div style="display:grid;grid-template-columns:10px 1fr 58px 58px 58px;column-gap:6px;align-items:center;margin-top:7px">
+  <span></span><span style="opacity:.7">Stage (ms)</span>
+  <span style="text-align:right;opacity:.7">avg</span>
+  <span style="text-align:right;opacity:.7">p95</span>
+  <span style="text-align:right;opacity:.7">max</span>"#,
+    )
+    .unwrap();
+    for (stage, stats) in panel.stages.iter().zip(panel.stage_stats) {
+        write!(
+            html,
+            r#"<span style="width:8px;height:8px;background:{};border-radius:2px"></span>
+  <span>{}</span>
+  <span style="text-align:right">{:.2}</span>
+  <span style="text-align:right">{:.2}</span>
+  <span style="text-align:right">{:.2}</span>"#,
+            stage.color, stage.label, stats.average, stats.p95, stats.max,
+        )
+        .unwrap();
+    }
+    write!(
+        html,
+        r#"<span style="width:8px;height:8px;background:rgba(255,255,255,.35);border-radius:2px"></span>
+  <span>Browser/rAF</span>
+  <span style="text-align:right">{other_average:.2}</span>
+  <span></span><span></span>
+</div>
+<div style="display:flex;justify-content:space-between;margin-top:8px;padding-top:7px;border-top:1px solid rgba(255,255,255,.25)">
+  <strong>Full CPU render</strong><strong>{:.2} ms avg</strong>
+</div>
+<div style="margin-top:3px;opacity:.65">{} samples</div>
+<div style="opacity:.65">{}</div>"#,
+        panel.total.average, panel.sample_count, panel.timing_note,
+    )
+    .unwrap();
+    html
+}
+
+pub fn now() -> f64 {
+    web_sys::window().unwrap().performance().unwrap().now()
+}
+
+fn push_sample(samples: &mut Vec<f64>, sample: f64) {
+    if samples.len() == MAX_SAMPLES {
+        samples.remove(0);
+    }
+    samples.push(sample);
+}
+
+struct SampleStats {
+    average: f64,
+    p95: f64,
+    max: f64,
+}
+
+impl SampleStats {
+    fn from_samples(samples: &[f64]) -> Option<Self> {
+        if samples.is_empty() {
+            return None;
+        }
+
+        let mut sorted = samples.to_vec();
+        sorted.sort_by(f64::total_cmp);
+        let p95_index = ((sorted.len() as f64 * 0.95).ceil() as usize)
+            .saturating_sub(1)
+            .min(sorted.len() - 1);
+
+        Some(Self {
+            average: samples.iter().sum::<f64>() / samples.len() as f64,
+            p95: sorted[p95_index],
+            max: *sorted.last().unwrap(),
+        })
+    }
+}

--- a/sparse_strips/vello_hybrid/examples/native_webgl/src/lib.rs
+++ b/sparse_strips/vello_hybrid/examples/native_webgl/src/lib.rs
@@ -16,8 +16,11 @@ use vello_common::{
     kurbo::{Affine, Vec2},
     paint::ImageSource,
 };
-use vello_example_scenes::AnyScene;
 use vello_example_scenes::image::ImageScene;
+use vello_example_scenes::{
+    AnyScene,
+    performance::{FrameTiming, PerformancePanel, PerformanceStage, now},
+};
 use vello_hybrid::{RenderSettings, Scene};
 use wasm_bindgen::prelude::*;
 use web_sys::{Event, HtmlCanvasElement, KeyboardEvent, MouseEvent, WheelEvent};
@@ -67,7 +70,7 @@ struct AppState {
     width: u32,
     height: u32,
     renderer_wrapper: RendererWrapper,
-    need_render: bool,
+    performance: PerformancePanel<2>,
     canvas: HtmlCanvasElement,
 }
 
@@ -90,7 +93,22 @@ impl AppState {
             width,
             height,
             renderer_wrapper,
-            need_render: true,
+            performance: PerformancePanel::new(
+                "Vello Hybrid · native WebGL2",
+                [
+                    PerformanceStage {
+                        label: "Scene build",
+                        description: "CPU time to reset and populate the scene.",
+                        color: "#ef4444",
+                    },
+                    PerformanceStage {
+                        label: "Render/submit",
+                        description: "CPU time to issue WebGL commands; GPU completion is excluded.",
+                        color: "#f59e0b",
+                    },
+                ],
+                "GPU executes asynchronously and is not timed",
+            ),
             canvas,
         };
 
@@ -101,11 +119,8 @@ impl AppState {
         app_state
     }
 
-    fn render(&mut self) {
-        if !self.need_render {
-            return;
-        }
-
+    fn render(&mut self) -> FrameTiming<2> {
+        let frame_start = now();
         self.scene.reset();
 
         // Render the current scene with transform
@@ -114,6 +129,7 @@ impl AppState {
             &mut self.renderer_wrapper.resources,
             self.transform,
         );
+        let scene_end = now();
 
         let render_size = vello_hybrid::RenderSize {
             width: self.width,
@@ -129,7 +145,26 @@ impl AppState {
                 &vello_hybrid::WebGlTextureBindings::new(),
             )
             .unwrap();
-        self.need_render = false;
+        let frame_end = now();
+
+        FrameTiming {
+            stages_ms: [scene_end - frame_start, frame_end - scene_end],
+            total_ms: frame_end - frame_start,
+        }
+    }
+
+    fn frame(&mut self, timestamp: f64) {
+        let timing = self.render();
+        let scene = self.current_scene + 1;
+        let scene_count = self.scenes.len();
+        self.performance.record(
+            timestamp,
+            Some(timing),
+            scene,
+            scene_count,
+            self.width,
+            self.height,
+        );
     }
 
     fn resize(&mut self, width: u32, height: u32) {
@@ -139,8 +174,7 @@ impl AppState {
         self.height = height;
 
         self.scene.reset_and_resize(width as u16, height as u16);
-
-        self.need_render = true;
+        self.performance.reset();
     }
 
     fn next_scene(&mut self) {
@@ -148,7 +182,7 @@ impl AppState {
         update_page_url(self.current_scene);
         self.update_title();
         self.transform = Affine::IDENTITY;
-        self.need_render = true;
+        self.performance.reset();
     }
 
     fn prev_scene(&mut self) {
@@ -160,7 +194,7 @@ impl AppState {
         update_page_url(self.current_scene);
         self.update_title();
         self.transform = Affine::IDENTITY;
-        self.need_render = true;
+        self.performance.reset();
     }
 
     fn update_title(&self) {
@@ -177,14 +211,11 @@ impl AppState {
 
     fn reset_transform(&mut self) {
         self.transform = Affine::IDENTITY;
-        self.need_render = true;
     }
 
     fn handle_key(&mut self, key: &str) {
-        if let Some(scene) = self.scenes.get_mut(self.current_scene)
-            && scene.handle_key(key)
-        {
-            self.need_render = true;
+        if let Some(scene) = self.scenes.get_mut(self.current_scene) {
+            scene.handle_key(key);
         }
     }
 
@@ -212,7 +243,6 @@ impl AppState {
                 y - last_client_pos.y,
             );
             self.transform = Affine::translate(delta) * self.transform;
-            self.need_render = true;
         }
 
         self.last_cursor_position = Some(current_pos);
@@ -242,8 +272,6 @@ impl AppState {
             * Affine::scale(zoom_factor)
             * Affine::translate(-cursor_pos)
             * self.transform;
-
-        self.need_render = true;
     }
 
     /// Upload images to the WebGL atlas texture
@@ -323,7 +351,7 @@ impl AppState {
 #[wasm_bindgen]
 extern "C" {
     #[wasm_bindgen(js_name = requestAnimationFrame)]
-    fn request_animation_frame(f: &Closure<dyn FnMut()>);
+    fn request_animation_frame(f: &Closure<dyn FnMut(f64)>);
 }
 
 /// Creates a `HTMLCanvasElement` of the given dimensions and renders the given scenes into it,
@@ -368,14 +396,14 @@ pub async fn run_interactive(canvas_width: u16, canvas_height: u16) {
 
     // Set up animation frame loop
     {
-        let f = Rc::new(RefCell::new(None));
+        let f = Rc::new(RefCell::new(None::<Closure<dyn FnMut(f64)>>));
         let g = f.clone();
         let app_state = app_state.clone();
 
-        *g.borrow_mut() = Some(Closure::wrap(Box::new(move || {
-            app_state.borrow_mut().render();
+        *g.borrow_mut() = Some(Closure::wrap(Box::new(move |timestamp: f64| {
+            app_state.borrow_mut().frame(timestamp);
             request_animation_frame(f.borrow().as_ref().unwrap());
-        }) as Box<dyn FnMut()>));
+        }) as Box<dyn FnMut(f64)>));
 
         request_animation_frame(g.borrow().as_ref().unwrap());
     }

--- a/sparse_strips/vello_hybrid/examples/wgpu_webgl/src/lib.rs
+++ b/sparse_strips/vello_hybrid/examples/wgpu_webgl/src/lib.rs
@@ -16,7 +16,11 @@ use vello_common::{
     kurbo::{Affine, Point},
     paint::{ImageId, ImageSource},
 };
-use vello_example_scenes::{AnyScene, image::ImageScene};
+use vello_example_scenes::{
+    AnyScene,
+    image::ImageScene,
+    performance::{FrameTiming, PerformancePanel, PerformanceStage, now},
+};
 use vello_hybrid::{Pixmap, RenderSettings, RenderTargetConfig, Renderer, Scene};
 use wasm_bindgen::prelude::*;
 use web_sys::{Event, HtmlCanvasElement, KeyboardEvent, MouseEvent, WheelEvent};
@@ -148,7 +152,7 @@ struct AppState {
     width: u32,
     height: u32,
     renderer_wrapper: RendererWrapper,
-    need_render: bool,
+    performance: PerformancePanel<3>,
     canvas: HtmlCanvasElement,
 }
 
@@ -170,7 +174,27 @@ impl AppState {
             width,
             height,
             renderer_wrapper,
-            need_render: true,
+            performance: PerformancePanel::new(
+                "Vello Hybrid · wgpu → WebGL2",
+                [
+                    PerformanceStage {
+                        label: "Scene build",
+                        description: "CPU time to reset and populate the scene.",
+                        color: "#ef4444",
+                    },
+                    PerformanceStage {
+                        label: "Render/encode",
+                        description: "CPU time to encode the renderer's WebGL commands.",
+                        color: "#f59e0b",
+                    },
+                    PerformanceStage {
+                        label: "Submit/present",
+                        description: "CPU time to submit commands and present the surface; GPU completion is excluded.",
+                        color: "#3b82f6",
+                    },
+                ],
+                "GPU executes asynchronously and is not timed",
+            ),
             canvas,
         };
 
@@ -182,11 +206,8 @@ impl AppState {
         app_state
     }
 
-    fn render(&mut self) {
-        if !self.need_render {
-            return;
-        }
-
+    fn render(&mut self) -> Option<FrameTiming<3>> {
+        let frame_start = now();
         self.scene.reset();
 
         // Render the current scene with transform
@@ -195,6 +216,7 @@ impl AppState {
             &mut self.renderer_wrapper.resources,
             self.transform,
         );
+        let scene_end = now();
 
         let render_size = vello_hybrid::RenderSize {
             width: self.width,
@@ -207,7 +229,7 @@ impl AppState {
             | CurrentSurfaceTexture::Timeout
             | CurrentSurfaceTexture::Outdated
             | CurrentSurfaceTexture::Suboptimal(_) => {
-                return;
+                return None;
             }
             CurrentSurfaceTexture::Lost => panic!("Surface was lost"),
             CurrentSurfaceTexture::Validation => {
@@ -237,11 +259,34 @@ impl AppState {
                 &vello_hybrid::TextureBindings::new(),
             )
             .unwrap();
+        let render_end = now();
 
         self.renderer_wrapper.queue.submit([encoder.finish()]);
         surface_texture.present();
+        let frame_end = now();
 
-        self.need_render = false;
+        Some(FrameTiming {
+            stages_ms: [
+                scene_end - frame_start,
+                render_end - scene_end,
+                frame_end - render_end,
+            ],
+            total_ms: frame_end - frame_start,
+        })
+    }
+
+    fn frame(&mut self, timestamp: f64) {
+        let timing = self.render();
+        let scene = self.current_scene + 1;
+        let scene_count = self.scenes.len();
+        self.performance.record(
+            timestamp,
+            timing,
+            scene,
+            scene_count,
+            self.width,
+            self.height,
+        );
     }
 
     fn resize(&mut self, width: u32, height: u32) {
@@ -252,8 +297,7 @@ impl AppState {
 
         self.scene.reset_and_resize(width as u16, height as u16);
         self.renderer_wrapper.resize(width, height);
-
-        self.need_render = true;
+        self.performance.reset();
     }
 
     fn next_scene(&mut self) {
@@ -261,7 +305,7 @@ impl AppState {
         update_page_url(self.current_scene);
         self.update_title();
         self.transform = Affine::IDENTITY;
-        self.need_render = true;
+        self.performance.reset();
     }
 
     fn prev_scene(&mut self) {
@@ -273,7 +317,7 @@ impl AppState {
         update_page_url(self.current_scene);
         self.update_title();
         self.transform = Affine::IDENTITY;
-        self.need_render = true;
+        self.performance.reset();
     }
 
     fn update_title(&self) {
@@ -290,14 +334,11 @@ impl AppState {
 
     fn reset_transform(&mut self) {
         self.transform = Affine::IDENTITY;
-        self.need_render = true;
     }
 
     fn handle_key(&mut self, key: &str) {
-        if let Some(scene) = self.scenes.get_mut(self.current_scene)
-            && scene.handle_key(key)
-        {
-            self.need_render = true;
+        if let Some(scene) = self.scenes.get_mut(self.current_scene) {
+            scene.handle_key(key);
         }
     }
 
@@ -318,7 +359,6 @@ impl AppState {
             && let Some(last_pos) = self.last_cursor_position
         {
             self.transform = self.transform.then_translate(current_pos - last_pos);
-            self.need_render = true;
         }
 
         self.last_cursor_position = Some(current_pos);
@@ -336,8 +376,6 @@ impl AppState {
                 y: 0.5 * self.height as f64,
             }),
         );
-
-        self.need_render = true;
     }
 
     fn upload_images_to_atlas(&mut self) {
@@ -430,7 +468,7 @@ impl AppState {
 #[wasm_bindgen]
 extern "C" {
     #[wasm_bindgen(js_name = requestAnimationFrame)]
-    fn request_animation_frame(f: &Closure<dyn FnMut()>);
+    fn request_animation_frame(f: &Closure<dyn FnMut(f64)>);
 }
 
 /// Creates a `HTMLCanvasElement` of the given dimensions and renders the given scenes into it,
@@ -476,14 +514,14 @@ pub async fn run_interactive(canvas_width: u16, canvas_height: u16) {
 
     // Set up animation frame loop
     {
-        let f = Rc::new(RefCell::new(None));
+        let f = Rc::new(RefCell::new(None::<Closure<dyn FnMut(f64)>>));
         let g = f.clone();
         let app_state = app_state.clone();
 
-        *g.borrow_mut() = Some(Closure::wrap(Box::new(move || {
-            app_state.borrow_mut().render();
+        *g.borrow_mut() = Some(Closure::wrap(Box::new(move |timestamp: f64| {
+            app_state.borrow_mut().frame(timestamp);
             request_animation_frame(f.borrow().as_ref().unwrap());
-        }) as Box<dyn FnMut()>));
+        }) as Box<dyn FnMut(f64)>));
 
         request_animation_frame(g.borrow().as_ref().unwrap());
     }


### PR DESCRIPTION
Add a reusable WASM performance panel and integrate it into the native WebGL, wgpu WebGL, and Vello CPU browser examples.

- Vello CPU

<img width="425" height="287" alt="image" src="https://github.com/user-attachments/assets/e6e94f3e-0d77-4cb9-bed2-a516ddd0de53" />


- Vello Hybrid WebGL backend

<img width="426" height="251" alt="image" src="https://github.com/user-attachments/assets/8999c63c-0c5d-4561-872e-9c6385fd7d9d" />

Created with assistance from GPT-5.6 Sol.