### PR TITLE
vello_hybrid: Do not apply a magic offset for image sampling

### DIFF
--- a/sparse_strips/vello_sparse_shaders/shaders/render.wesl
+++ b/sparse_strips/vello_sparse_shaders/shaders/render.wesl
@@ -404,13 +404,9 @@ fn fs_main(
             let image_tint = unpack4x8unorm(packed_tint);
             let is_multiply = image_texel2.z == TINT_MODE_MULTIPLY;
             let local_xy = sample_xy - image_offset;
-            // This offset doesn't exist in vello_cpu, and we use it because 45 degree skewing seems to cause
-            // artifacts on the GPU. We have something similar in place for gradients. It might be worth revisiting
-            // this to see whether a better approach is possible.
-            let offset = 0.00001;
             let extended_xy = vec2<f32>(
-                extend_mode(local_xy.x + offset, image_extend_modes.x, image_size.x),
-                extend_mode(local_xy.y + offset, image_extend_modes.y, image_size.y)
+                extend_mode(local_xy.x, image_extend_modes.x, image_size.x),
+                extend_mode(local_xy.y, image_extend_modes.y, image_size.y)
             );
 
             // TODO: add a fast path for images where we are using bilinear sampling and want transparent pixels,

--- a/sparse_strips/vello_sparse_tests/tests/image.rs
+++ b/sparse_strips/vello_sparse_tests/tests/image.rs
@@ -202,7 +202,7 @@ fn image_with_transform_scaling_non_uniform(ctx: &mut impl Renderer) {
     );
 }
 
-#[vello_test]
+#[vello_test(diff_pixels = 64)]
 fn image_with_transform_skew_x_1(ctx: &mut impl Renderer) {
     transform(
         ctx,
@@ -214,7 +214,7 @@ fn image_with_transform_skew_x_1(ctx: &mut impl Renderer) {
     );
 }
 
-#[vello_test]
+#[vello_test(diff_pixels = 64)]
 fn image_with_transform_skew_x_2(ctx: &mut impl Renderer) {
     transform(
         ctx,
@@ -226,7 +226,7 @@ fn image_with_transform_skew_x_2(ctx: &mut impl Renderer) {
     );
 }
 
-#[vello_test]
+#[vello_test(diff_pixels = 64)]
 fn image_with_transform_skew_y_1(ctx: &mut impl Renderer) {
     transform(
         ctx,
@@ -238,7 +238,7 @@ fn image_with_transform_skew_y_1(ctx: &mut impl Renderer) {
     );
 }
 
-#[vello_test]
+#[vello_test(diff_pixels = 64)]
 fn image_with_transform_skew_y_2(ctx: &mut impl Renderer) {
     transform(
         ctx,


### PR DESCRIPTION
I think we should avoid complicating the shaders by adding arbitrary offsets just to make specific tests work in CI. Vello CPU itself does not apply any such offset, so it produces an inconsistency between Vello CPU and Vello Hybrid. In addition to that, this offset doesn't actually fix anything, it just moves the problem to somewhere else: While this does remove the artifacts for the specific case of axis-aligned images that are skewed by 45%, if we were to shift the image slightly we would get the same artifacts.

The fact that NN images can cause artifacts is (in my view) inevitable, and if you want to avoid that you should just use bilinear image sampling instead.

I think I would like to do the same for gradients, but in a different PR.

(Open for options on how to handle the test images instead! Maybe I should convert them to use bilinear sampling instead?)