### PR TITLE
glifo: Make glyph atlas callbacks fallible

### DIFF
--- a/glifo/src/atlas/cache.rs
+++ b/glifo/src/atlas/cache.rs
@@ -302,17 +302,26 @@ impl GlyphAtlas {
     /// Replay all pending atlas command recorders (one per dirty page).
     ///
     /// The closure receives each non-empty recorder by mutable reference.
-    /// After the closure returns, the recorder's commands are cleared but
-    /// the allocation is kept for reuse next frame.
-    pub fn replay_pending_atlas_commands(&mut self, mut f: impl FnMut(&mut AtlasCommandRecorder)) {
+    /// All pending commands are cleared after replay, including when the closure
+    /// returns an error. The recorder allocations are kept for reuse next frame.
+    pub fn replay_pending_atlas_commands<E>(
+        &mut self,
+        mut f: impl FnMut(&mut AtlasCommandRecorder) -> Result<(), E>,
+    ) -> Result<(), E> {
+        let mut result = Ok(());
+
         for slot in &mut self.pending_atlas_commands {
             if let Some(recorder) = slot.as_mut()
                 && !recorder.commands.is_empty()
             {
-                f(recorder);
+                if result.is_ok() {
+                    result = f(recorder);
+                }
                 recorder.commands.clear();
             }
         }
+
+        result
     }
 
     /// Get (or create) the command recorder for the given atlas page.

--- a/vello_cpu/src/text.rs
+++ b/vello_cpu/src/text.rs
@@ -186,7 +186,10 @@ impl Resources {
                         ..Default::default()
                     },
                 );
-            });
+
+                Ok::<(), core::convert::Infallible>(())
+            })
+            .unwrap_or_else(|error| match error {});
 
         for (page_index, pixmap) in glyph_resources.pixmaps.iter().enumerate() {
             self.image_registry

--- a/vello_gpu/src/render/webgl/mod.rs
+++ b/vello_gpu/src/render/webgl/mod.rs
@@ -428,15 +428,13 @@ impl WebGlRenderer {
             resources.before_render(
                 self,
                 |renderer, glyph_renderer, atlas_count, atlas_config, atlas_id| {
-                    renderer
-                        .render_to_atlas(
-                            glyph_renderer,
-                            atlas_count,
-                            atlas_config,
-                            atlas_id,
-                            texture_bindings,
-                        )
-                        .expect("Failed to render glyphs to atlas");
+                    renderer.render_to_atlas(
+                        glyph_renderer,
+                        atlas_count,
+                        atlas_config,
+                        atlas_id,
+                        texture_bindings,
+                    )
                 },
                 |renderer, image_cache, upload, dst_x, dst_y| {
                     renderer.write_to_atlas(
@@ -445,8 +443,10 @@ impl WebGlRenderer {
                         &upload.pixmap,
                         Some([dst_x, dst_y]),
                     );
+
+                    Ok(())
                 },
-            );
+            )?;
         }
 
         self.render_scene(
@@ -465,7 +465,9 @@ impl WebGlRenderer {
             // page and then clear per atlas page instead of per rect.
             resources.after_render(self, |renderer, rect| {
                 clear_atlas_region(renderer, rect);
-            });
+
+                Ok::<(), RenderError>(())
+            })?;
         }
 
         Ok(())

--- a/vello_gpu/src/render/wgpu/mod.rs
+++ b/vello_gpu/src/render/wgpu/mod.rs
@@ -277,17 +277,15 @@ impl Renderer {
             resources.before_render(
                 self,
                 |renderer, glyph_renderer, atlas_count, atlas_config, atlas_id| {
-                    renderer
-                        .render_to_atlas(
-                            glyph_renderer,
-                            atlas_count,
-                            atlas_config,
-                            device,
-                            queue,
-                            atlas_id,
-                            texture_bindings,
-                        )
-                        .expect("Failed to render glyphs to atlas");
+                    renderer.render_to_atlas(
+                        glyph_renderer,
+                        atlas_count,
+                        atlas_config,
+                        device,
+                        queue,
+                        atlas_id,
+                        texture_bindings,
+                    )
                 },
                 |renderer, image_cache, upload, dst_x, dst_y| {
                     renderer.write_to_atlas(
@@ -299,8 +297,10 @@ impl Renderer {
                         &upload.pixmap,
                         Some([dst_x, dst_y]),
                     );
+
+                    Ok(())
                 },
-            );
+            )?;
         }
 
         let result = self.render_scene(
@@ -321,7 +321,9 @@ impl Renderer {
         #[cfg(feature = "text")]
         resources.after_render(self, |renderer, rect| {
             clear_atlas_region(queue, renderer, rect);
-        });
+
+            Ok::<(), RenderError>(())
+        })?;
         result
     }
 

