### PR TITLE
vello_hybrid: Use u16 for render sizes

### DIFF
--- a/vello_gpu/examples/native_webgl/src/lib.rs
+++ b/vello_gpu/examples/native_webgl/src/lib.rs
@@ -144,8 +144,8 @@ impl AppState {
         let scene_end = now();
 
         let render_size = vello_gpu::RenderSize {
-            width: self.width,
-            height: self.height,
+            width: self.width.try_into().unwrap(),
+            height: self.height.try_into().unwrap(),
         };
 
         if let Some(gpu_timer) = &mut self.renderer_wrapper.gpu_timer {
@@ -603,10 +603,7 @@ pub async fn render_scene(scene: Scene, width: u16, height: u16) {
         ..
     } = RendererWrapper::new(canvas);
 
-    let render_size = vello_gpu::RenderSize {
-        width: width as u32,
-        height: height as u32,
-    };
+    let render_size = vello_gpu::RenderSize { width, height };
     renderer
         .render(
             &scene,

--- a/vello_gpu/examples/render_to_file.rs
+++ b/vello_gpu/examples/render_to_file.rs
@@ -79,14 +79,11 @@ async fn run() {
         &device,
         &vello_gpu::RenderTargetConfig {
             format: texture.format(),
-            width: width.into(),
-            height: height.into(),
+            width,
+            height,
         },
     );
-    let render_size = vello_gpu::RenderSize {
-        width: width.into(),
-        height: height.into(),
-    };
+    let render_size = vello_gpu::RenderSize { width, height };
     let depth_texture_view = vello_gpu::Renderer::create_depth_texture_view(&device, &render_size);
     // Copy texture to buffer
     let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {

--- a/vello_gpu/examples/wgpu_webgl/src/lib.rs
+++ b/vello_gpu/examples/wgpu_webgl/src/lib.rs
@@ -102,13 +102,18 @@ impl RendererWrapper {
             &device,
             &RenderTargetConfig {
                 format: surface_format,
-                width,
-                height,
+                width: width.try_into().unwrap(),
+                height: height.try_into().unwrap(),
             },
             settings,
         );
-        let depth_texture_view =
-            Renderer::create_depth_texture_view(&device, &vello_gpu::RenderSize { width, height });
+        let depth_texture_view = Renderer::create_depth_texture_view(
+            &device,
+            &vello_gpu::RenderSize {
+                width: width.try_into().unwrap(),
+                height: height.try_into().unwrap(),
+            },
+        );
 
         Self {
             renderer,
@@ -135,7 +140,10 @@ impl RendererWrapper {
         self.surface.configure(&self.device, &surface_config);
         self.depth_texture_view = Renderer::create_depth_texture_view(
             &self.device,
-            &vello_gpu::RenderSize { width, height },
+            &vello_gpu::RenderSize {
+                width: width.try_into().unwrap(),
+                height: height.try_into().unwrap(),
+            },
         );
         if let Some(gpu_timer) = &mut self.gpu_timer {
             gpu_timer.reset();
@@ -231,8 +239,8 @@ impl AppState {
         let scene_end = now();
 
         let render_size = vello_gpu::RenderSize {
-            width: self.width,
-            height: self.height,
+            width: self.width.try_into().unwrap(),
+            height: self.height.try_into().unwrap(),
         };
 
         let surface_texture = match self.renderer_wrapper.surface.get_current_texture() {
@@ -710,10 +718,7 @@ pub async fn render_scene(scene: Scene, width: u16, height: u16) {
         ..
     } = RendererWrapper::new(canvas).await;
 
-    let render_size = vello_gpu::RenderSize {
-        width: width as u32,
-        height: height as u32,
-    };
+    let render_size = vello_gpu::RenderSize { width, height };
     let surface_texture = match surface.get_current_texture() {
         CurrentSurfaceTexture::Success(surface_texture) => surface_texture,
         e => panic!("Error getting initial surface: {e:?}"),

--- a/vello_gpu/examples/winit/src/main.rs
+++ b/vello_gpu/examples/winit/src/main.rs
@@ -346,8 +346,8 @@ impl ApplicationHandler for App<'_> {
 
                 let device_handle = &self.context.devices[surface.dev_id];
                 let render_size = RenderSize {
-                    width: surface.config.width,
-                    height: surface.config.height,
+                    width: surface.config.width.try_into().unwrap(),
+                    height: surface.config.height.try_into().unwrap(),
                 };
 
                 let surface_texture = match surface.surface.get_current_texture() {

--- a/vello_gpu/examples/winit/src/render_context.rs
+++ b/vello_gpu/examples/winit/src/render_context.rs
@@ -38,8 +38,8 @@ pub(crate) fn create_vello_renderer(
 ) -> (Renderer, Resources, RenderSize, TextureView) {
     let device = &render_cx.devices[surface.dev_id].device;
     let render_size = RenderSize {
-        width: surface.config.width,
-        height: surface.config.height,
+        width: surface.config.width.try_into().unwrap(),
+        height: surface.config.height.try_into().unwrap(),
     };
     let (renderer, resources) = Renderer::new(
         device,

--- a/vello_gpu/src/render/common.rs
+++ b/vello_gpu/src/render/common.rs
@@ -386,9 +386,9 @@ mod tests {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct RenderSize {
     /// Width of the rendering target.
-    pub width: u32,
+    pub width: u16,
     /// Height of the rendering target.
-    pub height: u32,
+    pub height: u16,
 }
 
 /// Configuration for the GPU renderer.

--- a/vello_gpu/src/render/webgl/mod.rs
+++ b/vello_gpu/src/render/webgl/mod.rs
@@ -3069,8 +3069,8 @@ impl WebGlRendererContext<'_> {
                     self.programs.resources.view_framebuffer_override.as_deref(),
                 );
                 (
-                    u16::try_from(self.programs.render_size.width).unwrap(),
-                    u16::try_from(self.programs.render_size.height).unwrap(),
+                    self.programs.render_size.width,
+                    self.programs.render_size.height,
                 )
             }
             DrawPassTarget::Layer(target) => {

--- a/vello_gpu/src/render/webgl/mod.rs
+++ b/vello_gpu/src/render/webgl/mod.rs
@@ -423,8 +423,8 @@ impl WebGlRenderer {
     ) -> Result<(), RenderError> {
         debug_assert_eq!(
             RenderSize {
-                width: self.gl.drawing_buffer_width() as u32,
-                height: self.gl.drawing_buffer_height() as u32
+                width: self.gl.drawing_buffer_width().try_into().unwrap(),
+                height: self.gl.drawing_buffer_height().try_into().unwrap()
             },
             *render_size,
             "Render size must match drawing buffer size"
@@ -512,8 +512,8 @@ impl WebGlRenderer {
 
         let (atlas_width, atlas_height) = atlas_config.atlas_size;
         let atlas_render_size = RenderSize {
-            width: u32::from(atlas_width),
-            height: u32::from(atlas_height),
+            width: atlas_width,
+            height: atlas_height,
         };
         let render_target_texture = self.atlas_texture(atlas_id).clone();
 
@@ -1744,8 +1744,8 @@ impl WebGlPrograms {
         // condition in case we add new fields in the future.
         if self.render_size != *new_render_size || self.negate_ndc != negate_ndc {
             let config = Config {
-                width: new_render_size.width,
-                height: new_render_size.height,
+                width: u32::from(new_render_size.width),
+                height: u32::from(new_render_size.height),
                 strip_height: u32::from(Tile::HEIGHT),
                 alphas_tex_width_bits: resource_texture_dimension_2d.trailing_zeros(),
                 encoded_paints_tex_width_bits: resource_texture_dimension_2d.trailing_zeros(),
@@ -2671,7 +2671,7 @@ impl WebGlRendererContext<'_> {
                 );
                 let width = self.programs.render_size.width;
                 let height = self.programs.render_size.height;
-                self.gl.viewport(0, 0, width as i32, height as i32);
+                self.gl.viewport(0, 0, i32::from(width), i32::from(height));
 
                 self.gl.bind_buffer_base(
                     WebGl2RenderingContext::UNIFORM_BUFFER,

--- a/vello_gpu/src/render/webgl/probe.rs
+++ b/vello_gpu/src/render/webgl/probe.rs
@@ -85,16 +85,13 @@ impl WebGlRenderer {
         );
 
         let (width, height) = vello_common::probe::canvas_size();
-        let render_size = RenderSize {
-            width: u32::from(width),
-            height: u32::from(height),
-        };
+        let render_size = RenderSize { width, height };
 
         let probe_texture = create_texture_storage(
             &self.gl,
             WebGl2RenderingContext::RGBA8,
-            render_size.width,
-            render_size.height,
+            u32::from(render_size.width),
+            u32::from(render_size.height),
             WebGl2RenderingContext::NEAREST,
             WebGl2RenderingContext::NEAREST,
         );

--- a/vello_gpu/src/render/wgpu/mod.rs
+++ b/vello_gpu/src/render/wgpu/mod.rs
@@ -91,9 +91,9 @@ pub struct RenderTargetConfig {
     /// Format of the rendering target
     pub format: wgpu::TextureFormat,
     /// Width of the rendering target
-    pub width: u32,
+    pub width: u16,
     /// Height of the rendering target
-    pub height: u32,
+    pub height: u16,
 }
 
 /// Runtime bindings for [externally owned textures](`TextureId`) sampled by image paints.
@@ -230,8 +230,8 @@ impl Renderer {
             .create_texture(&wgpu::TextureDescriptor {
                 label: Some("Vello GPU Depth Texture"),
                 size: Extent3d {
-                    width: render_size.width.max(1),
-                    height: render_size.height.max(1),
+                    width: u32::from(render_size.width.max(1)),
+                    height: u32::from(render_size.height.max(1)),
                     depth_or_array_layers: 1,
                 },
                 mip_level_count: 1,
@@ -367,8 +367,8 @@ impl Renderer {
 
         let (atlas_width, atlas_height) = atlas_config.atlas_size;
         let atlas_render_size = RenderSize {
-            width: u32::from(atlas_width),
-            height: u32::from(atlas_height),
+            width: atlas_width,
+            height: atlas_height,
         };
 
         let layer_view =
@@ -1611,8 +1611,8 @@ impl Programs {
         );
         let view_config_buffer = Self::create_config_buffer(
             device,
-            render_target_config.width,
-            render_target_config.height,
+            u32::from(render_target_config.width),
+            u32::from(render_target_config.height),
             resource_texture_dimension_2d,
         );
 
@@ -2322,8 +2322,8 @@ impl Programs {
     ) {
         if self.render_size != *new_render_size {
             let config = Config {
-                width: new_render_size.width,
-                height: new_render_size.height,
+                width: u32::from(new_render_size.width),
+                height: u32::from(new_render_size.height),
                 strip_height: Tile::HEIGHT.into(),
                 alphas_tex_width_bits: resource_texture_dimension_2d.trailing_zeros(),
                 encoded_paints_tex_width_bits: resource_texture_dimension_2d.trailing_zeros(),

--- a/vello_gpu/src/render/wgpu/mod.rs
+++ b/vello_gpu/src/render/wgpu/mod.rs
@@ -2991,8 +2991,8 @@ impl RendererContext<'_> {
         let (target_size, pipeline) = match target {
             DrawPassTarget::Root(_) => (
                 [
-                    u16::try_from(self.programs.render_size.width).unwrap(),
-                    u16::try_from(self.programs.render_size.height).unwrap(),
+                    self.programs.render_size.width,
+                    self.programs.render_size.height,
                 ],
                 &self.programs.root_clear_pipeline,
             ),

--- a/vello_tests/tests/renderer.rs
+++ b/vello_tests/tests/renderer.rs
@@ -360,15 +360,12 @@ impl HybridRenderer {
             &device,
             &vello_gpu::RenderTargetConfig {
                 format: texture.format(),
-                width: width.into(),
-                height: height.into(),
+                width,
+                height,
             },
             settings,
         );
-        let render_size = vello_gpu::RenderSize {
-            width: width.into(),
-            height: height.into(),
-        };
+        let render_size = vello_gpu::RenderSize { width, height };
         let depth_texture_view = use_depth_buffer
             .then(|| vello_gpu::Renderer::create_depth_texture_view(&device, &render_size));
 
@@ -593,10 +590,7 @@ impl Renderer for HybridRenderer {
         let width = self.scene.width();
         let height = self.scene.height();
 
-        let render_size = vello_gpu::RenderSize {
-            width: width.into(),
-            height: height.into(),
-        };
+        let render_size = vello_gpu::RenderSize { width, height };
 
         let mut texture_bindings = vello_gpu::TextureBindings::new();
         for (texture_id, texture) in &self.external_textures {
@@ -979,10 +973,7 @@ impl Renderer for HybridRenderer {
         let width = self.scene.width();
         let height = self.scene.height();
 
-        let render_size = vello_gpu::RenderSize {
-            width: width.into(),
-            height: height.into(),
-        };
+        let render_size = vello_gpu::RenderSize { width, height };
         self.renderer
             .render(
                 &self.scene,


### PR DESCRIPTION
This PR changes `RenderSize` and `RenderTargetConfig` to hold u16 instead of u32. Basically every part of the Vello pipeline assumes this as the maximum size, so there is no good reason to use u32 here, and this makes error handling a bit easier for the follow-up PR.
