### PR TITLE
vello_common: Support non-opaque image samplers

### DIFF
--- a/vello_common/src/encode.rs
+++ b/vello_common/src/encode.rs
@@ -8,7 +8,7 @@ use crate::color::palette::css::BLACK;
 use crate::color::{ColorSpaceTag, HueDirection, Srgb, gradient};
 use crate::kurbo::{Affine, Point, Vec2};
 use crate::math::{FloatExt, compute_erf7};
-use crate::paint::{Image, ImageSource, IndexedPaint, Paint, PremulColor, Tint};
+use crate::paint::{Image, ImageSource, IndexedPaint, Paint, PremulColor, Tint, TintMode};
 use crate::peniko::{ColorStop, ColorStops, Extend, Gradient, GradientKind, ImageQuality};
 use crate::util::f32_to_u8;
 use alloc::borrow::Cow;
@@ -481,15 +481,33 @@ impl EncodeExt for Image {
         &self,
         paints: &mut Vec<EncodedPaint>,
         transform: Affine,
-        tint: Option<Tint>,
+        mut tint: Option<Tint>,
     ) -> Paint {
         let idx = paints.len();
 
         let mut sampler = self.sampler;
 
+        // Fold `sampler.alpha` into the tint instead of adding a separate
+        // image-opacity path: in both `TintMode`s the rasterized output scales
+        // linearly with the tint's alpha, so multiplying the tint's alpha by
+        // `sampler.alpha` (synthesizing a white `Multiply` tint when there is
+        // none) applies the opacity exactly.
         if sampler.alpha != 1.0 {
-            // If the sampler alpha is not 1.0, we need to force alpha compositing.
-            unimplemented!("Applying opacity to image commands");
+            let a = sampler.alpha;
+            tint = Some(match tint {
+                Some(t) => {
+                    let [r, g, b, ta] = t.color.components;
+                    Tint {
+                        color: peniko::Color::new([r, g, b, ta * a]),
+                        mode: t.mode,
+                    }
+                }
+                None => Tint {
+                    color: peniko::Color::new([1.0, 1.0, 1.0, a]),
+                    mode: TintMode::Multiply,
+                },
+            });
+            sampler.alpha = 1.0;
         }
 
         let c = transform.as_coeffs();
@@ -511,10 +529,9 @@ impl EncodeExt for Image {
         let (x_advance, y_advance) = x_y_advances(&transform);
 
         // If the tint color has alpha < 1.0, the image will have opacities
-        // even if the source pixels are all opaque.
-        let has_opacity = tint.as_ref().is_some_and(|t| t.color.components[3] < 1.0)
-            // Not supported yet, but just to future-proof.
-            || sampler.alpha != 1.0;
+        // even if the source pixels are all opaque. `sampler.alpha` needs no
+        // separate check: it has already been folded into the tint above.
+        let has_opacity = tint.as_ref().is_some_and(|t| t.color.components[3] < 1.0);
 
         let encoded = EncodedImage {
             may_have_transparency: self.image.may_have_transparency() || has_opacity,
@@ -1359,5 +1376,97 @@ mod tests {
             gradient.encode_into(&mut buf, Affine::IDENTITY, None),
             GREEN.into()
         );
+    }
+
+    // Image `sampler.alpha` → tint fold (regression tests for the former
+    // `unimplemented!("Applying opacity to image commands")` panic).
+
+    use crate::paint::{Image, ImageId, ImageSource, Tint, TintMode};
+    use peniko::{Color, Extend, ImageQuality, ImageSampler};
+
+    fn dummy_image(alpha: f32) -> Image {
+        Image {
+            image: ImageSource::opaque_id_with_transparency_hint(ImageId::new(1), false),
+            sampler: ImageSampler {
+                x_extend: Extend::Pad,
+                y_extend: Extend::Pad,
+                quality: ImageQuality::Low,
+                alpha,
+            },
+        }
+    }
+
+    fn expect_image_paint(buf: &[super::EncodedPaint]) -> &super::EncodedImage {
+        match buf.last().expect("paint pushed") {
+            super::EncodedPaint::Image(img) => img,
+            other => panic!("expected EncodedPaint::Image, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn image_sampler_alpha_one_passes_tint_through_unchanged() {
+        let mut buf = vec![];
+        let img = dummy_image(1.0);
+        let tint = Some(Tint {
+            color: Color::new([0.5, 0.25, 0.75, 0.8]),
+            mode: TintMode::AlphaMask,
+        });
+        img.encode_into(&mut buf, Affine::IDENTITY, tint);
+
+        let enc = expect_image_paint(&buf);
+        assert_eq!(enc.sampler.alpha, 1.0);
+        let t = enc.tint.expect("tint survives");
+        assert_eq!(t.color.components, [0.5, 0.25, 0.75, 0.8]);
+        assert_eq!(t.mode, TintMode::AlphaMask);
+    }
+
+    #[test]
+    fn image_sampler_alpha_no_tint_synthesises_multiply_tint() {
+        let mut buf = vec![];
+        let img = dummy_image(0.4);
+        img.encode_into(&mut buf, Affine::IDENTITY, None);
+
+        let enc = expect_image_paint(&buf);
+        assert_eq!(enc.sampler.alpha, 1.0);
+        let t = enc.tint.expect("alpha fold synthesises a tint");
+        assert_eq!(t.color.components, [1.0, 1.0, 1.0, 0.4]);
+        assert_eq!(t.mode, TintMode::Multiply);
+        assert!(enc.may_have_transparency);
+    }
+
+    #[test]
+    fn image_sampler_alpha_with_existing_tint_scales_alpha_only() {
+        for mode in [TintMode::AlphaMask, TintMode::Multiply] {
+            let mut buf = vec![];
+            let img = dummy_image(0.5);
+            let tint = Some(Tint {
+                color: Color::new([0.2, 0.4, 0.6, 0.8]),
+                mode,
+            });
+            img.encode_into(&mut buf, Affine::IDENTITY, tint);
+
+            let enc = expect_image_paint(&buf);
+            assert_eq!(enc.sampler.alpha, 1.0, "α must be folded out");
+            let t = enc.tint.expect("tint survives");
+            assert_eq!(
+                t.color.components,
+                [0.2, 0.4, 0.6, 0.8 * 0.5],
+                "mode = {mode:?}"
+            );
+            assert_eq!(t.mode, mode, "mode must be preserved");
+        }
+    }
+
+    #[test]
+    fn image_sampler_alpha_zero_folds_to_fully_transparent_tint() {
+        let mut buf = vec![];
+        let img = dummy_image(0.0);
+        img.encode_into(&mut buf, Affine::IDENTITY, None);
+
+        let enc = expect_image_paint(&buf);
+        assert_eq!(enc.sampler.alpha, 1.0);
+        let t = enc.tint.expect("tint synthesised");
+        assert_eq!(t.color.components, [1.0, 1.0, 1.0, 0.0]);
+        assert!(enc.may_have_transparency);
     }
 }

--- a/vello_common/src/encode.rs
+++ b/vello_common/src/encode.rs
@@ -487,26 +487,12 @@ impl EncodeExt for Image {
 
         let mut sampler = self.sampler;
 
-        // Fold `sampler.alpha` into the tint instead of adding a separate
-        // image-opacity path: in both `TintMode`s the rasterized output scales
-        // linearly with the tint's alpha, so multiplying the tint's alpha by
-        // `sampler.alpha` (synthesizing a white `Multiply` tint when there is
-        // none) applies the opacity exactly.
         if sampler.alpha != 1.0 {
-            let a = sampler.alpha;
-            tint = Some(match tint {
-                Some(t) => {
-                    let [r, g, b, ta] = t.color.components;
-                    Tint {
-                        color: peniko::Color::new([r, g, b, ta * a]),
-                        mode: t.mode,
-                    }
-                }
-                None => Tint {
-                    color: peniko::Color::new([1.0, 1.0, 1.0, a]),
-                    mode: TintMode::Multiply,
-                },
+            let tint = tint.get_or_insert(Tint {
+                color: peniko::Color::WHITE,
+                mode: TintMode::Multiply,
             });
+            tint.color = tint.color.multiply_alpha(sampler.alpha);
             sampler.alpha = 1.0;
         }
 
@@ -529,8 +515,7 @@ impl EncodeExt for Image {
         let (x_advance, y_advance) = x_y_advances(&transform);
 
         // If the tint color has alpha < 1.0, the image will have opacities
-        // even if the source pixels are all opaque. `sampler.alpha` needs no
-        // separate check: it has already been folded into the tint above.
+        // even if the source pixels are all opaque.
         let has_opacity = tint.as_ref().is_some_and(|t| t.color.components[3] < 1.0);
 
         let encoded = EncodedImage {
@@ -1177,13 +1162,14 @@ mod private {
 
 #[cfg(test)]
 mod tests {
-    use super::{EncodeExt, Gradient};
+    use super::{EncodeExt, EncodedPaint, Gradient};
     use crate::color::DynamicColor;
     use crate::color::palette::css::{BLACK, BLUE, GREEN};
     use crate::kurbo::{Affine, Point};
+    use crate::paint::{Image, ImageId, ImageSource, Tint, TintMode};
     use crate::peniko::{ColorStop, ColorStops};
     use alloc::vec;
-    use peniko::{LinearGradientPosition, RadialGradientPosition};
+    use peniko::{Color, ImageSampler, LinearGradientPosition, RadialGradientPosition};
     use smallvec::smallvec;
 
     #[test]
@@ -1378,95 +1364,36 @@ mod tests {
         );
     }
 
-    // Image `sampler.alpha` → tint fold (regression tests for the former
-    // `unimplemented!("Applying opacity to image commands")` panic).
-
-    use crate::paint::{Image, ImageId, ImageSource, Tint, TintMode};
-    use peniko::{Color, Extend, ImageQuality, ImageSampler};
-
-    fn dummy_image(alpha: f32) -> Image {
-        Image {
+    #[test]
+    fn image_sampler_alpha_with_tint() {
+        let image = Image {
             image: ImageSource::opaque_id_with_transparency_hint(ImageId::new(1), false),
             sampler: ImageSampler {
-                x_extend: Extend::Pad,
-                y_extend: Extend::Pad,
-                quality: ImageQuality::Low,
-                alpha,
+                alpha: 0.5,
+                ..ImageSampler::default()
             },
-        }
-    }
+        };
 
-    fn expect_image_paint(buf: &[super::EncodedPaint]) -> &super::EncodedImage {
-        match buf.last().expect("paint pushed") {
-            super::EncodedPaint::Image(img) => img,
-            other => panic!("expected EncodedPaint::Image, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn image_sampler_alpha_one_passes_tint_through_unchanged() {
-        let mut buf = vec![];
-        let img = dummy_image(1.0);
-        let tint = Some(Tint {
-            color: Color::new([0.5, 0.25, 0.75, 0.8]),
-            mode: TintMode::AlphaMask,
-        });
-        img.encode_into(&mut buf, Affine::IDENTITY, tint);
-
-        let enc = expect_image_paint(&buf);
-        assert_eq!(enc.sampler.alpha, 1.0);
-        let t = enc.tint.expect("tint survives");
-        assert_eq!(t.color.components, [0.5, 0.25, 0.75, 0.8]);
-        assert_eq!(t.mode, TintMode::AlphaMask);
-    }
-
-    #[test]
-    fn image_sampler_alpha_no_tint_synthesises_multiply_tint() {
-        let mut buf = vec![];
-        let img = dummy_image(0.4);
-        img.encode_into(&mut buf, Affine::IDENTITY, None);
-
-        let enc = expect_image_paint(&buf);
-        assert_eq!(enc.sampler.alpha, 1.0);
-        let t = enc.tint.expect("alpha fold synthesises a tint");
-        assert_eq!(t.color.components, [1.0, 1.0, 1.0, 0.4]);
-        assert_eq!(t.mode, TintMode::Multiply);
-        assert!(enc.may_have_transparency);
-    }
-
-    #[test]
-    fn image_sampler_alpha_with_existing_tint_scales_alpha_only() {
         for mode in [TintMode::AlphaMask, TintMode::Multiply] {
-            let mut buf = vec![];
-            let img = dummy_image(0.5);
-            let tint = Some(Tint {
+            let mut paints = vec![];
+            let tint = Tint {
                 color: Color::new([0.2, 0.4, 0.6, 0.8]),
                 mode,
-            });
-            img.encode_into(&mut buf, Affine::IDENTITY, tint);
+            };
+            image.encode_into(&mut paints, Affine::IDENTITY, Some(tint));
 
-            let enc = expect_image_paint(&buf);
-            assert_eq!(enc.sampler.alpha, 1.0, "α must be folded out");
-            let t = enc.tint.expect("tint survives");
+            let EncodedPaint::Image(encoded) = &paints[0] else {
+                panic!("expected an image paint");
+            };
+            assert_eq!(encoded.sampler.alpha, 1.0);
             assert_eq!(
-                t.color.components,
-                [0.2, 0.4, 0.6, 0.8 * 0.5],
-                "mode = {mode:?}"
+                encoded.tint,
+                Some(Tint {
+                    color: Color::new([0.2, 0.4, 0.6, 0.4]),
+                    mode,
+                })
             );
-            assert_eq!(t.mode, mode, "mode must be preserved");
+            assert!(encoded.may_have_transparency);
         }
-    }
-
-    #[test]
-    fn image_sampler_alpha_zero_folds_to_fully_transparent_tint() {
-        let mut buf = vec![];
-        let img = dummy_image(0.0);
-        img.encode_into(&mut buf, Affine::IDENTITY, None);
-
-        let enc = expect_image_paint(&buf);
-        assert_eq!(enc.sampler.alpha, 1.0);
-        let t = enc.tint.expect("tint synthesised");
-        assert_eq!(t.color.components, [1.0, 1.0, 1.0, 0.0]);
-        assert!(enc.may_have_transparency);
     }
 }

--- a/vello_common/src/encode.rs
+++ b/vello_common/src/encode.rs
@@ -492,7 +492,8 @@ impl EncodeExt for Image {
                 color: peniko::Color::WHITE,
                 mode: TintMode::Multiply,
             });
-            tint.color = tint.color.multiply_alpha(sampler.alpha);
+            let alpha = (tint.color.components[3] * sampler.alpha).min(1.0);
+            tint.color = tint.color.with_alpha(alpha);
             sampler.alpha = 1.0;
         }
 
@@ -1395,5 +1396,35 @@ mod tests {
             );
             assert!(encoded.may_have_transparency);
         }
+    }
+
+    #[test]
+    fn image_sampler_alpha_with_tint_is_clamped() {
+        let image = Image {
+            image: ImageSource::opaque_id_with_transparency_hint(ImageId::new(1), false),
+            sampler: ImageSampler {
+                alpha: 2.0,
+                ..ImageSampler::default()
+            },
+        };
+        let mut paints = vec![];
+        let tint = Tint {
+            color: Color::new([0.2, 0.4, 0.6, 0.8]),
+            mode: TintMode::Multiply,
+        };
+
+        image.encode_into(&mut paints, Affine::IDENTITY, Some(tint));
+
+        let EncodedPaint::Image(encoded) = &paints[0] else {
+            panic!("expected an image paint");
+        };
+        assert_eq!(encoded.sampler.alpha, 1.0);
+        assert_eq!(
+            encoded.tint,
+            Some(Tint {
+                color: Color::new([0.2, 0.4, 0.6, 1.0]),
+                mode: TintMode::Multiply,
+            })
+        );
     }
 }

--- a/vello_tests/snapshots/image_sampler_alpha.png
+++ b/vello_tests/snapshots/image_sampler_alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bee7772b4a6a8b7fa69c822a7aa8164773087cbfe30a78c96301954e38509ab7
+size 195

--- a/vello_tests/snapshots/image_sampler_alpha.png
+++ b/vello_tests/snapshots/image_sampler_alpha.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bee7772b4a6a8b7fa69c822a7aa8164773087cbfe30a78c96301954e38509ab7
+oid sha256:f7ba700b92360ca9abb66a6b9b8a4ba96d57b0da9560ed21c421406c660a2286
 size 195

--- a/vello_tests/tests/image.rs
+++ b/vello_tests/tests/image.rs
@@ -746,6 +746,39 @@ fn image_spritesheet_tinted(ctx: &mut impl Renderer) {
     }
 }
 
+/// `ImageSampler::alpha` is folded into the tint, so it has to scale the image's
+/// opacity both without a tint (top-left) and on top of an existing one
+/// (top-right), leave the image untouched at `1.0` (bottom-left) and erase it
+/// completely at `0.0` (bottom-right).
+#[vello_test]
+fn image_sampler_alpha(ctx: &mut impl Renderer) {
+    let source = rgb_img_10x10(ctx);
+
+    let tinted = Some(Tint {
+        color: REBECCA_PURPLE,
+        mode: TintMode::Multiply,
+    });
+
+    for (x, y, alpha, tint) in [
+        (0.0, 0.0, 0.5, None),
+        (50.0, 0.0, 0.5, tinted),
+        (0.0, 50.0, 1.0, None),
+        (50.0, 50.0, 0.0, None),
+    ] {
+        ctx.set_transform(Affine::translate((x, y)) * Affine::scale(5.0));
+        ctx.set_tint(tint);
+        ctx.set_paint(Image {
+            image: source.clone(),
+            sampler: ImageSampler {
+                quality: ImageQuality::Low,
+                alpha,
+                ..ImageSampler::default()
+            },
+        });
+        ctx.fill_rect(&Rect::new(0.0, 0.0, 10.0, 10.0));
+    }
+}
+
 #[vello_test]
 fn image_fully_transparent_tint(ctx: &mut impl Renderer) {
     let image = Image {

--- a/vello_tests/tests/image.rs
+++ b/vello_tests/tests/image.rs
@@ -754,12 +754,16 @@ fn image_sampler_alpha(ctx: &mut impl Renderer) {
         color: REBECCA_PURPLE,
         mode: TintMode::Multiply,
     });
+    let masked = Some(Tint {
+        color: REBECCA_PURPLE,
+        mode: TintMode::AlphaMask,
+    });
 
     for (x, y, alpha, tint) in [
         (0.0, 0.0, 0.5, None),
         (50.0, 0.0, 0.5, tinted),
         (0.0, 50.0, 1.0, None),
-        (50.0, 50.0, 0.0, None),
+        (50.0, 50.0, 0.5, masked),
     ] {
         ctx.set_transform(Affine::translate((x, y)) * Affine::scale(5.0));
         ctx.set_tint(tint);

--- a/vello_tests/tests/image.rs
+++ b/vello_tests/tests/image.rs
@@ -746,10 +746,6 @@ fn image_spritesheet_tinted(ctx: &mut impl Renderer) {
     }
 }
 
-/// `ImageSampler::alpha` is folded into the tint, so it has to scale the image's
-/// opacity both without a tint (top-left) and on top of an existing one
-/// (top-right), leave the image untouched at `1.0` (bottom-left) and erase it
-/// completely at `0.0` (bottom-right).
 #[vello_test]
 fn image_sampler_alpha(ctx: &mut impl Renderer) {
     let source = rgb_img_10x10(ctx);


### PR DESCRIPTION
Adapted from #1736, unfortunately I didn't have push access to that branch, so I had to create a new one to push some cleanups.