### PR TITLE
vello_hybrid: Support configurable target clears

### DIFF
--- a/vello_gpu/examples/native_webgl/src/lib.rs
+++ b/vello_gpu/examples/native_webgl/src/lib.rs
@@ -158,6 +158,7 @@ impl AppState {
                 &mut self.renderer_wrapper.resources,
                 &render_size,
                 &vello_gpu::WebGlTextureBindings::new(),
+                vello_common::color::AlphaColor::TRANSPARENT,
             )
             .unwrap();
         if let Some(gpu_timer) = &mut self.renderer_wrapper.gpu_timer {
@@ -612,6 +613,7 @@ pub async fn render_scene(scene: Scene, width: u16, height: u16) {
             &mut resources,
             &render_size,
             &vello_gpu::WebGlTextureBindings::new(),
+            vello_common::color::AlphaColor::TRANSPARENT,
         )
         .unwrap();
 }

--- a/vello_gpu/examples/render_to_file.rs
+++ b/vello_gpu/examples/render_to_file.rs
@@ -103,6 +103,7 @@ async fn run() {
             &texture_view,
             Some(&depth_texture_view),
             &vello_gpu::TextureBindings::new(),
+            vello_gpu::TargetInit::Clear(vello_gpu::ClearSettings::default()),
         )
         .unwrap();
 

--- a/vello_gpu/examples/wgpu_webgl/src/lib.rs
+++ b/vello_gpu/examples/wgpu_webgl/src/lib.rs
@@ -272,6 +272,7 @@ impl AppState {
                 &surface_texture_view,
                 Some(&self.renderer_wrapper.depth_texture_view),
                 &vello_gpu::TextureBindings::new(),
+                vello_gpu::TargetInit::Clear(vello_gpu::ClearSettings::default()),
             )
             .unwrap();
         let render_end = now();
@@ -735,6 +736,7 @@ pub async fn render_scene(scene: Scene, width: u16, height: u16) {
             &surface_texture_view,
             Some(&depth_texture_view),
             &vello_gpu::TextureBindings::new(),
+            vello_gpu::TargetInit::Clear(vello_gpu::ClearSettings::default()),
         )
         .unwrap();
 

--- a/vello_gpu/examples/winit/src/main.rs
+++ b/vello_gpu/examples/winit/src/main.rs
@@ -401,6 +401,7 @@ impl ApplicationHandler for App<'_> {
                         &texture_view,
                         Some(depth_texture_view),
                         &texture_bindings,
+                        vello_hybrid::TargetInit::Clear(vello_hybrid::ClearSettings::default()),
                     )
                     .unwrap();
 

--- a/vello_gpu/examples/winit/src/main.rs
+++ b/vello_gpu/examples/winit/src/main.rs
@@ -401,7 +401,7 @@ impl ApplicationHandler for App<'_> {
                         &texture_view,
                         Some(depth_texture_view),
                         &texture_bindings,
-                        vello_hybrid::TargetInit::Clear(vello_hybrid::ClearSettings::default()),
+                        vello_gpu::TargetInit::Clear(vello_gpu::ClearSettings::default()),
                     )
                     .unwrap();
 

--- a/vello_gpu/src/lib.rs
+++ b/vello_gpu/src/lib.rs
@@ -102,7 +102,7 @@ pub use render::{
 };
 #[cfg(feature = "wgpu")]
 pub use render::{AtlasWriter, RenderTargetConfig, Renderer, TextureBindings};
-pub use render::{Config, GpuStrip, RenderSize};
+pub use render::{ClearSettings, Config, GpuStrip, RenderSize, TargetInit};
 #[cfg(all(feature = "webgl", feature = "probe"))]
 pub use render::{PROBE_ELEMENTS, Probe, ProbeFeature, ProbeResult, ProbeStatistics};
 #[cfg(all(feature = "webgl", feature = "probe"))]
@@ -113,7 +113,7 @@ pub use scene::{LayersConfig, MemorySettings, RenderSettings, Scene};
 pub use text::{GlyphRunBuilder, HybridGlyphRunBackend};
 pub use util::DimensionConstraints;
 pub use vello_common::TextureId;
-pub use vello_common::geometry::SizeU16;
+pub use vello_common::geometry::{RectU16, SizeU16};
 pub use vello_common::multi_atlas::{AllocationStrategy, AtlasConfig, AtlasId};
 pub use vello_common::pixmap::{Pixels, Pixmap};
 

--- a/vello_gpu/src/render/common.rs
+++ b/vello_gpu/src/render/common.rs
@@ -15,7 +15,8 @@ use crate::filter::FILTER_ATLAS_PADDING;
 use crate::scene::{LayersConfig, MemorySettings, RecordedDraw};
 use alloc::vec::Vec;
 use bytemuck::{Pod, Zeroable};
-use vello_common::geometry::SizeU16;
+use vello_common::color::{AlphaColor, Srgb};
+use vello_common::geometry::{RectU16, SizeU16};
 use vello_common::record::CommandRecorder;
 
 // GPU paint structure sizes in texels (1 texel = 16 bytes for RGBA32Uint texture format).
@@ -31,6 +32,42 @@ pub(crate) const GPU_BLURRED_ROUNDED_RECT_SIZE_TEXELS: u32 =
 // TODO: If we want to use native bilinear sampling for uploaded images,
 // we can pass 1 instead of 0 here.
 pub(crate) const IMAGE_PADDING: u16 = 0;
+
+/// Controls how the output target is cleared before drawing.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ClearSettings<'a> {
+    /// Clear the complete viewport to `color`.
+    Viewport {
+        /// The clear color.
+        color: AlphaColor<Srgb>,
+    },
+    /// Clear each rectangle to `color`.
+    Rects {
+        /// The clear color.
+        color: AlphaColor<Srgb>,
+        /// The rectangles to clear.
+        rects: &'a [RectU16],
+    },
+}
+
+impl ClearSettings<'_> {
+    pub(crate) fn clear_color(self) -> AlphaColor<Srgb> {
+        match self {
+            Self::Viewport { color } | Self::Rects { color, .. } => color,
+        }
+    }
+}
+
+/// Controls whether existing target contents are preserved or cleared before drawing.
+pub type TargetInit<'a> = vello_common::TargetInit<ClearSettings<'a>>;
+
+impl Default for ClearSettings<'_> {
+    fn default() -> Self {
+        Self::Viewport {
+            color: AlphaColor::TRANSPARENT,
+        }
+    }
+}
 
 /// Texture limits reported by the rendering device.
 #[derive(Debug, Clone, Copy)]
@@ -94,7 +131,7 @@ pub(crate) struct ScratchBuffers {
     pub(crate) copy_instances: Vec<GpuCopyInstance>,
 }
 
