### PR TITLE
vello_bench: Reduce the number of benchmarks run by default

### DIFF
--- a/sparse_strips/vello_bench/Cargo.toml
+++ b/sparse_strips/vello_bench/Cargo.toml
@@ -21,6 +21,7 @@ smallvec = { workspace = true }
 usvg = { workspace = true }
 
 [features]
+extended = []
 
 [[bench]]
 name = "main"

--- a/sparse_strips/vello_bench/README.md
+++ b/sparse_strips/vello_bench/README.md
@@ -4,10 +4,10 @@ In order to run the integration benchmarks with custom SVGs, you need to add the
 
 If you don't add any SVGs, the benchmarking harness will only use the ghostscript tiger by default.
 
-Run the core benchmarks with `cargo bench`. Set `EXTENDED=1` to include all benchmarks:
+Run the core benchmarks with `cargo bench`. Enable the `extended` feature to include all benchmarks:
 
 ```shell
-EXTENDED=1 cargo bench
+cargo bench --features extended
 ```
 
 You can also provide a filter for the name of the benchmarks you want to run, like

--- a/sparse_strips/vello_bench/README.md
+++ b/sparse_strips/vello_bench/README.md
@@ -4,9 +4,14 @@ In order to run the integration benchmarks with custom SVGs, you need to add the
 
 If you don't add any SVGs, the benchmarking harness will only use the ghostscript tiger by default.
 
-In order to run the benches, you can simply run `cargo bench`. However, in most cases you probably don't
-want to rerun all benchmarks, in which case you can also provide a filter for the name of the benchmarks
-you want to run, like `cargo bench -- fine/fill`
+Run the core benchmarks with `cargo bench`. Set `EXTENDED=1` to include all benchmarks:
+
+```shell
+EXTENDED=1 cargo bench
+```
+
+You can also provide a filter for the name of the benchmarks you want to run, like
+`cargo bench -- fine/fill`.
 
 ## Workflow
 

