### PR TITLE
vello_bench: Remove no-op benchmark

### DIFF
--- a/vello_bench/src/pixmap.rs
+++ b/vello_bench/src/pixmap.rs
@@ -12,18 +12,16 @@ const TRANSLUCENT_BLUE: [u8; 4] = [0, 0, 255, 128];
 
 pub fn pixmap(c: &mut Criterion) {
     let pixel_count = usize::from(WIDTH) * usize::from(HEIGHT);
-    let mut inputs = vec![
-        ("opaque", OPAQUE_BLUE.repeat(pixel_count)),
-        ("translucent", TRANSLUCENT_BLUE.repeat(pixel_count)),
-    ];
+    let opaque_input = ("opaque", OPAQUE_BLUE.repeat(pixel_count));
+    let mut unpremultiply_inputs = vec![("translucent", TRANSLUCENT_BLUE.repeat(pixel_count))];
 
     if crate::EXTENDED {
-        inputs.push(("interleaved", interleaved_pixels(pixel_count)));
-        inputs.push(("mixed_lanes", mixed_lane_pixels(pixel_count)));
+        unpremultiply_inputs.push(("interleaved", interleaved_pixels(pixel_count)));
+        unpremultiply_inputs.push(("mixed_lanes", mixed_lane_pixels(pixel_count)));
     }
 
     let mut group = c.benchmark_group("pixmap/premultiply");
-    for (name, rgba) in &inputs {
+    for (name, rgba) in std::iter::once(&opaque_input).chain(&unpremultiply_inputs) {
         group.bench_function(*name, |b| {
             b.iter_batched(
                 || rgba.clone(),
@@ -41,7 +39,7 @@ pub fn pixmap(c: &mut Criterion) {
     }
     group.finish();
 
-    let pixmaps = inputs
+    let pixmaps = unpremultiply_inputs
         .into_iter()
         .map(|(name, rgba)| {
             (


### PR DESCRIPTION
The benchmark is meaningless because since a recent optimization we don't unpremultiply opaque pixmaps, so we are just measuring benchmark overhead:

```
pixmap/unpremultiply/opaque
                        time:   [16.573 ns 16.982 ns 17.471 ns]
                        change: [+7.0639% +10.476% +14.304%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe
pixmap/unpremultiply/translucent
                        time:   [575.62 µs 577.08 µs 578.77 µs]
                        change: [+1.1873% +1.5481% +1.9011%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low severe
  3 (3.00%) low mild
  2 (2.00%) high mild
  3 (3.00%) high severe
```