### PR TITLE
Fix warning-denying builds on Rust 1.97

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ env:
   # If the compilation fails, then the version specified here needs to be bumped up to reality.
   # Be sure to also update the rust-version property in the workspace Cargo.toml file,
   # plus all the README.md files of the affected packages.
+  # Remove the MSRV jobs' single-use-lifetimes allowance once this is at least 1.97.
   RUST_MIN_VER: "1.89"
   # List of packages that will be checked with the minimum supported Rust version.
   # This should be limited to packages that are intended for publishing.
@@ -517,6 +518,8 @@ jobs:
   check-msrv:
     name: cargo check (msrv)
     runs-on: ${{ matrix.os }}
+    env:
+      RUSTFLAGS: '-A single-use-lifetimes'
     strategy:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
@@ -553,6 +556,8 @@ jobs:
   check-msrv-wasm:
     name: cargo check (msrv) (wasm32)
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: '-A single-use-lifetimes'
     steps:
       - uses: actions/checkout@v6
 

--- a/vello/src/scene.rs
+++ b/vello/src/scene.rs
@@ -97,10 +97,6 @@ impl Scene {
     ///
     /// **However, the transforms are *not* saved or modified by the layer stack.**
     /// That is, the `transform` argument to this function only applies a transform to the `clip` shape.
-    #[expect(
-        single_use_lifetimes,
-        reason = "False positive: https://github.com/rust-lang/rust/issues/129255"
-    )]
     #[track_caller]
     pub fn push_layer<'a>(
         &mut self,
@@ -147,10 +143,6 @@ impl Scene {
     /// This issue only occurs if there are no intermediate opaque layers, so can be worked around
     /// by drawing something opaque (or having an opaque `base_color`), then putting a layer around your entire scene
     /// with a [`Compose::SrcOver`].
-    #[expect(
-        single_use_lifetimes,
-        reason = "False positive: https://github.com/rust-lang/rust/issues/129255"
-    )]
     pub fn push_luminance_mask_layer<'a>(
         &mut self,
         clip_style: impl Into<StyleRef<'a>>,
@@ -185,10 +177,6 @@ impl Scene {
     ///
     /// **However, the transforms are *not* saved or modified by the layer stack.**
     /// That is, the `transform` argument to this function only applies a transform to the `clip` shape.
-    #[expect(
-        single_use_lifetimes,
-        reason = "False positive: https://github.com/rust-lang/rust/issues/129255"
-    )]
     pub fn push_clip_layer<'a>(
         &mut self,
         clip_style: impl Into<StyleRef<'a>>,
@@ -309,10 +297,6 @@ impl Scene {
     }
 
     /// Fills a shape using the specified style and brush.
-    #[expect(
-        single_use_lifetimes,
-        reason = "False positive: https://github.com/rust-lang/rust/issues/129255"
-    )]
     pub fn fill<'b>(
         &mut self,
         style: Fill,
@@ -340,10 +324,6 @@ impl Scene {
     }
 
     /// Strokes a shape using the specified style and brush.
-    #[expect(
-        single_use_lifetimes,
-        reason = "False positive: https://github.com/rust-lang/rust/issues/129255"
-    )]
     pub fn stroke<'b>(
         &mut self,
         style: &Stroke,

--- a/vello_encoding/src/encoding.rs
+++ b/vello_encoding/src/encoding.rs
@@ -273,10 +273,6 @@ impl Encoding {
     }
 
     /// Encodes a brush with an optional alpha modifier.
-    #[expect(
-        single_use_lifetimes,
-        reason = "False positive: https://github.com/rust-lang/rust/issues/129255"
-    )]
     pub fn encode_brush<'b>(&mut self, brush: impl Into<BrushRef<'b>>, alpha: f32) {
         use super::math::point_to_f32;
         match brush.into() {


### PR DESCRIPTION
## Problem

Building Vello with Rust 1.97 and `-D warnings` fails. Six functions use `#[expect(single_use_lifetimes)]` for a compiler false positive fixed in Rust 1.97. Because the lint no longer fires on Rust 1.97, the expectation is unfulfilled and becomes an error:

```text
error: this lint expectation is unfulfilled
  = note: `-D unfulfilled-lint-expectations` implied by `-D warnings`
```

This affects Rust 1.97 and newer when warnings are denied. Vello's MSRV is Rust 1.89 and its pinned stable CI toolchain is Rust 1.95, so the existing CI jobs did not expose the failure.

## Approach

Remove the source-level expectations and keep the old-compiler workaround only in the MSRV CI jobs. This follows the approach suggested in review: Rust 1.89 still gets `-A single-use-lifetimes`, while Rust 1.97 no longer sees an obsolete expectation.

The CI allowance can be removed when Vello's MSRV reaches Rust 1.97. Downstream projects that explicitly enable `single_use_lifetimes` while using Rust 1.89 through 1.96 may still need the same allowance.

## Changes

- Remove six `#[expect(single_use_lifetimes)]` attributes from `vello` and `vello_encoding`.
- Set `RUSTFLAGS=-A single-use-lifetimes` in the native and Wasm MSRV jobs.
- Add the removal condition next to `RUST_MIN_VER`.

## Testing

I reproduced the original failure on Rust 1.97.1, then checked the revised `vello` and `vello_encoding` crates with all features and the lockfile:

| Toolchain | Configuration | Result |
| --- | --- | --- |
| Rust 1.89.0 | MSRV CI allowance | pass |
| Rust 1.89.0 | `-D warnings` | pass |
| Rust 1.95.0 | `-D warnings` | pass |
| Rust 1.96.0 | `-D warnings` | pass |
| Rust 1.97.1 | `-D warnings` | pass |

Additional checks:

- warning-denying Clippy for `vello` and `vello_encoding` on Rust 1.95
- `cargo test -p vello_encoding --lib --all-features --locked` (31 passed)
- `cargo test -p vello --lib --all-features --locked`
- repository formatting and diff checks
- the full cross-platform CI matrix

_AI usage: This PR was prepared with assistance from an AI coding tool._
