### PR TITLE
Report image draws omitted by atlas capacity limits

### DIFF
--- a/vello/src/render.rs
+++ b/vello/src/render.rs
@@ -198,6 +198,15 @@ impl Render {
                 );
             }
         }
+        // Warn on the first resolve pass that omits any image draws.
+        if images.omitted != 0 && images.omitted_total == images.omitted as u64 {
+            log::warn!(
+                "image atlas {}x{} omitted {} image draw(s); further omissions will not be logged",
+                atlas_width,
+                atlas_height,
+                images.omitted,
+            );
+        }
         for image in images.images {
             recording.write_image(image_atlas, image.1, image.2, image.0.clone());
         }

--- a/vello_encoding/src/image_cache.rs
+++ b/vello_encoding/src/image_cache.rs
@@ -20,6 +20,10 @@ pub struct Images<'a> {
     ///
     /// This is only used for renderer-side debug logging.
     pub evicted: usize,
+    /// Image draws omitted because they could not be allocated this resolve pass.
+    pub omitted: usize,
+    /// Image draws omitted over the lifetime of this cache.
+    pub omitted_total: u64,
     /// Images that must be uploaded in the current resolve pass, with atlas locations.
     pub images: &'a [(ImageData, u32, u32)],
 }
@@ -45,6 +49,10 @@ pub(crate) struct ImageCache {
     /// This is exposed through [`Images::evicted`] for renderer-side debug logging, and also
     /// prevents repeated stale-eviction scans during the same resolve pass.
     evicted_in_resolve: usize,
+    /// Image draws omitted during the current resolve pass.
+    omitted_in_resolve: usize,
+    /// Image draws omitted over the lifetime of this cache.
+    omitted_total: u64,
     /// Map from image blob id to atlas residency.
     map: HashMap<u64, ResidentImage>,
     /// Images that must be uploaded in the current resolve pass, with atlas locations.
@@ -68,6 +76,8 @@ impl ImageCache {
             max_size,
             generation: 0,
             evicted_in_resolve: 0,
+            omitted_in_resolve: 0,
+            omitted_total: 0,
             map: HashMap::default(),
             images: Vec::default(),
         }
@@ -76,6 +86,7 @@ impl ImageCache {
     pub(crate) fn begin_resolve(&mut self) {
         self.generation = self.generation.wrapping_add(1);
         self.evicted_in_resolve = 0;
+        self.omitted_in_resolve = 0;
         self.images.clear();
     }
 
@@ -94,6 +105,8 @@ impl ImageCache {
             width: self.atlas.size().width as u32,
             height: self.atlas.size().height as u32,
             evicted: self.evicted_in_resolve,
+            omitted: self.omitted_in_resolve,
+            omitted_total: self.omitted_total,
             images: &self.images,
         }
     }
@@ -164,6 +177,11 @@ impl ImageCache {
             && image.height <= self.atlas.size().height as u32
     }
 
+    pub(crate) fn record_omission(&mut self) {
+        self.omitted_in_resolve = self.omitted_in_resolve.saturating_add(1);
+        self.omitted_total = self.omitted_total.saturating_add(1);
+    }
+
     pub(crate) fn evict_stale_entries(&mut self) -> bool {
         if self.evicted_in_resolve != 0 {
             return false;
@@ -230,6 +248,20 @@ mod tests {
         assert_eq!(cache.atlas.size().width, 32);
         cache.begin_resolve();
         assert_eq!(cache.atlas.size().width, 32);
+    }
+
+    #[test]
+    fn omission_count_is_per_pass_and_cumulative() {
+        let mut cache = ImageCache::new_with_sizes(16, 16);
+        cache.begin_resolve();
+        cache.record_omission();
+        cache.record_omission();
+        assert_eq!(cache.images().omitted, 2);
+        assert_eq!(cache.images().omitted_total, 2);
+
+        cache.begin_resolve();
+        assert_eq!(cache.images().omitted, 0);
+        assert_eq!(cache.images().omitted_total, 2);
     }
 
     #[test]

--- a/vello_encoding/src/resolve.rs
+++ b/vello_encoding/src/resolve.rs
@@ -527,7 +527,9 @@ impl Resolver {
                     } else {
                         // If the atlas is already maximum size, there's nothing we can do. Set
                         // the xy field to None so this image isn't rendered and then carry on--
-                        // other images might still fit.
+                        // other images might still fit. Record the omission so the renderer can
+                        // report why the image is missing.
+                        self.image_cache.record_omission();
                         break None;
                     }
                 };


### PR DESCRIPTION
## Problem

While debugging missing dynamic images, I found that Vello Classic silently omits an image draw when atlas allocation still fails after growing the atlas and evicting stale entries. The resolver uses no atlas location for that image and continues rendering, so the missing image has no visible explanation in the application log.

This can affect applications whose image set can exhaust the maximum atlas. Applications with small, fixed image sets are unlikely to encounter it.

## Approach

Report the existing failure rather than change atlas allocation or attempt recovery. The renderer emits one warning on the first resolve pass that omits images. Later omissions are suppressed to avoid logging every affected frame.

This is limited to logging because the current renderer API has no structured diagnostic channel for this condition. It does not recover the image or let the application react programmatically.

## Changes

- Count omitted image draws during each resolve pass.
- Keep a cumulative count over the image cache lifetime to suppress warnings after the first failing pass.
- Emit one renderer warning containing the atlas dimensions and number of draws omitted in that pass.
- Add a test covering per-pass reset and cumulative counter behavior.

The warning does not identify the affected image. It also cannot distinguish an image larger than the maximum atlas from an atlas occupied by other live images.

## Testing

- `cargo test -p vello_encoding --lib --all-features --locked` (32 passed)
- `cargo test -p vello --lib --all-features --locked`
- warning-denying Clippy for both crates on Rust 1.95
- repository formatting and diff checks
- the full cross-platform CI matrix

## Performance impact

I found no measurable steady-state performance impact. I benchmarked the changed per-resolve bookkeeping in release mode on an AMD Ryzen 9 7940HS, pinned to one core. Each revision ran 200 million iterations in six alternating runs.

| Revision | Median | Range |
| --- | ---: | ---: |
| Unmodified base | 1.519 ns/resolve | 1.506–1.547 ns |
| This PR | 1.526 ns/resolve | 1.521–1.543 ns |

The median difference was 0.007 ns, or 0.46%, and the ranges overlap. This is below the resolution of the benchmark and is not evidence of a regression.

The benchmark covers the bookkeeping performed on every image resolve. It does not include the failure-only warning. Each omitted image adds two saturating integer increments; the first failing resolve also emits one log message. Logging is more expensive than the counters, but occurs only once per image-cache lifetime after atlas allocation has already failed.

_AI usage: This PR was prepared with assistance from an AI coding tool._
