### PR TITLE
vello_cpu: Clamp opacity for layers

### DIFF
--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -485,7 +485,7 @@ impl RenderContext {
         });
 
         let blend_mode = blend_mode.unwrap_or_default();
-        let opacity = opacity.unwrap_or(1.0);
+        let opacity = opacity.unwrap_or(1.0).clamp(0.0, 1.0);
         let layer_transform = self
             .root_transforms
             .effective_path_transform(self.transforms());


### PR DESCRIPTION
We do the same in Vello Hybrid: https://github.com/linebender/vello/blob/c93cb0d5dd25fac2873f5548947fadf449c511bc/sparse_strips/vello_hybrid/src/util.rs#L108