--- a/sparse_strips/vello_bench/src/allocator.rs
+++ b/sparse_strips/vello_bench/src/allocator.rs
@@ -16,7 +16,7 @@ fn make_atlas() -> Atlas {
 }
 
 pub fn allocator(c: &mut Criterion) {
-    if !*crate::EXTENDED {
+    if !crate::EXTENDED {
         return;
     }
 

--- a/sparse_strips/vello_bench/src/allocator.rs
+++ b/sparse_strips/vello_bench/src/allocator.rs
@@ -16,6 +16,10 @@ fn make_atlas() -> Atlas {
 }
 
 pub fn allocator(c: &mut Criterion) {
+    if !*crate::EXTENDED {
+        return;
+    }
+
     allocate_varied(c);
     allocate_until_full(c);
     alloc_dealloc_churn(c);

--- a/sparse_strips/vello_bench/src/fine/blend.rs
+++ b/sparse_strips/vello_bench/src/fine/blend.rs
@@ -11,6 +11,10 @@ use vello_cpu::fine::{Fine, FineKernel};
 use vello_dev_macros::vello_bench;
 
 pub fn blend(c: &mut Criterion) {
+    if !*crate::EXTENDED {
+        return;
+    }
+
     normal(c);
     multiply(c);
     screen(c);

--- a/sparse_strips/vello_bench/src/fine/blend.rs
+++ b/sparse_strips/vello_bench/src/fine/blend.rs
@@ -11,7 +11,7 @@ use vello_cpu::fine::{Fine, FineKernel};
 use vello_dev_macros::vello_bench;
 
 pub fn blend(c: &mut Criterion) {
-    if !*crate::EXTENDED {
+    if !crate::EXTENDED {
         return;
     }
 

--- a/sparse_strips/vello_bench/src/fine/gradient.rs
+++ b/sparse_strips/vello_bench/src/fine/gradient.rs
@@ -21,15 +21,18 @@ use vello_dev_macros::vello_bench;
 pub fn gradient(c: &mut Criterion) {
     linear::opaque(c);
     radial::opaque(c);
-    radial::opaque_conical(c);
     sweep::opaque(c);
 
-    extend::pad(c);
-    extend::repeat(c);
-    extend::reflect(c);
+    if *crate::EXTENDED {
+        radial::opaque_conical(c);
 
-    many_stops(c);
-    transparent(c);
+        extend::pad(c);
+        extend::repeat(c);
+        extend::reflect(c);
+
+        many_stops(c);
+        transparent(c);
+    }
 }
 
 #[vello_bench]

--- a/sparse_strips/vello_bench/src/fine/gradient.rs
+++ b/sparse_strips/vello_bench/src/fine/gradient.rs
@@ -23,7 +23,7 @@ pub fn gradient(c: &mut Criterion) {
     radial::opaque(c);
     sweep::opaque(c);
 
-    if *crate::EXTENDED {
+    if crate::EXTENDED {
         radial::opaque_conical(c);
 
         extend::pad(c);

--- a/sparse_strips/vello_bench/src/fine/image.rs
+++ b/sparse_strips/vello_bench/src/fine/image.rs
@@ -20,7 +20,7 @@ pub fn image(c: &mut Criterion) {
     quality::low(c);
     quality::medium(c);
 
-    if *crate::EXTENDED {
+    if crate::EXTENDED {
         transform::none(c);
         transform::rotate(c);
 

--- a/sparse_strips/vello_bench/src/fine/image.rs
+++ b/sparse_strips/vello_bench/src/fine/image.rs
@@ -16,17 +16,20 @@ use vello_common::pixmap::Pixmap;
 use vello_cpu::fine::{Fine, FineKernel};
 
 pub fn image(c: &mut Criterion) {
-    transform::none(c);
     transform::scale(c);
-    transform::rotate(c);
-
     quality::low(c);
     quality::medium(c);
-    quality::high(c);
 
-    extend::pad(c);
-    extend::repeat(c);
-    extend::reflect(c);
+    if *crate::EXTENDED {
+        transform::none(c);
+        transform::rotate(c);
+
+        quality::high(c);
+
+        extend::pad(c);
+        extend::repeat(c);
+        extend::reflect(c);
+    }
 }
 
 mod extend {

--- a/sparse_strips/vello_bench/src/fine/rounded_blurred_rect.rs
+++ b/sparse_strips/vello_bench/src/fine/rounded_blurred_rect.rs
@@ -13,6 +13,10 @@ use vello_cpu::fine::{Fine, FineKernel};
 use vello_dev_macros::vello_bench;
 
 pub fn rounded_blurred_rect(c: &mut Criterion) {
+    if !*crate::EXTENDED {
+        return;
+    }
+
     with_transform(c);
     no_transform(c);
 }

--- a/sparse_strips/vello_bench/src/fine/rounded_blurred_rect.rs
+++ b/sparse_strips/vello_bench/src/fine/rounded_blurred_rect.rs
@@ -13,7 +13,7 @@ use vello_cpu::fine::{Fine, FineKernel};
 use vello_dev_macros::vello_bench;
 
 pub fn rounded_blurred_rect(c: &mut Criterion) {
-    if !*crate::EXTENDED {
+    if !crate::EXTENDED {
         return;
     }
 

--- a/sparse_strips/vello_bench/src/glyph.rs
+++ b/sparse_strips/vello_bench/src/glyph.rs
@@ -12,6 +12,10 @@ use vello_common::pixmap::Pixmap;
 use vello_cpu::{Glyph, RenderContext, RenderSettings, Resources};
 
 pub fn glyph(c: &mut Criterion) {
+    if !*crate::EXTENDED {
+        return;
+    }
+
     let mut g = c.benchmark_group("glyph");
 
     const WIDTH: u16 = 256;

--- a/sparse_strips/vello_bench/src/glyph.rs
+++ b/sparse_strips/vello_bench/src/glyph.rs
@@ -12,7 +12,7 @@ use vello_common::pixmap::Pixmap;
 use vello_cpu::{Glyph, RenderContext, RenderSettings, Resources};
 
 pub fn glyph(c: &mut Criterion) {
-    if !*crate::EXTENDED {
+    if !crate::EXTENDED {
         return;
     }
 

--- a/sparse_strips/vello_bench/src/integration.rs
+++ b/sparse_strips/vello_bench/src/integration.rs
@@ -15,6 +15,10 @@ use vello_cpu::{RenderContext, Resources};
 
 /// Image scene rendering benchmark.
 pub fn images(c: &mut Criterion) {
+    if !*crate::EXTENDED {
+        return;
+    }
+
     let mut g = c.benchmark_group("images");
 
     let flower_image = load_flower_image();

--- a/sparse_strips/vello_bench/src/integration.rs
+++ b/sparse_strips/vello_bench/src/integration.rs
@@ -15,7 +15,7 @@ use vello_cpu::{RenderContext, Resources};
 
 /// Image scene rendering benchmark.
 pub fn images(c: &mut Criterion) {
-    if !*crate::EXTENDED {
+    if !crate::EXTENDED {
         return;
     }
 

--- a/sparse_strips/vello_bench/src/lib.rs
+++ b/sparse_strips/vello_bench/src/lib.rs
@@ -19,6 +19,6 @@ pub mod strip;
 pub mod tile;
 
 pub(crate) const SEED: [u8; 32] = [0; 32];
-pub(crate) static EXTENDED: LazyLock<bool> = LazyLock::new(|| std::env::var("EXTENDED").is_ok());
+pub(crate) const EXTENDED: bool = cfg!(feature = "extended");
 pub static DATA_PATH: LazyLock<PathBuf> =
     LazyLock::new(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("data"));

--- a/sparse_strips/vello_bench/src/lib.rs
+++ b/sparse_strips/vello_bench/src/lib.rs
@@ -19,5 +19,6 @@ pub mod strip;
 pub mod tile;
 
 pub(crate) const SEED: [u8; 32] = [0; 32];
+pub(crate) static EXTENDED: LazyLock<bool> = LazyLock::new(|| std::env::var("EXTENDED").is_ok());
 pub static DATA_PATH: LazyLock<PathBuf> =
     LazyLock::new(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("data"));

--- a/sparse_strips/vello_bench/src/pixmap.rs
+++ b/sparse_strips/vello_bench/src/pixmap.rs
@@ -12,12 +12,15 @@ const TRANSLUCENT_BLUE: [u8; 4] = [0, 0, 255, 128];
 
 pub fn pixmap(c: &mut Criterion) {
     let pixel_count = usize::from(WIDTH) * usize::from(HEIGHT);
-    let inputs = [
+    let mut inputs = vec![
         ("opaque", OPAQUE_BLUE.repeat(pixel_count)),
         ("translucent", TRANSLUCENT_BLUE.repeat(pixel_count)),
-        ("interleaved", interleaved_pixels(pixel_count)),
-        ("mixed_lanes", mixed_lane_pixels(pixel_count)),
     ];
+
+    if *crate::EXTENDED {
+        inputs.push(("interleaved", interleaved_pixels(pixel_count)));
+        inputs.push(("mixed_lanes", mixed_lane_pixels(pixel_count)));
+    }
 
     let mut group = c.benchmark_group("pixmap/premultiply");
     for (name, rgba) in &inputs {
@@ -38,17 +41,20 @@ pub fn pixmap(c: &mut Criterion) {
     }
     group.finish();
 
-    let pixmaps = inputs.map(|(name, rgba)| {
-        (
-            name,
-            Pixmap::from_parts(
-                rgba,
-                WIDTH,
-                HEIGHT,
-                PixelMetadata::new(ImageAlphaType::Alpha, true),
-            ),
-        )
-    });
+    let pixmaps = inputs
+        .into_iter()
+        .map(|(name, rgba)| {
+            (
+                name,
+                Pixmap::from_parts(
+                    rgba,
+                    WIDTH,
+                    HEIGHT,
+                    PixelMetadata::new(ImageAlphaType::Alpha, true),
+                ),
+            )
+        })
+        .collect::<Vec<_>>();
 
     let mut group = c.benchmark_group("pixmap/unpremultiply");
     for (name, pixmap) in &pixmaps {

--- a/sparse_strips/vello_bench/src/pixmap.rs
+++ b/sparse_strips/vello_bench/src/pixmap.rs
@@ -17,7 +17,7 @@ pub fn pixmap(c: &mut Criterion) {
         ("translucent", TRANSLUCENT_BLUE.repeat(pixel_count)),
     ];
 
-    if *crate::EXTENDED {
+    if crate::EXTENDED {
         inputs.push(("interleaved", interleaved_pixels(pixel_count)));
         inputs.push(("mixed_lanes", mixed_lane_pixels(pixel_count)));
     }

--- a/sparse_strips/vello_bench/src/sort.rs
+++ b/sparse_strips/vello_bench/src/sort.rs
@@ -5,6 +5,10 @@ use crate::data::get_data_items;
 use criterion::{BenchmarkId, Criterion};
 
 pub fn sort(c: &mut Criterion) {
+    if !*crate::EXTENDED {
+        return;
+    }
+
     let mut g = c.benchmark_group("sort");
     g.sample_size(50);
 

--- a/sparse_strips/vello_bench/src/sort.rs
+++ b/sparse_strips/vello_bench/src/sort.rs
@@ -5,7 +5,7 @@ use crate::data::get_data_items;
 use criterion::{BenchmarkId, Criterion};
 
 pub fn sort(c: &mut Criterion) {
-    if !*crate::EXTENDED {
+    if !crate::EXTENDED {
         return;
     }
 

--- a/sparse_strips/vello_bench/src/strip.rs
+++ b/sparse_strips/vello_bench/src/strip.rs
@@ -76,7 +76,7 @@ pub fn render_strips(c: &mut Criterion) {
 }
 
 pub fn render_strips_cull(c: &mut Criterion) {
-    if !*crate::EXTENDED {
+    if !crate::EXTENDED {
         return;
     }
 

--- a/sparse_strips/vello_bench/src/strip.rs
+++ b/sparse_strips/vello_bench/src/strip.rs
@@ -76,6 +76,10 @@ pub fn render_strips(c: &mut Criterion) {
 }
 
 pub fn render_strips_cull(c: &mut Criterion) {
+    if !*crate::EXTENDED {
+        return;
+    }
+
     let mut g_cull = c.benchmark_group("render_strips_culled50");
     g_cull.sample_size(50);
 

--- a/sparse_strips/vello_bench/src/tile.rs
+++ b/sparse_strips/vello_bench/src/tile.rs
@@ -37,11 +37,13 @@ pub fn tile(c: &mut Criterion) {
         tiler.make_tiles_analytic_aa(Level::new(), lines, w, h);
     });
 
-    run_tile_benchmark::<false, _>(c, "tile_msaa", |tiler, lines, w, h| {
-        tiler.make_tiles_msaa(lines, w, h);
-    });
+    if *crate::EXTENDED {
+        run_tile_benchmark::<false, _>(c, "tile_msaa", |tiler, lines, w, h| {
+            tiler.make_tiles_msaa(lines, w, h);
+        });
 
-    run_tile_benchmark::<true, _>(c, "tile_aaa_shift50", |tiler, lines, w, h| {
-        tiler.make_tiles_analytic_aa(Level::new(), lines, w, h);
-    });
+        run_tile_benchmark::<true, _>(c, "tile_aaa_shift50", |tiler, lines, w, h| {
+            tiler.make_tiles_analytic_aa(Level::new(), lines, w, h);
+        });
+    }
 }

--- a/sparse_strips/vello_bench/src/tile.rs
+++ b/sparse_strips/vello_bench/src/tile.rs
@@ -37,7 +37,7 @@ pub fn tile(c: &mut Criterion) {
         tiler.make_tiles_analytic_aa(Level::new(), lines, w, h);
     });
 
-    if *crate::EXTENDED {
+    if crate::EXTENDED {
         run_tile_benchmark::<false, _>(c, "tile_msaa", |tiler, lines, w, h| {
             tiler.make_tiles_msaa(lines, w, h);
         });


### PR DESCRIPTION
A small annoyance for me has been that we have a lot of benchmarks, therefore, running the whole benchmark suite takes really long. But in reality, there are only a few benchmarks that we really care about _in the usual case_ when trying to figure out whether there are any major regressions (in my case, as part of updating `fearless_simd`). Therefore, this PR proposes running only a small subset of benchmarks by default, and requiring the user to opt-in explicitly to run the whole benchmark suite. 