### PR TITLE
vello_bench: Add CPU allocation regression benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,9 @@ jobs:
         with:
           toolchain: ${{ env.RUST_STABLE_VER }}
 
+      - name: install native dependencies
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libfontconfig-dev
+
       - name: restore cache
         uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,23 @@ jobs:
       - name: Run cargo rdme (glifo)
         run: cargo rdme --check --workspace-project=glifo
 
+  allocation-benchmarks:
+    name: CPU allocation benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE_VER }}
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: check CPU allocation regressions
+        run: cargo bench -p vello_bench --locked --bench allocations
+
   clippy-stable:
     name: cargo clippy
     runs-on: ${{ matrix.os }}

--- a/vello_bench/Cargo.toml
+++ b/vello_bench/Cargo.toml
@@ -27,5 +27,9 @@ extended = []
 name = "main"
 harness = false
 
+[[bench]]
+name = "allocations"
+harness = false
+
 [lints]
 workspace = true

--- a/vello_bench/README.md
+++ b/vello_bench/README.md
@@ -13,6 +13,22 @@ cargo bench --features extended
 You can also provide a filter for the name of the benchmarks you want to run, like
 `cargo bench -- fine/fill`.
 
+Run the deterministic CPU allocation regression benchmarks with:
+
+```shell
+cargo bench --bench allocations
+```
+
+These benchmarks use fixed workloads, fallback SIMD, and single-threaded rendering. They fail when
+an allocation metric exceeds its recorded limit; update a limit only after verifying that the
+increase is intentional. One frame is measured by default; pass `--frames` to measure a longer run:
+
+```shell
+cargo bench --bench allocations -- --frames 1,10,100
+# Space-separated counts are also accepted:
+cargo bench --bench allocations -- --frames 1 10 100
+```
+
 ## Workflow
 
 Save a control run with:

--- a/vello_bench/benches/allocations.rs
+++ b/vello_bench/benches/allocations.rs
@@ -1,0 +1,17 @@
+// Copyright 2026 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#![allow(missing_docs, reason = "Not needed for benchmarks")]
+
+use vello_bench::allocations::{CountingAllocator, run, tiger};
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+fn main() {
+    run(&[
+        tiger::HOT_SCENE_BUILD,
+        tiger::HOT_RASTERIZE,
+        tiger::HOT_FULL_FRAME,
+    ]);
+}

