### PR TITLE
vello_hybrid: Allow binding multiple external textures per draw call

### DIFF
--- a/sparse_strips/vello_hybrid/src/draw.rs
+++ b/sparse_strips/vello_hybrid/src/draw.rs
@@ -468,18 +468,20 @@ impl ExternalTextureBindings {
     /// Returns `None` when all four slots are occupied by other textures.
     #[inline]
     fn get_or_insert(&mut self, texture_id: TextureId) -> Option<u8> {
-        if let Some(slot) = self
-            .texture_ids
-            .iter()
-            .position(|candidate| *candidate == Some(texture_id))
-        {
-            return Some(u8::try_from(slot).unwrap());
+        // This iteration order assumes slots are assigned without leaving "holes" in-between,
+        // i.e. if we hit `None`, any later slot is also guaranteed to be `None`.
+        for (slot, candidate) in self.texture_ids.iter_mut().enumerate() {
+            match *candidate {
+                Some(id) if id == texture_id => return Some(u8::try_from(slot).unwrap()),
+                None => {
+                    *candidate = Some(texture_id);
+                    return Some(u8::try_from(slot).unwrap());
+                }
+                _ => {}
+            }
         }
 
-        let slot = self.texture_ids.iter().position(Option::is_none)?;
-        self.texture_ids[slot] = Some(texture_id);
-
-        Some(u8::try_from(slot).unwrap())
+        None
     }
 
     #[inline]

--- a/sparse_strips/vello_hybrid/src/draw.rs
+++ b/sparse_strips/vello_hybrid/src/draw.rs
@@ -4,7 +4,9 @@
 //! Draw construction for strip render passes.
 
 use crate::GpuStrip;
-use crate::paint::{COLOR_SOURCE_LAYER, COLOR_SOURCE_SHIFT, PaintResolver};
+use crate::paint::{
+    COLOR_SOURCE_LAYER, COLOR_SOURCE_SHIFT, EXTERNAL_TEXTURE_SLOT_SHIFT, PaintResolver,
+};
 use crate::rect::{RectPart, split_rect};
 use crate::scene::{RecordedDraw, RecordedPath};
 use crate::target::{DrawTarget, LayerTextureRegion};
@@ -36,14 +38,16 @@ impl Draw {
     fn push(
         &mut self,
         strips: &mut Vec<GpuStrip>,
-        gpu_strip: GpuStrip,
+        mut gpu_strip: GpuStrip,
         external_texture_id: Option<TextureId>,
     ) {
-        push_external_texture_run(
+        if let Some(slot) = assign_external_texture_slot(
             &mut self.external_texture_runs,
             self.strip_ranges.len(),
             external_texture_id,
-        );
+        ) {
+            gpu_strip.paint_and_rect_flag |= u32::from(slot) << EXTERNAL_TEXTURE_SLOT_SHIFT;
+        }
 
         strips.push_ranged(&mut self.strip_ranges, gpu_strip);
     }
@@ -65,12 +69,14 @@ pub(crate) struct OpaqueDraw {
 }
 
 impl OpaqueDraw {
-    fn push(&mut self, strip: GpuStrip, external_texture_id: Option<TextureId>) {
-        push_external_texture_run(
+    fn push(&mut self, mut strip: GpuStrip, external_texture_id: Option<TextureId>) {
+        if let Some(slot) = assign_external_texture_slot(
             &mut self.external_texture_runs,
             self.strips.len(),
             external_texture_id,
-        );
+        ) {
+            strip.paint_and_rect_flag |= u32::from(slot) << EXTERNAL_TEXTURE_SLOT_SHIFT;
+        }
 
         self.strips.push(strip);
     }
@@ -444,32 +450,77 @@ impl LayerTextureRegion {
     }
 }
 
-/// Specifies a run of strips that can be drawn with the same external texture binding.
+/// Number of externally supplied textures that can be sampled by one strip draw.
+pub(crate) const EXTERNAL_TEXTURE_SLOT_COUNT: usize = 4;
+
+/// External texture bindings for one strip draw.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct ExternalTextureBindings {
+    texture_ids: [Option<TextureId>; EXTERNAL_TEXTURE_SLOT_COUNT],
+}
+
+impl ExternalTextureBindings {
+    pub(crate) const EMPTY: Self = Self {
+        texture_ids: [None; EXTERNAL_TEXTURE_SLOT_COUNT],
+    };
+
+    /// Return the existing slot for `texture_id`, or insert it into the first empty slot.
+    /// Returns `None` when all four slots are occupied by other textures.
+    #[inline]
+    fn get_or_insert(&mut self, texture_id: TextureId) -> Option<u8> {
+        if let Some(slot) = self
+            .texture_ids
+            .iter()
+            .position(|candidate| *candidate == Some(texture_id))
+        {
+            return Some(u8::try_from(slot).unwrap());
+        }
+
+        let slot = self.texture_ids.iter().position(Option::is_none)?;
+        self.texture_ids[slot] = Some(texture_id);
+
+        Some(u8::try_from(slot).unwrap())
+    }
+
+    #[inline]
+    pub(crate) fn as_array(self) -> [Option<TextureId>; EXTERNAL_TEXTURE_SLOT_COUNT] {
+        self.texture_ids
+    }
+}
+
+/// Specifies a run of strips that can be drawn with the same external texture bindings.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ExternalTextureRun {
-    /// External texture bound for the run.
-    pub(crate) texture_id: TextureId,
+    /// External textures bound for the run.
+    pub(crate) bindings: ExternalTextureBindings,
     /// Start index of the strip range for this run. The end is implicitly the start of the next
     /// run, or, for the last run, the total number of strips in the pass.
     pub(crate) strips_start: usize,
 }
 
-fn push_external_texture_run(
+fn assign_external_texture_slot(
     runs: &mut Vec<ExternalTextureRun>,
     strips_len: usize,
     external_texture_id: Option<TextureId>,
-) {
-    let Some(texture_id) = external_texture_id else {
-        return;
-    };
-    if runs.last().is_some_and(|run| run.texture_id == texture_id) {
-        return;
+) -> Option<u8> {
+    let texture_id = external_texture_id?;
+
+    if let Some(slot) = runs
+        .last_mut()
+        .and_then(|run| run.bindings.get_or_insert(texture_id))
+    {
+        return Some(slot);
     }
 
+    let mut bindings = ExternalTextureBindings::EMPTY;
+    let slot = bindings.get_or_insert(texture_id).unwrap();
+    let strips_start = if runs.is_empty() { 0 } else { strips_len };
     runs.push(ExternalTextureRun {
-        texture_id,
-        strips_start: if runs.is_empty() { 0 } else { strips_len },
+        bindings,
+        strips_start,
     });
+
+    Some(slot)
 }
 
 /// Assigns monotonically increasing depth values to opaque strips.
@@ -526,7 +577,7 @@ impl StripAlphaFillSegmentExt for StripAlphaFillSegment {
 mod tests {
     use super::{Draw, DrawBuffers, DrawBuilder, DrawState, ExternalTextureRun, OpaqueDraw};
     use crate::GpuStrip;
-    use crate::paint::PaintResolver;
+    use crate::paint::{EXTERNAL_TEXTURE_SLOT_SHIFT, PaintResolver};
     use crate::scene::{RecordedDraw, RecordedRect};
     use crate::target::{
         DrawTarget, LayerTextureId, LayerTextureRegion, RootTarget, TextureParity, TextureRegion,
@@ -616,9 +667,16 @@ mod tests {
         draw.strips().iter().map(|strip| strip.x).collect()
     }
 
-    fn run_starts(runs: &[ExternalTextureRun]) -> Vec<(TextureId, usize)> {
+    fn external_texture_slots(draw: &OpaqueDraw) -> Vec<u32> {
+        draw.strips()
+            .iter()
+            .map(|strip| (strip.paint_and_rect_flag >> EXTERNAL_TEXTURE_SLOT_SHIFT) & 0x3)
+            .collect()
+    }
+
+    fn run_states(runs: &[ExternalTextureRun]) -> Vec<([Option<TextureId>; 4], usize)> {
         runs.iter()
-            .map(|run| (run.texture_id, run.strips_start))
+            .map(|run| (run.bindings.as_array(), run.strips_start))
             .collect()
     }
 
@@ -686,8 +744,57 @@ mod tests {
         }
 
         assert_eq!(
-            run_starts(&draw.external_texture_runs),
-            [(texture_a, 0), (texture_b, 2), (texture_a, 4)]
+            run_states(&draw.external_texture_runs),
+            [([Some(texture_a), Some(texture_b), None, None], 0)]
+        );
+    }
+
+    #[test]
+    fn fifth_external_texture_starts_a_fresh_run() {
+        let textures = [
+            TextureId(10),
+            TextureId(20),
+            TextureId(30),
+            TextureId(40),
+            TextureId(50),
+        ];
+        let encoded = textures.map(external);
+        let offsets = [0; 5];
+        let resolver = PaintResolver::new(&encoded, &offsets);
+        let mut case = DrawCase::new(RootTarget::UserSurface, RectU16::new(0, 0, 32, 8));
+        let mut draw = Draw::default();
+
+        for (draw_index, paint_index) in [0, 1, 2, 3, 4, 0].into_iter().enumerate() {
+            case.rect(
+                &mut draw,
+                rect(draw_index as f64 * 4.0),
+                indexed(paint_index),
+                resolver,
+            );
+        }
+
+        assert_eq!(
+            run_states(&draw.external_texture_runs),
+            [
+                (
+                    [
+                        Some(textures[0]),
+                        Some(textures[1]),
+                        Some(textures[2]),
+                        Some(textures[3])
+                    ],
+                    0
+                ),
+                ([Some(textures[4]), Some(textures[0]), None, None], 4),
+            ]
+        );
+        assert_eq!(
+            case.buffers
+                .strips
+                .iter()
+                .map(|strip| (strip.paint_and_rect_flag >> EXTERNAL_TEXTURE_SLOT_SHIFT) & 0x3)
+                .collect::<Vec<_>>(),
+            [0, 1, 2, 3, 0, 1]
         );
     }
 
@@ -702,7 +809,10 @@ mod tests {
         case.rect(&mut draw, rect(0.0), indexed(0), resolver);
         case.rect(&mut draw, rect(4.0), indexed(1), resolver);
 
-        assert_eq!(run_starts(&draw.external_texture_runs), [(texture, 0)]);
+        assert_eq!(
+            run_states(&draw.external_texture_runs),
+            [([Some(texture), None, None, None], 0)]
+        );
     }
 
     #[test]
@@ -720,61 +830,117 @@ mod tests {
         assert_eq!(draw.strip_ranges.len(), 3);
         // Images in the atlas are handled separately from external textures, so
         // it's fine to collapse them.
-        assert_eq!(run_starts(&draw.external_texture_runs), [(texture, 0)]);
+        assert_eq!(
+            run_states(&draw.external_texture_runs),
+            [([Some(texture), None, None, None], 0)]
+        );
     }
 
     #[test]
     fn opaque_reverse_rebases_texture_runs() {
-        let texture_a = TextureId(10);
-        let texture_b = TextureId(20);
-        let texture_c = TextureId(30);
+        let textures = [
+            TextureId(10),
+            TextureId(20),
+            TextureId(30),
+            TextureId(40),
+            TextureId(50),
+            TextureId(60),
+            TextureId(70),
+            TextureId(80),
+        ];
         let mut draw = OpaqueDraw::default();
 
         for (x, texture_id) in [
             (0, None),
-            (1, Some(texture_a)),
-            (2, Some(texture_a)),
+            (1, Some(textures[0])),
+            (2, Some(textures[0])),
             (3, None),
             (4, None),
             (5, None),
-            (6, Some(texture_b)),
-            (7, Some(texture_b)),
-            (8, Some(texture_c)),
+            (6, Some(textures[1])),
+            (7, Some(textures[1])),
+            (8, Some(textures[2])),
             (9, None),
-            (10, Some(texture_c)),
+            (10, Some(textures[2])),
             (11, None),
             (12, None),
-            (13, Some(texture_a)),
+            (13, Some(textures[0])),
             (14, None),
-            (15, Some(texture_b)),
+            (15, Some(textures[1])),
+            (16, Some(textures[3])),
+            (17, None),
+            (18, Some(textures[0])),
+            (19, Some(textures[4])),
+            (20, None),
+            (21, Some(textures[4])),
+            (22, Some(textures[0])),
+            (23, Some(textures[5])),
+            (24, Some(textures[5])),
+            (25, None),
+            (26, Some(textures[6])),
+            (27, None),
+            (28, Some(textures[7])),
+            (29, Some(textures[7])),
+            (30, Some(textures[1])),
+            (31, None),
         ] {
             draw.push(gpu_strip(x), texture_id);
         }
         assert_eq!(
-            run_starts(draw.external_texture_runs()),
+            run_states(draw.external_texture_runs()),
             [
-                (texture_a, 0),
-                (texture_b, 6),
-                (texture_c, 8),
-                (texture_a, 13),
-                (texture_b, 15),
+                (
+                    [
+                        Some(textures[0]),
+                        Some(textures[1]),
+                        Some(textures[2]),
+                        Some(textures[3]),
+                    ],
+                    0,
+                ),
+                (
+                    [
+                        Some(textures[4]),
+                        Some(textures[0]),
+                        Some(textures[5]),
+                        Some(textures[6]),
+                    ],
+                    19,
+                ),
+                ([Some(textures[7]), Some(textures[1]), None, None], 28,),
             ]
         );
+        let original_slots = external_texture_slots(&draw);
 
         draw.reverse();
 
+        assert_eq!(strip_xs(&draw), (0..32).rev().collect::<Vec<_>>());
         assert_eq!(
-            strip_xs(&draw),
-            [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+            external_texture_slots(&draw),
+            original_slots.into_iter().rev().collect::<Vec<_>>()
         );
         assert_eq!(
-            run_starts(draw.external_texture_runs()),
+            run_states(draw.external_texture_runs()),
             [
-                (texture_b, 0),
-                (texture_a, 1),
-                (texture_c, 3),
-                (texture_b, 8),
-                (texture_a, 10),
+                ([Some(textures[7]), Some(textures[1]), None, None], 0,),
+                (
+                    [
+                        Some(textures[4]),
+                        Some(textures[0]),
+                        Some(textures[5]),
+                        Some(textures[6]),
+                    ],
+                    4,
+                ),
+                (
+                    [
+                        Some(textures[0]),
+                        Some(textures[1]),
+                        Some(textures[2]),
+                        Some(textures[3]),
+                    ],
+                    13,
+                ),
             ]
         );
     }
@@ -789,7 +955,7 @@ mod tests {
         draw.reverse();
 
         assert_eq!(strip_xs(&draw), [2, 1, 0]);
-        assert_eq!(run_starts(draw.external_texture_runs()), []);
+        assert!(draw.external_texture_runs().is_empty());
     }
 
     #[test]

--- a/sparse_strips/vello_hybrid/src/paint.rs
+++ b/sparse_strips/vello_hybrid/src/paint.rs
@@ -21,7 +21,8 @@ const PAINT_TYPE_BLURRED_ROUNDED_RECT: u32 = 5;
 // See the layout information in `render.wesl`.
 pub(crate) const COLOR_SOURCE_SHIFT: u32 = 29;
 const PAINT_TYPE_SHIFT: u32 = 26;
-const PAINT_TEXTURE_INDEX_MASK: u32 = (1 << PAINT_TYPE_SHIFT) - 1;
+pub(crate) const EXTERNAL_TEXTURE_SLOT_SHIFT: u32 = 24;
+const PAINT_TEXTURE_INDEX_MASK: u32 = (1 << EXTERNAL_TEXTURE_SLOT_SHIFT) - 1;
 
 /// Shader-ready paint metadata for a strip.
 #[derive(Clone, Copy)]
@@ -103,6 +104,10 @@ impl<'a> PaintResolver<'a> {
                     EncodedPaint::BlurredRoundedRect(_) => (PAINT_TYPE_BLURRED_ROUNDED_RECT, None),
                 };
 
+                debug_assert!(
+                    gpu_offset <= PAINT_TEXTURE_INDEX_MASK,
+                    "paint offsets fit in 24 bits because resource textures are capped at 4096×4096"
+                );
                 PackedPaint {
                     payload: PaintPayload::Position,
                     paint: (COLOR_SOURCE_PAYLOAD << COLOR_SOURCE_SHIFT)

--- a/sparse_strips/vello_hybrid/src/render/webgl/mod.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl/mod.rs
@@ -2340,6 +2340,7 @@ fn get_strip_uniforms(gl: &WebGl2RenderingContext, program: &Program) -> StripUn
     let encoded_paints_texture_fs_name = render::fragment::ENCODED_PAINTS_TEXTURE;
     let encoded_paints_texture_vs_name = render::vertex::ENCODED_PAINTS_TEXTURE;
     let gradient_texture_name = render::fragment::GRADIENT_TEXTURE;
+    // TODO: Change it so this is based on `EXTERNAL_TEXTURE_SLOT_COUNT`.
     let external_texture_names = [
         render::fragment::EXTERNAL_TEXTURE_0,
         render::fragment::EXTERNAL_TEXTURE_1,

--- a/sparse_strips/vello_hybrid/src/render/webgl/mod.rs
+++ b/sparse_strips/vello_hybrid/src/render/webgl/mod.rs
@@ -24,7 +24,7 @@ only break in edge cases, and some of them are also only related to conversions 
 pub(crate) mod probe;
 pub(crate) mod resource;
 
-use crate::draw::ExternalTextureRun;
+use crate::draw::{EXTERNAL_TEXTURE_SLOT_COUNT, ExternalTextureBindings, ExternalTextureRun};
 use crate::render::common::IMAGE_PADDING;
 use crate::util::RangedSlice;
 use crate::{
@@ -90,8 +90,8 @@ const GPU_PAINT_PLACEHOLDER: GpuEncodedPaint = GpuEncodedPaint::LinearGradient(G
     transform: [0.0; 6],
 });
 
-/// Texture unit the strip program samples external textures from.
-const EXTERNAL_TEXTURE_UNIT: u32 = 5;
+/// First texture unit from which the strip program samples external textures.
+const EXTERNAL_TEXTURE_UNIT_START: u32 = 5;
 
 /// Query the WebGL context for the max texture size.
 fn get_max_texture_dimension_2d(gl: &WebGl2RenderingContext) -> u32 {
@@ -1138,8 +1138,8 @@ struct StripUniforms {
     encoded_paints_texture_vs: WebGlUniformLocation,
     /// Gradient texture location.
     gradient_texture: WebGlUniformLocation,
-    /// External texture location.
-    external_texture: WebGlUniformLocation,
+    /// External texture locations, indexed by shader slot.
+    external_textures: [WebGlUniformLocation; EXTERNAL_TEXTURE_SLOT_COUNT],
 }
 
 /// Contains all WebGL resources needed for rendering.
@@ -1167,7 +1167,7 @@ pub(crate) struct WebGlResources {
     encoded_paints_texture_height: u32,
     /// Gradient texture for gradient ramp data.
     gradient_texture: Texture,
-    /// Placeholder texture bound to the strip shader's `external_texture` sampler.
+    /// Placeholder texture bound to unoccupied external texture slots.
     placeholder_external_texture: Texture,
     /// Height of gradient texture.
     gradient_texture_height: u32,
@@ -2340,7 +2340,12 @@ fn get_strip_uniforms(gl: &WebGl2RenderingContext, program: &Program) -> StripUn
     let encoded_paints_texture_fs_name = render::fragment::ENCODED_PAINTS_TEXTURE;
     let encoded_paints_texture_vs_name = render::vertex::ENCODED_PAINTS_TEXTURE;
     let gradient_texture_name = render::fragment::GRADIENT_TEXTURE;
-    let external_texture_name = render::fragment::EXTERNAL_TEXTURE;
+    let external_texture_names = [
+        render::fragment::EXTERNAL_TEXTURE_0,
+        render::fragment::EXTERNAL_TEXTURE_1,
+        render::fragment::EXTERNAL_TEXTURE_2,
+        render::fragment::EXTERNAL_TEXTURE_3,
+    ];
 
     StripUniforms {
         config_vs_block_index,
@@ -2363,9 +2368,8 @@ fn get_strip_uniforms(gl: &WebGl2RenderingContext, program: &Program) -> StripUn
         gradient_texture: gl
             .get_uniform_location(program, gradient_texture_name)
             .unwrap(),
-        external_texture: gl
-            .get_uniform_location(program, external_texture_name)
-            .unwrap(),
+        external_textures: external_texture_names
+            .map(|name| gl.get_uniform_location(program, name).unwrap()),
     }
 }
 
@@ -2901,14 +2905,10 @@ impl WebGlRendererContext<'_> {
                 let end = external_texture_runs
                     .get(i + 1)
                     .map_or(count, |next| i32::try_from(next.strips_start).unwrap());
-                let texture = self
-                    .texture_bindings
-                    .get(run.texture_id)
-                    .expect("external texture bindings were validated during paint preparation");
-                self.bind_external_texture(Some(texture));
+                self.bind_external_textures(&run.bindings);
                 self.draw_strip_range(first_instance + start, end - start);
             }
-            self.bind_external_texture(None);
+            self.bind_external_textures(&ExternalTextureBindings::EMPTY);
         }
 
         self.set_strip_attrib_offset(0);
@@ -2927,15 +2927,21 @@ impl WebGlRendererContext<'_> {
         self.draw_instanced_quads(count);
     }
 
-    /// Bind `texture`, or the placeholder when `None`, as the texture sampled by paints with an
-    /// external image source.
-    fn bind_external_texture(&self, texture: Option<&WebGlTexture>) {
-        self.gl
-            .active_texture(WebGl2RenderingContext::TEXTURE0 + EXTERNAL_TEXTURE_UNIT);
-        self.gl.bind_texture(
-            WebGl2RenderingContext::TEXTURE_2D,
-            Some(texture.unwrap_or(&self.programs.resources.placeholder_external_texture)),
-        );
+    /// Bind the external texture slots.
+    fn bind_external_textures(&self, bindings: &ExternalTextureBindings) {
+        for (slot, texture_id) in bindings.as_array().into_iter().enumerate() {
+            self.gl.active_texture(
+                WebGl2RenderingContext::TEXTURE0
+                    + EXTERNAL_TEXTURE_UNIT_START
+                    + u32::try_from(slot).unwrap(),
+            );
+            let texture: &WebGlTexture = match texture_id {
+                Some(texture_id) => self.texture_bindings.get(texture_id).unwrap(),
+                None => &self.programs.resources.placeholder_external_texture,
+            };
+            self.gl
+                .bind_texture(WebGl2RenderingContext::TEXTURE_2D, Some(texture));
+        }
     }
 
     /// Point the strip vertex attributes at the instance at `first_instance`.
@@ -3074,11 +3080,19 @@ impl WebGlRendererContext<'_> {
 
         // External textures are rebound per run while drawing. Start from the placeholder so the
         // sampler is valid for draws that don't reference one.
-        self.bind_external_texture(None);
-        self.gl.uniform1i(
-            Some(&self.programs.strip_uniforms.external_texture),
-            EXTERNAL_TEXTURE_UNIT as i32,
-        );
+        self.bind_external_textures(&ExternalTextureBindings::EMPTY);
+        for (slot, uniform) in self
+            .programs
+            .strip_uniforms
+            .external_textures
+            .iter()
+            .enumerate()
+        {
+            self.gl.uniform1i(
+                Some(uniform),
+                i32::try_from(EXTERNAL_TEXTURE_UNIT_START).unwrap() + i32::try_from(slot).unwrap(),
+            );
+        }
 
         // TODO: Today, we only support early-z rejection on the final view. If we wanted to support
         // intermediate layers, we would require separate depth buffers for each target. We can explore

--- a/sparse_strips/vello_hybrid/src/render/wgpu/mod.rs
+++ b/sparse_strips/vello_hybrid/src/render/wgpu/mod.rs
@@ -18,7 +18,7 @@
 only break in edge cases, and some of them are also only related to conversions from f64 to f32."
 )]
 
-use crate::draw::ExternalTextureRun;
+use crate::draw::{EXTERNAL_TEXTURE_SLOT_COUNT, ExternalTextureBindings, ExternalTextureRun};
 use crate::render::common::IMAGE_PADDING;
 use crate::util::RangedSlice;
 use crate::{
@@ -1035,9 +1035,9 @@ struct GpuResources {
     atlas_size: (u16, u16),
     /// Number of real atlas layers currently exposed by the texture view.
     atlas_layer_count: u32,
-    /// Bind group for paint sources: an atlas textures as texture array plus an external texture.
+    /// Bind group for paint sources: an atlas texture array plus four external texture slots.
     atlas_bind_group: BindGroup,
-    /// Transparent 1x1 placeholder texture in case no external texture is bound by the user.
+    /// Transparent 1x1 placeholder used for unoccupied external texture slots.
     placeholder_external_texture_view: TextureView,
     /// Texture for encoded paints
     encoded_paints_texture: Texture,
@@ -1161,31 +1161,36 @@ impl Programs {
                 ],
             });
 
+        let external_texture_layout_entry = |binding| wgpu::BindGroupLayoutEntry {
+            binding,
+            visibility: wgpu::ShaderStages::FRAGMENT,
+            ty: wgpu::BindingType::Texture {
+                sample_type: wgpu::TextureSampleType::Float { filterable: false },
+                view_dimension: wgpu::TextureViewDimension::D2,
+                multisampled: false,
+            },
+            count: None,
+        };
+        let paint_source_layout_entries = [
+            wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Texture {
+                    sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                    view_dimension: wgpu::TextureViewDimension::D2Array,
+                    multisampled: false,
+                },
+                count: None,
+            },
+            external_texture_layout_entry(1),
+            external_texture_layout_entry(2),
+            external_texture_layout_entry(3),
+            external_texture_layout_entry(4),
+        ];
         let atlas_bind_group_layout =
             device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
                 label: Some("Paint Source Bind Group Layout"),
-                entries: &[
-                    wgpu::BindGroupLayoutEntry {
-                        binding: 0,
-                        visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
-                        ty: wgpu::BindingType::Texture {
-                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
-                            view_dimension: wgpu::TextureViewDimension::D2Array,
-                            multisampled: false,
-                        },
-                        count: None,
-                    },
-                    wgpu::BindGroupLayoutEntry {
-                        binding: 1,
-                        visibility: wgpu::ShaderStages::FRAGMENT,
-                        ty: wgpu::BindingType::Texture {
-                            sample_type: wgpu::TextureSampleType::Float { filterable: false },
-                            view_dimension: wgpu::TextureViewDimension::D2,
-                            multisampled: false,
-                        },
-                        count: None,
-                    },
-                ],
+                entries: &paint_source_layout_entries,
             });
 
         let encoded_paints_bind_group_layout =
@@ -1695,7 +1700,7 @@ impl Programs {
             device,
             &atlas_bind_group_layout,
             &atlas_texture_array_view,
-            &placeholder_external_texture_view,
+            [&placeholder_external_texture_view; EXTERNAL_TEXTURE_SLOT_COUNT],
         );
 
         // Create a 1x1 stub atlas texture array for use during render_to_atlas.
@@ -1707,7 +1712,7 @@ impl Programs {
             device,
             &atlas_bind_group_layout,
             &stub_atlas_view,
-            &placeholder_external_texture_view,
+            [&placeholder_external_texture_view; EXTERNAL_TEXTURE_SLOT_COUNT],
         );
 
         const INITIAL_ENCODED_PAINTS_TEXTURE_HEIGHT: u32 = 1;
@@ -2126,7 +2131,7 @@ impl Programs {
         device: &Device,
         atlas_bind_group_layout: &BindGroupLayout,
         atlas_texture_array_view: &TextureView,
-        external_texture_view: &TextureView,
+        external_texture_views: [&TextureView; EXTERNAL_TEXTURE_SLOT_COUNT],
     ) -> BindGroup {
         let entries = [
             wgpu::BindGroupEntry {
@@ -2135,7 +2140,19 @@ impl Programs {
             },
             wgpu::BindGroupEntry {
                 binding: 1,
-                resource: wgpu::BindingResource::TextureView(external_texture_view),
+                resource: wgpu::BindingResource::TextureView(external_texture_views[0]),
+            },
+            wgpu::BindGroupEntry {
+                binding: 2,
+                resource: wgpu::BindingResource::TextureView(external_texture_views[1]),
+            },
+            wgpu::BindGroupEntry {
+                binding: 3,
+                resource: wgpu::BindingResource::TextureView(external_texture_views[2]),
+            },
+            wgpu::BindGroupEntry {
+                binding: 4,
+                resource: wgpu::BindingResource::TextureView(external_texture_views[3]),
             },
         ];
         device.create_bind_group(&wgpu::BindGroupDescriptor {
@@ -2474,7 +2491,7 @@ impl Programs {
                     device,
                     atlas_bind_group_layout,
                     &new_atlas_texture_array_view,
-                    &resources.placeholder_external_texture_view,
+                    [&resources.placeholder_external_texture_view; EXTERNAL_TEXTURE_SLOT_COUNT],
                 );
                 resources.atlas_texture_array_view = new_atlas_texture_array_view;
                 resources.atlas_bind_group = new_atlas_bind_group;
@@ -2505,7 +2522,7 @@ impl Programs {
                 device,
                 atlas_bind_group_layout,
                 &new_atlas_texture_array_view,
-                &resources.placeholder_external_texture_view,
+                [&resources.placeholder_external_texture_view; EXTERNAL_TEXTURE_SLOT_COUNT],
             );
 
             // Replace the old resources
@@ -2519,13 +2536,13 @@ impl Programs {
     fn create_external_paint_source_bind_group(
         &self,
         device: &Device,
-        external_texture_view: &TextureView,
+        external_texture_views: [&TextureView; EXTERNAL_TEXTURE_SLOT_COUNT],
     ) -> BindGroup {
         Self::create_paint_source_bind_group(
             device,
             &self.atlas_bind_group_layout,
             &self.resources.atlas_texture_array_view,
-            external_texture_view,
+            external_texture_views,
         )
     }
 
@@ -2748,25 +2765,31 @@ struct RendererContext<'a> {
     view: &'a TextureView,
     depth_view: Option<&'a TextureView>,
     texture_bindings: &'a TextureBindings,
-    external_paint_source_bind_groups: HashMap<TextureId, BindGroup>,
+    external_paint_source_bind_groups: HashMap<ExternalTextureBindings, BindGroup>,
     scratch_buffers: &'a mut ScratchBuffers,
 }
 
 impl RendererContext<'_> {
-    fn external_paint_source_bind_group_for_texture(
+    fn external_paint_source_bind_group_for_textures(
         &mut self,
-        texture_id: TextureId,
+        bindings: ExternalTextureBindings,
     ) -> &BindGroup {
-        match self.external_paint_source_bind_groups.entry(texture_id) {
+        match self.external_paint_source_bind_groups.entry(bindings) {
             Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => {
-                let texture_view = self
-                    .texture_bindings
-                    .get(texture_id)
-                    .expect("external texture bindings were validated during paint preparation");
+                let texture_views = bindings.as_array().map(|texture_id| {
+                    texture_id.map_or(
+                        &self.programs.resources.placeholder_external_texture_view,
+                        |texture_id| {
+                            self.texture_bindings.get(texture_id).expect(
+                                "external texture bindings were validated during paint preparation",
+                            )
+                        },
+                    )
+                });
                 let bind_group = self
                     .programs
-                    .create_external_paint_source_bind_group(self.device, texture_view);
+                    .create_external_paint_source_bind_group(self.device, texture_views);
                 entry.insert(bind_group)
             }
         }
@@ -2792,7 +2815,7 @@ impl RendererContext<'_> {
         // Create bind groups for all external textures passed in by the user that are used this
         // pass.
         for run in external_texture_runs {
-            self.external_paint_source_bind_group_for_texture(run.texture_id);
+            self.external_paint_source_bind_group_for_textures(run.bindings);
         }
 
         self.programs
@@ -2899,7 +2922,7 @@ impl RendererContext<'_> {
             for (i, run) in external_texture_runs.iter().enumerate() {
                 let paint_source_bind_group = self
                     .external_paint_source_bind_groups
-                    .get(&run.texture_id)
+                    .get(&run.bindings)
                     .unwrap();
                 render_pass.set_bind_group(1, paint_source_bind_group, &[]);
                 let start = u32::try_from(run.strips_start).unwrap();

--- a/sparse_strips/vello_sparse_shaders/shaders/render.wesl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render.wesl
@@ -73,8 +73,9 @@ const PAINT_TYPE_RADIAL_GRADIENT: u32 = 3u;
 const PAINT_TYPE_SWEEP_GRADIENT: u32 = 4u;
 const PAINT_TYPE_BLURRED_ROUNDED_RECT: u32 = 5u;
 
-// Paint texture index mask (extracts lower 26 bits from paint field).
-const PAINT_TEXTURE_INDEX_MASK: u32 = 0x03FFFFFFu;
+// 24 bits for paint indices.
+const PAINT_TEXTURE_INDEX_MASK: u32 = 0x00FFFFFFu;
+const EXTERNAL_TEXTURE_SLOT_SHIFT: u32 = 24u;
 
 const RECT_STRIP_FLAG: u32 = 0x80000000u;
 
@@ -129,7 +130,8 @@ struct Config {
 //       - Bits 26-28: `paint_type` (0 = solid, 1 = image, 2 = linear_gradient, 3 = radial_gradient, 4 = sweep_gradient)
 //       - Bits 0-25:
 //         - If paint_type = 0: unused
-//         - If paint_type >= 1: `paint_texture_idx`
+//         - Bits 0-23: `paint_texture_idx` for every non-solid paint
+//         - Bits 24-25: external texture slot for external images; unused otherwise
 //
 //     When color_source = 1 (COLOR_SOURCE_LAYER):
 //       - Bits 0-7: opacity (0-255)
@@ -223,7 +225,16 @@ var<uniform> config: Config;
 var atlas_texture_array: texture_2d_array<f32>;
 
 @group(1) @binding(1)
-var external_texture: texture_2d<f32>;
+var external_texture_0: texture_2d<f32>;
+
+@group(1) @binding(2)
+var external_texture_1: texture_2d<f32>;
+
+@group(1) @binding(3)
+var external_texture_2: texture_2d<f32>;
+
+@group(1) @binding(4)
+var external_texture_3: texture_2d<f32>;
 
 @group(2) @binding(0)
 var encoded_paints_texture: texture_2d<u32>;
@@ -421,14 +432,42 @@ fn fs_main(
 
             var sample_color: vec4<f32>;
             if image_source_kind == IMAGE_SOURCE_EXTERNAL {
+                let external_texture_slot =
+                    (paint_and_rect_flag >> EXTERNAL_TEXTURE_SLOT_SHIFT) & 0x3u;
                 let final_xy = image_offset + extended_xy;
-                sample_color = sample_external_image(
-                    external_texture,
-                    image_quality,
-                    final_xy,
-                    image_offset,
-                    image_size,
-                );
+                if external_texture_slot == 0u {
+                    sample_color = sample_external_image(
+                        external_texture_0,
+                        image_quality,
+                        final_xy,
+                        image_offset,
+                        image_size,
+                    );
+                } else if external_texture_slot == 1u {
+                    sample_color = sample_external_image(
+                        external_texture_1,
+                        image_quality,
+                        final_xy,
+                        image_offset,
+                        image_size,
+                    );
+                } else if external_texture_slot == 2u {
+                    sample_color = sample_external_image(
+                        external_texture_2,
+                        image_quality,
+                        final_xy,
+                        image_offset,
+                        image_size,
+                    );
+                } else {
+                    sample_color = sample_external_image(
+                        external_texture_3,
+                        image_quality,
+                        final_xy,
+                        image_offset,
+                        image_size,
+                    );
+                }
             } else if image_quality == IMAGE_QUALITY_HIGH {
                 let final_xy = image_offset + extended_xy;
                 sample_color = bicubic_sample(

--- a/sparse_strips/vello_sparse_shaders/shaders/render.wesl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render.wesl
@@ -150,10 +150,10 @@ struct Config {
 // ├── paint_type = 3 (PAINT_TYPE_RADIAL_GRADIENT) - Radial gradient (with kind discriminator)
 // ├── paint_type = 4 (PAINT_TYPE_SWEEP_GRADIENT) - Sweep gradient rendering
 //     ├── payload = [x, y] scene coordinates (packed as u16s)
-//     └── bits 0-25 = paint_texture_idx
+//     └── bits 0-23 = paint_texture_idx
 // └── paint_type = 5 (PAINT_TYPE_BLURRED_ROUNDED_RECT) - Analytic blurred rounded rectangle
 //     ├── payload = [x, y] scene coordinates (packed as u16s)
-//     └── bits 0-25 = paint_texture_idx
+//     └── bits 0-23 = paint_texture_idx
 //
 // color_source = 1 (COLOR_SOURCE_LAYER) - Use rendered layer texture
 // ├── payload = [x, y] source layer texture origin (packed as u16s)


### PR DESCRIPTION
This PR adds support for binding up to 4 external textures in a single draw call. This is achieved by simply making use of more shader slots (which WebGL2 guarantees to support at least 16, so we are still well below the limit) and changing the CPU batching algorithm to support multiple external images in a single pass. This reduces the number of draw calls emitted, but does make the shader more branchy. Once we move to specialized shaders, we should carefully re-evaluate whether the branching makes image rendering slower, but for our current uber shader it does not seem to make a difference. And our previous experiments have shown that the CPU-side overhead of draw calls can also be considerable, so in this regard this PR is an improvement.

The main motivation for this PR however is to enable the follow-up PR that removes 2D texure arrays to keep the draw count minimal.
