### PR TITLE
fix: avoid enabling both Vello Hybrid web renderers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ web-sys = "0.3.91"
 
 vello_common = { version = "0.2.0", path = "sparse_strips/vello_common", default-features = false }
 vello_cpu = { version = "0.2.0", path = "sparse_strips/vello_cpu" }
-vello_hybrid = { version = "0.2.0", path = "sparse_strips/vello_hybrid" }
+vello_hybrid = { version = "0.2.0", path = "sparse_strips/vello_hybrid", default-features = false }
 vello_sparse_shaders = { version = "0.2.0", path = "sparse_strips/vello_sparse_shaders" }
 glifo = { version = "0.3.0", path = "glifo", default-features = false }
 vello_example_scenes = { path = "sparse_strips/vello_example_scenes" }

--- a/sparse_strips/vello_example_scenes/Cargo.toml
+++ b/sparse_strips/vello_example_scenes/Cargo.toml
@@ -24,7 +24,7 @@ bytemuck = { workspace = true, features = [] }
 smallvec = { workspace = true }
 glifo = { workspace = true }
 skrifa = { workspace = true }
-vello_hybrid = { workspace = true }
+vello_hybrid = { workspace = true, default-features = false, features = ["text"] }
 vello_common = { workspace = true, features = ["pico_svg", "png"] }
 image = { workspace = true, features = ["jpeg"] }
 vello_cpu = { workspace = true, optional = true }

--- a/sparse_strips/vello_hybrid/examples/native_webgl/Cargo.toml
+++ b/sparse_strips/vello_hybrid/examples/native_webgl/Cargo.toml
@@ -19,7 +19,7 @@ console_log = { workspace = true }
 js-sys = { workspace = true }
 log = { workspace = true }
 vello_common = { workspace = true }
-vello_hybrid = { workspace = true, features = ["webgl"] }
+vello_hybrid = { workspace = true, default-features = false, features = ["text", "webgl"] }
 vello_example_scenes = { workspace = true, features = ["webgl_gpu_timing"] }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }

--- a/sparse_strips/vello_hybrid/examples/wgpu_webgl/Cargo.toml
+++ b/sparse_strips/vello_hybrid/examples/wgpu_webgl/Cargo.toml
@@ -19,7 +19,7 @@ console_log = { workspace = true }
 js-sys = { workspace = true }
 log = { workspace = true }
 vello_common = { workspace = true }
-vello_hybrid = { workspace = true }
+vello_hybrid = { workspace = true, features = ["text", "wgpu", "wgpu_default"] }
 vello_example_scenes = { workspace = true, features = ["webgl_gpu_timing"] }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }

--- a/sparse_strips/vello_hybrid/examples/winit/Cargo.toml
+++ b/sparse_strips/vello_hybrid/examples/winit/Cargo.toml
@@ -13,6 +13,6 @@ workspace = true
 winit = { workspace = true }
 wgpu = { workspace = true, default-features = true }
 vello_common = { workspace = true }
-vello_hybrid = { workspace = true }
+vello_hybrid = { workspace = true, features = ["text", "wgpu", "wgpu_default"] }
 vello_example_scenes = { workspace = true }
 pollster = { workspace = true }

--- a/sparse_strips/vello_hybrid/src/render/common.rs
+++ b/sparse_strips/vello_hybrid/src/render/common.rs
@@ -695,7 +695,7 @@ pub(crate) fn maybe_warn_about_webgl_feature_conflict() {
         && wgpu::Backends::all().contains(wgpu::Backends::GL)
     {
         log::warn!(
-            r#"Both WebGL and wgpu with the \"webgl\" feature are enabled.
+            r#"Both WebGL and wgpu with the "webgl" feature are enabled.
 For optimal performance and binary size on web targets, use only the dedicated WebGL renderer."#
         );
     }

--- a/sparse_strips/vello_sparse_tests/Cargo.toml
+++ b/sparse_strips/vello_sparse_tests/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/regenerate_probe_reference.rs"
 glifo = { workspace = true }
 vello_common = { workspace = true, features = ["std", "probe"] }
 vello_cpu = { workspace = true, features = ["multithreading", "std", "f32_pipeline"] }
-vello_hybrid = { workspace = true }
+vello_hybrid = { workspace = true, features = ["text", "wgpu", "wgpu_default"] }
 fearless_simd = { workspace = true, features = [
     "force_support_fallback", # We require the `force_support_callback` feature to test the fallback path.
 ] }


### PR DESCRIPTION
Prevent native WebGL builds from also enabling wgpu by explicitly selecting Vello Hybrid features per consumer.

Created with assistance from GPT-5.6 Sol.