--- a/vello_bench/src/allocations/counter.rs
+++ b/vello_bench/src/allocations/counter.rs
@@ -1,0 +1,150 @@
+// Copyright 2026 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cmp::Ordering;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering::Relaxed};
+
+static ACTIVE: AtomicBool = AtomicBool::new(false);
+static ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
+static REALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
+static ALLOCATED_BYTES: AtomicUsize = AtomicUsize::new(0);
+static LIVE_BYTES: AtomicUsize = AtomicUsize::new(0);
+static PEAK_LIVE_BYTES: AtomicUsize = AtomicUsize::new(0);
+
+/// A system allocator wrapper that records allocations inside [`measure`].
+#[derive(Debug)]
+pub struct CountingAllocator;
+
+// SAFETY: Every operation delegates to `System` with the original arguments. The additional
+// bookkeeping does not inspect or modify allocated memory.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: The caller upholds `GlobalAlloc::alloc`'s contract.
+        let ptr = unsafe { System.alloc(layout) };
+        if !ptr.is_null() {
+            record_allocation(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: The caller upholds `GlobalAlloc::alloc_zeroed`'s contract.
+        let ptr = unsafe { System.alloc_zeroed(layout) };
+        if !ptr.is_null() {
+            record_allocation(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        LIVE_BYTES.fetch_sub(layout.size(), Relaxed);
+        // SAFETY: The caller upholds `GlobalAlloc::dealloc`'s contract.
+        unsafe { System.dealloc(ptr, layout) };
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // SAFETY: The caller upholds `GlobalAlloc::realloc`'s contract.
+        let new_ptr = unsafe { System.realloc(ptr, layout, new_size) };
+        if !new_ptr.is_null() {
+            let old_size = layout.size();
+            if new_size >= old_size {
+                let added = new_size - old_size;
+                let live = LIVE_BYTES.fetch_add(added, Relaxed) + added;
+                record_peak(live);
+            } else {
+                LIVE_BYTES.fetch_sub(old_size - new_size, Relaxed);
+            }
+
+            if ACTIVE.load(Relaxed) {
+                REALLOCATIONS.fetch_add(1, Relaxed);
+                ALLOCATED_BYTES.fetch_add(new_size.saturating_sub(old_size), Relaxed);
+            }
+        }
+        new_ptr
+    }
+}
+
+/// Allocation activity observed while running one measured operation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AllocationStats {
+    /// Successful allocation calls.
+    pub allocations: usize,
+    /// Successful reallocation calls.
+    pub reallocations: usize,
+    /// Bytes newly requested from allocation and growing reallocation calls.
+    pub allocated_bytes: usize,
+    /// Maximum increase in live requested bytes over the starting value.
+    pub additional_peak_bytes: usize,
+    /// Change in live requested bytes from the beginning to the end.
+    pub retained_bytes: isize,
+}
+
+/// Measures allocations made while executing `operation`.
+///
+/// Only one measurement may be active in the process. The measured operation should run on one
+/// thread and avoid unrelated background work because the allocator observes all process threads.
+pub fn measure<T>(operation: impl FnOnce() -> T) -> (T, AllocationStats) {
+    assert!(
+        ACTIVE
+            .compare_exchange(false, true, Relaxed, Relaxed)
+            .is_ok(),
+        "allocation measurements cannot be nested"
+    );
+
+    ALLOCATIONS.store(0, Relaxed);
+    REALLOCATIONS.store(0, Relaxed);
+    ALLOCATED_BYTES.store(0, Relaxed);
+    let initial_live_bytes = LIVE_BYTES.load(Relaxed);
+    PEAK_LIVE_BYTES.store(initial_live_bytes, Relaxed);
+
+    let mut guard = MeasurementGuard(true);
+    let output = operation();
+    ACTIVE.store(false, Relaxed);
+    guard.0 = false;
+
+    let final_live_bytes = LIVE_BYTES.load(Relaxed);
+    let peak_live_bytes = PEAK_LIVE_BYTES.load(Relaxed);
+    let stats = AllocationStats {
+        allocations: ALLOCATIONS.load(Relaxed),
+        reallocations: REALLOCATIONS.load(Relaxed),
+        allocated_bytes: ALLOCATED_BYTES.load(Relaxed),
+        additional_peak_bytes: peak_live_bytes.saturating_sub(initial_live_bytes),
+        retained_bytes: signed_difference(final_live_bytes, initial_live_bytes),
+    };
+
+    (output, stats)
+}
+
+fn record_allocation(size: usize) {
+    let live = LIVE_BYTES.fetch_add(size, Relaxed) + size;
+    if ACTIVE.load(Relaxed) {
+        ALLOCATIONS.fetch_add(1, Relaxed);
+        ALLOCATED_BYTES.fetch_add(size, Relaxed);
+        record_peak(live);
+    }
+}
+
+fn record_peak(live: usize) {
+    if ACTIVE.load(Relaxed) {
+        PEAK_LIVE_BYTES.fetch_max(live, Relaxed);
+    }
+}
+
+fn signed_difference(value: usize, baseline: usize) -> isize {
+    match value.cmp(&baseline) {
+        Ordering::Greater => isize::try_from(value - baseline).unwrap_or(isize::MAX),
+        Ordering::Equal => 0,
+        Ordering::Less => -isize::try_from(baseline - value).unwrap_or(isize::MAX),
+    }
+}
+
+struct MeasurementGuard(bool);
+
+impl Drop for MeasurementGuard {
+    fn drop(&mut self) {
+        if self.0 {
+            ACTIVE.store(false, Relaxed);
+        }
+    }
+}

--- a/vello_bench/src/allocations/mod.rs
+++ b/vello_bench/src/allocations/mod.rs
@@ -1,0 +1,135 @@
+// Copyright 2026 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+mod counter;
+mod report;
+pub mod tiger;
+
+pub use counter::{AllocationStats, CountingAllocator, measure};
+use report::{BenchmarkReport, BenchmarkResult};
+
+const DEFAULT_MEASURED_FRAMES: usize = 1;
+
+#[derive(Clone, Copy, Debug)]
+pub struct AllocationBenchmark {
+    name: &'static str,
+    measure: fn(usize) -> AllocationStats,
+    limits_per_frame: AllocationLimits,
+}
+
+impl AllocationBenchmark {
+    pub const fn new(
+        name: &'static str,
+        measure: fn(usize) -> AllocationStats,
+        limits_per_frame: AllocationLimits,
+    ) -> Self {
+        Self {
+            name,
+            measure,
+            limits_per_frame,
+        }
+    }
+
+    fn run(self, measured_frames: usize) -> BenchmarkResult {
+        BenchmarkResult {
+            measured_frames,
+            name: self.name,
+            stats: (self.measure)(measured_frames),
+            limits: self.limits_per_frame.for_frames(measured_frames),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct AllocationLimits {
+    allocations: usize,
+    reallocations: usize,
+    allocated_bytes: usize,
+    additional_peak_bytes: usize,
+    retained_bytes: isize,
+}
+
+impl AllocationLimits {
+    pub const ZERO: Self = Self::new(0, 0, 0, 0, 0);
+
+    pub const fn new(
+        allocations: usize,
+        reallocations: usize,
+        allocated_bytes: usize,
+        additional_peak_bytes: usize,
+        retained_bytes: isize,
+    ) -> Self {
+        Self {
+            allocations,
+            reallocations,
+            allocated_bytes,
+            additional_peak_bytes,
+            retained_bytes,
+        }
+    }
+
+    fn for_frames(self, frames: usize) -> Self {
+        Self {
+            allocations: self.allocations.checked_mul(frames).unwrap(),
+            reallocations: self.reallocations.checked_mul(frames).unwrap(),
+            allocated_bytes: self.allocated_bytes.checked_mul(frames).unwrap(),
+            additional_peak_bytes: self.additional_peak_bytes,
+            retained_bytes: self.retained_bytes,
+        }
+    }
+}
+
+pub fn run(benchmarks: &[AllocationBenchmark]) {
+    let measured_frame_counts = measured_frame_counts();
+    let mut results = Vec::with_capacity(measured_frame_counts.len() * benchmarks.len());
+    for measured_frames in measured_frame_counts {
+        results.extend(
+            benchmarks
+                .iter()
+                .map(|benchmark| benchmark.run(measured_frames)),
+        );
+    }
+
+    let report = BenchmarkReport::new(results);
+    report.print();
+    if report.has_failures() {
+        std::process::exit(1);
+    }
+}
+
+fn measured_frame_counts() -> Vec<usize> {
+    let mut measured_frame_counts = Vec::new();
+    let mut args = std::env::args().skip(1).peekable();
+
+    while let Some(arg) = args.next() {
+        if arg == "--frames" {
+            let initial_count = measured_frame_counts.len();
+            while args.peek().is_some_and(|arg| !arg.starts_with('-')) {
+                parse_frame_counts(&args.next().unwrap(), &mut measured_frame_counts);
+            }
+            assert!(
+                measured_frame_counts.len() > initial_count,
+                "expected at least one frame count after `--frames`"
+            );
+        } else if let Some(value) = arg.strip_prefix("--frames=") {
+            parse_frame_counts(value, &mut measured_frame_counts);
+        }
+    }
+
+    if measured_frame_counts.is_empty() {
+        measured_frame_counts.push(DEFAULT_MEASURED_FRAMES);
+    }
+    measured_frame_counts
+}
+
+fn parse_frame_counts(value: &str, measured_frame_counts: &mut Vec<usize>) {
+    for value in value.split(',').filter(|value| !value.is_empty()) {
+        let measured_frames = value
+            .parse()
+            .expect("frame count must be a positive integer");
+        assert!(measured_frames > 0, "frame count must be greater than zero");
+        if !measured_frame_counts.contains(&measured_frames) {
+            measured_frame_counts.push(measured_frames);
+        }
+    }
+}

--- a/vello_bench/src/allocations/report.rs
+++ b/vello_bench/src/allocations/report.rs
@@ -1,0 +1,260 @@
+// Copyright 2026 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use std::io::IsTerminal;
+
+use super::{AllocationLimits, AllocationStats};
+
+pub(super) struct BenchmarkReport {
+    results: Vec<BenchmarkResult>,
+    failed_workloads: Vec<FailedWorkload>,
+}
+
+impl BenchmarkReport {
+    pub(super) fn new(results: Vec<BenchmarkResult>) -> Self {
+        let failed_workloads = results
+            .iter()
+            .filter_map(|result| {
+                let failures = result.limit_failures();
+                (!failures.is_empty()).then_some(FailedWorkload {
+                    measured_frames: result.measured_frames,
+                    name: result.name,
+                    failures,
+                })
+            })
+            .collect();
+
+        Self {
+            results,
+            failed_workloads,
+        }
+    }
+
+    pub(super) fn print(&self) {
+        print_results(&self.results);
+
+        if self.failed_workloads.is_empty() {
+            println!(
+                "\nAll allocation limits passed ({}/{} workloads).",
+                self.results.len(),
+                self.results.len()
+            );
+            return;
+        }
+
+        eprintln!(
+            "\nAllocation limits failed for {}/{} workloads:",
+            self.failed_workloads.len(),
+            self.results.len()
+        );
+        for workload in &self.failed_workloads {
+            eprintln!("  {} ({} frames)", workload.name, workload.measured_frames);
+            for failure in &workload.failures {
+                eprintln!(
+                    "    {}: {} (limit: {})",
+                    failure.metric, failure.actual, failure.limit
+                );
+            }
+        }
+    }
+
+    pub(super) fn has_failures(&self) -> bool {
+        !self.failed_workloads.is_empty()
+    }
+}
+
+fn print_results(results: &[BenchmarkResult]) {
+    let use_color = std::io::stdout().is_terminal() && std::env::var_os("NO_COLOR").is_none();
+    println!("CPU allocation benchmarks (averages per frame)\n");
+    println!("  Allocations/frame   New heap blocks allocated per average frame.");
+    println!("  Reallocations/frame Existing heap blocks resized per average frame.");
+    println!("  Allocated bytes     New bytes requested per average frame.");
+    println!("  Peak bytes          Maximum additional live bytes during the complete run.");
+    println!("  Retained bytes      Net live-byte increase after the complete run.\n");
+    println!(
+        "{:>6} {:<27} {:>20} {:>18} {:>25} {:>23} {:>16}",
+        "Frames",
+        "Workload",
+        "Allocations/frame",
+        "Reallocations/frame",
+        "Allocated bytes/frame",
+        "Peak bytes",
+        "Retained bytes",
+    );
+    println!("{}", "-".repeat(142));
+    let mut previous_frame_count = None;
+    for result in results {
+        if previous_frame_count.is_some_and(|count| count != result.measured_frames) {
+            println!();
+        }
+        previous_frame_count = Some(result.measured_frames);
+
+        println!(
+            "{:>6} {:<27} {} {} {} {} {}",
+            result.measured_frames,
+            result.name,
+            result.format_average_metric(
+                result.stats.allocations,
+                result.limits.allocations,
+                20,
+                use_color,
+            ),
+            result.format_average_metric(
+                result.stats.reallocations,
+                result.limits.reallocations,
+                18,
+                use_color,
+            ),
+            result.format_average_metric(
+                result.stats.allocated_bytes,
+                result.limits.allocated_bytes,
+                25,
+                use_color,
+            ),
+            format_metric(
+                result.stats.additional_peak_bytes as i128,
+                result.limits.additional_peak_bytes as i128,
+                23,
+                use_color,
+            ),
+            format_metric(
+                result.stats.retained_bytes as i128,
+                result.limits.retained_bytes as i128,
+                16,
+                use_color,
+            ),
+        );
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct BenchmarkResult {
+    pub(super) measured_frames: usize,
+    pub(super) name: &'static str,
+    pub(super) stats: AllocationStats,
+    pub(super) limits: AllocationLimits,
+}
+
+impl BenchmarkResult {
+    fn format_average_metric(
+        self,
+        value: usize,
+        baseline: usize,
+        width: usize,
+        use_color: bool,
+    ) -> String {
+        let measured_frames = self.measured_frames as f64;
+        let average = value as f64 / measured_frames;
+        let baseline_average = baseline as f64 / measured_frames;
+        let delta = value as i128 - baseline as i128;
+        let value = if delta == 0 {
+            format_average(average)
+        } else if baseline == 0 {
+            format!(
+                "{} ({:+}, new)",
+                format_average(average),
+                delta as f64 / measured_frames
+            )
+        } else {
+            let delta_average = delta as f64 / measured_frames;
+            let percentage = (average - baseline_average) / baseline_average.abs() * 100.0;
+            format!(
+                "{} ({delta_average:+.2}, {percentage:+.1}%)",
+                format_average(average)
+            )
+        };
+        let value = format!("{value:>width$}");
+
+        color_metric(value, delta, use_color)
+    }
+
+    fn limit_failures(self) -> Vec<LimitFailure> {
+        let metrics = [
+            (
+                "allocations",
+                self.stats.allocations as i128,
+                self.limits.allocations as i128,
+            ),
+            (
+                "reallocations",
+                self.stats.reallocations as i128,
+                self.limits.reallocations as i128,
+            ),
+            (
+                "allocated bytes",
+                self.stats.allocated_bytes as i128,
+                self.limits.allocated_bytes as i128,
+            ),
+            (
+                "additional peak bytes",
+                self.stats.additional_peak_bytes as i128,
+                self.limits.additional_peak_bytes as i128,
+            ),
+            (
+                "retained bytes",
+                self.stats.retained_bytes as i128,
+                self.limits.retained_bytes as i128,
+            ),
+        ];
+
+        metrics
+            .into_iter()
+            .filter_map(|(metric, actual, limit)| {
+                (actual > limit).then_some(LimitFailure {
+                    metric,
+                    actual,
+                    limit,
+                })
+            })
+            .collect()
+    }
+}
+
+fn format_average(value: f64) -> String {
+    if value.fract() == 0.0 {
+        format!("{value:.0}")
+    } else {
+        format!("{value:.2}")
+    }
+}
+
+fn format_metric(value: i128, baseline: i128, width: usize, use_color: bool) -> String {
+    let delta = value - baseline;
+    let value = if delta != 0 {
+        if baseline == 0 {
+            format!("{value} ({delta:+}, new)")
+        } else {
+            let percentage = delta as f64 / baseline.abs() as f64 * 100.0;
+            format!("{value} ({delta:+}, {percentage:+.1}%)")
+        }
+    } else {
+        value.to_string()
+    };
+    let value = format!("{value:>width$}");
+
+    color_metric(value, delta, use_color)
+}
+
+fn color_metric(value: String, delta: i128, use_color: bool) -> String {
+    if !use_color || delta == 0 {
+        value
+    } else if delta < 0 {
+        format!("\u{1b}[32m{value}\u{1b}[0m")
+    } else {
+        format!("\u{1b}[31m{value}\u{1b}[0m")
+    }
+}
+
+#[derive(Debug)]
+struct FailedWorkload {
+    measured_frames: usize,
+    name: &'static str,
+    failures: Vec<LimitFailure>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct LimitFailure {
+    metric: &'static str,
+    actual: i128,
+    limit: i128,
+}

--- a/vello_bench/src/allocations/tiger.rs
+++ b/vello_bench/src/allocations/tiger.rs
@@ -1,0 +1,125 @@
+// Copyright 2026 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use std::hint::black_box;
+
+use super::{AllocationBenchmark, AllocationLimits, AllocationStats, measure};
+use crate::data::{DataItem, get_data_items};
+use vello_common::fearless_simd::Level;
+use vello_common::kurbo::Stroke;
+use vello_common::pixmap::Pixmap;
+use vello_cpu::{RenderContext, RenderSettings, Resources};
+
+pub const HOT_SCENE_BUILD: AllocationBenchmark = AllocationBenchmark::new(
+    "tiger/hot_scene_build",
+    measure_hot_scene_build,
+    AllocationLimits::ZERO,
+);
+
+pub const HOT_RASTERIZE: AllocationBenchmark = AllocationBenchmark::new(
+    "tiger/hot_rasterize",
+    measure_hot_rasterize,
+    AllocationLimits::new(4, 0, 7_232, 7_232, 0),
+);
+
+pub const HOT_FULL_FRAME: AllocationBenchmark = AllocationBenchmark::new(
+    "tiger/hot_full_frame",
+    measure_hot_full_frame,
+    AllocationLimits::new(4, 0, 7_232, 7_232, 0),
+);
+
+fn measure_hot_scene_build(measured_frames: usize) -> AllocationStats {
+    let item = tiger();
+    let mut context = new_context(item);
+
+    populate_scene(&mut context, item);
+    context.flush();
+
+    let (_, stats) = measure(|| {
+        for _ in 0..measured_frames {
+            context.reset();
+            populate_scene(&mut context, item);
+            context.flush();
+            black_box(&context);
+        }
+    });
+    stats
+}
+
+fn measure_hot_rasterize(measured_frames: usize) -> AllocationStats {
+    let item = tiger();
+    let mut context = new_context(item);
+    populate_scene(&mut context, item);
+    context.flush();
+
+    let mut resources = Resources::new();
+    let mut target = Pixmap::new(item.width, item.height);
+    context.render(&mut target, &mut resources);
+
+    let (_, stats) = measure(|| {
+        for _ in 0..measured_frames {
+            context.render(&mut target, &mut resources);
+            black_box(&target);
+        }
+    });
+    stats
+}
+
+fn measure_hot_full_frame(measured_frames: usize) -> AllocationStats {
+    let item = tiger();
+    let mut context = new_context(item);
+    let mut resources = Resources::new();
+    let mut target = Pixmap::new(item.width, item.height);
+
+    render_frame(&mut context, &mut resources, &mut target, item);
+
+    let (_, stats) = measure(|| {
+        for _ in 0..measured_frames {
+            render_frame(&mut context, &mut resources, &mut target, item);
+            black_box(&target);
+        }
+    });
+    stats
+}
+
+fn tiger() -> &'static DataItem {
+    get_data_items()
+        .first()
+        .expect("the benchmark data always contains the Ghostscript tiger")
+}
+
+fn new_context(item: &DataItem) -> RenderContext {
+    RenderContext::new_with(
+        item.width,
+        item.height,
+        RenderSettings {
+            level: Level::baseline(),
+            num_threads: 0,
+        },
+    )
+}
+
+fn render_frame(
+    context: &mut RenderContext,
+    resources: &mut Resources,
+    target: &mut Pixmap,
+    item: &DataItem,
+) {
+    context.reset();
+    populate_scene(context, item);
+    context.flush();
+    context.render(target, resources);
+}
+
+fn populate_scene(context: &mut RenderContext, item: &DataItem) {
+    for fill in &item.fills {
+        context.set_transform(fill.transform);
+        context.fill_path(&fill.path);
+    }
+
+    for stroke in &item.strokes {
+        context.set_transform(stroke.transform);
+        context.set_stroke(Stroke::new(f64::from(stroke.stroke_width)));
+        context.stroke_path(&stroke.path);
+    }
+}

--- a/vello_bench/src/lib.rs
+++ b/vello_bench/src/lib.rs
@@ -7,6 +7,7 @@
 use std::path::PathBuf;
 use std::sync::LazyLock;
 
+pub mod allocations;
 pub mod allocator;
 pub mod data;
 pub mod fine;


### PR DESCRIPTION
Add deterministic allocation regression benchmarks. Added for warmed-up Tiger scene building, rasterization, and full-frame rendering. The benchmarks support configurable frame counts, enforce allocation limits, report regressions, and run in CI.

Created with assistance from GPT-5.6 Sol.

