### PR TITLE
vello_cpu: Update target transparency hints

### DIFF
--- a/vello_common/src/lib.rs
+++ b/vello_common/src/lib.rs
@@ -89,6 +89,7 @@ pub mod render_state;
 pub mod simd;
 pub mod strip;
 pub mod strip_generator;
+pub mod target;
 pub mod tile;
 pub mod transforms;
 pub mod util;
@@ -98,6 +99,7 @@ pub use fearless_simd;
 pub use peniko;
 pub use peniko::color;
 pub use peniko::kurbo;
+pub use target::TargetInit;
 
 /// A handle to an external, user-provided texture.
 ///

--- a/vello_common/src/paint.rs
+++ b/vello_common/src/paint.rs
@@ -262,6 +262,11 @@ impl PremulColor {
     pub fn is_opaque(&self) -> bool {
         self.premul_f32.components[3] == 1.0
     }
+
+    /// Return whether the color is fully transparent.
+    pub fn is_transparent(&self) -> bool {
+        self.premul_f32.components[3] == 0.0
+    }
 }
 
 /// How tint color is applied to an image.

--- a/vello_common/src/pixmap.rs
+++ b/vello_common/src/pixmap.rs
@@ -40,6 +40,8 @@ pub struct PixmapMut<'a> {
     height: u16,
     /// Buffer of the pixmap in RGBA8 format.
     buf: &'a mut [u8],
