### PR TITLE
Make Vello Classic bump-buffer reservations configurable

### DIFF
--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -143,7 +143,7 @@ use peniko::ImageData;
 pub use wgpu;
 
 pub use scene::{DrawGlyphs, Scene};
-pub use vello_encoding::{FontEmbolden, Glyph, NormalizedCoord};
+pub use vello_encoding::{BumpAllocationSizes, FontEmbolden, Glyph, NormalizedCoord};
 
 use low_level::ShaderId;
 #[cfg(feature = "wgpu")]
@@ -332,6 +332,7 @@ pub struct Renderer {
     resolver: Resolver,
     image_atlas: Option<recording::ImageProxy>,
     shaders: FullShaders,
+    bump_allocation_sizes: BumpAllocationSizes,
     #[cfg(feature = "debug_layers")]
     debug: debug::DebugRenderer,
     #[cfg(feature = "wgpu-profiler")]
@@ -448,6 +449,7 @@ impl Renderer {
             resolver: Resolver::new(),
             image_atlas: None,
             shaders,
+            bump_allocation_sizes: BumpAllocationSizes::default(),
             #[cfg(feature = "debug_layers")]
             debug,
             #[cfg(feature = "wgpu-profiler")]
@@ -455,6 +457,24 @@ impl Renderer {
             #[cfg(feature = "wgpu-profiler")]
             profile_result: None,
         })
+    }
+
+    /// Sets the reservations for buffers allocated through the GPU bump allocator.
+    ///
+    /// The default values accommodate Vello's test scenes and `paris-30k`. Smaller
+    /// reservations can reduce memory use, but exhausted buffers omit parts of a frame.
+    /// Callers should only customize these values when they can bound or validate their
+    /// workloads.
+    pub fn set_bump_allocation_sizes(&mut self, sizes: BumpAllocationSizes) {
+        if self.bump_allocation_sizes != sizes {
+            self.engine.clear_pool();
+            self.bump_allocation_sizes = sizes;
+        }
+    }
+
+    /// Returns the current bump-buffer reservations.
+    pub fn bump_allocation_sizes(&self) -> BumpAllocationSizes {
+        self.bump_allocation_sizes
     }
 
     /// Renders a scene to the target texture.