-/// Per-instance data for clearing a rectangle in an intermediate texture.
+/// Per-instance data for clearing a rectangle in a render target.
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Pod, Zeroable)]
 pub(crate) struct GpuClearInstance {
@@ -104,6 +141,8 @@ pub(crate) struct GpuClearInstance {
     pub(crate) size: [u32; 2],
     /// Width and height of the target texture.
     pub(crate) target_size: [u32; 2],
+    /// Premultiplied clear color.
+    pub(crate) color: u32,
 }
 
 impl MemorySettings {

--- a/vello_gpu/src/render/mod.rs
+++ b/vello_gpu/src/render/mod.rs
@@ -14,7 +14,7 @@ mod webgl;
 #[cfg(feature = "wgpu")]
 mod wgpu;
 
-pub use common::{Config, GpuStrip, RenderSize};
+pub use common::{ClearSettings, Config, GpuStrip, RenderSize, TargetInit};
 
 #[cfg(all(feature = "webgl", feature = "probe"))]
 pub use vello_common::probe::{PROBE_ELEMENTS, Probe, ProbeFeature, ProbeResult, ProbeStatistics};

--- a/vello_gpu/src/render/webgl/mod.rs
+++ b/vello_gpu/src/render/webgl/mod.rs
@@ -1456,12 +1456,8 @@ impl WebGlPrograms {
         self.maybe_resize_alphas_tex(gl, resource_texture_dimension_2d, alphas.len());
         self.maybe_resize_encoded_paints_tex(gl, resource_texture_dimension_2d, paint_idxs);
         self.maybe_resize_filter_data_tex(gl, filter_context);
-        self.maybe_update_config_buffer(
-            gl,
-            resource_texture_dimension_2d,
-            render_size,
-            DrawPassTarget::Root(root_target),
-        );
+        let negate_ndc = DrawPassTarget::Root(root_target).negate_ndc();
+        self.maybe_update_config_buffer(gl, resource_texture_dimension_2d, render_size, negate_ndc);
 
         self.upload_alpha_texture(gl, alphas);
         self.upload_encoded_paints_texture(gl, encoded_paints, paint_idxs);
@@ -1739,10 +1735,8 @@ impl WebGlPrograms {
         gl: &WebGl2RenderingContext,
         resource_texture_dimension_2d: u32,
         new_render_size: &RenderSize,
-        target: DrawPassTarget,
+        negate_ndc: bool,
     ) {
-        let negate_ndc = target.negate_ndc();
-
         // TODO: Collect all attributes that influence the config buffer into a
         // single struct and compare that, such that we cannot forget to update the
         // condition in case we add new fields in the future.

--- a/vello_gpu/src/render/webgl/mod.rs
+++ b/vello_gpu/src/render/webgl/mod.rs
@@ -3439,6 +3439,7 @@ fn upload_rgba32ui_rows(
     )
     .unwrap();
 }
+
 impl DrawPassTarget {
     fn negate_ndc(self) -> bool {
         // Only negate if we are rendering to the main frame buffer.

--- a/vello_gpu/src/render/webgl/mod.rs
+++ b/vello_gpu/src/render/webgl/mod.rs
@@ -3080,7 +3080,6 @@ impl WebGlRendererContext<'_> {
             }
         };
 
-        self.gl.viewport(0, 0, i32::from(width), i32::from(height));
         let [r, g, b, a] = color.premultiply().components;
         self.gl.clear_color(r, g, b, a);
 

--- a/vello_gpu/src/render/webgl/mod.rs
+++ b/vello_gpu/src/render/webgl/mod.rs
@@ -28,7 +28,8 @@ use crate::draw::{EXTERNAL_TEXTURE_SLOT_COUNT, ExternalTextureBindings, External
 use crate::render::common::IMAGE_PADDING;
 use crate::util::RangedSlice;
 use crate::{
-    GpuStrip, LayersConfig, RenderError, RenderSettings, RenderSize, Resources,
+    ClearSettings, GpuStrip, LayersConfig, RenderError, RenderSettings, RenderSize, Resources,
+    TargetInit,
     blend::{BlendStrip, GpuBlendInstance},
     copy::GpuCopyInstance,
     filter::{FilterContext, FilterInstanceData, FilterPassPlan},
@@ -62,6 +63,7 @@ use core::fmt::Debug;
 use glifo::PendingClearRect;
 use hashbrown::HashMap;
 use resource::{Buffer, FragmentShader, Framebuffer, Program, Texture, VertexArray, VertexShader};
+use vello_common::color::{AlphaColor, Srgb};
 use vello_common::image_cache::{ImageCache, ImageResource};
 use vello_common::multi_atlas::{AtlasConfig, AtlasId};
 use vello_common::{
@@ -413,6 +415,11 @@ impl WebGlRenderer {
         resources: &mut Resources,
         render_size: &RenderSize,
         texture_bindings: &WebGlTextureBindings,
+        // Note that in WebGL, the contents of drawing buffers are not guaranteed to be preserved
+        // unless `preserveDrawingBuffer` has been set to `true` (which is highly discouraged).
+        // Therefore, for the WebGL backend we currently don't expose more configurable clear
+        // options.
+        clear_color: AlphaColor<Srgb>,
     ) -> Result<(), RenderError> {
         debug_assert_eq!(
             RenderSize {
@@ -453,7 +460,7 @@ impl WebGlRenderer {
             scene,
             &resources.image_cache,
             render_size,
-            true,
+            TargetInit::Clear(ClearSettings::Viewport { color: clear_color }),
             RootTarget::UserSurface,
             texture_bindings,
             None,
@@ -539,7 +546,7 @@ impl WebGlRenderer {
             scene,
             &dummy_image_cache,
             &atlas_render_size,
-            false,
+            TargetInit::SrcOver,
             RootTarget::AtlasLayer,
             texture_bindings,
             Some(&render_target_texture),
@@ -568,16 +575,12 @@ impl WebGlRenderer {
     /// Shared render pipeline: prepares GPU resources, runs the scheduler, and
     /// maintains caches.
     ///
-    /// When `clear` is true the view framebuffer is cleared to transparent black
-    /// before drawing. This must happen *after* `prepare` (which may create/resize
-    /// the framebuffer attachment). Atlas renders skip the clear so previously
-    /// rendered atlas content is preserved.
     pub(crate) fn render_scene(
         &mut self,
         scene: &Scene,
         image_cache: &ImageCache,
         render_size: &RenderSize,
-        clear: bool,
+        target_init: TargetInit<'_>,
         root_output_target: RootTarget,
         texture_bindings: &WebGlTextureBindings,
         render_target_texture: Option<&WebGlTexture>,
@@ -631,10 +634,8 @@ impl WebGlRenderer {
             render_size,
             &self.paint_idxs,
             &self.schedule_storage.filter_context,
+            root_output_target,
         );
-        if clear {
-            self.programs.clear_view_framebuffer(&self.gl);
-        }
         self.programs.resources.depth_cleared_this_frame = false;
         let mut ctx = WebGlRendererContext {
             programs: &mut self.programs,
@@ -643,6 +644,9 @@ impl WebGlRenderer {
             scratch_buffers: &mut self.scratch_buffers,
             use_depth_buffer: self.use_depth_buffer,
         };
+        if let TargetInit::Clear(clear) = target_init {
+            ctx.clear_pass_inner(DrawPassTarget::Root(root_output_target), clear);
+        }
         crate::schedule::execute(
             &mut ctx,
             &mut self.schedule_storage,
@@ -1445,13 +1449,19 @@ impl WebGlPrograms {
         render_size: &RenderSize,
         paint_idxs: &[u32],
         filter_context: &FilterContext,
+        root_target: RootTarget,
     ) {
         let resource_texture_dimension_2d = self.resources.resource_texture_dimension_2d;
 
         self.maybe_resize_alphas_tex(gl, resource_texture_dimension_2d, alphas.len());
         self.maybe_resize_encoded_paints_tex(gl, resource_texture_dimension_2d, paint_idxs);
         self.maybe_resize_filter_data_tex(gl, filter_context);
-        self.maybe_update_config_buffer(gl, resource_texture_dimension_2d, render_size);
+        self.maybe_update_config_buffer(
+            gl,
+            resource_texture_dimension_2d,
+            render_size,
+            DrawPassTarget::Root(root_target),
+        );
 
         self.upload_alpha_texture(gl, alphas);
         self.upload_encoded_paints_texture(gl, encoded_paints, paint_idxs);
@@ -1729,9 +1739,9 @@ impl WebGlPrograms {
         gl: &WebGl2RenderingContext,
         resource_texture_dimension_2d: u32,
         new_render_size: &RenderSize,
+        target: DrawPassTarget,
     ) {
-        // Only negate if we are rendering to the main frame buffer.
-        let negate_ndc = self.resources.view_framebuffer_override.is_none();
+        let negate_ndc = target.negate_ndc();
 
         // TODO: Collect all attributes that influence the config buffer into a
         // single struct and compare that, such that we cannot forget to update the
@@ -1859,18 +1869,6 @@ impl WebGlPrograms {
         // Restore the luts back to the cache.
         luts.truncate(old_luts_len);
         gradient_cache.restore_luts(luts);
-    }
-
-    /// Clear the view framebuffer.
-    // TODO: Investigate adding tests for the clear_view behavior.
-    fn clear_view_framebuffer(&mut self, gl: &WebGl2RenderingContext) {
-        gl.bind_framebuffer(
-            WebGl2RenderingContext::FRAMEBUFFER,
-            self.resources.view_framebuffer_override.as_deref(),
-        );
-        gl.disable(WebGl2RenderingContext::SCISSOR_TEST);
-        gl.clear_color(0.0, 0.0, 0.0, 0.0);
-        gl.clear(WebGl2RenderingContext::COLOR_BUFFER_BIT);
     }
 
     /// Uploads two strip slices (opaque then alpha) into a single GPU buffer.
@@ -3064,32 +3062,69 @@ impl WebGlRendererContext<'_> {
         self.draw_instanced_quads(i32::try_from(instances.len()).unwrap());
     }
 
-    fn clear_pass_inner(&self, target: LayerTextureId, rects: &[RectU16]) {
-        let size = self.texture_size();
-        self.gl.disable(WebGl2RenderingContext::BLEND);
-        self.gl.clear_color(0.0, 0.0, 0.0, 0.0);
-        let framebuffer = self.programs.resources.layer_framebuffer(target);
-        self.gl
-            .bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, Some(framebuffer));
-        self.gl
-            .viewport(0, 0, i32::from(size.width()), i32::from(size.height()));
-        self.gl.enable(WebGl2RenderingContext::SCISSOR_TEST);
+    fn clear_pass_inner(&self, target: DrawPassTarget, settings: ClearSettings<'_>) {
+        let color = settings.clear_color();
 
-        // It's unclear whether it's better to scissor + clear repeatedly, or to do
-        // one instanced clear pass via a shader. But using this approach should give the
-        // GPU more semantic information about what we want to do, so it seems reasonable
-        // to assume that this is better.
-        for rect in rects {
-            self.gl.scissor(
-                i32::from(rect.x0),
-                i32::from(rect.y0),
-                i32::from(rect.width()),
-                i32::from(rect.height()),
-            );
-            self.gl.clear(WebGl2RenderingContext::COLOR_BUFFER_BIT);
+        let negate_ndc = target.negate_ndc();
+        let (width, height) = match target {
+            DrawPassTarget::Root(_) => {
+                self.gl.bind_framebuffer(
+                    WebGl2RenderingContext::FRAMEBUFFER,
+                    self.programs.resources.view_framebuffer_override.as_deref(),
+                );
+                (
+                    u16::try_from(self.programs.render_size.width).unwrap(),
+                    u16::try_from(self.programs.render_size.height).unwrap(),
+                )
+            }
+            DrawPassTarget::Layer(target) => {
+                let size = self.texture_size();
+                let framebuffer = self.programs.resources.layer_framebuffer(target);
+                self.gl
+                    .bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, Some(framebuffer));
+                (size.width(), size.height())
+            }
+        };
+
+        self.gl.viewport(0, 0, i32::from(width), i32::from(height));
+        let [r, g, b, a] = color.premultiply().components;
+        self.gl.clear_color(r, g, b, a);
+
+        match settings {
+            ClearSettings::Viewport { .. } => {
+                self.gl.disable(WebGl2RenderingContext::SCISSOR_TEST);
+                self.gl.clear(WebGl2RenderingContext::COLOR_BUFFER_BIT);
+            }
+            ClearSettings::Rects { rects, .. } => {
+                self.gl.enable(WebGl2RenderingContext::SCISSOR_TEST);
+                let bounds = RectU16::new(0, 0, width, height);
+
+                // It's unclear whether it's better to scissor + clear repeatedly, or to do
+                // one instanced clear pass via a shader. But using this approach should give the
+                // GPU more semantic information about what we want to do, so it seems reasonable
+                // to assume that this is better.
+                for rect in rects
+                    .iter()
+                    .map(|rect| rect.intersect(bounds))
+                    .filter(|rect| !rect.is_empty())
+                {
+                    let y = if negate_ndc {
+                        height - rect.y1
+                    } else {
+                        rect.y0
+                    };
+
+                    self.gl.scissor(
+                        i32::from(rect.x0),
+                        i32::from(y),
+                        i32::from(rect.width()),
+                        i32::from(rect.height()),
+                    );
+                    self.gl.clear(WebGl2RenderingContext::COLOR_BUFFER_BIT);
+                }
+                self.gl.disable(WebGl2RenderingContext::SCISSOR_TEST);
+            }
         }
-        self.gl.disable(WebGl2RenderingContext::SCISSOR_TEST);
-        self.gl.enable(WebGl2RenderingContext::BLEND);
     }
 }
 
@@ -3151,7 +3186,13 @@ impl Backend for WebGlRendererContext<'_> {
     }
 
     fn clear_pass(&mut self, target: LayerTextureId, rects: &[RectU16]) -> Result<(), Self::Error> {
-        self.clear_pass_inner(target, rects);
+        self.clear_pass_inner(
+            DrawPassTarget::Layer(target),
+            ClearSettings::Rects {
+                color: AlphaColor::TRANSPARENT,
+                rects,
+            },
+        );
 
         Ok(())
     }
@@ -3403,4 +3444,10 @@ fn upload_rgba32ui_rows(
         Some(&packed_array),
     )
     .unwrap();
+}
+impl DrawPassTarget {
+    fn negate_ndc(self) -> bool {
+        // Only negate if we are rendering to the main frame buffer.
+        matches!(self, Self::Root(RootTarget::UserSurface))
+    }
 }

--- a/vello_gpu/src/render/webgl/probe.rs
+++ b/vello_gpu/src/render/webgl/probe.rs
@@ -7,7 +7,7 @@ use crate::render::webgl::{
     create_texture_storage,
 };
 use crate::target::RootTarget;
-use crate::{RenderError, RenderSize, Scene, WebGlRenderer};
+use crate::{ClearSettings, RenderError, RenderSize, Scene, TargetInit, WebGlRenderer};
 use alloc::{borrow::Cow, format};
 use core::ops::Deref;
 use thiserror::Error;
@@ -146,7 +146,7 @@ impl WebGlRenderer {
             &scene,
             &ImageCache::new_dummy(),
             &render_size,
-            true,
+            TargetInit::Clear(ClearSettings::default()),
             RootTarget::AtlasLayer,
             &texture_bindings,
             Some(&probe_texture),

--- a/vello_gpu/src/render/wgpu/mod.rs
+++ b/vello_gpu/src/render/wgpu/mod.rs
@@ -22,7 +22,8 @@ use crate::draw::{EXTERNAL_TEXTURE_SLOT_COUNT, ExternalTextureBindings, External
 use crate::render::common::IMAGE_PADDING;
 use crate::util::RangedSlice;
 use crate::{
-    GpuStrip, LayersConfig, RenderError, RenderSettings, RenderSize, Resources,
+    ClearSettings, GpuStrip, LayersConfig, RenderError, RenderSettings, RenderSize, Resources,
+    TargetInit,
     blend::{BlendStrip, GpuBlendInstance},
     copy::GpuCopyInstance,
     filter::{FilterContext, FilterInstanceData, FilterPassPlan},
@@ -55,6 +56,7 @@ use core::{fmt::Debug, num::NonZeroU64};
 #[cfg(feature = "text")]
 use glifo::PendingClearRect;
 use hashbrown::{HashMap, hash_map::Entry};
+use vello_common::color::{AlphaColor, Srgb};
 use vello_common::image_cache::{ImageCache, ImageResource};
 use vello_common::multi_atlas::{AtlasConfig, AtlasId};
 use vello_common::{
@@ -271,6 +273,7 @@ impl Renderer {
         view: &TextureView,
         depth_view: Option<&TextureView>,
         texture_bindings: &TextureBindings,
+        target_init: TargetInit<'_>,
     ) -> Result<(), RenderError> {
         #[cfg(feature = "text")]
         {
@@ -313,7 +316,7 @@ impl Renderer {
             depth_view,
             &resources.image_cache,
             &scene.encoded_paints,
-            true,
+            target_init,
             RootTarget::UserSurface,
             texture_bindings,
         );
@@ -384,7 +387,7 @@ impl Renderer {
             None,
             &dummy_image_cache,
             encoded_paints,
-            false,
+            TargetInit::SrcOver,
             RootTarget::AtlasLayer,
             texture_bindings,
         );
@@ -411,9 +414,6 @@ impl Renderer {
 
     /// Shared render pipeline: prepares GPU resources, runs the scheduler against
     /// the provided `view` at `render_size`, and maintains caches.
-    ///
-    /// When `clear` is true the render target is cleared to transparent black
-    /// before drawing (normal frame rendering).
     fn render_scene(
         &mut self,
         scene: &Scene,
@@ -425,7 +425,7 @@ impl Renderer {
         depth_view: Option<&TextureView>,
         image_cache: &ImageCache,
         encoded_paints: &[EncodedPaint],
-        clear: bool,
+        target_init: TargetInit<'_>,
         root_output_target: RootTarget,
         texture_bindings: &TextureBindings,
     ) -> Result<(), RenderError> {
@@ -476,9 +476,6 @@ impl Renderer {
             &self.schedule_storage.filter_context,
         );
 
-        if clear {
-            Self::clear_view(encoder, view);
-        }
         let mut ctx = RendererContext {
             programs: &mut self.programs,
             device,
@@ -489,7 +486,10 @@ impl Renderer {
             texture_bindings,
             external_texture_bind_groups: HashMap::new(),
             scratch_buffers: &mut self.scratch_buffers,
+            root_load_op: wgpu::LoadOp::Load,
         };
+
+        ctx.init_root_clear(target_init, root_output_target);
 
         crate::schedule::execute(
             &mut ctx,
@@ -499,30 +499,11 @@ impl Renderer {
         )
         .unwrap_or_else(|error| match error {});
 
+        ctx.finish_root_clear();
+
         self.gradient_cache.maintain();
 
         Ok(())
-    }
-
-    /// Clear the view to transparent black.
-    // TODO: Investigate adding tests for the clear_view behavior.
-    fn clear_view(encoder: &mut CommandEncoder, view: &TextureView) {
-        encoder.begin_render_pass(&RenderPassDescriptor {
-            label: Some("Clear View"),
-            color_attachments: &[Some(RenderPassColorAttachment {
-                view,
-                resolve_target: None,
-                ops: wgpu::Operations {
-                    load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
-                    store: wgpu::StoreOp::Store,
-                },
-                depth_slice: None,
-            })],
-            depth_stencil_attachment: None,
-            occlusion_query_set: None,
-            timestamp_writes: None,
-            multiview_mask: None,
-        });
     }
 
     /// Upload image to cache and atlas in one step. Returns the `ImageId`.
@@ -959,6 +940,8 @@ struct Programs {
     filter_pipeline: RenderPipeline,
     /// Layer-clear pipeline.
     clear_pipeline: RenderPipeline,
+    /// User-target rectangle-clear pipeline.
+    root_clear_pipeline: RenderPipeline,
     /// Pipeline for clearing atlas regions.
     atlas_clear_pipeline: RenderPipeline,
     /// Blend pipeline.
@@ -1269,43 +1252,50 @@ impl Programs {
             Some(depth_stencil(true)),
         );
 
-        let clear_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-            label: Some("Clear Pipeline"),
-            layout: Some(&clear_pipeline_layout),
-            vertex: wgpu::VertexState {
-                module: &clear_shader,
-                entry_point: Some("vs_main"),
-                buffers: &[wgpu::VertexBufferLayout {
-                    array_stride: size_of::<GpuClearInstance>() as u64,
-                    step_mode: wgpu::VertexStepMode::Instance,
-                    attributes: &wgpu::vertex_attr_array![
-                        0 => Uint32x2,
-                        1 => Uint32x2,
-                        2 => Uint32x2,
-                    ],
-                }],
-                compilation_options: PipelineCompilationOptions::default(),
-            },
-            fragment: Some(wgpu::FragmentState {
-                module: &clear_shader,
-                entry_point: Some("fs_main"),
-                targets: &[Some(ColorTargetState {
-                    format: wgpu::TextureFormat::Rgba8Unorm,
-                    // No blending needed for clearing
-                    blend: None,
-                    write_mask: ColorWrites::ALL,
-                })],
-                compilation_options: PipelineCompilationOptions::default(),
-            }),
-            primitive: wgpu::PrimitiveState {
-                topology: wgpu::PrimitiveTopology::TriangleStrip,
-                ..Default::default()
-            },
-            depth_stencil: None,
-            multisample: wgpu::MultisampleState::default(),
-            multiview_mask: None,
-            cache: None,
-        });
+        let clear_vertex_state = wgpu::VertexBufferLayout {
+            array_stride: size_of::<GpuClearInstance>() as u64,
+            step_mode: wgpu::VertexStepMode::Instance,
+            attributes: &wgpu::vertex_attr_array![
+                0 => Uint32x2,
+                1 => Uint32x2,
+                2 => Uint32x2,
+                3 => Uint32,
+            ],
+        };
+        let create_clear_pipeline = |label, format| {
+            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some(label),
+                layout: Some(&clear_pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &clear_shader,
+                    entry_point: Some("vs_main"),
+                    buffers: core::slice::from_ref(&clear_vertex_state),
+                    compilation_options: PipelineCompilationOptions::default(),
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &clear_shader,
+                    entry_point: Some("fs_main"),
+                    targets: &[Some(ColorTargetState {
+                        format,
+                        blend: None,
+                        write_mask: ColorWrites::ALL,
+                    })],
+                    compilation_options: PipelineCompilationOptions::default(),
+                }),
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleStrip,
+                    ..Default::default()
+                },
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState::default(),
+                multiview_mask: None,
+                cache: None,
+            })
+        };
+        let clear_pipeline =
+            create_clear_pipeline("Clear Pipeline", wgpu::TextureFormat::Rgba8Unorm);
+        let root_clear_pipeline =
+            create_clear_pipeline("Root Clear Pipeline", render_target_config.format);
 
         // Create atlas clear pipeline
         let atlas_clear_pipeline_layout =
@@ -1314,6 +1304,7 @@ impl Programs {
                 bind_group_layouts: &[],
                 immediate_size: 0,
             });
+        // TODO: Change the atlas clear pipeline to use the existing layer clear mechanism.
         let atlas_clear_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
             label: Some("Atlas Clear Pipeline"),
             layout: Some(&atlas_clear_pipeline_layout),
@@ -1326,7 +1317,7 @@ impl Programs {
             },
             fragment: Some(wgpu::FragmentState {
                 module: &clear_shader,
-                entry_point: Some("fs_main"),
+                entry_point: Some("fs_transparent"),
                 targets: &[Some(ColorTargetState {
                     format: wgpu::TextureFormat::Rgba8Unorm,
                     blend: None,
@@ -1740,6 +1731,7 @@ impl Programs {
                 height: render_target_config.height,
             },
             clear_pipeline,
+            root_clear_pipeline,
             atlas_clear_pipeline,
             filter_input_bind_group_layouts,
             filter_sampler,
@@ -2562,9 +2554,55 @@ struct RendererContext<'a> {
     texture_bindings: &'a TextureBindings,
     external_texture_bind_groups: HashMap<ExternalTextureBindings, BindGroup>,
     scratch_buffers: &'a mut ScratchBuffers,
+    root_load_op: wgpu::LoadOp<wgpu::Color>,
 }
 
 impl RendererContext<'_> {
+    fn init_root_clear(&mut self, target_init: TargetInit<'_>, root_target: RootTarget) {
+        self.root_load_op = match target_init {
+            TargetInit::SrcOver => wgpu::LoadOp::Load,
+            TargetInit::Clear(ClearSettings::Viewport { color }) => {
+                wgpu::LoadOp::Clear(clear_color(color))
+            }
+            TargetInit::Clear(clear @ ClearSettings::Rects { .. }) => {
+                self.clear_pass_inner(DrawPassTarget::Root(root_target), clear);
+
+                wgpu::LoadOp::Load
+            }
+        };
+    }
+
+    fn finish_root_clear(&mut self) {
+        // If the load mode was set to clear but no actual drawing instructions were
+        // emitted, we still need to start a pass to clear the output.
+        if let wgpu::LoadOp::Clear(color) = self.take_root_load_op() {
+            Self::clear_full_target(self.encoder, self.view, color);
+        }
+    }
+
+    fn take_root_load_op(&mut self) -> wgpu::LoadOp<wgpu::Color> {
+        core::mem::replace(&mut self.root_load_op, wgpu::LoadOp::Load)
+    }
+
+    fn clear_full_target(encoder: &mut CommandEncoder, view: &TextureView, color: wgpu::Color) {
+        encoder.begin_render_pass(&RenderPassDescriptor {
+            label: Some("Clear Target"),
+            color_attachments: &[Some(RenderPassColorAttachment {
+                view,
+                depth_slice: None,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(color),
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            occlusion_query_set: None,
+            timestamp_writes: None,
+            multiview_mask: None,
+        });
+    }
+
     fn external_texture_bind_group_for_textures(
         &mut self,
         bindings: ExternalTextureBindings,
@@ -2621,6 +2659,12 @@ impl RendererContext<'_> {
         let opaque_count = opaque_count as u32;
         let alpha_count = alpha_count as u32;
 
+        let color_load_op = if matches!(target, DrawPassTarget::Root(_)) {
+            self.take_root_load_op()
+        } else {
+            // For layer targets we always want to load.
+            wgpu::LoadOp::Load
+        };
         let (view, config_buffer, bind_group_target) = match target {
             DrawPassTarget::Root(_) => (
                 self.view,
@@ -2692,7 +2736,7 @@ impl RendererContext<'_> {
                 depth_slice: None,
                 resolve_target: None,
                 ops: wgpu::Operations {
-                    load: wgpu::LoadOp::Load,
+                    load: color_load_op,
                     store: wgpu::StoreOp::Store,
                 },
             })],
@@ -2926,20 +2970,58 @@ impl RendererContext<'_> {
         }
     }
 
-    fn clear_pass_inner(&mut self, target: LayerTextureId, rects: &[RectU16]) {
-        let texture_size = self.texture_size();
-        let target_size = [
-            u32::from(texture_size.width()),
-            u32::from(texture_size.height()),
-        ];
+    fn clear_pass_inner(&mut self, target: DrawPassTarget, settings: ClearSettings<'_>) {
+        let color = settings.clear_color();
+
+        let view = match target {
+            DrawPassTarget::Root(_) => self.view,
+            DrawPassTarget::Layer(target) => self.programs.resources.layer_view(target),
+        };
+        let rects = match settings {
+            ClearSettings::Viewport { .. } => {
+                Self::clear_full_target(self.encoder, view, clear_color(color));
+
+                return;
+            }
+            ClearSettings::Rects { rects, .. } => rects,
+        };
+
+        let (target_size, pipeline) = match target {
+            DrawPassTarget::Root(_) => (
+                [
+                    u16::try_from(self.programs.render_size.width).unwrap(),
+                    u16::try_from(self.programs.render_size.height).unwrap(),
+                ],
+                &self.programs.root_clear_pipeline,
+            ),
+            DrawPassTarget::Layer(_) => {
+                let texture_size = self.texture_size();
+                (
+                    [texture_size.width(), texture_size.height()],
+                    &self.programs.clear_pipeline,
+                )
+            }
+        };
+        let bounds = RectU16::new(0, 0, target_size[0], target_size[1]);
+        let target_size = target_size.map(u32::from);
+        let color = color.premultiply().to_rgba8().to_u32();
         self.scratch_buffers.clear_instances.clear();
-        self.scratch_buffers
-            .clear_instances
-            .extend(rects.iter().copied().map(|rect| GpuClearInstance {
-                origin: [u32::from(rect.x0), u32::from(rect.y0)],
-                size: [u32::from(rect.width()), u32::from(rect.height())],
-                target_size,
-            }));
+        self.scratch_buffers.clear_instances.extend(
+            rects
+                .iter()
+                .map(|rect| rect.intersect(bounds))
+                .filter(|rect| !rect.is_empty())
+                .map(|rect| GpuClearInstance {
+                    origin: [u32::from(rect.x0), u32::from(rect.y0)],
+                    size: [u32::from(rect.width()), u32::from(rect.height())],
+                    target_size,
+                    color,
+                }),
+        );
+
+        if self.scratch_buffers.clear_instances.is_empty() {
+            return;
+        }
 
         let clear_buffer = self
             .device
@@ -2948,7 +3030,6 @@ impl RendererContext<'_> {
                 contents: bytemuck::cast_slice(&self.scratch_buffers.clear_instances),
                 usage: wgpu::BufferUsages::VERTEX,
             });
-        let view = self.programs.resources.layer_view(target);
         let mut render_pass = self.encoder.begin_render_pass(&RenderPassDescriptor {
             label: Some("Clear Rects"),
             color_attachments: &[Some(RenderPassColorAttachment {
@@ -2965,7 +3046,7 @@ impl RendererContext<'_> {
             timestamp_writes: None,
             multiview_mask: None,
         });
-        render_pass.set_pipeline(&self.programs.clear_pipeline);
+        render_pass.set_pipeline(pipeline);
         render_pass.set_vertex_buffer(0, clear_buffer.slice(..));
         render_pass.draw(
             0..4,
@@ -3032,7 +3113,13 @@ impl Backend for RendererContext<'_> {
     }
 
     fn clear_pass(&mut self, target: LayerTextureId, rects: &[RectU16]) -> Result<(), Self::Error> {
-        self.clear_pass_inner(target, rects);
+        self.clear_pass_inner(
+            DrawPassTarget::Layer(target),
+            ClearSettings::Rects {
+                color: AlphaColor::TRANSPARENT,
+                rects,
+            },
+        );
 
         Ok(())
     }
@@ -3294,5 +3381,15 @@ impl AtlasWriter for Arc<Pixmap> {
     ) {
         self.as_ref()
             .write_to_atlas(device, queue, encoder, atlas_texture, offset, width, height);
+    }
+}
+
+fn clear_color(color: AlphaColor<Srgb>) -> wgpu::Color {
+    let [r, g, b, a] = color.premultiply().components;
+    wgpu::Color {
+        r: f64::from(r),
+        g: f64::from(g),
+        b: f64::from(b),
+        a: f64::from(a),
     }
 }

--- a/vello_gpu_shaders/shaders/clear.wesl
+++ b/vello_gpu_shaders/shaders/clear.wesl
@@ -3,17 +3,26 @@
 
 import package::helpers::geometry::{pixel_to_ndc, quad_corner};
 
+struct ClearVertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) @interpolate(flat) color: vec4<f32>,
+}
+
 @vertex
 fn vs_main(
     @builtin(vertex_index) vertex_index: u32,
     @location(0) origin: vec2<u32>,
     @location(1) size: vec2<u32>,
     @location(2) target_size: vec2<u32>,
-) -> @builtin(position) vec4<f32> {
+    @location(3) color: u32,
+) -> ClearVertexOutput {
     let corner = quad_corner(vertex_index);
     let pixel = vec2<f32>(origin) + corner * vec2<f32>(size);
     let ndc = pixel_to_ndc(pixel, vec2<f32>(target_size));
-    return vec4<f32>(ndc, 0.0, 1.0);
+    return ClearVertexOutput(
+        vec4<f32>(ndc, 0.0, 1.0),
+        unpack4x8unorm(color),
+    );
 }
 
 // This vertex shader is used for clearing atlas regions.
@@ -36,7 +45,11 @@ fn vs_main_fullscreen(
 }
 
 @fragment
-fn fs_main(@builtin(position) position: vec4<f32>) -> @location(0) vec4<f32> {
-    // Clear with transparent pixels
+fn fs_main(@location(0) @interpolate(flat) color: vec4<f32>) -> @location(0) vec4<f32> {
+    return color;
+}
+
+@fragment
+fn fs_transparent(@builtin(position) position: vec4<f32>) -> @location(0) vec4<f32> {
     return vec4<f32>(0.0, 0.0, 0.0, 0.0);
-} 
+}

--- a/vello_tests/snapshots/clear_area_empty_rects_preserve_existing_pixels.png
+++ b/vello_tests/snapshots/clear_area_empty_rects_preserve_existing_pixels.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd29167eb4a248c5e19aa4cf0007921998d25fe0a9d4c43022e27379ed9f972d
+size 98

--- a/vello_tests/snapshots/clear_area_rects_clear_to_translucent_color.png
+++ b/vello_tests/snapshots/clear_area_rects_clear_to_translucent_color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:310dc3d81af7938fd0d9e8ceed0a524f32a01671b5d6bc705e9c5972285d1a65
+size 132

--- a/vello_tests/snapshots/clear_area_rects_clear_to_transparent.png
+++ b/vello_tests/snapshots/clear_area_rects_clear_to_transparent.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65eeb207d80224d756b5940c2088548ede0dc38173250d7439f5a92c4b446318
+size 132

--- a/vello_tests/snapshots/clear_area_rects_use_requested_color.png
+++ b/vello_tests/snapshots/clear_area_rects_use_requested_color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c18844089f4d424b4c077b5a907acd7f89a42677f0e67fdd4c696d9fd490f0c6
+size 151

--- a/vello_tests/snapshots/clear_area_viewport_clears_without_drawing.png
+++ b/vello_tests/snapshots/clear_area_viewport_clears_without_drawing.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:370f6acde4d6770f06ce24137d209c71cbc8ebd4ca07c5e3e4d9f7186876af09
+size 91

--- a/vello_tests/snapshots/clear_area_viewport_is_preserved_under_src_over.png
+++ b/vello_tests/snapshots/clear_area_viewport_is_preserved_under_src_over.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4af6e7f71d090d131ccd18f715079301e691e7daea96c658a9cc73bd1f43028c
+size 98

--- a/vello_tests/snapshots/clear_area_viewport_uses_requested_color.png
+++ b/vello_tests/snapshots/clear_area_viewport_uses_requested_color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d3c4078ac495591c281890b8c41548b09157276176a4330012337e8839d5fbb5
+size 111

--- a/vello_tests/snapshots/clear_background_isolates_root_blend.png
+++ b/vello_tests/snapshots/clear_background_isolates_root_blend.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6babb839d0a37e070f9c8573d1bed10462ddb464da81caa384bfc9f230cf7a5f
+size 106

--- a/vello_tests/snapshots/clear_disabled_preserves_existing_pixels.png
+++ b/vello_tests/snapshots/clear_disabled_preserves_existing_pixels.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56f57423e0ff37d0284ae02f3dfa6ceffad893302f86b5aa4d17dabb5ba1b25d
+size 82

--- a/vello_tests/snapshots/src_over_isolates_root_blend.png
+++ b/vello_tests/snapshots/src_over_isolates_root_blend.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6babb839d0a37e070f9c8573d1bed10462ddb464da81caa384bfc9f230cf7a5f
+size 106

--- a/vello_tests/tests/mod.rs
+++ b/vello_tests/tests/mod.rs
@@ -50,6 +50,7 @@ mod mix;
 mod opacity;
 mod renderer;
 mod scenes;
+mod target;
 #[macro_use]
 mod util;
 #[cfg(target_arch = "wasm32")]

--- a/vello_tests/tests/renderer.rs
+++ b/vello_tests/tests/renderer.rs
@@ -6,15 +6,20 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use glifo::GlyphRunBackend;
+use vello_common::color::{AlphaColor, Srgb};
 use vello_common::filter_effects::Filter;
 use vello_common::kurbo::{Affine, BezPath, Rect, Stroke};
 use vello_common::mask::Mask;
 use vello_common::paint::{ImageId, ImageSource, PaintType, Tint};
 use vello_common::peniko::{BlendMode, Fill, FontData};
 use vello_common::pixmap::Pixmap;
-use vello_cpu::{Level, RasterizerSettings, RenderContext, RenderMode, RenderSettings, Resources};
+use vello_cpu::{
+    Level, RasterizerSettings, RenderContext, RenderMode, RenderSettings, Resources,
+    TargetInit as CpuTargetInit,
+};
 use vello_gpu::{
-    RenderSettings as HybridRenderSettings, Resources as HybridResources, Scene, TextureId,
+    ClearSettings, RectU16, RenderSettings as HybridRenderSettings, Resources as HybridResources,
+    Scene, TargetInit as HybridTargetInit, TextureId,
 };
 #[cfg(all(target_arch = "wasm32", feature = "webgl"))]
 use web_sys::WebGl2RenderingContext;
@@ -83,6 +88,7 @@ pub(crate) trait Renderer: Sized {
     fn set_filter_effect(&mut self, filter: Filter);
     fn reset_filter_effect(&mut self);
     fn reset(&mut self);
+    fn set_target_init(&mut self, target_init: HybridTargetInit<'static>);
     fn render(&mut self);
     fn snapshot(&mut self) -> Pixmap;
     fn register_external_texture(&mut self, pixmap: Arc<Pixmap>) -> TextureId;
@@ -95,6 +101,7 @@ pub(crate) struct CpuRenderer {
     resources: Resources,
     render_mode: RenderMode,
     target: Pixmap,
+    target_init: HybridTargetInit<'static>,
 }
 
 impl Renderer for CpuRenderer {
@@ -113,6 +120,7 @@ impl Renderer for CpuRenderer {
             resources: Resources::new(),
             render_mode,
             target: Pixmap::new(width, height),
+            target_init: HybridTargetInit::Clear(ClearSettings::default()),
         }
     }
 
@@ -240,12 +248,29 @@ impl Renderer for CpuRenderer {
         self.ctx.reset();
     }
 
+    fn set_target_init(&mut self, target_init: HybridTargetInit<'static>) {
+        self.target_init = target_init;
+    }
+
     fn render(&mut self) {
+        let target_init = match self.target_init {
+            HybridTargetInit::SrcOver => CpuTargetInit::SrcOver,
+            HybridTargetInit::Clear(ClearSettings::Viewport { color }) => {
+                CpuTargetInit::Clear(color)
+            }
+            HybridTargetInit::Clear(ClearSettings::Rects { color, rects }) => {
+                apply_rect_clear(&mut self.target, color, rects);
+
+                CpuTargetInit::SrcOver
+            }
+        };
+
         self.ctx.render_with(
             &mut self.target,
             &mut self.resources,
             RasterizerSettings {
                 render_mode: self.render_mode,
+                target_init,
                 ..Default::default()
             },
         );
@@ -284,6 +309,7 @@ pub(crate) struct HybridRenderer {
     renderer: vello_gpu::Renderer,
     external_textures: HashMap<TextureId, wgpu::TextureView>,
     next_external_texture_id: u64,
+    target_init: HybridTargetInit<'static>,
     gpu_test_guard: Option<std::sync::MutexGuard<'static, ()>>,
 }
 
@@ -357,6 +383,7 @@ impl HybridRenderer {
             renderer,
             external_textures: HashMap::new(),
             next_external_texture_id: 1,
+            target_init: HybridTargetInit::Clear(ClearSettings::default()),
             gpu_test_guard: None,
         }
     }
@@ -548,6 +575,10 @@ impl Renderer for HybridRenderer {
         self.scene.reset();
     }
 
+    fn set_target_init(&mut self, target_init: HybridTargetInit<'static>) {
+        self.target_init = target_init;
+    }
+
     fn render(&mut self) {
         // On some platforms using `cargo test` triggers segmentation faults in wgpu when the GPU
         // tests are run in parallel (likely related to the number of device resources being
@@ -587,6 +618,7 @@ impl Renderer for HybridRenderer {
                 &self.texture_view,
                 self.depth_texture_view.as_ref(),
                 &texture_bindings,
+                self.target_init,
             )
             .unwrap();
 
@@ -735,6 +767,7 @@ pub(crate) struct HybridRenderer {
     gl: WebGl2RenderingContext,
     external_textures: vello_gpu::WebGlTextureBindings,
     next_external_texture_id: u64,
+    clear_color: AlphaColor<Srgb>,
 }
 
 #[cfg(all(target_arch = "wasm32", feature = "webgl"))]
@@ -807,6 +840,7 @@ impl Renderer for HybridRenderer {
             gl,
             external_textures: vello_gpu::WebGlTextureBindings::new(),
             next_external_texture_id: 1,
+            clear_color: AlphaColor::TRANSPARENT,
         }
     }
 
@@ -932,6 +966,15 @@ impl Renderer for HybridRenderer {
         self.scene.reset();
     }
 
+    fn set_target_init(&mut self, target_init: HybridTargetInit<'static>) {
+        self.clear_color = match target_init {
+            HybridTargetInit::Clear(ClearSettings::Viewport { color }) => color,
+            HybridTargetInit::SrcOver | HybridTargetInit::Clear(ClearSettings::Rects { .. }) => {
+                panic!("WebGL only supports clearing the complete viewport")
+            }
+        };
+    }
+
     fn render(&mut self) {
         let width = self.scene.width();
         let height = self.scene.height();
@@ -946,11 +989,14 @@ impl Renderer for HybridRenderer {
                 &mut self.resources,
                 &render_size,
                 &self.external_textures,
+                self.clear_color,
             )
             .unwrap();
     }
 
     fn snapshot(&mut self) -> Pixmap {
+        use vello_common::peniko::ImageAlphaType;
+        use vello_common::pixmap::PixelMetadata;
         use web_sys::WebGl2RenderingContext;
 
         let width = self.scene.width();
@@ -976,10 +1022,12 @@ impl Renderer for HybridRenderer {
             a[y * row_bytes..(y + 1) * row_bytes].swap_with_slice(&mut b[..row_bytes]);
         }
 
-        let mut pixmap = Pixmap::new(width, height);
-        let pixmap_data = pixmap.data_as_u8_slice_mut();
-        pixmap_data.copy_from_slice(&pixels);
-        pixmap
+        Pixmap::from_parts(
+            pixels,
+            width,
+            height,
+            PixelMetadata::new(ImageAlphaType::AlphaPremultiplied, true),
+        )
     }
 
     fn register_external_texture(&mut self, pixmap: Arc<Pixmap>) -> TextureId {
@@ -1039,5 +1087,26 @@ impl Renderer for HybridRenderer {
 
     fn register_image(&mut self, pixmap: Arc<Pixmap>) -> ImageId {
         self.upload_image(&pixmap)
+    }
+}
+
+// Vello CPU does not expose rectangle clears (because it would be pretty inefficient),
+// so we simulate them here for the snapshot tests.
+fn apply_rect_clear(pixmap: &mut Pixmap, color: AlphaColor<Srgb>, rects: &[RectU16]) {
+    let color = color.premultiply().to_rgba8();
+    let width = usize::from(pixmap.width());
+    let bounds = RectU16::new(0, 0, pixmap.width(), pixmap.height());
+    let data = pixmap.data_mut();
+
+    for rect in rects
+        .iter()
+        .map(|rect| rect.intersect(bounds))
+        .filter(|rect| !rect.is_empty())
+    {
+        for y in usize::from(rect.y0)..usize::from(rect.y1) {
+            let start = y * width + usize::from(rect.x0);
+            let end = y * width + usize::from(rect.x1);
+            data[start..end].fill(color);
+        }
     }
 }

--- a/vello_tests/tests/target.rs
+++ b/vello_tests/tests/target.rs
@@ -1,0 +1,136 @@
+// Copyright 2026 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Tests for initializing the output target.
+
+use crate::renderer::Renderer;
+use vello_common::color::AlphaColor;
+use vello_common::color::palette::css::{BLUE, LIME};
+use vello_common::kurbo::{Rect, Shape};
+use vello_common::peniko::{BlendMode, Compose, Mix};
+use vello_dev_macros::vello_test;
+use vello_gpu::{ClearSettings, RectU16, TargetInit};
+
+const CLEAR_RECTS: &[RectU16] = &[
+    RectU16::new(6, 6, 32, 32),
+    RectU16::new(56, 10, 90, 44),
+    RectU16::new(22, 58, 66, 92),
+];
+const EMPTY_CLEAR_RECTS: &[RectU16] = &[
+    RectU16::new(100, 100, u16::MAX, u16::MAX),
+    RectU16::new(24, 24, 12, 12),
+];
+
+fn prepare_clear_test(ctx: &mut impl Renderer) {
+    ctx.flush();
+    ctx.render();
+    ctx.reset();
+}
+
+fn draw_destructive_root_blend(ctx: &mut impl Renderer) {
+    ctx.set_paint(LIME);
+    ctx.fill_rect(&Rect::new(8.0, 24.0, 92.0, 76.0));
+
+    let rect = Rect::new(36.0, 36.0, 64.0, 64.0);
+    let clip = rect.to_path(0.1);
+    ctx.push_layer(
+        Some(&clip),
+        Some(BlendMode::new(Mix::Normal, Compose::Clear)),
+        None,
+        None,
+        None,
+    );
+    ctx.fill_rect(&rect);
+    ctx.pop_layer();
+}
+
+#[vello_test]
+fn clear_area_viewport_uses_requested_color(ctx: &mut impl Renderer) {
+    prepare_clear_test(ctx);
+    ctx.set_target_init(TargetInit::Clear(ClearSettings::Viewport {
+        color: AlphaColor::from_rgba8(18, 52, 86, 120),
+    }));
+    ctx.set_paint(LIME);
+    ctx.fill_rect(&Rect::new(16.0, 16.0, 48.0, 48.0));
+}
+
+#[vello_test]
+fn clear_area_viewport_is_preserved_under_src_over(ctx: &mut impl Renderer) {
+    prepare_clear_test(ctx);
+    ctx.set_target_init(TargetInit::Clear(ClearSettings::Viewport { color: BLUE }));
+    ctx.set_blend_mode(BlendMode::default());
+    ctx.set_paint(LIME.with_alpha(0.5));
+    ctx.fill_rect(&Rect::new(16.0, 16.0, 48.0, 48.0));
+}
+
+#[vello_test]
+fn clear_area_viewport_clears_without_drawing(ctx: &mut impl Renderer) {
+    ctx.set_paint(BLUE);
+    ctx.fill_rect(&Rect::new(0.0, 0.0, 100.0, 100.0));
+    prepare_clear_test(ctx);
+
+    ctx.set_target_init(TargetInit::Clear(ClearSettings::Viewport { color: LIME }));
+}
+
+#[vello_test]
+fn clear_background_isolates_root_blend(ctx: &mut impl Renderer) {
+    prepare_clear_test(ctx);
+    ctx.set_target_init(TargetInit::Clear(ClearSettings::Viewport { color: BLUE }));
+    draw_destructive_root_blend(ctx);
+}
+
+#[vello_test(skip_webgl)]
+fn src_over_isolates_root_blend(ctx: &mut impl Renderer) {
+    ctx.set_paint(BLUE);
+    ctx.fill_rect(&Rect::new(0.0, 0.0, 100.0, 100.0));
+    prepare_clear_test(ctx);
+
+    ctx.set_target_init(TargetInit::SrcOver);
+    draw_destructive_root_blend(ctx);
+}
+
+#[vello_test(skip_webgl)]
+fn clear_area_rects_use_requested_color(ctx: &mut impl Renderer) {
+    prepare_clear_test(ctx);
+    ctx.set_target_init(TargetInit::Clear(ClearSettings::Rects {
+        color: AlphaColor::from_rgba8(18, 52, 86, 120),
+        rects: CLEAR_RECTS,
+    }));
+    ctx.set_paint(LIME);
+    ctx.fill_rect(&Rect::new(8.0, 8.0, 24.0, 24.0));
+}
+
+#[vello_test(skip_webgl)]
+fn clear_area_rects_clear_to_transparent(ctx: &mut impl Renderer) {
+    prepare_clear_test(ctx);
+    ctx.set_target_init(TargetInit::Clear(ClearSettings::Rects {
+        color: AlphaColor::TRANSPARENT,
+        rects: CLEAR_RECTS,
+    }));
+}
+
+#[vello_test(skip_webgl)]
+fn clear_area_rects_clear_to_translucent_color(ctx: &mut impl Renderer) {
+    prepare_clear_test(ctx);
+    ctx.set_target_init(TargetInit::Clear(ClearSettings::Rects {
+        color: BLUE.with_alpha(0.1),
+        rects: CLEAR_RECTS,
+    }));
+}
+
+#[vello_test(skip_webgl)]
+fn clear_area_empty_rects_preserve_existing_pixels(ctx: &mut impl Renderer) {
+    prepare_clear_test(ctx);
+    ctx.set_target_init(TargetInit::Clear(ClearSettings::Rects {
+        color: AlphaColor::from_rgba8(18, 52, 86, 120),
+        rects: EMPTY_CLEAR_RECTS,
+    }));
+    ctx.set_paint(LIME);
+    ctx.fill_rect(&Rect::new(16.0, 16.0, 48.0, 48.0));
+}
+
+#[vello_test(skip_webgl)]
+fn clear_disabled_preserves_existing_pixels(ctx: &mut impl Renderer) {
+    prepare_clear_test(ctx);
+    ctx.set_target_init(TargetInit::SrcOver);
+}

--- a/vello_tests/vello_dev_macros/src/test.rs
+++ b/vello_tests/vello_dev_macros/src/test.rs
@@ -31,6 +31,8 @@ struct Arguments {
     skip_multithreaded: bool,
     /// Whether the test should not be run on the GPU (`vello_gpu`).
     skip_hybrid: bool,
+    /// Whether the test should not be run using the WebGL backend.
+    skip_webgl: bool,
     /// Whether only `vello_gpu` should run and generate the reference image.
     hybrid_only: bool,
     /// Whether to additionally run `vello_gpu` with depth buffering disabled.
@@ -60,6 +62,7 @@ impl Default for Arguments {
             skip_cpu: false,
             skip_multithreaded: false,
             skip_hybrid: false,
+            skip_webgl: false,
             hybrid_only: false,
             hybrid_no_depth: false,
             no_ref: false,
@@ -187,6 +190,7 @@ pub(crate) fn vello_test_inner(attr: TokenStream, item: TokenStream) -> TokenStr
         skip_cpu,
         skip_multithreaded,
         mut skip_hybrid,
+        skip_webgl,
         hybrid_only,
         hybrid_no_depth,
         ignore_reason,
@@ -266,7 +270,7 @@ pub(crate) fn vello_test_inner(attr: TokenStream, item: TokenStream) -> TokenStr
     } else {
         empty_snippet.clone()
     };
-    let ignore_hybrid_webgl = if skip_hybrid {
+    let ignore_hybrid_webgl = if skip_hybrid || skip_webgl {
         ignore_snippet.clone()
     } else {
         empty_snippet.clone()
@@ -780,6 +784,7 @@ fn parse_args(attribute_input: &AttributeInput) -> Arguments {
                     "skip_cpu" => args.skip_cpu = true,
                     "skip_multithreaded" => args.skip_multithreaded = true,
                     "skip_hybrid" => args.skip_hybrid = true,
+                    "skip_webgl" => args.skip_webgl = true,
                     "hybrid_only" => {
                         args.skip_cpu = true;
                         args.hybrid_only = true;


### PR DESCRIPTION
This PR builds on top of the previous PRs that have introduced a way of specifying how the target should be initialized. In this PR, we implement this for Vello Hybrid. Unlike for Vello CPU, we also add an operation that allows clearing multiple rectangular regions with the provided clear color, since this is an operation that can be implemented efficiently on the GPU and is useful for dirty rect rendering. I think the code is mostly self-explanatory, so I won’t describe this in much more detail here.

However, there is one thing worth mentioning: As you can see, the `SrcOver` and `ClearSettings::Rects` options are currently only exposed by wgpu when rendering to the root target. **In the WebGL backend, we currently only support clearing the whole viewport** (when rendering to the root viewport). The reason for this is that, for the default drawing buffer, if the option `preserveDrawingBuffer` is set to false (which is the default and also highly recommended for good performance), there actually isn’t any guarantee that the existing contents are still preserved once the frame has been presented. Therefore, I think it’s misleading if we offer an option to only clear parts of the framebuffer, or not at all. Perhaps we can consider allowing this to be set to `true` in the future, but for now I think it’s the better option if we simply force a clear operation so that users cannot get this wrong accidentally.
