### PR TITLE
vello_hybrid: Don't store active texture and texture bindings in state guard

### DIFF
--- a/vello_gpu/src/render/webgl/mod.rs
+++ b/vello_gpu/src/render/webgl/mod.rs
@@ -1926,8 +1926,6 @@ pub(crate) struct WebGlStateGuard {
     config: WebGlStateConfig,
     original_framebuffer: Option<WebGlFramebuffer>,
     original_read_framebuffer: Option<WebGlFramebuffer>,
-    original_active_texture: Option<u32>,
-    original_texture_2d: Option<WebGlTexture>,
     original_pixel_pack_buffer: Option<WebGlBuffer>,
 }
 
@@ -1952,23 +1950,6 @@ impl WebGlStateGuard {
             None
         };
 
-        let original_active_texture = if config.active_texture {
-            gl.get_parameter(WebGl2RenderingContext::ACTIVE_TEXTURE)
-                .ok()
-                .and_then(|v| v.as_f64())
-                .map(|v| v as u32)
-        } else {
-            None
-        };
-
-        let original_texture_2d = if config.texture_2d {
-            gl.get_parameter(WebGl2RenderingContext::TEXTURE_BINDING_2D)
-                .ok()
-                .and_then(|v| v.dyn_into::<WebGlTexture>().ok())
-        } else {
-            None
-        };
-
         let original_pixel_pack_buffer = if config.pixel_pack_buffer {
             gl.get_parameter(WebGl2RenderingContext::PIXEL_PACK_BUFFER_BINDING)
                 .ok()
@@ -1982,8 +1963,6 @@ impl WebGlStateGuard {
             config,
             original_framebuffer,
             original_read_framebuffer,
-            original_active_texture,
-            original_texture_2d,
             original_pixel_pack_buffer,
         }
     }
@@ -2005,7 +1984,6 @@ impl WebGlStateGuard {
             gl,
             WebGlStateConfig {
                 read_framebuffer: true,
-                texture_2d: true,
                 ..Default::default()
             },
         )
@@ -2032,19 +2010,6 @@ impl Drop for WebGlStateGuard {
             );
         }
 