--- a/vello_gpu/src/text.rs
+++ b/vello_gpu/src/text.rs
@@ -72,7 +72,10 @@ impl Resources {
         u32::try_from(self.image_cache.atlas_count()).unwrap()
     }
 
-    fn replay_pending_atlas_commands(&mut self, mut f: impl FnMut(&Scene, AtlasId)) {
+    fn replay_pending_atlas_commands<E>(
+        &mut self,
+        mut f: impl FnMut(&Scene, AtlasId) -> Result<(), E>,
+    ) -> Result<(), E> {
         if let Some(glyph_resources) = self.glyph_resources.as_mut() {
             glyph_resources
                 .glyph_atlas
@@ -85,22 +88,30 @@ impl Resources {
                     f(
                         &glyph_resources.glyph_renderer,
                         AtlasId::new(recorder.page_index),
-                    );
-                });
+                    )
+                })?;
         }
+
+        Ok(())
     }
 
-    pub(crate) fn before_render<T>(
+    pub(crate) fn before_render<T, E>(
         &mut self,
         backend: &mut T,
-        mut render_to_atlas: impl FnMut(&mut T, &Scene, u32, AtlasConfig, AtlasId),
-        mut upload_to_atlas: impl FnMut(&mut T, &ImageCache, &PendingBitmapUpload, u16, u16),
-    ) {
+        mut render_to_atlas: impl FnMut(&mut T, &Scene, u32, AtlasConfig, AtlasId) -> Result<(), E>,
+        mut upload_to_atlas: impl FnMut(
+            &mut T,
+            &ImageCache,
+            &PendingBitmapUpload,
+            u16,
+            u16,
+        ) -> Result<(), E>,
+    ) -> Result<(), E> {
         let atlas_count = self.atlas_count();
         let atlas_config = self.atlas_config();
         self.replay_pending_atlas_commands(|glyph_renderer, atlas_id| {
-            render_to_atlas(backend, glyph_renderer, atlas_count, atlas_config, atlas_id);
-        });
+            render_to_atlas(backend, glyph_renderer, atlas_count, atlas_config, atlas_id)
+        })?;
 
         const PADDING: u16 = GLYPH_PADDING;
 
@@ -109,23 +120,27 @@ impl Resources {
                 let resource = self.image_cache.get(upload.image_id).unwrap();
                 let dst_x = resource.offset[0] + PADDING;
                 let dst_y = resource.offset[1] + PADDING;
-                upload_to_atlas(backend, &self.image_cache, &upload, dst_x, dst_y);
+                upload_to_atlas(backend, &self.image_cache, &upload, dst_x, dst_y)?;
             }
         }
+
+        Ok(())
     }
 
-    pub(crate) fn after_render<T>(
+    pub(crate) fn after_render<T, E>(
         &mut self,
         backend: &mut T,
-        mut clear_rect: impl FnMut(&mut T, &PendingClearRect),
-    ) {
+        mut clear_rect: impl FnMut(&mut T, &PendingClearRect) -> Result<(), E>,
+    ) -> Result<(), E> {
         self.glyph_prep_cache.maintain();
         if let Some(glyph_resources) = self.glyph_resources.as_mut() {
             glyph_resources.maintain(&mut self.image_cache);
             for rect in glyph_resources.glyph_atlas.drain_pending_clear_rects() {
-                clear_rect(backend, &rect);
+                clear_rect(backend, &rect)?;
             }
         }
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This PR makes the glyph rendering methods in glifo fallible. We need this so that we can introduce proper error types in the WebGL (and in the future also WGPU) backend and propagate them up.