+    /// Opacity metadata of the owning [`Pixmap`], when this view was created from one.
+    may_have_transparency: Option<&'a mut bool>,
 }
 
 impl<'a> PixmapMut<'a> {
@@ -48,7 +50,12 @@ impl<'a> PixmapMut<'a> {
     /// Returns `None` if `buf` is not exactly `width * height * 4` bytes long.
     pub fn new(width: u16, height: u16, buf: &'a mut [u8]) -> Option<Self> {
         if buf.len() == usize::from(width) * usize::from(height) * 4 {
-            Some(Self { width, height, buf })
+            Some(Self {
+                width,
+                height,
+                buf,
+                may_have_transparency: None,
+            })
         } else {
             None
         }
@@ -67,6 +74,14 @@ impl<'a> PixmapMut<'a> {
     /// Returns a mutable reference to the underlying data as premultiplied RGBA8 bytes.
     pub fn data_mut(&mut self) -> &mut [u8] {
         self.buf
+    }
+
+    /// Update the opacity hint of the owning [`Pixmap`], if one exists.
+    #[doc(hidden)]
+    pub fn set_may_have_transparency(&mut self, may_have_transparency: bool) {
+        if let Some(flag) = self.may_have_transparency.as_deref_mut() {
+            *flag = may_have_transparency;
+        }
     }
 }
 
@@ -364,6 +379,7 @@ impl Pixmap {
             width: self.width,
             height: self.height,
             buf: bytemuck::cast_slice_mut(&mut self.buf),
+            may_have_transparency: Some(&mut self.may_have_transparency),
         }
     }
 

--- a/vello_common/src/target.rs
+++ b/vello_common/src/target.rs
@@ -1,0 +1,23 @@
+// Copyright 2026 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Configuring how a render target is initialized before drawing.
+
+/// Controls how existing target contents are handled before drawing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TargetInit<C> {
+    /// Composite rendered content over the existing target contents with src-over blending.
+    SrcOver,
+    /// Clear the drawing surface with the specified color before drawing.
+    Clear(C),
+}
+
+impl<C> TargetInit<C> {
+    /// Transform the clear value while preserving the target initialization mode.
+    pub fn map<T>(self, f: impl FnOnce(C) -> T) -> TargetInit<T> {
+        match self {
+            Self::SrcOver => TargetInit::SrcOver,
+            Self::Clear(clear) => TargetInit::Clear(f(clear)),
+        }
+    }
+}

--- a/vello_common/src/target.rs
+++ b/vello_common/src/target.rs
@@ -9,6 +9,10 @@ pub enum TargetInit<C> {
     /// Composite rendered content over the existing target contents with src-over blending.
     SrcOver,
     /// Clear the drawing surface with the specified color before drawing.
+    ///
+    /// The clear color is treated as an isolated background on top of which the fully
+    /// rendered scene is composited. In particular, it will not be used as the backdrop
+    /// for blending operations in the main scene.
     Clear(C),
 }
 

--- a/vello_cpu/src/dispatch/multi_threaded.rs
+++ b/vello_cpu/src/dispatch/multi_threaded.rs
@@ -1,6 +1,7 @@
 // Copyright 2025 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use crate::RasterizerSettings;
 use crate::coarse::CommandBucketer;
 use crate::coarse::depth::DepthBuffer;
 use crate::dispatch::Dispatcher;
@@ -12,7 +13,6 @@ use crate::kurbo::{Affine, BezPath, PathEl, Point, Rect, Stroke};
 use crate::peniko::{BlendMode, Fill};
 use crate::record::RecordedFill;
 use crate::region::Regions;
-use crate::{CompositeMode, RasterizerSettings};
 use alloc::boxed::Box;
 use alloc::sync::Arc;
 use alloc::vec;
@@ -31,7 +31,7 @@ use vello_common::fearless_simd::{Level, Simd, dispatch};
 use vello_common::filter::FilterData;
 use vello_common::geometry::RectU16;
 use vello_common::mask::Mask;
-use vello_common::paint::{ImageResolver, Paint};
+use vello_common::paint::{ImageResolver, Paint, PremulColor};
 use vello_common::pixmap::PixmapMut;
 use vello_common::record::{CommandRecorder, LayerClip, LayerProps, PoppedLayer};
 use vello_common::strip::Strip;
@@ -398,7 +398,7 @@ impl MultiThreadedDispatcher {
         let mut bucketer = self.bucketer.lock().unwrap();
         let filters = FilterContext::new(0);
         bucketer.reset(RectU16::new(0, 0, scene_width, scene_height));
-        let use_src_over = settings.composite_mode == CompositeMode::SrcOver;
+        let target_init = settings.target_init.map(PremulColor::from_alpha_color);
         bucketer.bucket_commands(
             &self.recorder.nodes,
             &self.recorder.draws,
@@ -447,7 +447,7 @@ impl MultiThreadedDispatcher {
                         region,
                         &bucketer,
                         resources,
-                        use_src_over,
+                        target_init,
                         self.recorder.root_is_blend_target,
                     );
                 });

--- a/vello_cpu/src/dispatch/single_threaded.rs
+++ b/vello_cpu/src/dispatch/single_threaded.rs
@@ -1,6 +1,7 @@
 // Copyright 2025 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use crate::RasterizerSettings;
 use crate::coarse::CommandBucketer;
 use crate::coarse::depth::DepthBuffer;
 use crate::dispatch::Dispatcher;
@@ -10,14 +11,15 @@ use crate::kurbo::{Affine, BezPath, Rect, Stroke};
 use crate::peniko::{BlendMode, Fill};
 use crate::record::RecordedFill;
 use crate::region::Regions;
-use crate::{CompositeMode, RasterizerSettings};
 use core::cell::RefCell;
+use vello_common::TargetInit;
+use vello_common::color::AlphaColor;
 use vello_common::encode::EncodedPaint;
 use vello_common::fearless_simd::{Level, Simd};
 use vello_common::filter::FilterData;
 use vello_common::geometry::RectU16;
 use vello_common::mask::Mask;
-use vello_common::paint::{ImageResolver, Paint};
+use vello_common::paint::{ImageResolver, Paint, PremulColor};
 use vello_common::pixmap::{Pixmap, PixmapMut};
 use vello_common::record::{
     CommandRecorder, LayerClip, LayerProps, Node, PoppedLayer, RecordedLayerKind,
@@ -109,7 +111,7 @@ impl SingleThreadedDispatcher {
         image_resolver: &dyn ImageResolver,
     ) {
         let filters = self.rasterize_filter_layers::<S, F>(simd, encoded_paints, image_resolver);
-        let use_src_over = settings.composite_mode == CompositeMode::SrcOver;
+        let target_init = settings.target_init.map(PremulColor::from_alpha_color);
         let params = FineRenderParams {
             scene_size: (scene_width, scene_height),
             target_offset: settings.offset,
@@ -122,7 +124,7 @@ impl SingleThreadedDispatcher {
             &filters,
             target,
             params,
-            use_src_over,
+            target_init,
             self.recorder.root_is_blend_target,
             encoded_paints,
             image_resolver,
@@ -137,7 +139,7 @@ impl SingleThreadedDispatcher {
         filter_ctx: &FilterContext,
         mut target: PixmapMut<'_>,
         params: FineRenderParams,
-        use_src_over: bool,
+        target_init: TargetInit<PremulColor>,
         root_is_blend_target: bool,
         encoded_paints: &[EncodedPaint],
         image_resolver: &dyn ImageResolver,
@@ -171,7 +173,7 @@ impl SingleThreadedDispatcher {
             &bucketer,
             resources,
             &mut regions,
-            use_src_over,
+            target_init,
             root_is_blend_target,
         );
     }
@@ -181,7 +183,7 @@ impl SingleThreadedDispatcher {
         bucketer: &CommandBucketer,
         resources: FineResources<'_>,
         regions: &mut Regions<'_>,
-        use_src_over: bool,
+        target_init: TargetInit<PremulColor>,
         root_is_blend_target: bool,
     ) {
         // TODO: Reuse fine and depth buffer across targets?
@@ -194,7 +196,7 @@ impl SingleThreadedDispatcher {
                 region,
                 bucketer,
                 resources,
-                use_src_over,
+                target_init,
                 root_is_blend_target,
             );
         });
@@ -257,7 +259,7 @@ impl SingleThreadedDispatcher {
                 &filter_ctx,
                 (&mut pixmap).into(),
                 params,
-                false,
+                TargetInit::Clear(PremulColor::from_alpha_color(AlphaColor::TRANSPARENT)),
                 false,
                 encoded_paints,
                 image_resolver,

--- a/vello_cpu/src/fine/mod.rs
+++ b/vello_cpu/src/fine/mod.rs
@@ -28,6 +28,8 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::fmt::Debug;
 use core::iter;
+use vello_common::TargetInit;
+use vello_common::color::AlphaColor;
 use vello_common::encode::{
     EncodedBlurredRoundedRectangle, EncodedGradient, EncodedImage, EncodedKind, EncodedPaint,
 };
@@ -469,7 +471,7 @@ pub(crate) fn rasterize_region<S: Simd, T: FineKernel<S>>(
     region: &mut Region<'_>,
     bucketer: &CommandBucketer,
     resources: FineResources<'_>,
-    mut unpack_dest: bool,
+    mut target_init: TargetInit<PremulColor>,
     root_is_blend_target: bool,
 ) {
     let scene_y = region.row_idx as u16 * Tile::HEIGHT;
@@ -480,12 +482,17 @@ pub(crate) fn rasterize_region<S: Simd, T: FineKernel<S>>(
     depth.clear();
 
     let has_cmds = !row.depth_cmds.is_empty() || !row.render_cmds.is_empty();
-    let isolate_bg = unpack_dest && root_is_blend_target && has_cmds;
+    let isolate_bg = root_is_blend_target
+        && has_cmds
+        && match target_init {
+            TargetInit::SrcOver => true,
+            TargetInit::Clear(color) => !color.is_transparent(),
+        };
     if isolate_bg {
-        fine.init_uncovered_range(span, region, unpack_dest, depth);
+        fine.init_uncovered_range(span, region, target_init, depth);
         fine.push_buf(None);
 
-        unpack_dest = false;
+        target_init = TargetInit::Clear(PremulColor::from_alpha_color(AlphaColor::TRANSPARENT));
     }
 
     // Render depth-buffer commands front-to-back, with depth-buffer read and write.
@@ -498,8 +505,8 @@ pub(crate) fn rasterize_region<S: Simd, T: FineKernel<S>>(
         });
     }
 
-    // Clear any regions in the fine buffer that haven't been filled with an opaque fill.
-    fine.init_uncovered_range(span, region, unpack_dest, depth);
+    // Initialize any regions in the fine buffer that haven't been filled with an opaque fill.
+    fine.init_uncovered_range(span, region, target_init, depth);
 
     // Render the main commands back-to-front, with depth-buffer read.
     for cmd in &row.render_cmds {
@@ -581,29 +588,56 @@ impl<S: Simd, T: FineKernel<S>> Fine<S, T> {
     // a certain range of pixels is already filled with an opaque paint. Therefore, we only
     // need to clear (or unpack) the parts that are not covered by such a paint.
     /// Initialize every range in the buffer that has not been filled yet
-    /// with a solid paint.
-    ///
-    /// In case [`ComositeMode::SrcOver`] was chosen, it will be initialized with
-    /// the pixels from the user-supplied pixmap. Otherwise, the range will simply be zeroed.
+    /// with a paint.
     fn init_uncovered_range(
         &mut self,
         scratch_span: Span,
         region: &mut Region<'_>,
-        use_src_over: bool,
+        target_init: TargetInit<PremulColor>,
         depth: &DepthBuffer,
     ) {
-        depth.for_each_unset_run(scratch_span, |span| {
-            let x = span.pixel_x();
-            let end = span.pixel_end();
-
-            if use_src_over {
-                let mut region = region.sub_span(x, end - x);
-                self.unpack(x, &mut region);
-            } else {
-                let range = Self::scratch_range(Span::new(x, end - x));
-                self.blend_buffers.last_mut().unwrap()[range].fill(T::Numeric::ZERO);
+        match target_init {
+            TargetInit::SrcOver => {
+                depth.for_each_unset_run(
+                    scratch_span,
+                    #[inline]
+                    |span| {
+                        let (x, end) = (span.pixel_x(), span.pixel_end());
+                        let mut region = region.sub_span(x, end - x);
+                        self.unpack(x, &mut region);
+                    },
+                );
             }
-        });
+            // We can hint the compiler to lower this into a memory-zeroing operation,
+            // hence why we handle this case explicitly.
+            TargetInit::Clear(color) if color.is_transparent() => {
+                depth.for_each_unset_run(
+                    scratch_span,
+                    #[inline]
+                    |span| {
+                        let (x, end) = (span.pixel_x(), span.pixel_end());
+                        let range = Self::scratch_range(Span::new(x, end - x));
+                        self.blend_buffers.last_mut().unwrap()[range].fill(T::Numeric::ZERO);
+                    },
+                );
+            }
+            TargetInit::Clear(color) => {
+                let color = T::extract_color(color);
+                depth.for_each_unset_run(
+                    scratch_span,
+                    #[inline]
+                    |span| {
+                        let (x, end) = (span.pixel_x(), span.pixel_end());
+                        let range = Self::scratch_range(Span::new(x, end - x));
+                        T::copy_solid(
+                            self.simd,
+                            &mut self.blend_buffers.last_mut().unwrap()[range],
+                            color,
+                        );
+                    },
+                );
+            }
+        }
     }
 
     fn push_buf(&mut self, span: Option<Span>) {

--- a/vello_cpu/src/lib.rs
+++ b/vello_cpu/src/lib.rs
@@ -168,7 +168,7 @@ pub mod fine;
 pub mod region;
 
 pub use render::{
-    CompositeMode, PixelFormat, RasterizerSettings, RenderContext, RenderSettings, Resources,
+    PixelFormat, RasterizerSettings, RenderContext, RenderSettings, Resources, TargetInit,
 };
 // Note: The first one is not something that should be
 // exposed, but is currently needed by vello_tests.

--- a/vello_cpu/src/render.rs
+++ b/vello_cpu/src/render.rs
@@ -814,6 +814,16 @@ impl RenderContext {
             }
         }
 
+        // The background is always isolated, so we don't need to worry about destructive
+        // blend modes.
+        match settings.target_init {
+            TargetInit::Clear(color) => {
+                target.set_may_have_transparency(color.components[3] != 1.0);
+            }
+            // Whatever is the current hint can be preserved.
+            TargetInit::SrcOver => {}
+        }
+
         self.dispatcher.rasterize(
             target,
             self.width,
@@ -1211,6 +1221,47 @@ mod tests {
                 a: 255,
             }
         );
+    }
+
+    #[test]
+    fn opaque_clear_updates_target_transparency_hint() {
+        let mut ctx = RenderContext::new(1, 1);
+        ctx.flush();
+        let mut resources = Resources::new();
+        let mut pixmap = Pixmap::new(1, 1);
+
+        ctx.render_with(
+            &mut pixmap,
+            &mut resources,
+            RasterizerSettings {
+                target_init: TargetInit::Clear(BLUE),
+                ..Default::default()
+            },
+        );
+
+        assert!(!pixmap.may_have_transparency());
+        assert_eq!(pixmap.sample(0, 0), blue_pixel());
+    }
+
+    #[test]
+    fn translucent_clear_updates_target_transparency_hint() {
+        let mut ctx = RenderContext::new(1, 1);
+        ctx.flush();
+        let mut resources = Resources::new();
+        let mut pixmap = solid_pixmap(1, 1, blue_pixel());
+        let clear_color = RED.with_alpha(0.5);
+
+        ctx.render_with(
+            &mut pixmap,
+            &mut resources,
+            RasterizerSettings {
+                target_init: TargetInit::Clear(clear_color),
+                ..Default::default()
+            },
+        );
+
+        assert!(pixmap.may_have_transparency());
+        assert_eq!(pixmap.sample(0, 0), clear_color.premultiply().to_rgba8());
     }
 
     #[cfg(feature = "multithreading")]

--- a/vello_cpu/src/render.rs
+++ b/vello_cpu/src/render.rs
@@ -20,6 +20,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 use hashbrown::HashMap;
 use vello_common::blurred_rounded_rect::BlurredRoundedRectangle;
+use vello_common::color::{AlphaColor, Srgb};
 use vello_common::encode::{EncodeExt, EncodedPaint};
 use vello_common::fearless_simd::Level;
 use vello_common::filter::FilterData;
@@ -89,22 +90,8 @@ impl Resources {
     }
 }
 
-// TODO: Consider changing `Replace` to overwrite only the rendered region, leaving pixels outside
-// it unchanged. See https://github.com/linebender/vello/pull/1665#issuecomment-4667033939
-
-/// The composition mode that should be used when rendering into a pixmap.
-///
-/// For performance reason it is _highly_ recommended that you use `CompositeMode::Replace`, even
-/// if you know that the pixmap is already cleared. Only use `SrcOver` if you really have to
-/// preserve existing contents.
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-pub enum CompositeMode {
-    /// Clear the destination pixmap and render the scene into it.
-    #[default]
-    Replace,
-    /// Render the scene into the pixmap using src-over compositing.
-    SrcOver,
-}
+/// How the destination pixmap is initialized before rendering.
+pub type TargetInit = vello_common::TargetInit<AlphaColor<Srgb>>;
 
 /// The pixel format to assume for the destination pixmap.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
@@ -115,7 +102,7 @@ pub enum PixelFormat {
 }
 
 /// Settings used when rasterizing a scene into a pixmap.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct RasterizerSettings {
     /// Whether to prioritize speed or quality when rendering.
     ///
@@ -127,8 +114,8 @@ pub struct RasterizerSettings {
     /// rasterization will happen using u8/u16,
     /// while [`RenderMode::OptimizeQuality`] will use a f32-based pipeline.
     pub render_mode: RenderMode,
-    /// How rendered content is composited into the destination.
-    pub composite_mode: CompositeMode,
+    /// How the destination is initialized before drawing.
+    pub target_init: TargetInit,
     /// Pixel format of the destination.
     pub pixel_format: PixelFormat,
     /// Offset in destination pixels where the render context origin is placed.
@@ -141,7 +128,7 @@ impl Default for RasterizerSettings {
     fn default() -> Self {
         Self {
             render_mode: RenderMode::OptimizeSpeed,
-            composite_mode: CompositeMode::Replace,
+            target_init: TargetInit::Clear(AlphaColor::TRANSPARENT),
             pixel_format: PixelFormat::Rgba8,
             offset: (0, 0),
         }
@@ -780,8 +767,8 @@ impl RenderContext {
     ///
     /// 2. In case the pixmap width/height is larger than the offset plus the width/height of the
     ///    [`RenderContext`], any remaining rows/columns are simply treated as padding (**however**,
-    ///    when using [`CompositeMode::Replace`], then the _whole_ destination pixmap will
-    ///    be cleared, not just the area covered by the scene). One potential reason for doing this
+    ///    when using [`TargetInit::Clear`], then the _whole_ destination pixmap will
+    ///    be cleared to the requested color, not just the area covered by the scene). One potential reason for doing this
     ///    is that certain platforms, for example macOS, require a specific byte stride for buffers.
     ///    For example, let's say that a byte stride of 128 is imposed by the platform, but the actual
     ///    size of the scene you are drawing is only 20x20. In this case, you can create a pixmap
@@ -810,8 +797,21 @@ impl RenderContext {
         // If the scene covers the whole pixmap than packing will take care
         // of clearing everything anyway, so no reason to clear it explicitly
         // here.
-        if settings.composite_mode == CompositeMode::Replace && !target_fully_covered {
-            target.data_mut().fill(0);
+        if let TargetInit::Clear(color) = settings.target_init
+            && !target_fully_covered
+        {
+            let color = color.premultiply().to_rgba8().to_u32();
+            let data = target.data_mut();
+            if color == 0 {
+                data.fill(0);
+            } else {
+                // TODO: Optimize with SIMD? Unfortunately we can't just cast to u32 and use
+                // `fill` because the user-provided slice might not have the correct alignment.
+                let color = color.to_ne_bytes();
+                for pixel in data.chunks_exact_mut(4) {
+                    pixel.copy_from_slice(&color);
+                }
+            }
         }
 
         self.dispatcher.rasterize(
@@ -962,7 +962,7 @@ impl ImageResolver for ImageRegistry {
 mod tests {
     #[cfg(feature = "text")]
     use crate::peniko::{Blob, FontData};
-    use crate::{CompositeMode, RasterizerSettings, RenderContext, Resources};
+    use crate::{RasterizerSettings, RenderContext, Resources, TargetInit};
     #[cfg(feature = "text")]
     use alloc::sync::Arc;
     use alloc::vec;
@@ -1165,7 +1165,7 @@ mod tests {
     }
 
     #[test]
-    fn render_src_over_opaque() {
+    fn render_preserves_target_under_opaque_draw() {
         let ctx = red_rect_context(2, 1, Rect::new(0.0, 0.0, 1.0, 1.0));
         let mut resources = Resources::new();
         let mut pixmap = solid_pixmap(2, 1, blue_pixel());
@@ -1174,7 +1174,7 @@ mod tests {
             &mut pixmap,
             &mut resources,
             RasterizerSettings {
-                composite_mode: CompositeMode::SrcOver,
+                target_init: TargetInit::SrcOver,
                 ..Default::default()
             },
         );
@@ -1184,7 +1184,7 @@ mod tests {
     }
 
     #[test]
-    fn render_src_over_transparent() {
+    fn render_preserves_target_under_translucent_draw() {
         let mut ctx = RenderContext::new(1, 1);
         ctx.set_paint(RED.with_alpha(0.5));
         ctx.fill_rect(&Rect::new(0.0, 0.0, 1.0, 1.0));
@@ -1197,7 +1197,7 @@ mod tests {
             &mut pixmap,
             &mut resources,
             RasterizerSettings {
-                composite_mode: CompositeMode::SrcOver,
+                target_init: TargetInit::SrcOver,
                 ..Default::default()
             },
         );

--- a/vello_cpu/src/text.rs
+++ b/vello_cpu/src/text.rs
@@ -13,8 +13,8 @@
 
 use crate::render::{ATLAS_IMAGE_ID_BASE, DEFAULT_GLYPH_ATLAS_SIZE};
 use crate::{
-    CompositeMode, Image, ImageSource, PaintType, Pixmap, RasterizerSettings, RenderContext,
-    RenderMode, RenderSettings, Resources, color, kurbo, peniko,
+    Image, ImageSource, PaintType, Pixmap, RasterizerSettings, RenderContext, RenderMode,
+    RenderSettings, Resources, TargetInit, color, kurbo, peniko,
 };
 use alloc::boxed::Box;
 use alloc::sync::Arc;
@@ -182,7 +182,7 @@ impl Resources {
                     &mut Self::default(),
                     RasterizerSettings {
                         render_mode,
-                        composite_mode: CompositeMode::SrcOver,
+                        target_init: TargetInit::SrcOver,
                         ..Default::default()
                     },
                 );

--- a/vello_tests/tests/basic.rs
+++ b/vello_tests/tests/basic.rs
@@ -16,8 +16,7 @@ use vello_common::peniko::{Fill, Gradient};
 use vello_cpu::color::palette::css::BLACK;
 use vello_cpu::peniko::LinearGradientPosition;
 use vello_cpu::{
-    CompositeMode, Glyph, Level, Pixmap, RasterizerSettings, RenderContext, RenderMode,
-    RenderSettings,
+    Glyph, Level, Pixmap, RasterizerSettings, RenderContext, RenderMode, RenderSettings, TargetInit,
 };
 use vello_dev_macros::vello_test;
 
@@ -519,7 +518,7 @@ fn implicit_subpaths(ctx: &mut impl Renderer) {
 /// This demonstrates the glyph caching workflow:
 /// 1. Create a small `RenderContext` sized for a single glyph
 /// 2. Render the glyph into that context
-/// 3. Render it with `CompositeMode::SrcOver` and an offset into a larger spritesheet
+/// 3. Render it with `TargetInit::SrcOver` and an offset into a larger spritesheet
 #[test]
 fn render_src_over_with_offset() {
     let settings = RenderSettings {
@@ -567,7 +566,7 @@ fn render_src_over_with_offset() {
             &mut glyph_resources,
             RasterizerSettings {
                 render_mode: RenderMode::OptimizeQuality,
-                composite_mode: CompositeMode::SrcOver,
+                target_init: TargetInit::SrcOver,
                 offset: (dst_x, dst_y),
                 ..Default::default()
             },


### PR DESCRIPTION
This PR implements an optimization that changes the `may_have_transparency` flag of a pixmap that is a render target. In particular, if the background is opaque, we know that there cannot be any transparency in the final pixmap (as long as there is no non-default blend against the root). As a consequence, we can detect that the pixmap is opaque and do not need to pay the cost of unnecessarily unpremultiplying its pixels!