-        if self.config.active_texture
-            && let Some(active_texture) = self.original_active_texture
-        {
-            self.gl.active_texture(active_texture);
-        }
-
-        if self.config.texture_2d {
-            self.gl.bind_texture(
-                WebGl2RenderingContext::TEXTURE_2D,
-                self.original_texture_2d.as_ref(),
-            );
-        }
-
         if self.config.pixel_pack_buffer {
             self.gl.bind_buffer(
                 WebGl2RenderingContext::PIXEL_PACK_BUFFER,
@@ -2060,10 +2025,6 @@ pub(crate) struct WebGlStateConfig {
     pub(crate) framebuffer: bool,
     /// Save/restore read framebuffer binding (`READ_FRAMEBUFFER_BINDING`)
     pub(crate) read_framebuffer: bool,
-    /// Save/restore active texture unit (`ACTIVE_TEXTURE`)
-    pub(crate) active_texture: bool,
-    /// Save/restore 2D texture binding (`TEXTURE_BINDING_2D`)
-    pub(crate) texture_2d: bool,
     /// Save/restore pixel pack buffer binding (`PIXEL_PACK_BUFFER_BINDING`)
     pub(crate) pixel_pack_buffer: bool,
 }
@@ -3344,14 +3305,6 @@ fn copy_to_texture(
     dest_offset: [u32; 2],
     copy_size: [u32; 2],
 ) {
-    let _active_texture_guard = WebGlStateGuard::with_config(
-        gl,
-        WebGlStateConfig {
-            active_texture: true,
-            ..Default::default()
-        },
-    );
-
     gl.active_texture(WebGl2RenderingContext::TEXTURE0);
     let _state_guard = WebGlStateGuard::for_texture_copy(gl);
     let read_framebuffer = Framebuffer::new(gl);

--- a/vello_gpu/src/render/webgl/mod.rs
+++ b/vello_gpu/src/render/webgl/mod.rs
@@ -115,6 +115,10 @@ pub enum WebGlRendererInitStatus {
 }
 
 /// Vello GPU's WebGL2 renderer.
+///
+/// Note that any operation of [`WebGlRenderer`] might modify the global state of the underlying
+/// WebGl context; state like the active texture unit and texture bindings are therefore not
+/// guaranteed to be restored to their original value after each method call.
 #[derive(Debug)]
 pub struct WebGlRenderer {
     /// Programs for rendering.

--- a/vello_gpu/src/render/webgl/mod.rs
+++ b/vello_gpu/src/render/webgl/mod.rs
@@ -117,7 +117,7 @@ pub enum WebGlRendererInitStatus {
 /// Vello GPU's WebGL2 renderer.
 ///
 /// Note that any operation of [`WebGlRenderer`] might modify the global state of the underlying
-/// WebGl context; state like the active texture unit and texture bindings are therefore not
+/// WebGL context; state like the active texture unit and texture bindings are therefore not
 /// guaranteed to be restored to their original value after each method call.
 #[derive(Debug)]
 pub struct WebGlRenderer {

--- a/vello_gpu/src/render/webgl/probe.rs
+++ b/vello_gpu/src/render/webgl/probe.rs
@@ -79,8 +79,6 @@ impl WebGlRenderer {
             &self.gl,
             WebGlStateConfig {
                 framebuffer: true,
-                active_texture: true,
-                texture_2d: true,
                 pixel_pack_buffer: true,
                 ..Default::default()
             },

--- a/vello_tests/tests/image_atlas.rs
+++ b/vello_tests/tests/image_atlas.rs
@@ -12,11 +12,11 @@ use vello_common::{
 };
 use vello_gpu::{
     AtlasConfig, AtlasId, AtlasTextureInfo, MemorySettings, RenderError, RenderSettings, Scene,
-    TextureId, WebGlRenderer, WebGlTextureBindings, WebGlTextureWithDimensions,
+    TextureId, WebGlRenderer, WebGlTextureBindings,
 };
 use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
-use web_sys::{HtmlCanvasElement, WebGl2RenderingContext, WebGlTexture};
+use web_sys::{HtmlCanvasElement, WebGl2RenderingContext};
 
 fn create_canvas() -> HtmlCanvasElement {
     web_sys::window()
@@ -24,31 +24,6 @@ fn create_canvas() -> HtmlCanvasElement {
         .document()
         .unwrap()
         .create_element("canvas")
-        .unwrap()
-        .dyn_into()
-        .unwrap()
-}
-
-fn solid_texture(gl: &WebGl2RenderingContext, pixel: [u8; 4]) -> WebGlTexture {
-    let texture = gl.create_texture().unwrap();
-    gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, Some(&texture));
-    gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_u8_array(
-        WebGl2RenderingContext::TEXTURE_2D,
-        0,
-        WebGl2RenderingContext::RGBA8 as i32,
-        1,
-        1,
-        0,
-        WebGl2RenderingContext::RGBA,
-        WebGl2RenderingContext::UNSIGNED_BYTE,
-        Some(&pixel),
-    )
-    .unwrap();
-    texture
-}
-
-fn texture_binding_2d(gl: &WebGl2RenderingContext) -> WebGlTexture {
-    gl.get_parameter(WebGl2RenderingContext::TEXTURE_BINDING_2D)
         .unwrap()
         .dyn_into()
         .unwrap()
@@ -171,56 +146,5 @@ fn image_atlas_rejects_sampling_from_its_render_target() {
             Err(RenderError::TextureFeedbackLoop(id)) if id == texture_id
         ),
         "sampling from the render target should fail"
-    );
-}
-
-#[wasm_bindgen_test]
-fn texture_copy_preserves_texture_bindings() {
-    let canvas = create_canvas();
-    let settings = RenderSettings {
-        memory_settings: MemorySettings {
-            image_atlas_config: AtlasConfig {
-                initial_atlas_count: 1,
-                max_atlases: 1,
-                atlas_size: (1, 1),
-                ..AtlasConfig::default()
-            },
-            ..MemorySettings::default()
-        },
-        ..RenderSettings::default()
-    };
-    let (mut renderer, mut resources) = WebGlRenderer::new_with(&canvas, settings, true);
-    let gl = renderer.gl_context().clone();
-
-    let source = solid_texture(&gl, [255, 0, 0, 255]);
-    let texture_zero = solid_texture(&gl, [0, 255, 0, 255]);
-    let texture_seven = solid_texture(&gl, [0, 0, 255, 255]);
-
-    gl.active_texture(WebGl2RenderingContext::TEXTURE0);
-    gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, Some(&texture_zero));
-    gl.active_texture(WebGl2RenderingContext::TEXTURE7);
-    gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, Some(&texture_seven));
-
-    renderer.upload_image(
-        &mut resources,
-        &WebGlTextureWithDimensions {
-            texture: source,
-            width: 1,
-            height: 1,
-        },
-    );
-
-    gl.active_texture(WebGl2RenderingContext::TEXTURE0);
-    assert_eq!(
-        texture_binding_2d(&gl),
-        texture_zero,
-        "the texture copy should preserve texture unit 0's binding",
-    );
-
-    gl.active_texture(WebGl2RenderingContext::TEXTURE7);
-    assert_eq!(
-        texture_binding_2d(&gl),
-        texture_seven,
-        "the texture copy should preserve other texture units' bindings",
     );
 }

--- a/vello_tests/tests/image_atlas.rs
+++ b/vello_tests/tests/image_atlas.rs
@@ -175,7 +175,7 @@ fn image_atlas_rejects_sampling_from_its_render_target() {
 }
 
 #[wasm_bindgen_test]
-fn texture_copy_restores_texture_zero_binding_when_another_unit_is_active() {
+fn texture_copy_preserves_texture_bindings() {
     let canvas = create_canvas();
     let settings = RenderSettings {
         memory_settings: MemorySettings {
@@ -210,24 +210,17 @@ fn texture_copy_restores_texture_zero_binding_when_another_unit_is_active() {
         },
     );
 
-    assert_eq!(
-        gl.get_parameter(WebGl2RenderingContext::ACTIVE_TEXTURE)
-            .unwrap()
-            .as_f64()
-            .unwrap() as u32,
-        WebGl2RenderingContext::TEXTURE7,
-        "the texture copy should restore the active texture unit",
-    );
-    assert_eq!(
-        texture_binding_2d(&gl),
-        texture_seven,
-        "the texture copy should preserve the active unit's binding",
-    );
-
     gl.active_texture(WebGl2RenderingContext::TEXTURE0);
     assert_eq!(
         texture_binding_2d(&gl),
         texture_zero,
         "the texture copy should preserve texture unit 0's binding",
+    );
+
+    gl.active_texture(WebGl2RenderingContext::TEXTURE7);
+    assert_eq!(
+        texture_binding_2d(&gl),
+        texture_seven,
+        "the texture copy should preserve other texture units' bindings",
     );
 }


### PR DESCRIPTION
Follow up to https://github.com/linebender/vello/pull/1874. As was shown there, it seems like in Safari and Firefox `ACTIVE_TEXTURE` queries can still be expensive and aren't cached on the CPU side.

We were already not being fully consistent about this before, anyway (for example, `write_to_atlas` would update the texture 0 binding without restoring it later on). Since we want to work towards getting rid of all `getParameter` queries, I think the best thing to do here is to simply not make any promises about what textures are active and which bindings are preserved when running Vello Hybrid.