### PR TITLE
feat: support unminified shader generation

### DIFF
--- a/sparse_strips/vello_sparse_shaders/Cargo.toml
+++ b/sparse_strips/vello_sparse_shaders/Cargo.toml
@@ -35,6 +35,7 @@ wesl = "=0.4.0"
 
 [features]
 glsl = ["dep:naga"]
+unminified = []
 
 [[bin]]
 name = "vello_sparse_shaders"

--- a/sparse_strips/vello_sparse_shaders/README.md
+++ b/sparse_strips/vello_sparse_shaders/README.md
@@ -35,6 +35,13 @@ cargo run -p vello_sparse_shaders --features glsl
 
 The generated files will be written into the `generated_glsl` folder.
 
+To retain authored identifiers and Naga's readable formatting for debugging, enable the diagnostic
+`unminified` feature as well:
+
+```sh
+cargo run -p vello_sparse_shaders --features glsl,unminified
+```
+
 ## Minimum supported Rust Version (MSRV)
 
 This version of Vello Hybrid Shaders has been verified to compile with **Rust 1.88** and later.

--- a/sparse_strips/vello_sparse_shaders/build.rs
+++ b/sparse_strips/vello_sparse_shaders/build.rs
@@ -4,21 +4,23 @@
 //! Build-time shader pipeline.
 //!
 //! Every top-level file in `shaders` is treated as a root module. WESL links each root with its
-//! imports, then the linked WGSL is parsed into Naga IR. Named declarations are deterministically
-//! shortened while renderer-facing entry-point names remain unchanged, and redundant comments and
-//! whitespace are removed from the serialized WGSL.
+//! imports. By default, the linked WGSL is parsed into Naga IR, named declarations are
+//! deterministically shortened while renderer-facing entry-point names remain unchanged, and
+//! redundant comments and whitespace are removed from the serialized WGSL. The `unminified`
+//! feature preserves the linked source for local inspection.
 //!
-//! The generated module always embeds the minified WGSL. With the `glsl` feature, it also contains
-//! minified vertex and fragment GLSL plus reflection metadata. Global names are recorded before
-//! renaming so that this metadata continues to expose the resource names authored in WESL.
+//! The generated module embeds WGSL and, with the `glsl` feature, vertex and fragment GLSL plus
+//! reflection metadata. Global names are recorded before default-mode renaming so that this
+//! metadata continues to expose the resource names authored in WESL.
 //!
 //! ```text
-//! shaders/*.wesl -> linked WGSL -> renamed Naga IR -> minified WGSL
-//!                                                       |-> WGSL constants ---------|
-//!                                                       |                           |
-//!                                                       |-> [glsl] GLSL + reflection|
-//!                                                                                   |
-//!                                            OUT_DIR/compiled_shaders.rs <----------|
+//!                                      |-> [default] renamed/minified WGSL -|
+//! shaders/*.wesl -> linked WGSL -------|                                    |-> WGSL constants
+//!                                      |-> [unminified] linked WGSL --------|
+//!                                                                           |-> [glsl] GLSL
+//!                                                                           |   + reflection
+//!                                                                           |
+//!                                  OUT_DIR/compiled_shaders.rs <------------|
 //! ```
 
 use std::env;
@@ -101,13 +103,24 @@ fn compile_shader<R: wesl::Resolver>(compiler: &Wesl<R>, name: String) -> Shader
         .compile(&module_path)
         .unwrap_or_else(|error| panic!("Unable to compile `{name}.wesl`: {error}"))
         .to_string();
+
+    #[cfg(feature = "unminified")]
+    let wgsl_source = linked_wgsl;
+    #[cfg(all(feature = "unminified", feature = "glsl"))]
+    let original_global_names = std::collections::BTreeMap::new();
+
+    #[cfg(not(feature = "unminified"))]
     let minified = minify::minify_wgsl(&linked_wgsl);
+    #[cfg(not(feature = "unminified"))]
+    let wgsl_source = minified.source;
+    #[cfg(all(not(feature = "unminified"), feature = "glsl"))]
+    let original_global_names = minified.original_global_names;
 
     ShaderInfo {
         name,
-        wgsl_source: minified.source,
+        wgsl_source,
         #[cfg(feature = "glsl")]
-        original_global_names: minified.original_global_names,
+        original_global_names,
     }
 }
 

--- a/sparse_strips/vello_sparse_shaders/src/compile.rs
+++ b/sparse_strips/vello_sparse_shaders/src/compile.rs
@@ -97,6 +97,7 @@ fn compile_stage(
         &module.global_variables,
         original_global_names,
     );
+    #[cfg(not(feature = "unminified"))]
     let source = crate::minify::minify_whitespace(&source, true);
 
     Stage {


### PR DESCRIPTION
Follow-up to [review feedback on #1846](https://github.com/linebender/vello/pull/1846#pullrequestreview-5030208458), adding an opt-in unminified feature for generating readable WGSL and GLSL during shader debugging. The default pipeline remains unchanged and continues to emit minified shaders.

Created with assistance from GPT-5.6 Sol.