### PR TITLE
vello_cpu: Isolate root draw blend modes

### DIFF
--- a/sparse_strips/vello_common/src/record.rs
+++ b/sparse_strips/vello_common/src/record.rs
@@ -47,6 +47,9 @@ pub trait Drawable {
     /// Return the **tile-aligned** bounding box of the given object, if it
     /// has one.
     fn bbox(&self, strips: &[Strip]) -> Option<RectU16>;
+
+    /// Return the blend mode applied directly by this draw, if any.
+    fn blend_mode(&self) -> Option<&BlendMode>;
 }
 
 /// A node in the recorded render graph.
@@ -421,6 +424,14 @@ impl<D: Drawable> CommandRecorder<D> {
     /// Push a draw command.
     #[inline]
     pub fn push_draw(&mut self, draw: D, strips: &[Strip]) {
+        if self.active_layer.is_none()
+            && draw
+                .blend_mode()
+                .is_some_and(|blend_mode| *blend_mode != BlendMode::default())
+        {
+            self.root_is_blend_target = true;
+        }
+
         self.record_bbox(|| draw.bbox(strips));
         let draw_idx = self.draws.len() as u32;
         self.draws.push(draw);
@@ -466,6 +477,10 @@ mod tests {
         fn bbox(&self, _strips: &[Strip]) -> Option<RectU16> {
             Some(RectU16::new(0, 0, 64, 4))
         }
+
+        fn blend_mode(&self) -> Option<&BlendMode> {
+            None
+        }
     }
 
     #[derive(Debug)]
@@ -474,6 +489,23 @@ mod tests {
     impl Drawable for EmptyDraw {
         fn bbox(&self, _strips: &[Strip]) -> Option<RectU16> {
             None
+        }
+
+        fn blend_mode(&self) -> Option<&BlendMode> {
+            None
+        }
+    }
+
+    #[derive(Debug)]
+    struct BlendedDraw(BlendMode);
+
+    impl Drawable for BlendedDraw {
+        fn bbox(&self, _strips: &[Strip]) -> Option<RectU16> {
+            Some(RectU16::new(0, 0, 64, 4))
+        }
+
+        fn blend_mode(&self) -> Option<&BlendMode> {
+            Some(&self.0)
         }
     }
 
@@ -679,6 +711,22 @@ mod tests {
         recorder.pop_layer();
         recorder.push_layer(blended_layer_props(), None);
 
+        assert!(recorder.root_is_blend_target);
+    }
+
+    #[test]
+    fn draw_blend_metadata_distinguishes_root_and_nested_targets() {
+        let mut recorder = CommandRecorder::<BlendedDraw>::new(DEFAULT_SIZE, DEFAULT_SIZE);
+
+        recorder.push_draw(BlendedDraw(BlendMode::default()), &[]);
+        assert!(!recorder.root_is_blend_target);
+
+        recorder.push_layer(layer_props(), None);
+        recorder.push_draw(BlendedDraw(Mix::Multiply.into()), &[]);
+        assert!(!recorder.root_is_blend_target);
+        recorder.pop_layer();
+
+        recorder.push_draw(BlendedDraw(Mix::Multiply.into()), &[]);
         assert!(recorder.root_is_blend_target);
     }
 

--- a/sparse_strips/vello_cpu/src/coarse/mod.rs
+++ b/sparse_strips/vello_cpu/src/coarse/mod.rs
@@ -7,4 +7,4 @@ pub(crate) mod depth;
 
 pub(crate) use bucketer::{CommandBucketer, RowState};
 pub use cmd::PaintFillAttrs;
-pub(crate) use cmd::{LayerFillAttrs, RenderCmd};
+pub(crate) use cmd::RenderCmd;

--- a/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/multi_threaded.rs
@@ -398,6 +398,7 @@ impl MultiThreadedDispatcher {
         let mut bucketer = self.bucketer.lock().unwrap();
         let filters = FilterContext::new(0);
         bucketer.reset(RectU16::new(0, 0, scene_width, scene_height));
+        let use_src_over = settings.composite_mode == CompositeMode::SrcOver;
         bucketer.bucket_commands(
             &self.recorder.nodes,
             &self.recorder.draws,
@@ -410,7 +411,6 @@ impl MultiThreadedDispatcher {
         let alpha_slots = self.alpha_storage.take();
         {
             let alpha_buffers = alpha_slots.iter().map(Vec::as_slice).collect::<Vec<_>>();
-            let use_src_over = settings.composite_mode == CompositeMode::SrcOver;
             let resources = FineResources {
                 alpha_buffers: &alpha_buffers,
                 encoded_paints,
@@ -448,6 +448,7 @@ impl MultiThreadedDispatcher {
                         &bucketer,
                         resources,
                         use_src_over,
+                        self.recorder.root_is_blend_target,
                     );
                 });
             });

--- a/sparse_strips/vello_cpu/src/dispatch/single_threaded.rs
+++ b/sparse_strips/vello_cpu/src/dispatch/single_threaded.rs
@@ -123,6 +123,7 @@ impl SingleThreadedDispatcher {
             target,
             params,
             use_src_over,
+            self.recorder.root_is_blend_target,
             encoded_paints,
             image_resolver,
         );
@@ -137,6 +138,7 @@ impl SingleThreadedDispatcher {
         mut target: PixmapMut<'_>,
         params: FineRenderParams,
         use_src_over: bool,
+        root_is_blend_target: bool,
         encoded_paints: &[EncodedPaint],
         image_resolver: &dyn ImageResolver,
     ) {
@@ -164,7 +166,14 @@ impl SingleThreadedDispatcher {
             params.target_offset,
             bucketer.rows().len(),
         );
-        Self::rasterize_target::<S, F>(simd, &bucketer, resources, &mut regions, use_src_over);
+        Self::rasterize_target::<S, F>(
+            simd,
+            &bucketer,
+            resources,
+            &mut regions,
+            use_src_over,
+            root_is_blend_target,
+        );
     }
 
     fn rasterize_target<S: Simd, F: FineKernel<S>>(
@@ -173,6 +182,7 @@ impl SingleThreadedDispatcher {
         resources: FineResources<'_>,
         regions: &mut Regions<'_>,
         use_src_over: bool,
+        root_is_blend_target: bool,
     ) {
         // TODO: Reuse fine and depth buffer across targets?
         let mut fine = Fine::<S, F>::new(simd, bucketer.width());
@@ -185,6 +195,7 @@ impl SingleThreadedDispatcher {
                 bucketer,
                 resources,
                 use_src_over,
+                root_is_blend_target,
             );
         });
     }
@@ -246,6 +257,7 @@ impl SingleThreadedDispatcher {
                 &filter_ctx,
                 (&mut pixmap).into(),
                 params,
+                false,
                 false,
                 encoded_paints,
                 image_resolver,

--- a/sparse_strips/vello_cpu/src/fine/mod.rs
+++ b/sparse_strips/vello_cpu/src/fine/mod.rs
@@ -12,7 +12,7 @@ mod highp;
 mod lowp;
 
 use crate::coarse::depth::DepthBuffer;
-use crate::coarse::{CommandBucketer, LayerFillAttrs, RenderCmd, RowState};
+use crate::coarse::{CommandBucketer, RenderCmd, RowState};
 use crate::filter::context::ScratchBuffer;
 use crate::fine::common::gradient::GradientPainter;
 pub(crate) use crate::fine::common::gradient::calculate_t_vals;
@@ -469,7 +469,8 @@ pub(crate) fn rasterize_region<S: Simd, T: FineKernel<S>>(
     region: &mut Region<'_>,
     bucketer: &CommandBucketer,
     resources: FineResources<'_>,
-    unpack_dest: bool,
+    mut unpack_dest: bool,
+    root_is_blend_target: bool,
 ) {
     let scene_y = region.row_idx as u16 * Tile::HEIGHT;
     let row = &bucketer.rows()[region.row_idx];
@@ -477,6 +478,15 @@ pub(crate) fn rasterize_region<S: Simd, T: FineKernel<S>>(
 
     fine.set_row_y(scene_y);
     depth.clear();
+
+    let has_cmds = !row.depth_cmds.is_empty() || !row.render_cmds.is_empty();
+    let isolate_bg = unpack_dest && root_is_blend_target && has_cmds;
+    if isolate_bg {
+        fine.init_uncovered_range(span, region, unpack_dest, depth);
+        fine.push_buf(None);
+
+        unpack_dest = false;
+    }
 
     // Render depth-buffer commands front-to-back, with depth-buffer read and write.
     for &cmd in row.depth_cmds.iter().rev() {
@@ -494,6 +504,11 @@ pub(crate) fn rasterize_region<S: Simd, T: FineKernel<S>>(
     // Render the main commands back-to-front, with depth-buffer read.
     for cmd in &row.render_cmds {
         fine.run_cmd(*cmd, bucketer, row, scene_y, resources, depth);
+    }
+
+    if isolate_bg {
+        fine.layer_fill(scene_y, span, BlendMode::default(), 1.0, None, None);
+        fine.pop_buf();
     }
 
     // Pack the composited result back into the pixmap.
@@ -585,10 +600,29 @@ impl<S: Simd, T: FineKernel<S>> Fine<S, T> {
                 let mut region = region.sub_span(x, end - x);
                 self.unpack(x, &mut region);
             } else {
-                self.blend_buffers[0][Self::scratch_range(Span::new(x, end - x))]
-                    .fill(T::Numeric::ZERO);
+                let range = Self::scratch_range(Span::new(x, end - x));
+                self.blend_buffers.last_mut().unwrap()[range].fill(T::Numeric::ZERO);
             }
         });
+    }
+
+    fn push_buf(&mut self, span: Option<Span>) {
+        let mut buf = self.buffer_pool.take();
+        // Reused vectors will retain their length, so in most cases this
+        // will be a no-op.
+        buf.resize(self.blend_buffers[0].len(), T::Numeric::ZERO);
+
+        // Instead of always zeroing out the whole buffer, only zero the
+        // row-local span that will be read when compositing this layer.
+        if let Some(span) = span.and_then(|span| span.intersect(self.buffer_span)) {
+            buf[Self::scratch_range(span)].fill(T::Numeric::ZERO);
+        }
+        self.blend_buffers.push(buf);
+    }
+
+    fn pop_buf(&mut self) {
+        let popped = self.blend_buffers.pop().unwrap();
+        self.buffer_pool.submit(popped);
     }
 
     /// Writes the current buffer contents to the output row.
@@ -661,23 +695,8 @@ impl<S: Simd, T: FineKernel<S>> Fine<S, T> {
                     paint_fill(self, span);
                 }
             }
-            RenderCmd::PushBuf(span) => {
-                let mut buf = self.buffer_pool.take();
-                // Reused vectors will retain their length, so in most cases this
-                // will be a no-op.
-                buf.resize(self.blend_buffers[0].len(), T::Numeric::ZERO);
-
-                // Instead of always zeroing out the whole buffer, only zero the
-                // row-local span that will be read when compositing this layer.
-                if let Some(span) = span.and_then(|span| span.intersect(self.buffer_span)) {
-                    buf[Self::scratch_range(span)].fill(T::Numeric::ZERO);
-                }
-                self.blend_buffers.push(buf);
-            }
-            RenderCmd::PopBuf => {
-                let popped = self.blend_buffers.pop().unwrap();
-                self.buffer_pool.submit(popped);
-            }
+            RenderCmd::PushBuf(span) => self.push_buf(span),
+            RenderCmd::PopBuf => self.pop_buf(),
             RenderCmd::LayerFill(cmd) => {
                 let Some(span) = cmd.span.intersect(self.buffer_span) else {
                     return;
@@ -694,7 +713,14 @@ impl<S: Simd, T: FineKernel<S>> Fine<S, T> {
                         &alpha_buffer[alpha_offset..]
                     });
 
-                    fine.layer_fill(row_y, span, attrs, alphas);
+                    fine.layer_fill(
+                        row_y,
+                        span,
+                        attrs.blend_mode,
+                        attrs.opacity,
+                        attrs.mask.as_ref(),
+                        alphas,
+                    );
                 };
 
                 // Same as for paint fills.
@@ -763,13 +789,15 @@ impl<S: Simd, T: FineKernel<S>> Fine<S, T> {
         &mut self,
         row_y: u16,
         span: Span,
-        attrs: &LayerFillAttrs,
+        blend_mode: BlendMode,
+        opacity: f32,
+        mask: Option<&Mask>,
         alphas: Option<&[u8]>,
     ) {
-        if attrs.opacity != 1.0 {
-            self.opacity(span, attrs.opacity);
+        if opacity != 1.0 {
+            self.opacity(span, opacity);
         }
-        if let Some(mask) = attrs.mask.as_ref() {
+        if let Some(mask) = mask {
             self.mask(row_y, span, mask);
         }
 
@@ -780,7 +808,7 @@ impl<S: Simd, T: FineKernel<S>> Fine<S, T> {
         let source = &mut source[range.clone()];
         let target = &mut target[range];
 
-        if attrs.blend_mode == BlendMode::default() {
+        if blend_mode == BlendMode::default() {
             T::alpha_composite_buffer(self.simd, target, source, alphas);
         } else {
             T::blend(
@@ -791,7 +819,7 @@ impl<S: Simd, T: FineKernel<S>> Fine<S, T> {
                 source
                     .chunks_exact(T::Composite::LENGTH)
                     .map(|s| T::Composite::from_slice(self.simd, s)),
-                attrs.blend_mode,
+                blend_mode,
                 alphas,
                 None,
             );

--- a/sparse_strips/vello_cpu/src/record.rs
+++ b/sparse_strips/vello_cpu/src/record.rs
@@ -41,4 +41,8 @@ impl Drawable for RecordedFill {
     fn bbox(&self, strips: &[Strip]) -> Option<RectU16> {
         strip_bbox(strips)
     }
+
+    fn blend_mode(&self) -> Option<&BlendMode> {
+        Some(&self.blend_mode)
+    }
 }

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -102,6 +102,10 @@ impl Drawable for RecordedDraw {
             }
         }
     }
+
+    fn blend_mode(&self) -> Option<&BlendMode> {
+        None
+    }
 }
 
 /// Settings to apply to the render context.


### PR DESCRIPTION
This PR implements two changes:

Each draw also holds information about blending, and we use this to determine a more accurate `root_is_blend_target` flag for Vello CPU, where paths themselves can also have blend modes. For Vello Hybrid this doesn't change anything because paths themselves can't have blend modes themselves, only layers.

When rendering, we ensure that the background (if it's not just transparent) is isolated if the root is a blend target. What this means is that, in case our new scene has a non-default blend at the root, it cannot modify the background that was loaded from the previous pixmap contents. 

It's not necessarily the case that the previous behavior was "incorrect", one could also argue the usefulness of the previous behavior, but I believe this new approach matches more precisely how a background should behave (especially for the follow-up PRs where you can set a background color) and it aligns us with what Vello Hybrid does: In Vello Hybrid, when rendering onto a framebuffer with already drawn contents, we use the GPU to load them as the backdrop for whatever our new scene contains. However, a non-default blend mode in our new scene can never modify the existing backdrop, while this was possible in Vello CPU up until now. It's not even possible to implement that same behavior in Vello Hybrid even if we wanted to, because we cannot sample from the main drawing buffer.

We only perform the isolation if there really is a non-default blend operation against the root and there actually is a non-default background, so the normal case will not have anyperformance penalty associated with it. There is no test for this now, but in a later PR I will add one that ensures Vello Hybrid and Vello CPU are consistent here (test `root_blend_target_is_isolated`).