@@ -485,6 +505,7 @@ impl Renderer {
             &self.shaders,
             &mut self.image_atlas,
             params,
+            &self.bump_allocation_sizes,
         );
         let external_resources = [ExternalResource::Image(
             *target.as_image().unwrap(),
@@ -734,6 +755,7 @@ impl Renderer {
             &self.shaders,
             &mut self.image_atlas,
             params,
+            &self.bump_allocation_sizes,
             robust,
         );
         let target = render.out_image();

--- a/vello/src/render.rs
+++ b/vello/src/render.rs
@@ -87,8 +87,16 @@ pub(crate) fn render_full(
     shaders: &FullShaders,
     image_atlas: &mut Option<ImageProxy>,
     params: &RenderParams,
+    bump_sizes: &vello_encoding::BumpAllocationSizes,
 ) -> (Recording, ResourceProxy) {
-    render_encoding_full(scene.encoding(), resolver, shaders, image_atlas, params)
+    render_encoding_full(
+        scene.encoding(),
+        resolver,
+        shaders,
+        image_atlas,
+        params,
+        bump_sizes,
+    )
 }
 
 #[cfg(feature = "wgpu")]
@@ -102,10 +110,18 @@ pub(crate) fn render_encoding_full(
     shaders: &FullShaders,
     image_atlas: &mut Option<ImageProxy>,
     params: &RenderParams,
+    bump_sizes: &vello_encoding::BumpAllocationSizes,
 ) -> (Recording, ResourceProxy) {
     let mut render = Render::new();
-    let mut recording =
-        render.render_encoding_coarse(encoding, resolver, shaders, image_atlas, params, false);
+    let mut recording = render.render_encoding_coarse(
+        encoding,
+        resolver,
+        shaders,
+        image_atlas,
+        params,
+        bump_sizes,
+        false,
+    );
     let out_image = render.out_image();
     render.record_fine(shaders, &mut recording);
     (recording, out_image.into())
@@ -139,6 +155,7 @@ impl Render {
         shaders: &FullShaders,
         persistent_image_atlas: &mut Option<ImageProxy>,
         params: &RenderParams,
+        bump_sizes: &vello_encoding::BumpAllocationSizes,
         robust: bool,
     ) -> Recording {
         use vello_encoding::RenderConfig;
@@ -201,8 +218,13 @@ impl Render {
         for image in images.images {
             recording.write_image(image_atlas, image.1, image.2, image.0.clone());
         }
-        let cpu_config =
-            RenderConfig::new(&layout, params.width, params.height, &params.base_color);
+        let cpu_config = RenderConfig::new_with_bump_sizes(
+            &layout,
+            params.width,
+            params.height,
+            &params.base_color,
+            bump_sizes,
+        );
         // HACK: The coarse workgroup counts is the number of active bins.
         if (cpu_config.workgroup_counts.coarse.0
             * cpu_config.workgroup_counts.coarse.1

--- a/vello/src/wgpu_engine.rs
+++ b/vello/src/wgpu_engine.rs
@@ -784,6 +784,10 @@ impl WgpuEngine {
         self.downloads.remove(&buf.id);
     }
 
+    pub(crate) fn clear_pool(&mut self) {
+        self.pool.bufs.clear();
+    }
+
     fn create_bind_group_layout_entries(
         layout: impl Iterator<Item = (BindType, wgpu::ShaderStages)>,
     ) -> Vec<wgpu::BindGroupLayoutEntry> {

--- a/vello_encoding/src/config.rs
+++ b/vello_encoding/src/config.rs
@@ -166,6 +166,23 @@ pub struct RenderConfig {
 
 impl RenderConfig {
     pub fn new(layout: &Layout, width: u32, height: u32, base_color: &peniko::Color) -> Self {
+        Self::new_with_bump_sizes(
+            layout,
+            width,
+            height,
+            base_color,
+            &BumpAllocationSizes::default(),
+        )
+    }
+
+    /// Creates a render configuration with explicit bump-buffer reservations.
+    pub fn new_with_bump_sizes(
+        layout: &Layout,
+        width: u32,
+        height: u32,
+        base_color: &peniko::Color,
+        bump_sizes: &BumpAllocationSizes,
+    ) -> Self {
         let new_width = width.next_multiple_of(TILE_WIDTH);
         let new_height = height.next_multiple_of(TILE_HEIGHT);
         let width_in_tiles = new_width / TILE_WIDTH;
@@ -173,7 +190,7 @@ impl RenderConfig {
         let n_path_tags = layout.path_tags_size();
         let workgroup_counts =
             WorkgroupCounts::new(layout, width_in_tiles, height_in_tiles, n_path_tags);
-        let buffer_sizes = BufferSizes::new(layout, &workgroup_counts);
+        let buffer_sizes = BufferSizes::new_with_bump_sizes(layout, &workgroup_counts, bump_sizes);
         Self {
             gpu: ConfigUniform {
                 width_in_tiles,
@@ -328,6 +345,46 @@ impl<T: Sized> PartialOrd for BufferSize<T> {
     }
 }
 
+/// Element counts reserved for buffers allocated through the GPU bump allocator.
+///
+/// The defaults preserve Vello's existing fixed reservations. Smaller values can
+/// reduce memory use, but an exhausted buffer causes parts of a frame to be omitted.
+/// Callers should only customize these values when they can bound or validate their
+/// workloads.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct BumpAllocationSizes {
+    /// Line-soup elements.
+    pub lines: u32,
+    /// `u32` elements in the combined draw-info and binning buffer.
+    ///
+    /// The allocation is raised to fit the draw-info prefix when necessary.
+    pub bin_data: u32,
+    /// Tile elements.
+    pub tiles: u32,
+    /// Segment-count elements.
+    pub seg_counts: u32,
+    /// Path-segment elements.
+    pub segments: u32,
+    /// `u32` elements in the blend-spill buffer (256 elements per spill).
+    pub blend_spill: u32,
+    /// `u32` elements in the per-tile command-list buffer.
+    pub ptcl: u32,
+}
+
+impl Default for BumpAllocationSizes {
+    fn default() -> Self {
+        Self {
+            lines: 1 << 21,
+            bin_data: 1 << 18,
+            tiles: 1 << 21,
+            seg_counts: 1 << 21,
+            segments: 1 << 21,
+            blend_spill: 1 << 20,
+            ptcl: 1 << 23,
+        }
+    }
+}
+
 /// Computed sizes for all buffers.
 #[derive(Copy, Clone, Debug, Default)]
 pub struct BufferSizes {
@@ -361,6 +418,15 @@ pub struct BufferSizes {
 
 impl BufferSizes {
     pub fn new(layout: &Layout, workgroups: &WorkgroupCounts) -> Self {
+        Self::new_with_bump_sizes(layout, workgroups, &BumpAllocationSizes::default())
+    }
+
+    /// Computes buffer sizes using explicit bump-buffer reservations.
+    pub fn new_with_bump_sizes(
+        layout: &Layout,
+        workgroups: &WorkgroupCounts,
+        bump_sizes: &BumpAllocationSizes,
+    ) -> Self {
         let n_paths = layout.n_paths;
         let n_draw_objects = layout.n_draw_objects;
         let n_clips = layout.n_clips;
@@ -395,17 +461,17 @@ impl BufferSizes {
         let aligned_n_bins = align_up(n_bins, 256);
         let bin_headers = BufferSize::new(binning_wgs * aligned_n_bins);
 
-        // The following buffer sizes have been hand picked to accommodate the vello test scenes as
-        // well as paris-30k. These should instead get derived from the scene layout using
-        // reasonable heuristics.
-        let bin_data = BufferSize::new(1 << 18);
-        let tiles = BufferSize::new(1 << 21);
-        let lines = BufferSize::new(1 << 21);
-        let seg_counts = BufferSize::new(1 << 21);
-        let segments = BufferSize::new(1 << 21);
-        // 16 * 16 (1 << 8) is one blend spill, so this allows for 4096 spills.
-        let blend_spill = BufferSize::new(1 << 20);
-        let ptcl = BufferSize::new(1 << 23);
+        // The defaults were hand-picked to accommodate Vello's test scenes and paris-30k.
+        // Callers with bounded workloads can provide different reservations.
+        // BufferSize::new bounds every allocation away from zero because these
+        // buffers are still bound even when a scene does not use them.
+        let bin_data = BufferSize::new(bump_sizes.bin_data.max(layout.bin_data_start));
+        let tiles = BufferSize::new(bump_sizes.tiles);
+        let lines = BufferSize::new(bump_sizes.lines);
+        let seg_counts = BufferSize::new(bump_sizes.seg_counts);
+        let segments = BufferSize::new(bump_sizes.segments);
+        let blend_spill = BufferSize::new(bump_sizes.blend_spill);
+        let ptcl = BufferSize::new(bump_sizes.ptcl);
         Self {
             path_reduced,
             path_reduced2,
@@ -437,4 +503,73 @@ impl BufferSizes {
 
 const fn align_up(len: u32, alignment: u32) -> u32 {
     len + (len.wrapping_neg() & (alignment - 1))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BufferSizes, BumpAllocationSizes, WorkgroupCounts};
+    use crate::Layout;
+
+    fn sizes(layout: &Layout, bump_sizes: &BumpAllocationSizes) -> BufferSizes {
+        let workgroups = WorkgroupCounts::new(layout, 1, 1, layout.path_tags_size());
+        BufferSizes::new_with_bump_sizes(layout, &workgroups, bump_sizes)
+    }
+
+    #[test]
+    fn default_bump_sizes_preserve_existing_reservations() {
+        let sizes = sizes(&Layout::new(), &BumpAllocationSizes::default());
+        assert_eq!(sizes.lines.len(), 1 << 21);
+        assert_eq!(sizes.bin_data.len(), 1 << 18);
+        assert_eq!(sizes.tiles.len(), 1 << 21);
+        assert_eq!(sizes.seg_counts.len(), 1 << 21);
+        assert_eq!(sizes.segments.len(), 1 << 21);
+        assert_eq!(sizes.blend_spill.len(), 1 << 20);
+        assert_eq!(sizes.ptcl.len(), 1 << 23);
+    }
+
+    #[test]
+    fn custom_bump_sizes_are_used() {
+        let mut layout = Layout::new();
+        layout.bin_data_start = 32;
+        let custom = BumpAllocationSizes {
+            lines: 2,
+            bin_data: 3,
+            tiles: 4,
+            seg_counts: 5,
+            segments: 6,
+            blend_spill: 7,
+            ptcl: 8,
+        };
+        let sizes = sizes(&layout, &custom);
+        assert_eq!(sizes.lines.len(), 2);
+        assert_eq!(sizes.bin_data.len(), layout.bin_data_start);
+        assert_eq!(sizes.tiles.len(), 4);
+        assert_eq!(sizes.seg_counts.len(), 5);
+        assert_eq!(sizes.segments.len(), 6);
+        assert_eq!(sizes.blend_spill.len(), 7);
+        assert_eq!(sizes.ptcl.len(), 8);
+    }
+
+    #[test]
+    fn zero_bump_sizes_still_create_bindable_buffers() {
+        let sizes = sizes(
+            &Layout::new(),
+            &BumpAllocationSizes {
+                lines: 0,
+                bin_data: 0,
+                tiles: 0,
+                seg_counts: 0,
+                segments: 0,
+                blend_spill: 0,
+                ptcl: 0,
+            },
+        );
+        assert_eq!(sizes.lines.len(), 1);
+        assert_eq!(sizes.bin_data.len(), 1);
+        assert_eq!(sizes.tiles.len(), 1);
+        assert_eq!(sizes.seg_counts.len(), 1);
+        assert_eq!(sizes.segments.len(), 1);
+        assert_eq!(sizes.blend_spill.len(), 1);
+        assert_eq!(sizes.ptcl.len(), 1);
+    }
 }

--- a/vello_encoding/src/lib.rs
+++ b/vello_encoding/src/lib.rs
@@ -49,8 +49,8 @@ mod resolve;
 pub use binning::BinHeader;
 pub use clip::{Clip, ClipBbox, ClipBic, ClipElement};
 pub use config::{
-    BufferSize, BufferSizes, BumpAllocatorMemory, BumpAllocators, ConfigUniform, IndirectCount,
-    RenderConfig, WorkgroupCounts, WorkgroupSize,
+    BufferSize, BufferSizes, BumpAllocationSizes, BumpAllocatorMemory, BumpAllocators,
+    ConfigUniform, IndirectCount, RenderConfig, WorkgroupCounts, WorkgroupSize,
 };
 pub use draw::{
     DRAW_INFO_FLAGS_FILL_RULE_BIT, DrawBbox, DrawBeginClip, DrawBlurRoundedRect, DrawColor,


### PR DESCRIPTION
## Problem

While reducing Vello Classic's fixed GPU bump-buffer allocations for a memory-constrained renderer, I found that the seven capacities are hard-coded. Using smaller downstream constants reduced the requested buffer capacity, but an undersized buffer can omit geometry without returning an error.

This affects embedders that need a different memory budget and can validate a bounded set of scenes. Applications using the existing defaults are unaffected by this change.

## Approach

Keep the current capacities as the default, but allow callers to provide different values. This avoids changing memory behavior for existing users and leaves responsibility for validating smaller capacities with the caller.

This does not attempt automatic sizing or recovery. Vello cannot currently rerender the damaged frame reliably after discovering that a buffer was exhausted.

## Changes

- Add `BumpAllocationSizes`, containing the element count for each of the seven bump-buffer allocations.
- Add `RenderConfig::new_with_bump_sizes` and `BufferSizes::new_with_bump_sizes`; the existing constructors continue to use the current defaults.
- Add `Renderer::set_bump_allocation_sizes` and a corresponding getter.
- Clear pooled buffers when the configuration changes.
- Clamp zero-sized allocations to one element and ensure `bin_data` still fits its draw-info prefix.
- Add tests for default, custom, and zero-valued configurations.

An undersized configuration can still produce incomplete frames. The new API also exposes details of the Classic pipeline and changing profiles clears the buffer pool.

## Testing

I compared unmodified `main` with this profile:

```rust
BumpAllocationSizes {
    lines: 1 << 21,
    bin_data: 1 << 18,
    tiles: 1 << 20,
    seg_counts: 1 << 20,
    segments: 1 << 20,
    blend_spill: 1 << 18,
    ptcl: 1 << 22,
}
```

Both were release builds using Rust 1.95 on Linux with Vulkan/llvmpipe. Each result used 20 warm-up frames and 60 measured frames, repeated three times with the two builds alternated. The table reports the median of the three per-run medians.

| Scene | Default buffer capacity | Test profile capacity | Default | Test profile |
| --- | ---: | ---: | ---: | ---: |
| `splash` | 165.0 MiB | 60.5 MiB | 2.993 ms | 2.866 ms |
| `many_clips` | 165.0 MiB | 60.5 MiB | 2.650 ms | 2.631 ms |
| `image_sampling_bicubic` | 165.0 MiB | 60.5 MiB | 1.875 ms | 2.001 ms |
| `longpathdash_butt` | 165.0 MiB | 60.5 MiB | 35.182 ms | 34.823 ms |

The profile requests 60.5 MiB across these seven buffers instead of 165.0 MiB, a reduction of 104.5 MiB (63.3%) in their requested capacity. This is not a measurement of total GPU or process memory; it excludes other resources, alignment, pooling, and driver overhead.

Run-to-run timing variation was larger than most differences in the table, so these results do not show a speed-up or slowdown. They also do not cover discrete GPUs, Metal, or browsers.

Debug counter readback reported `failed == 0` for the four scenes above. The same profile reported `failed == 1` for `mmark_80k`, confirming that the profile is not suitable for every scene.

Additional checks:

- `cargo test -p vello_encoding --lib --all-features` (34 passed)
- `cargo test -p vello --lib --all-features`
- warning-denying Clippy for both crates on Rust 1.95
- the full cross-platform CI matrix

_AI usage: This PR was prepared with assistance from an AI coding tool._
