### PR TITLE
vello_tests: Unignore probe test

### DIFF
--- a/vello_tests/tests/wasm_binary_invariants.rs
+++ b/vello_tests/tests/wasm_binary_invariants.rs
@@ -40,8 +40,6 @@ async fn no_simd_instruction_inclusion() {
     );
 }
 
-// This test is ignored by default due to flakiness in Github CI.
-#[ignore]
 #[cfg(feature = "webgl")]
 #[wasm_bindgen_test]
 async fn webgl_probe_succeeds() {


### PR DESCRIPTION
It seems like whatever caused the issue before, as part of our refactors this test doesn't seem to be flaky anymore. Tried this in my fork and it passed twice in a row.