### PR TITLE
docs: clarify renderer selection and repository migration

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,33 +1,68 @@
 # Architecture
 
-Vello contains two renderer families: the Sparse Strips renderers at the repository root and the original compute-centric renderer under `research/`. They pursue the same broad 2D rendering goals with different pipelines and hardware requirements.
+Vello contains two renderer families:
 
-See the [project README](README.md) for renderer selection and package migration guidance.
+1. [`vello_cpu`](vello_cpu), a CPU-only renderer, and
+   [`vello_gpu`](vello_gpu), a GPU-accelerated renderer, both based on the
+   Sparse Strips architecture.
+2. The experimental [`vello`](research/vello_research) renderer, which is based
+   on compute shaders.
+
+See the [project README](README.md) for renderer selection and package
+migration guidance.
 
 ## Goals
 
-The project aims to provide high-quality, high-performance 2D rendering for GUI applications, creative tools, scientific visualization, and similar workloads. Its implementations explore how CPU SIMD, multithreading, conventional GPU rasterization, and GPU compute can be applied to vector graphics.
+The project aims to provide high-quality, high-performance 2D rendering for GUI
+applications, creative tools, scientific visualization, and similar workloads.
+Its implementations explore how CPU SIMD, multithreading, conventional GPU
+rasterization, and GPU compute can be applied to vector graphics.
 
 ## Sparse Strips renderers
 
-Vello CPU and Vello GPU share a CPU-side pipeline implemented primarily in `vello_common`. Paths are flattened, binned into tiles, and represented as sparse horizontal strips. Coverage data is retained where it is needed around path boundaries, while fully covered regions can be represented compactly. This limits intermediate work and memory to the parts of the scene that affect the final image.
+Vello CPU and Vello GPU share a CPU-side pipeline implemented primarily in
+`vello_common`. Paths are flattened, binned into tiles, and represented as
+sparse horizontal strips. Coverage data is retained where it is needed around
+path boundaries, while fully covered regions can be represented compactly. This
+limits intermediate work and memory to the parts of the scene that affect the
+final image.
 
 The resulting representation can be consumed by different backends:
 
-- `vello_cpu` rasterizes and composites the strips into a CPU pixmap. It uses SIMD and can use multiple threads, but requires no GPU.
-- `vello_gpu` performs the same broad preprocessing on the CPU, then uploads scheduled strips and paint data for GPU rasterization and compositing. Its wgpu and WebGL2 backends use vertex and fragment rendering rather than requiring compute shaders.
+- `vello_cpu` rasterizes and composites the strips into a CPU pixmap. It uses
+  SIMD and can use multiple threads, but requires no GPU.
+- `vello_gpu` performs the same broad preprocessing on the CPU, then uploads
+  scheduled strips and paint data for GPU rasterization and compositing. Its
+  wgpu and WebGL2 backends use vertex and fragment rendering rather than
+  requiring compute shaders.
 
-The two renderers share geometry, tiling, paint, image, filter, and strip data structures through `vello_common`, as well as test scenes and snapshot infrastructure under `vello_tests`. Text and glyph-run support is shared through `glifo`.
+The two renderers share geometry, tiling, paint, image, filter, and strip data
+structures through `vello_common`, as well as test scenes and snapshot
+infrastructure under `vello_tests`. Text and glyph-run support is shared through
+`glifo`.
 
-The design grew from the sparse rendering approach described in [*Potato: a hybrid CPU/GPU 2D renderer design*][potato]. The [Vello CPU thesis][vello-cpu-thesis] provides a more detailed explanation of the pipeline, although implementation details continue to evolve.
+The design grew from the sparse rendering approach described in
+[*Potato: a hybrid CPU/GPU 2D renderer design*][potato]. The
+[Vello CPU thesis][vello-cpu-thesis] provides a more detailed explanation of
+the pipeline, although parts of the description in the thesis are already
+outdated and implementation details continue to evolve.
 
 ## Compute-centric research renderer
 
-The package published as `vello` is the original compute-centric renderer. A scene is encoded into compact path, draw, transform, and resource buffers. Those buffers are resolved into a `Recording` of GPU operations, and `WgpuEngine` uploads resources and dispatches the compute pipeline. Prefix-scan algorithms parallelize work that traditional renderers often perform sequentially.
+The package published as `vello` is the original compute-centric renderer. A
+scene is encoded into compact path, draw, transform, and resource buffers. Those
+buffers are resolved into a `Recording` of GPU operations, and `WgpuEngine`
+uploads resources and dispatches the compute pipeline. Prefix-scan algorithms
+parallelize work that traditional renderers often perform sequentially.
 
-This approach can perform very well on dynamic, vector-heavy scenes, but it requires compute shader support and has different compatibility and memory trade-offs from the Sparse Strips renderers. It remains under `research/` together with its dedicated shaders, examples, tests, and design history.
+This approach can perform very well on dynamic, vector-heavy scenes, but it
+requires compute shader support and has different compatibility and memory
+trade-offs from the Sparse Strips renderers. It remains under `research/`
+together with its dedicated shaders, examples, tests, and design history.
 
-CPU implementations of parts of the compute pipeline live in `research/vello_shaders/src/cpu`. They are used for testing and debugging; they do not provide a complete standalone CPU renderer. Use `vello_cpu` for that.
+CPU implementations of parts of the compute pipeline live in
+`research/vello_shaders/src/cpu`. They are used for testing and debugging; they
+do not provide a complete standalone CPU renderer. Use `vello_cpu` for that.
 
 ## Repository structure
 
@@ -36,37 +71,48 @@ The user-facing Sparse Strips implementation is organized at the root:
 - `vello_common/` — shared geometry, tiling, paint, and strip infrastructure.
 - `vello_cpu/` — CPU renderer.
 - `vello_gpu/` — GPU renderer with CPU-side preprocessing.
-- `vello_gpu_shaders/` — WESL sources and generated WGSL/GLSL used by `vello_gpu`.
+- `vello_gpu_shaders/` — WESL sources and generated WGSL/GLSL used by
+  `vello_gpu`.
 - `glifo/` — text and glyph-run support shared by the Sparse Strips renderers.
-- `vello_tests/` — shared integration tests, snapshots, scenes, and browser tooling.
+- `vello_tests/` — shared integration tests, snapshots, scenes, and browser
+  tooling.
 - `vello_bench/` — Sparse Strips benchmarks.
 
 Compute-centric packages and support code are grouped under `research/`:
 
 - `research/vello_research/` — source for the published `vello` package.
 - `research/vello_encoding/` — compact scene encoding used by `vello`.
-- `research/vello_shaders/` — compute shaders, preprocessing, and CPU reference kernels.
+- `research/vello_shaders/` — compute shaders, preprocessing, and CPU
+  reference kernels.
 - `research/vello_research_tests/` — compute-renderer tests and snapshots.
 - `research/examples/` — standalone compute-renderer examples.
 - `research/xtask/` — snapshot and comparison maintenance tooling.
 - `research/doc/` — historical design documents, roadmaps, and blog links.
 
-The explicit `vello_research` folder name communicates the implementation's role in this repository. Its Cargo package name remains `vello`; likewise, `vello_encoding` and `vello_shaders` retain their published package names.
-
 ## Shader source systems
 
-Vello GPU shaders are authored as WESL in `vello_gpu_shaders/shaders`. The crate links them into WGSL and can generate GLSL plus reflection metadata for the WebGL2 backend.
+Vello GPU shaders are authored as WESL in `vello_gpu_shaders/shaders`. The crate
+links them into WGSL and can generate GLSL plus reflection metadata for the
+WebGL2 backend.
 
-The compute renderer uses WGSL sources in `research/vello_shaders/shader`. Because WGSL has no built-in metaprogramming, these shaders use a small preprocessor supporting:
+The compute renderer uses WGSL sources in `research/vello_shaders/shader`.
+Because WGSL has no built-in metaprogramming, these shaders use a small
+preprocessor supporting:
 
 1. `import`, which imports shared code from `shader/shared`.
-2. `ifdef`, `ifndef`, `else`, and `endif`, controlled by definitions supplied outside the shader.
+2. `ifdef`, `ifndef`, `else`, and `endif`, controlled by definitions supplied
+   outside the shader.
 
-This format is compatible with [`wgsl-analyzer`]. New imports must also be listed in `.vscode/settings.json` for editor support.
+This format is compatible with [`wgsl-analyzer`]. New imports must also be
+listed in `.vscode/settings.json` for editor support.
 
 ## Research history
 
-Historical documents about the compute renderer are in `research/doc/`. [blogs.md](research/doc/blogs.md) links to development articles, and the [2023 roadmap](research/doc/roadmap_2023.md) records earlier project goals. The [path segment encoding](research/doc/pathseg.md) document describes the compute renderer's compact path representation.
+Historical documents about the compute renderer are in `research/doc/`.
+[blogs.md](research/doc/blogs.md) links to development articles, and the
+[2023 roadmap](research/doc/roadmap_2023.md) records earlier project goals. The
+[path segment encoding](research/doc/pathseg.md) document describes the compute
+renderer's compact path representation.
 
 [`wgsl-analyzer`]: https://marketplace.visualstudio.com/items?itemName=wgsl-analyzer.wgsl-analyzer
 [potato]: https://docs.google.com/document/d/1gEqf7ehTzd89Djf_VpkL0B_Fb15e0w5fuv_UzyacAPU/edit

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,96 +1,73 @@
 # Architecture
 
-This document should be updated semi-regularly. Feel free to open an issue if it hasn't been updated in more than a year.
+Vello contains two renderer families: the Sparse Strips renderers at the repository root and the original compute-centric renderer under `research/`. They pursue the same broad 2D rendering goals with different pipelines and hardware requirements.
+
+See the [project README](README.md) for renderer selection and package migration guidance.
 
 ## Goals
 
-The major goal of Vello is to provide a high quality GPU accelerated renderer suitable for a range of 2D graphics applications, including rendering for GUI applications, creative tools, and scientific visualization.
+The project aims to provide high-quality, high-performance 2D rendering for GUI applications, creative tools, scientific visualization, and similar workloads. Its implementations explore how CPU SIMD, multithreading, conventional GPU rasterization, and GPU compute can be applied to vector graphics.
 
-Vello emerges from being a research project, which attempts to answer these hypotheses:
+## Sparse Strips renderers
 
-- To what extent is a compute-centered approach better than rasterization ([Direct2D])?
-- To what extent do advanced GPU features (subgroups, descriptor arrays, device-scoped barriers) help?
-- Can we improve quality and extend the imaging model in useful ways?
+Vello CPU and Vello GPU share a CPU-side pipeline implemented primarily in `vello_common`. Paths are flattened, binned into tiles, and represented as sparse horizontal strips. Coverage data is retained where it is needed around path boundaries, while fully covered regions can be represented compactly. This limits intermediate work and memory to the parts of the scene that affect the final image.
 
-Another goal of the overall project is to explain how the renderer is built, and to advance the state of building applications on GPU compute shaders more generally.
-Much of the progress on Vello is documented in blog entries.
-See [blogs.md](research/doc/blogs.md) for pointers to those.
+The resulting representation can be consumed by different backends:
 
-Ideally, we'd like our documentation to be more structured; we may refactor it in the future (see [#488]).
+- `vello_cpu` rasterizes and composites the strips into a CPU pixmap. It uses SIMD and can use multiple threads, but requires no GPU.
+- `vello_gpu` performs the same broad preprocessing on the CPU, then uploads scheduled strips and paint data for GPU rasterization and compositing. Its wgpu and WebGL2 backends use vertex and fragment rendering rather than requiring compute shaders.
 
+The two renderers share geometry, tiling, paint, image, filter, and strip data structures through `vello_common`, as well as test scenes and snapshot infrastructure under `vello_tests`. Text and glyph-run support is shared through `glifo`.
 
-## Roadmap
+The design grew from the sparse rendering approach described in [*Potato: a hybrid CPU/GPU 2D renderer design*][potato]. The [Vello CPU thesis][vello-cpu-thesis] provides a more detailed explanation of the pipeline, although implementation details continue to evolve.
 
-The [roadmap for 2023](research/doc/roadmap_2023.md) is still largely applicable.
-The "Semi-stable encoding format" section and most of the "CPU fallback" section can be considered implemented.
+## Compute-centric research renderer
 
-Our current priority is to fill in missing features and to fix rendering artifacts, so that Vello can reach feature parity with other 2D graphics engines.
+The package published as `vello` is the original compute-centric renderer. A scene is encoded into compact path, draw, transform, and resource buffers. Those buffers are resolved into a `Recording` of GPU operations, and `WgpuEngine` uploads resources and dispatches the compute pipeline. Prefix-scan algorithms parallelize work that traditional renderers often perform sequentially.
 
+This approach can perform very well on dynamic, vector-heavy scenes, but it requires compute shader support and has different compatibility and memory trade-offs from the Sparse Strips renderers. It remains under `research/` together with its dedicated shaders, examples, tests, and design history.
 
-## File structure
+CPU implementations of parts of the compute pipeline live in `research/vello_shaders/src/cpu`. They are used for testing and debugging; they do not provide a complete standalone CPU renderer. Use `vello_cpu` for that.
 
-The repository is structured as such:
+## Repository structure
 
-- `research/doc/` - Historical documents detailing the vision for the compute renderer as it was developed.
-- `research/examples/` - Example projects using the compute renderer. Each example is its own crate, with its own dependencies. The simplest example is called `simple`.
-- `research/vello_research/` - Code for the main `vello` crate.
-- `research/vello_encoding/` - Types that represent the data that needs to be rendered.
-- `research/vello_shaders/` - Infrastructure to preprocess and cross-compile shaders at compile time; see "Shader templating".
-  - `shader/` - This is where the magic happens. WGSL shaders that define the compute operations (often variations of prefix sum) that Vello does to render a scene.
-    - `shared/` - Shared types, functions and constants included in other shaders through non-standard `#import` preprocessor directives (see "Shader templating").
-  - `cpu/` - Functions that perform the same work as their equivalently-named WGSL shaders for the CPU fallbacks. The name is a bit loose; they're "shaders" in the sense that they work on resource bindings with the exact same layout as actual GPU shaders.
-- `research/vello_research_tests/` - Helper code for writing research renderer tests.
+The user-facing Sparse Strips implementation is organized at the root:
 
+- `vello_common/` — shared geometry, tiling, paint, and strip infrastructure.
+- `vello_cpu/` — CPU renderer.
+- `vello_gpu/` — GPU renderer with CPU-side preprocessing.
+- `vello_gpu_shaders/` — WESL sources and generated WGSL/GLSL used by `vello_gpu`.
+- `glifo/` — text and glyph-run support shared by the Sparse Strips renderers.
+- `vello_tests/` — shared integration tests, snapshots, scenes, and browser tooling.
+- `vello_bench/` — Sparse Strips benchmarks.
 
-## Shader templating
+Compute-centric packages and support code are grouped under `research/`:
 
-WGSL has no meta-programming support, which limits code-sharing.
-We use a strategy common to many projects (eg Bevy) which is to implement a limited, simple preprocessor for our shaders.
+- `research/vello_research/` — source for the published `vello` package.
+- `research/vello_encoding/` — compact scene encoding used by `vello`.
+- `research/vello_shaders/` — compute shaders, preprocessing, and CPU reference kernels.
+- `research/vello_research_tests/` — compute-renderer tests and snapshots.
+- `research/examples/` — standalone compute-renderer examples.
+- `research/xtask/` — snapshot and comparison maintenance tooling.
+- `research/doc/` — historical design documents, roadmaps, and blog links.
 
-This preprocessor implements the following directives:
+The explicit `vello_research` folder name communicates the implementation's role in this repository. Its Cargo package name remains `vello`; likewise, `vello_encoding` and `vello_shaders` retain their published package names.
 
-1. `import`, which imports from `shader/shared`
-2. `ifdef`, `ifndef`, `else` and `endif`, as standard.
-  These must be at the start of their lines.  
-  Note that there is no support for creating definitions in-shader, these are only specified externally (in `src/shaders.rs`).
-  Note also that this definitions cannot currently be used in-code (`import`s may be used instead)
+## Shader source systems
 
-This format is compatible with [`wgsl-analyzer`], which we recommend using.
-If you run into any issues, please report them on Zulip ([#vello > wgsl-analyzer issues](https://xi.zulipchat.com/#narrow/channel/197075-vello/topic/wgsl-analyzer.20issues/with/429480999)), and/or on the [`wgsl-analyzer`] issue tracker.  
-Note that new imports must currently be added to `.vscode/settings.json` for this support to work correctly.
-`wgsl-analyzer` only supports imports in very few syntactic locations, so we limit their use to these places.
+Vello GPU shaders are authored as WESL in `vello_gpu_shaders/shaders`. The crate links them into WGSL and can generate GLSL plus reflection metadata for the WebGL2 backend.
 
+The compute renderer uses WGSL sources in `research/vello_shaders/shader`. Because WGSL has no built-in metaprogramming, these shaders use a small preprocessor supporting:
 
-## Path encoding
+1. `import`, which imports shared code from `shader/shared`.
+2. `ifdef`, `ifndef`, `else`, and `endif`, controlled by definitions supplied outside the shader.
 
-See the [Path segment encoding](research/doc/pathseg.md) document.
+This format is compatible with [`wgsl-analyzer`]. New imports must also be listed in `.vscode/settings.json` for editor support.
 
+## Research history
 
-## Intermediary layers
-
-There are multiple layers of separation between "draw shape in Scene" and "commands are sent to wgpu":
-
-- First, everything you do in `Scene` appends data to an `Encoding`.
-The encoding owns multiple buffers representing compressed path commands, draw commands, transforms, etc. It's a linearized representation of the things you asked the `Scene` to draw.
-- From that encoding, we generate a `Recording`, which is an array of commands; each `Command` represents an operation interacting with the GPU (think "upload buffer", "dispatch", "download buffer", etc).
-- We then use `WgpuEngine` to send these commands to the actual GPU.
-
-In principle, other backends could consume a `Recording`, but for now the only implemented wgpu backend is `WgpuEngine`.
-
-
-### CPU rendering
-
-The code in `research/vello_shaders/src/cpu/*.rs` and `research/vello_shaders/src/cpu.rs` provides *some* support for CPU-side rendering. It's in an awkward place right now:
-
-- It's called through WgpuEngine, so the dependency on wgpu is still there.
-- Fine rasterization (the part at the end that puts pixels on screen) doesn't work in CPU yet (see [#386]).
-- Every single WGSL shader needs a CPU equivalent, which is pretty cumbersome.
-
-Still, it's useful for testing and debugging.
-
+Historical documents about the compute renderer are in `research/doc/`. [blogs.md](research/doc/blogs.md) links to development articles, and the [2023 roadmap](research/doc/roadmap_2023.md) records earlier project goals. The [path segment encoding](research/doc/pathseg.md) document describes the compute renderer's compact path representation.
 
 [`wgsl-analyzer`]: https://marketplace.visualstudio.com/items?itemName=wgsl-analyzer.wgsl-analyzer
-[direct2d]: https://docs.microsoft.com/en-us/windows/win32/direct2d/direct2d-portal
-[#488]: https://github.com/linebender/vello/issues/488
-[#467]: https://github.com/linebender/vello/issues/467
-[#386]: https://github.com/linebender/vello/issues/386
+[potato]: https://docs.google.com/document/d/1gEqf7ehTzd89Djf_VpkL0B_Fb15e0w5fuv_UzyacAPU/edit
+[vello-cpu-thesis]: https://ethz.ch/content/dam/ethz/special-interest/infk/inst-pls/plf-dam/documents/StudentProjects/MasterTheses/2025-Laurenz-Thesis.pdf

--- a/README.md
+++ b/README.md
@@ -1,65 +1,94 @@
-<!--
-
-This repo-level readme needs restructuring, pending some Linebender templating decisions.
-https://xi.zulipchat.com/#narrow/channel/419691-linebender/topic/Bikeshedding.20badges/with/452312397
-
-For now, prefer updating the package-level readmes, e.g. research/vello_research/README.md.
-
--->
-
 <div align="center">
 
 # Vello
 
-**A GPU compute-centric 2D renderer**
+**High-performance 2D renderers written in Rust**
 
 [![Linebender Zulip](https://img.shields.io/badge/Linebender-%23vello-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/197075-vello)
 [![dependency status](https://deps.rs/repo/github/linebender/vello/status.svg)](https://deps.rs/repo/github/linebender/vello)
 [![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
-[![wgpu version](https://img.shields.io/badge/wgpu-v29.0.1-orange.svg)](https://crates.io/crates/wgpu)
-
-[![Crates.io](https://img.shields.io/crates/v/vello.svg)](https://crates.io/crates/vello)
-[![Docs](https://docs.rs/vello/badge.svg)](https://docs.rs/vello)
 [![Build status](https://github.com/linebender/vello/workflows/CI/badge.svg)](https://github.com/linebender/vello/actions)
 
 </div>
 
-The Vello project is a set of high-performance vector renderers written in Rust:
+Vello is a project for high-performance 2D vector rendering. It contains three renderer implementations with different hardware requirements and maturity profiles.
 
-- **Vello** is an experimental renderer with a focus on doing as much work as possible with GPU compute.
-- **Vello CPU** is a pure Rust, CPU-only renderer optimized for multithreading and SIMD.
-- **Vello GPU** is a renderer that does heavy pre-processing on the CPU but still does most of the work on the GPU. It aims to be the main Vello implementation for production use-cases.
+## Choose a renderer
 
-Quickstart to run an example program:
+### Vello CPU
+
+[`vello_cpu`](vello_cpu) is a CPU-only Sparse Strips renderer optimized for multithreading and SIMD. It is the most mature choice when predictable CPU rendering, software rendering, or support for devices without a suitable GPU is required.
+
+### Vello GPU
+
+[`vello_gpu`](vello_gpu) is a Sparse Strips renderer that preprocesses paths on the CPU and uses the GPU for rasterization and compositing. It supports wgpu rendering and a WebGL2 backend without requiring compute shaders. Choose it when GPU acceleration and broad GPU compatibility are important. Vello GPU is intended to become the primary renderer for production GPU use cases as it matures; Vello CPU currently has the more mature Sparse Strips implementation.
+
+### Vello compute renderer
+
+The [`vello`](research/vello_research) crate is the original compute-centric renderer. It performs most rendering work in GPU compute shaders and remains an experimental implementation for compute-capable GPUs. Its source and supporting crates now live under [`research/`](research/README.md).
+
+Vello CPU and Vello GPU share the Sparse Strips architecture and common infrastructure in [`vello_common`](vello_common). See [ARCHITECTURE.md](ARCHITECTURE.md) for how the renderer families differ.
+
+## Quick start
+
+Run the windowed example for the renderer you want to try:
 
 ```shell
-cargo run -p with_winit
+# Vello CPU
+cargo run -p vello_cpu_winit --release
+
+# Vello GPU
+cargo run -p vello_gpu_winit --release
+
+# Compute-centric research renderer
+cargo run -p with_winit --release
 ```
 
-![image](https://github.com/linebender/vello/assets/8573618/cc2b742e-2135-4b70-8051-c49aeddb5d19)
+Package-specific setup and API examples are in the [`vello_cpu`](vello_cpu), [`vello_gpu`](vello_gpu), and [`vello`](research/vello_research) READMEs.
 
-Significant changes are documented in [the changelog].
+## Repository layout
+
+- [`vello_cpu/`](vello_cpu) and [`vello_gpu/`](vello_gpu) contain the user-facing Sparse Strips renderers.
+- [`vello_common/`](vello_common) and [`vello_gpu_shaders/`](vello_gpu_shaders) support those renderers.
+- [`glifo/`](glifo) provides text and glyph-run support shared by both Sparse Strips renderers.
+- [`vello_tests/`](vello_tests) contains their shared development tests, snapshots, scenes, and browser tooling.
+- [`research/`](research/README.md) contains the compute-centric renderer, its encoding and shader crates, examples, tests, historical design documents, and changelog.
+- [`vello_bench/`](vello_bench) contains Sparse Strips benchmarks.
+
+Release histories are maintained in the [`vello` changelog](research/CHANGELOG.md), [`vello_cpu` changelog](vello_cpu/CHANGELOG.md), [`vello_gpu` changelog](vello_gpu/CHANGELOG.md), and [`vello_common` changelog](vello_common/CHANGELOG.md).
+
+## Package names and source folders
+
+Cargo package names do not have to match their source directory names. The research folders were renamed to make their role in this repository explicit without forcing existing crates.io users to migrate:
+
+- `research/vello_research/` still publishes as [`vello`](https://crates.io/crates/vello).
+- `research/vello_encoding/` still publishes as [`vello_encoding`](https://crates.io/crates/vello_encoding).
+- `research/vello_shaders/` still publishes as [`vello_shaders`](https://crates.io/crates/vello_shaders).
+
+Existing users of these three packages keep the same dependency and Rust import names. Only local or Git-based tooling that refers directly to repository folders needs to use the new `research/` paths.
+
+The repository's Sparse Strips package names did change: `vello_hybrid` became `vello_gpu`, and `vello_sparse_shaders` became `vello_gpu_shaders`. Git and local path dependencies that track this repository must use the new package and Rust import names. Existing crates.io releases under the old names remain available, and publication under the new names may lag behind the repository rename; check crates.io before selecting a released version.
+
+The development-only `vello_sparse_tests` package became the root-level `vello_tests`, while the research test helper package became `vello_research_tests`.
+
+There is no empty root-level `vello/` placeholder. A future shared abstraction can introduce a root directory when it has a concrete API; the current folder layout does not require changing the established `vello` package identity.
 
 ## Motivation
 
-Vello is meant to fill the same place in the graphics stack as other vector graphics renderers like [Skia](https://skia.org/), [Cairo](https://www.cairographics.org/), and its predecessor project [Piet](https://github.com/linebender/piet).
-On a basic level, that means it provides tools to render shapes, images, gradients, text, etc, using a PostScript-inspired API, the same that powers SVG files and [the browser `<canvas>` element](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D).
+Vello is intended to fill the same place in the graphics stack as vector renderers such as [Skia](https://skia.org/), [Cairo](https://www.cairographics.org/), and its predecessor project [Piet](https://github.com/linebender/piet). Its renderers draw shapes, images, gradients, and text using a PostScript-inspired imaging model like those behind SVG and the browser [`<canvas>` element](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D).
 
-The selling point of Vello's implementations is that they get better performance than other renderers by better leveraging the SIMD, multithreading and the GPU.
-
+The implementations explore complementary ways to use SIMD, multithreading, and GPUs while sharing the same broader rendering goals.
 
 ## Minimum supported Rust Version (MSRV)
 
 This version of Vello has been verified to compile with **Rust 1.89** and later.
 
-Future versions of Vello might increase the Rust version requirement.
-It will not be treated as a breaking change and as such can even happen with small patch releases.
+Future versions of Vello might increase the Rust version requirement. It will not be treated as a breaking change and as such can even happen with small patch releases.
 
 <details>
 <summary>Click here if compiling fails.</summary>
 
-As time has passed, some of Vello's dependencies could have released versions with a higher Rust requirement.
-If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
+As time has passed, some of Vello's dependencies could have released versions with a higher Rust requirement. If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
 
 ```sh
 # Use the problematic dependency's name and version
@@ -70,11 +99,9 @@ cargo update -p package_name --precise 0.1.1
 
 ## Community
 
-Discussion of Vello development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#vello channel](https://xi.zulipchat.com/#narrow/channel/197075-vello).
-All public content can be read without logging in.
+Discussion of Vello development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#vello channel](https://xi.zulipchat.com/#narrow/channel/197075-vello). All public content can be read without logging in.
 
-Contributions are welcome by pull request.
-The [Rust code of conduct] applies.
+Contributions are welcome by pull request. The [Rust code of conduct] applies.
 
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache 2.0 license, shall be licensed as noted in the [License](#license) section, without any additional terms or conditions.
 
@@ -87,21 +114,8 @@ Licensed under either of
 
 at your option.
 
-In addition, all files in the [`research/vello_shaders/shader`](https://github.com/linebender/vello/tree/main/research/vello_shaders/shader) and [`research/vello_shaders/src/cpu`](https://github.com/linebender/vello/tree/main/research/vello_shaders/src/cpu) directories and subdirectories thereof are alternatively licensed under the Unlicense ([research/vello_shaders/shader/UNLICENSE](https://github.com/linebender/vello/tree/main/research/vello_shaders/shader/UNLICENSE) or <http://unlicense.org/>).
-For clarity, these files are also licensed under either of the above licenses.
-The intent is for this research to be used in as broad a context as possible.
+In addition, all files in the [`research/vello_shaders/shader`](https://github.com/linebender/vello/tree/main/research/vello_shaders/shader) and [`research/vello_shaders/src/cpu`](https://github.com/linebender/vello/tree/main/research/vello_shaders/src/cpu) directories and subdirectories thereof are alternatively licensed under the Unlicense ([research/vello_shaders/shader/UNLICENSE](https://github.com/linebender/vello/blob/main/research/vello_shaders/shader/UNLICENSE) or <http://unlicense.org/>). For clarity, these files are also licensed under either of the above licenses. The intent is for this research to be used in as broad a context as possible.
 
 The files in subdirectories of the [`assets`](https://github.com/linebender/vello/tree/main/assets) directory are licensed solely under their respective licenses, available in the `LICENSE` file in their directories.
 
-[piet-metal]: https://github.com/linebender/piet-metal
-[`wgpu`]: https://wgpu.rs/
-[Xilem]: https://github.com/linebender/xilem/
 [Rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct
-[`custom-hal-archive-with-shaders`]: https://github.com/linebender/piet-gpu/tree/custom-hal-archive-with-shaders
-[`custom-hal-archive`]: https://github.com/linebender/piet-gpu/tree/custom-hal-archive
-[piet-dx12]: https://github.com/bzm3r/piet-dx12
-[GhostScript tiger]: https://commons.wikimedia.org/wiki/File:Ghostscript_Tiger.svg
-[winit]: https://github.com/rust-windowing/winit
-[Bevy]: https://bevyengine.org/
-[Requiem for piet-gpu-hal]: https://raphlinus.github.io/rust/gpu/2023/01/07/requiem-piet-gpu-hal.html
-[the changelog]: https://github.com/linebender/vello/tree/main/research/CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -11,23 +11,37 @@
 
 </div>
 
-Vello is a project for high-performance 2D vector rendering. It contains three renderer implementations with different hardware requirements and maturity profiles.
+Vello is a project for high-performance 2D vector rendering. It contains three
+renderer implementations with different hardware requirements and maturity
+profiles.
 
 ## Choose a renderer
 
 ### Vello CPU
 
-[`vello_cpu`](vello_cpu) is a CPU-only Sparse Strips renderer optimized for multithreading and SIMD. It is the most mature choice when predictable CPU rendering, software rendering, or support for devices without a suitable GPU is required.
+[`vello_cpu`](vello_cpu) is a CPU-only renderer optimized for multithreading and
+SIMD. It is the most mature choice when predictable CPU rendering, software
+rendering, or support for devices without a suitable GPU is required.
 
 ### Vello GPU
 
-[`vello_gpu`](vello_gpu) is a Sparse Strips renderer that preprocesses paths on the CPU and uses the GPU for rasterization and compositing. It supports wgpu rendering and a WebGL2 backend without requiring compute shaders. Choose it when GPU acceleration and broad GPU compatibility are important. Vello GPU is intended to become the primary renderer for production GPU use cases as it matures; Vello CPU currently has the more mature Sparse Strips implementation.
+[`vello_gpu`](vello_gpu) is a renderer that preprocesses paths on the CPU and
+uses the GPU for rasterization and compositing. It supports a native WebGL2
+backend and a wgpu backend without requiring compute shaders. Choose it when GPU
+acceleration and broad GPU compatibility are important. Vello GPU is intended
+to become the primary renderer for production GPU use cases as it matures; Vello
+CPU is currently overall more mature.
 
 ### Vello compute renderer
 
-The [`vello`](research/vello_research) crate is the original compute-centric renderer. It performs most rendering work in GPU compute shaders and remains an experimental implementation for compute-capable GPUs. Its source and supporting crates now live under [`research/`](research/README.md).
+The [`vello`](research/vello_research) crate is the original compute-centric
+renderer. It performs most rendering work in GPU compute shaders and remains an
+experimental implementation for compute-capable GPUs. Its source and supporting
+crates now live under [`research/`](research/README.md).
 
-Vello CPU and Vello GPU share the Sparse Strips architecture and common infrastructure in [`vello_common`](vello_common). See [ARCHITECTURE.md](ARCHITECTURE.md) for how the renderer families differ.
+Vello CPU and Vello GPU share the Sparse Strips architecture and common
+infrastructure in [`vello_common`](vello_common). See
+[ARCHITECTURE.md](ARCHITECTURE.md) for how the renderer families differ.
 
 ## Quick start
 
@@ -44,51 +58,58 @@ cargo run -p vello_gpu_winit --release
 cargo run -p with_winit --release
 ```
 
-Package-specific setup and API examples are in the [`vello_cpu`](vello_cpu), [`vello_gpu`](vello_gpu), and [`vello`](research/vello_research) READMEs.
+Package-specific setup and API examples are in the
+[`vello_cpu`](vello_cpu), [`vello_gpu`](vello_gpu), and
+[`vello`](research/vello_research) READMEs.
 
 ## Repository layout
 
-- [`vello_cpu/`](vello_cpu) and [`vello_gpu/`](vello_gpu) contain the user-facing Sparse Strips renderers.
-- [`vello_common/`](vello_common) and [`vello_gpu_shaders/`](vello_gpu_shaders) support those renderers.
-- [`glifo/`](glifo) provides text and glyph-run support shared by both Sparse Strips renderers.
-- [`vello_tests/`](vello_tests) contains their shared development tests, snapshots, scenes, and browser tooling.
-- [`research/`](research/README.md) contains the compute-centric renderer, its encoding and shader crates, examples, tests, historical design documents, and changelog.
+- [`vello_cpu/`](vello_cpu) and [`vello_gpu/`](vello_gpu) contain the
+  user-facing Sparse Strips renderers.
+- [`vello_common/`](vello_common) and
+  [`vello_gpu_shaders/`](vello_gpu_shaders) support those renderers.
+- [`glifo/`](glifo) provides text and glyph-run support shared by both Sparse
+  Strips renderers.
+- [`vello_tests/`](vello_tests) contains their shared development tests,
+  snapshots, scenes, and browser tooling.
+- [`research/`](research/README.md) contains the compute-centric renderer, its
+  encoding and shader crates, examples, tests, historical design documents, and
+  changelog.
 - [`vello_bench/`](vello_bench) contains Sparse Strips benchmarks.
 
-Release histories are maintained in the [`vello` changelog](research/CHANGELOG.md), [`vello_cpu` changelog](vello_cpu/CHANGELOG.md), [`vello_gpu` changelog](vello_gpu/CHANGELOG.md), and [`vello_common` changelog](vello_common/CHANGELOG.md).
-
-## Package names and source folders
-
-Cargo package names do not have to match their source directory names. The research folders were renamed to make their role in this repository explicit without forcing existing crates.io users to migrate:
-
-- `research/vello_research/` still publishes as [`vello`](https://crates.io/crates/vello).
-- `research/vello_encoding/` still publishes as [`vello_encoding`](https://crates.io/crates/vello_encoding).
-- `research/vello_shaders/` still publishes as [`vello_shaders`](https://crates.io/crates/vello_shaders).
-
-Existing users of these three packages keep the same dependency and Rust import names. Only local or Git-based tooling that refers directly to repository folders needs to use the new `research/` paths.
-
-The repository's Sparse Strips package names did change: `vello_hybrid` became `vello_gpu`, and `vello_sparse_shaders` became `vello_gpu_shaders`. Git and local path dependencies that track this repository must use the new package and Rust import names. Existing crates.io releases under the old names remain available, and publication under the new names may lag behind the repository rename; check crates.io before selecting a released version.
-
-The development-only `vello_sparse_tests` package became the root-level `vello_tests`, while the research test helper package became `vello_research_tests`.
-
-There is no empty root-level `vello/` placeholder. A future shared abstraction can introduce a root directory when it has a concrete API; the current folder layout does not require changing the established `vello` package identity.
+Release histories are maintained in the
+[`vello` changelog](research/CHANGELOG.md),
+[`vello_cpu` changelog](vello_cpu/CHANGELOG.md),
+[`vello_gpu` changelog](vello_gpu/CHANGELOG.md), and
+[`vello_common` changelog](vello_common/CHANGELOG.md).
 
 ## Motivation
 
-Vello is intended to fill the same place in the graphics stack as vector renderers such as [Skia](https://skia.org/), [Cairo](https://www.cairographics.org/), and its predecessor project [Piet](https://github.com/linebender/piet). Its renderers draw shapes, images, gradients, and text using a PostScript-inspired imaging model like those behind SVG and the browser [`<canvas>` element](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D).
+Vello is intended to fill the same place in the graphics stack as vector
+renderers such as [Skia](https://skia.org/),
+[Cairo](https://www.cairographics.org/), and its predecessor project
+[Piet](https://github.com/linebender/piet). Its renderers draw shapes, images,
+gradients, and text using a PostScript-inspired imaging model like those behind
+SVG and the browser [`<canvas>` element][canvas].
 
-The implementations explore complementary ways to use SIMD, multithreading, and GPUs while sharing the same broader rendering goals.
+The implementations explore complementary ways to use SIMD, multithreading,
+and GPUs while sharing the same broader rendering goals.
 
 ## Minimum supported Rust Version (MSRV)
 
 This version of Vello has been verified to compile with **Rust 1.89** and later.
 
-Future versions of Vello might increase the Rust version requirement. It will not be treated as a breaking change and as such can even happen with small patch releases.
+Future versions of Vello might increase the Rust version requirement. It will
+not be treated as a breaking change and as such can even happen with small
+patch releases.
 
 <details>
 <summary>Click here if compiling fails.</summary>
 
-As time has passed, some of Vello's dependencies could have released versions with a higher Rust requirement. If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
+As time has passed, some of Vello's dependencies could have released versions
+with a higher Rust requirement. If you encounter a compilation issue due to a
+dependency and don't want to upgrade your Rust toolchain, then you could
+downgrade the dependency.
 
 ```sh
 # Use the problematic dependency's name and version
@@ -99,23 +120,45 @@ cargo update -p package_name --precise 0.1.1
 
 ## Community
 
-Discussion of Vello development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#vello channel](https://xi.zulipchat.com/#narrow/channel/197075-vello). All public content can be read without logging in.
+Discussion of Vello development happens in the
+[Linebender Zulip](https://xi.zulipchat.com/), specifically the
+[#vello channel](https://xi.zulipchat.com/#narrow/channel/197075-vello). All
+public content can be read without logging in.
 
 Contributions are welcome by pull request. The [Rust code of conduct] applies.
 
-Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache 2.0 license, shall be licensed as noted in the [License](#license) section, without any additional terms or conditions.
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache 2.0 license, shall be
+licensed as noted in the [License](#license) section, without any additional
+terms or conditions.
 
 ## License
 
 Licensed under either of
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or
+  <http://opensource.org/licenses/MIT>)
 
 at your option.
 
-In addition, all files in the [`research/vello_shaders/shader`](https://github.com/linebender/vello/tree/main/research/vello_shaders/shader) and [`research/vello_shaders/src/cpu`](https://github.com/linebender/vello/tree/main/research/vello_shaders/src/cpu) directories and subdirectories thereof are alternatively licensed under the Unlicense ([research/vello_shaders/shader/UNLICENSE](https://github.com/linebender/vello/blob/main/research/vello_shaders/shader/UNLICENSE) or <http://unlicense.org/>). For clarity, these files are also licensed under either of the above licenses. The intent is for this research to be used in as broad a context as possible.
+In addition, all files in the
+[`research/vello_shaders/shader`][vello-shaders-dir] and
+[`research/vello_shaders/src/cpu`][vello-shaders-cpu-dir] directories and
+subdirectories thereof are alternatively licensed under the Unlicense
+([research/vello_shaders/shader/UNLICENSE][shader-unlicense] or
+<http://unlicense.org/>). For clarity, these files are also licensed under
+either of the above licenses. The intent is for this research to be used in as
+broad a context as possible.
 
-The files in subdirectories of the [`assets`](https://github.com/linebender/vello/tree/main/assets) directory are licensed solely under their respective licenses, available in the `LICENSE` file in their directories.
+The files in subdirectories of the [`assets`][assets] directory are licensed
+solely under their respective licenses, available in the `LICENSE` file in
+their directories.
 
 [Rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct
+[assets]: https://github.com/linebender/vello/tree/main/assets
+[canvas]: https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D
+[shader-unlicense]: https://github.com/linebender/vello/blob/main/research/vello_shaders/shader/UNLICENSE
+[vello-shaders-cpu-dir]: https://github.com/linebender/vello/tree/main/research/vello_shaders/src/cpu
+[vello-shaders-dir]: https://github.com/linebender/vello/tree/main/research/vello_shaders/shader

--- a/research/README.md
+++ b/research/README.md
@@ -1,0 +1,52 @@
+# Vello compute renderer research
+
+This directory contains Vello's original compute-centric renderer and the code, examples, tests, and design history dedicated to it. The renderer performs most of its work in GPU compute shaders and requires a compute-capable GPU.
+
+For the CPU and broadly compatible GPU renderers at the repository root, start with the [project README](../README.md). See [ARCHITECTURE.md](../ARCHITECTURE.md) for a comparison of the renderer families.
+
+## Folder names and published package names
+
+The source folders use explicit research-oriented names so their role is clear in the repository. This did not rename the established crates.io packages:
+
+- [`vello_research/`](vello_research) contains the package published as [`vello`](https://crates.io/crates/vello).
+- [`vello_encoding/`](vello_encoding) contains the package published as [`vello_encoding`](https://crates.io/crates/vello_encoding).
+- [`vello_shaders/`](vello_shaders) contains the package published as [`vello_shaders`](https://crates.io/crates/vello_shaders).
+
+Users of those packages keep the same dependency and Rust import names. For example, the `vello` dependency key and `use vello::...` imports remain valid. Only local path dependencies and tools that refer to repository folders must use paths such as `research/vello_research`.
+
+The folder name `vello_research` describes this implementation's current role; this project does not publish a separate `vello_research` package.
+
+## Contents
+
+- [`vello_research/`](vello_research) — public `vello` rendering API and wgpu backend.
+- [`vello_encoding/`](vello_encoding) — scene encoding shared with the compute pipeline.
+- [`vello_shaders/`](vello_shaders) — compute shaders, shader preprocessing, and CPU reference kernels.
+- [`vello_research_tests/`](vello_research_tests) — integration tests, snapshots, and comparison helpers.
+- [`examples/`](examples) — standalone examples, including winit and headless applications.
+- [`xtask/`](xtask) — snapshot and comparison maintenance commands.
+- [`doc/`](doc) — historical design documents, roadmaps, and development notes.
+- [`CHANGELOG.md`](CHANGELOG.md) — release history for the `vello` package.
+
+## Getting started
+
+Run the main windowed example from the repository root:
+
+```shell
+cargo run -p with_winit --release
+```
+
+Other entry points include the `simple`, `simple_sdl2`, and `headless` example packages under [`examples/`](examples). The package README in [`vello_research/`](vello_research) has API setup, features, WebAssembly instructions, integrations, current limitations, and additional examples.
+
+## Repository migration
+
+The source directories moved as follows:
+
+- `vello/` → `research/vello_research/`
+- `vello_encoding/` → `research/vello_encoding/`
+- `vello_shaders/` → `research/vello_shaders/`
+- the former compute-renderer `vello_tests/` → `research/vello_research_tests/`
+- `examples/`, `doc/`, and `xtask/` → their corresponding paths under `research/`
+
+These are repository path changes. The published `vello`, `vello_encoding`, and `vello_shaders` package identities remain unchanged.
+
+The current root-level `vello_tests/` is a different, development-only package for Vello CPU and Vello GPU. It was formerly named `vello_sparse_tests`.

--- a/research/README.md
+++ b/research/README.md
@@ -1,30 +1,39 @@
 # Vello compute renderer research
 
-This directory contains Vello's original compute-centric renderer and the code, examples, tests, and design history dedicated to it. The renderer performs most of its work in GPU compute shaders and requires a compute-capable GPU.
+This directory contains Vello's original compute-centric renderer and the code,
+examples, tests, and design history dedicated to it. The renderer performs most
+of its work in GPU compute shaders and requires a compute-capable GPU.
 
-For the CPU and broadly compatible GPU renderers at the repository root, start with the [project README](../README.md). See [ARCHITECTURE.md](../ARCHITECTURE.md) for a comparison of the renderer families.
+For the CPU and broadly compatible GPU renderers at the repository root, start
+with the [project README](../README.md). See
+[ARCHITECTURE.md](../ARCHITECTURE.md) for a comparison of the renderer families.
 
-## Folder names and published package names
+## Packages
 
-The source folders use explicit research-oriented names so their role is clear in the repository. This did not rename the established crates.io packages:
+The research packages are organized as follows:
 
-- [`vello_research/`](vello_research) contains the package published as [`vello`](https://crates.io/crates/vello).
-- [`vello_encoding/`](vello_encoding) contains the package published as [`vello_encoding`](https://crates.io/crates/vello_encoding).
-- [`vello_shaders/`](vello_shaders) contains the package published as [`vello_shaders`](https://crates.io/crates/vello_shaders).
-
-Users of those packages keep the same dependency and Rust import names. For example, the `vello` dependency key and `use vello::...` imports remain valid. Only local path dependencies and tools that refer to repository folders must use paths such as `research/vello_research`.
-
-The folder name `vello_research` describes this implementation's current role; this project does not publish a separate `vello_research` package.
+- [`vello_research/`](vello_research) contains the package published as
+  [`vello`](https://crates.io/crates/vello).
+- [`vello_encoding/`](vello_encoding) contains the package published as
+  [`vello_encoding`](https://crates.io/crates/vello_encoding).
+- [`vello_shaders/`](vello_shaders) contains the package published as
+  [`vello_shaders`](https://crates.io/crates/vello_shaders).
 
 ## Contents
 
-- [`vello_research/`](vello_research) — public `vello` rendering API and wgpu backend.
-- [`vello_encoding/`](vello_encoding) — scene encoding shared with the compute pipeline.
-- [`vello_shaders/`](vello_shaders) — compute shaders, shader preprocessing, and CPU reference kernels.
-- [`vello_research_tests/`](vello_research_tests) — integration tests, snapshots, and comparison helpers.
-- [`examples/`](examples) — standalone examples, including winit and headless applications.
+- [`vello_research/`](vello_research) — public `vello` rendering API and wgpu
+  backend.
+- [`vello_encoding/`](vello_encoding) — scene encoding shared with the compute
+  pipeline.
+- [`vello_shaders/`](vello_shaders) — compute shaders, shader preprocessing,
+  and CPU reference kernels.
+- [`vello_research_tests/`](vello_research_tests) — integration tests,
+  snapshots, and comparison helpers.
+- [`examples/`](examples) — standalone examples, including winit and headless
+  applications.
 - [`xtask/`](xtask) — snapshot and comparison maintenance commands.
-- [`doc/`](doc) — historical design documents, roadmaps, and development notes.
+- [`doc/`](doc) — historical design documents, roadmaps, and development
+  notes.
 - [`CHANGELOG.md`](CHANGELOG.md) — release history for the `vello` package.
 
 ## Getting started
@@ -35,7 +44,10 @@ Run the main windowed example from the repository root:
 cargo run -p with_winit --release
 ```
 
-Other entry points include the `simple`, `simple_sdl2`, and `headless` example packages under [`examples/`](examples). The package README in [`vello_research/`](vello_research) has API setup, features, WebAssembly instructions, integrations, current limitations, and additional examples.
+Other entry points include the `simple`, `simple_sdl2`, and `headless` example
+packages under [`examples/`](examples). The package README in
+[`vello_research/`](vello_research) has API setup, features, WebAssembly
+instructions, integrations, current limitations, and additional examples.
 
 ## Repository migration
 
@@ -44,9 +56,13 @@ The source directories moved as follows:
 - `vello/` → `research/vello_research/`
 - `vello_encoding/` → `research/vello_encoding/`
 - `vello_shaders/` → `research/vello_shaders/`
-- the former compute-renderer `vello_tests/` → `research/vello_research_tests/`
-- `examples/`, `doc/`, and `xtask/` → their corresponding paths under `research/`
+- the former compute-renderer `vello_tests/` →
+  `research/vello_research_tests/`
+- `examples/`, `doc/`, and `xtask/` → their corresponding paths under
+  `research/`
 
-These are repository path changes. The published `vello`, `vello_encoding`, and `vello_shaders` package identities remain unchanged.
+These are repository path changes. The published `vello`, `vello_encoding`, and
+`vello_shaders` package identities remain unchanged.
 
-The current root-level `vello_tests/` is a different, development-only package for Vello CPU and Vello GPU. It was formerly named `vello_sparse_tests`.
+The current root-level `vello_tests/` is a different, development-only package
+for Vello CPU and Vello GPU. It was formerly named `vello_sparse_tests`.

--- a/research/vello_encoding/README.md
+++ b/research/vello_encoding/README.md
@@ -16,11 +16,13 @@
 
 This package contains types that represent data that [Vello] can render.
 
+Its source now lives under `research/`, but its published package and Rust crate name remain `vello_encoding`.
+
 Significant changes are documented in [the changelog].
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Vello Encoding has been verified to compile with **Rust 1.92** and later.
+This version of Vello Encoding has been verified to compile with **Rust 1.89** and later.
 
 Future versions of Vello Encoding might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.
@@ -50,11 +52,11 @@ The [Rust code of conduct] applies.
 
 Licensed under either of
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+- Apache License, Version 2.0 ([LICENSE-APACHE](../../LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](../../LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.
 
 [Rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct
-[Vello]: https://github.com/linebender/vello
+[Vello]: ../vello_research
 [the changelog]: https://github.com/linebender/vello/tree/main/research/CHANGELOG.md

--- a/research/vello_encoding/README.md
+++ b/research/vello_encoding/README.md
@@ -8,30 +8,31 @@
 [![Documentation build status.](https://img.shields.io/docsrs/vello_encoding.svg)](https://docs.rs/vello_encoding)
 [![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
 \
-[![Linebender Zulip chat.](https://img.shields.io/badge/Linebender-%23vello-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/197075-vello)
-[![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/linebender/vello/ci.yml?logo=github&label=CI)](https://github.com/linebender/vello/actions)
+[![Linebender Zulip chat.](https://img.shields.io/badge/Linebender-%23vello-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/197075-vello) [![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/linebender/vello/ci.yml?logo=github&label=CI)](https://github.com/linebender/vello/actions)
 [![Dependency staleness status.](https://deps.rs/crate/vello_encoding/latest/status.svg)](https://deps.rs/crate/vello_encoding)
 
 </div>
 
 This package contains types that represent data that [Vello] can render.
 
-Its source now lives under `research/`, but its published package and Rust crate name remain `vello_encoding`.
-
 Significant changes are documented in [the changelog].
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Vello Encoding has been verified to compile with **Rust 1.89** and later.
+This version of Vello Encoding has been verified to compile with **Rust 1.89**
+and later.
 
 Future versions of Vello Encoding might increase the Rust version requirement.
-It will not be treated as a breaking change and as such can even happen with small patch releases.
+It will not be treated as a breaking change and as such can even happen with
+small patch releases.
 
 <details>
 <summary>Click here if compiling fails.</summary>
 
-As time has passed, some of Vello Encoding's dependencies could have released versions with a higher Rust requirement.
-If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
+As time has passed, some of Vello Encoding's dependencies could have released
+versions with a higher Rust requirement. If you encounter a compilation issue
+due to a dependency and don't want to upgrade your Rust toolchain, then you
+could downgrade the dependency.
 
 ```sh
 # Use the problematic dependency's name and version
@@ -42,21 +43,25 @@ cargo update -p package_name --precise 0.1.1
 
 ## Community
 
-Discussion of Vello Encoding development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#vello channel](https://xi.zulipchat.com/#narrow/channel/197075-vello).
-All public content can be read without logging in.
+Discussion of Vello Encoding development happens in the
+[Linebender Zulip](https://xi.zulipchat.com/), specifically the
+[#vello channel](https://xi.zulipchat.com/#narrow/channel/197075-vello). All
+public content can be read without logging in.
 
-Contributions are welcome by pull request.
-The [Rust code of conduct] applies.
+Contributions are welcome by pull request. The [Rust code of conduct] applies.
 
 ## License
 
 Licensed under either of
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](../../LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
-- MIT license ([LICENSE-MIT](../../LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+- Apache License, Version 2.0 ([LICENSE-APACHE](../../LICENSE-APACHE) or
+  <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](../../LICENSE-MIT) or
+  <http://opensource.org/licenses/MIT>)
 
 at your option.
 
 [Rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct
 [Vello]: ../vello_research
-[the changelog]: https://github.com/linebender/vello/tree/main/research/CHANGELOG.md
+[the changelog]:
+  https://github.com/linebender/vello/tree/main/research/CHANGELOG.md

--- a/research/vello_research/README.md
+++ b/research/vello_research/README.md
@@ -2,23 +2,21 @@
 
 # Vello
 
-**Compute-centric 2D renderer research**
+**GPU compute-centric 2D renderer research**
 
 [![Latest published version.](https://img.shields.io/crates/v/vello.svg)](https://crates.io/crates/vello)
 [![Documentation build status.](https://img.shields.io/docsrs/vello.svg)](https://docs.rs/vello)
 [![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
 [![Required wgpu version.](https://img.shields.io/badge/wgpu-v29.0.3-orange.svg)](https://crates.io/crates/wgpu)
 \
-[![Linebender Zulip chat.](https://img.shields.io/badge/Linebender-%23vello-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/197075-vello)
-[![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/linebender/vello/ci.yml?logo=github&label=CI)](https://github.com/linebender/vello/actions)
+[![Linebender Zulip chat.](https://img.shields.io/badge/Linebender-%23vello-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/197075-vello) [![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/linebender/vello/ci.yml?logo=github&label=CI)](https://github.com/linebender/vello/actions)
 [![Dependency staleness status.](https://deps.rs/crate/vello/latest/status.svg)](https://deps.rs/crate/vello)
 
 </div>
 
-Vello is a 2D graphics rendering engine written in Rust, with a focus on GPU compute.
-It can draw large 2D scenes with interactive or near-interactive performance, using [`wgpu`] for GPU access.
-
-The source for this package now lives in `research/vello_research/` to identify its compute-centric research role within the repository. Its published Cargo package and Rust crate name remain `vello`; existing crates.io users do not need to rename their dependencies or imports. See the [research overview](../README.md) for the folder map and migration details.
+Vello is a 2D graphics rendering engine written in Rust, with a focus on GPU
+compute. It can draw large 2D scenes with interactive or near-interactive
+performance, using [`wgpu`] for GPU access.
 
 Quickstart to run an example program:
 
@@ -41,12 +39,14 @@ The `vello` crate provides the following Cargo features:
 - `hot_reload` enables development-only shader hot reloading inside the Vello
   repository.
 
-See the [Cargo feature documentation](https://doc.rust-lang.org/cargo/reference/features.html)
+See the
+[Cargo feature documentation](https://doc.rust-lang.org/cargo/reference/features.html)
 for details on enabling and combining features.
 
 > ⚠️ WARNING
 >
-> Vello can currently be considered in an alpha state. In particular, we're still working on the following:
+> Vello can currently be considered in an alpha state. In particular, we're
+> still working on the following:
 >
 > - [Implementing blur and filter effects](https://github.com/linebender/vello/issues/476).
 > - [Conflations artifacts](https://github.com/linebender/vello/issues/49).
@@ -57,21 +57,32 @@ Significant changes are documented in [the changelog].
 
 ## Motivation
 
-Vello is meant to fill the same place in the graphics stack as other vector graphics renderers like [Skia](https://skia.org/), [Cairo](https://www.cairographics.org/), and its predecessor project [Piet](https://github.com/linebender/piet).
-On a basic level, that means it provides tools to render shapes, images, gradients, text, etc, using a PostScript-inspired API, the same that powers SVG files and [the browser `<canvas>` element](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D).
+Vello is meant to fill the same place in the graphics stack as other vector
+graphics renderers like [Skia](https://skia.org/),
+[Cairo](https://www.cairographics.org/), and its predecessor project
+[Piet](https://github.com/linebender/piet). On a basic level, that means it
+provides tools to render shapes, images, gradients, text, etc, using a
+PostScript-inspired API, the same that powers SVG files and
+[the browser `<canvas>` element](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D).
 
-Vello's selling point is that it gets better performance than other renderers by better leveraging the GPU.
-In traditional PostScript-style renderers, some steps of the render process like sorting and clipping either need to be handled in the CPU or done through the use of intermediary textures.
-Vello avoids this by using prefix-sum algorithms to parallelize work that usually needs to happen in sequence, so that work can be offloaded to the GPU with minimal use of temporary buffers.
+Vello's selling point is that it gets better performance than other renderers by
+better leveraging the GPU. In traditional PostScript-style renderers, some steps
+of the render process like sorting and clipping either need to be handled in the
+CPU or done through the use of intermediary textures. Vello avoids this by using
+prefix-sum algorithms to parallelize work that usually needs to happen in
+sequence, so that work can be offloaded to the GPU with minimal use of temporary
+buffers.
 
 This means that Vello needs a GPU with support for compute shaders to run.
 
 ## Getting started
 
-Vello is meant to be integrated deep in UI render stacks.
-While drawing in a Vello scene is easy, actually rendering that scene to a surface requires setting up a wgpu context, which is a non-trivial task.
+Vello is meant to be integrated deep in UI render stacks. While drawing in a
+Vello scene is easy, actually rendering that scene to a surface requires setting
+up a wgpu context, which is a non-trivial task.
 
-To use Vello as the renderer for your PDF reader / GUI toolkit / etc, your code will have to look roughly like this:
+To use Vello as the renderer for your PDF reader / GUI toolkit / etc, your code
+will have to look roughly like this:
 
 ```rust
 // Initialize wgpu and get handles
@@ -116,11 +127,15 @@ renderer
 // wgpu::util::TextureBlitter.
 ```
 
-See the repository's [`research/examples`](https://github.com/linebender/vello/tree/main/research/examples) directory for code that integrates with frameworks like winit.
+See the repository's
+[`research/examples`](https://github.com/linebender/vello/tree/main/research/examples)
+directory for code that integrates with frameworks like winit.
 
 ## Performance
 
-We've observed 177 fps for the paris-30k test scene on an M1 Max, at a resolution of 1600 pixels square, which is excellent performance and represents something of a best case for the engine.
+We've observed 177 fps for the paris-30k test scene on an M1 Max, at a
+resolution of 1600 pixels square, which is excellent performance and represents
+something of a best case for the engine.
 
 More formal benchmarks are on their way.
 
@@ -128,28 +143,38 @@ More formal benchmarks are on their way.
 
 ### SVG
 
-A separate Linebender integration for rendering SVG files is available through [`vello_svg`](https://github.com/linebender/vello_svg).
+A separate Linebender integration for rendering SVG files is available through
+[`vello_svg`](https://github.com/linebender/vello_svg).
 
 ### Lottie
 
-A separate Linebender integration for playing Lottie animations is available through [`velato`](https://github.com/linebender/velato).
+A separate Linebender integration for playing Lottie animations is available
+through [`velato`](https://github.com/linebender/velato).
 
 ### Bevy
 
-A separate Linebender integration for rendering raw scenes or Lottie and SVG files in [Bevy] through [`bevy_vello`](https://github.com/linebender/bevy_vello).
+A separate Linebender integration for rendering raw scenes or Lottie and SVG
+files in [Bevy] through
+[`bevy_vello`](https://github.com/linebender/bevy_vello).
 
 ## Examples
 
-Our examples are provided in separate packages in the repository's [`research/examples`](https://github.com/linebender/vello/tree/main/research/examples) directory.
-This allows them to have independent dependencies and faster builds.
+Our examples are provided in separate packages in the repository's
+[`research/examples`](https://github.com/linebender/vello/tree/main/research/examples)
+directory. This allows them to have independent dependencies and faster builds.
 Examples must be selected using the `--package` (or `-p`) Cargo flag.
 
 ### Winit
 
-Our [winit] example ([research/examples/with_winit](https://github.com/linebender/vello/tree/main/research/examples/with_winit)) demonstrates rendering to a [winit] window.
-By default, this renders the [GhostScript Tiger] as well as all SVG files you add in the [assets/downloads](https://github.com/linebender/vello/tree/main/assets/downloads) directory.
-A custom list of SVG file paths (and directories to render all SVG files from) can be provided as arguments instead.
-It also includes a collection of test scenes showing the capabilities of `vello`, which can be shown with `--test-scenes`.
+Our [winit] example
+([research/examples/with_winit](https://github.com/linebender/vello/tree/main/research/examples/with_winit))
+demonstrates rendering to a [winit] window. By default, this renders the
+[GhostScript Tiger] as well as all SVG files you add in the
+[assets/downloads](https://github.com/linebender/vello/tree/main/assets/downloads)
+directory. A custom list of SVG file paths (and directories to render all SVG
+files from) can be provided as arguments instead. It also includes a collection
+of test scenes showing the capabilities of `vello`, which can be shown with
+`--test-scenes`.
 
 ```shell
 cargo run -p with_winit
@@ -159,19 +184,22 @@ cargo run -p with_winit
 
 ## Platforms
 
-We aim to target all environments which can support WebGPU with the [default limits](https://www.w3.org/TR/webgpu/#limits).
-We defer to [`wgpu`] for this support.
-Other platforms are more tricky, and may require special building/running procedures.
+We aim to target all environments which can support WebGPU with the
+[default limits](https://www.w3.org/TR/webgpu/#limits). We defer to [`wgpu`] for
+this support. Other platforms are more tricky, and may require special
+building/running procedures.
 
 ### Web
 
-Because Vello relies heavily on compute shaders, we rely on the emerging WebGPU standard to run on the web.
-Browser support for WebGPU is still evolving.
-Vello has been tested using production versions of Chrome, but WebGPU support in Firefox and Safari is still experimental.
-It may be necessary to use development browsers and explicitly enable WebGPU.
+Because Vello relies heavily on compute shaders, we rely on the emerging WebGPU
+standard to run on the web. Browser support for WebGPU is still evolving. Vello
+has been tested using production versions of Chrome, but WebGPU support in
+Firefox and Safari is still experimental. It may be necessary to use development
+browsers and explicitly enable WebGPU.
 
 The following command builds and runs a web version of the [winit demo](#winit).
-This uses [`cargo-run-wasm`](https://github.com/rukai/cargo-run-wasm) to build the example for web, and host a local server for it
+This uses [`cargo-run-wasm`](https://github.com/rukai/cargo-run-wasm) to build
+the example for web, and host a local server for it
 
 ```shell
 # Make sure the Rust toolchain supports the wasm32 target
@@ -181,15 +209,19 @@ rustup target add wasm32-unknown-unknown
 cargo run_wasm -p with_winit --bin with_winit_bin
 ```
 
-There is also a web demo [available here](https://linebender.github.io/vello) on supporting web browsers.
+There is also a web demo [available here](https://linebender.github.io/vello) on
+supporting web browsers.
 
 > ⚠️ WARNING
 >
-> The web is not currently a primary target for Vello, and WebGPU implementations are incomplete, so you might run into issues running this example.
+> The web is not currently a primary target for Vello, and WebGPU
+> implementations are incomplete, so you might run into issues running this
+> example.
 
 ### Android
 
-The [`with_winit`](#winit) example supports running on Android, using [cargo apk](https://crates.io/crates/cargo-apk).
+The [`with_winit`](#winit) example supports running on Android, using
+[cargo apk](https://crates.io/crates/cargo-apk).
 
 ```shell
 cargo apk run -p with_winit --lib
@@ -197,11 +229,14 @@ cargo apk run -p with_winit --lib
 
 > 💡 TIP
 >
-> cargo apk doesn't support running in release mode without configuration.
-> See [their crates page docs](https://crates.io/crates/cargo-apk) (around `package.metadata.android.signing.<profile>`).
+> cargo apk doesn't support running in release mode without configuration. See
+> [their crates page docs](https://crates.io/crates/cargo-apk) (around
+> `package.metadata.android.signing.<profile>`).
 >
 > See also [cargo-apk#16](https://github.com/rust-mobile/cargo-apk/issues/16).
-> To run in release mode, you must add the following to `research/examples/with_winit/Cargo.toml` (changing `$HOME` to your home directory):
+> To run in release mode, you must add the following to
+> `research/examples/with_winit/Cargo.toml` (changing `$HOME` to your home
+> directory):
 
 ```toml
 [package.metadata.android.signing.release]
@@ -211,12 +246,14 @@ keystore_password = "android"
 
 > 📝 NOTE
 >
-> As `cargo apk` does not allow passing command line arguments or environment variables to the app when ran, these can be embedded into the
-> program at compile time (currently for Android only)
-> `with_winit` currently supports the environment variables:
+> As `cargo apk` does not allow passing command line arguments or environment
+> variables to the app when ran, these can be embedded into the program at
+> compile time (currently for Android only) `with_winit` currently supports the
+> environment variables:
 >
 > - `VELLO_STATIC_LOG`, which is equivalent to `RUST_LOG`
-> - `VELLO_STATIC_ARGS`, which is equivalent to passing in command line arguments
+> - `VELLO_STATIC_ARGS`, which is equivalent to passing in command line
+>   arguments
 
 For example (with unix shell environment variable syntax):
 
@@ -228,14 +265,17 @@ VELLO_STATIC_LOG="vello=trace" VELLO_STATIC_ARGS="--test-scenes" cargo apk run -
 
 This version of Vello has been verified to compile with **Rust 1.89** and later.
 
-Future versions of Vello might increase the Rust version requirement.
-It will not be treated as a breaking change and as such can even happen with small patch releases.
+Future versions of Vello might increase the Rust version requirement. It will
+not be treated as a breaking change and as such can even happen with small patch
+releases.
 
 <details>
 <summary>Click here if compiling fails.</summary>
 
-As time has passed, some of Vello's dependencies could have released versions with a higher Rust requirement.
-If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
+As time has passed, some of Vello's dependencies could have released versions
+with a higher Rust requirement. If you encounter a compilation issue due to a
+dependency and don't want to upgrade your Rust toolchain, then you could
+downgrade the dependency.
 
 ```sh
 # Use the problematic dependency's name and version
@@ -246,24 +286,31 @@ cargo update -p package_name --precise 0.1.1
 
 ## Community
 
-Discussion of Vello development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#vello channel](https://xi.zulipchat.com/#narrow/channel/197075-vello).
-All public content can be read without logging in.
+Discussion of Vello development happens in the
+[Linebender Zulip](https://xi.zulipchat.com/), specifically the
+[#vello channel](https://xi.zulipchat.com/#narrow/channel/197075-vello). All
+public content can be read without logging in.
 
-Contributions are welcome by pull request.
-The [Rust code of conduct] applies.
+Contributions are welcome by pull request. The [Rust code of conduct] applies.
 
 ## History
 
-Vello was previously known as `piet-gpu`.
-This prior incarnation used a custom cross-API hardware abstraction layer, called `piet-gpu-hal`, instead of [`wgpu`].
+Vello was previously known as `piet-gpu`. This prior incarnation used a custom
+cross-API hardware abstraction layer, called `piet-gpu-hal`, instead of
+[`wgpu`].
 
-An archive of this version can be found in the branches [`custom-hal-archive-with-shaders`] and [`custom-hal-archive`].
-This succeeded the previous prototype, [piet-metal], and included work adapted from [piet-dx12].
+An archive of this version can be found in the branches
+[`custom-hal-archive-with-shaders`] and [`custom-hal-archive`]. This succeeded
+the previous prototype, [piet-metal], and included work adapted from
+[piet-dx12].
 
-The decision to lay down `piet-gpu-hal` in favor of WebGPU is discussed in detail in the blog post [Requiem for piet-gpu-hal].
+The decision to lay down `piet-gpu-hal` in favor of WebGPU is discussed in
+detail in the blog post [Requiem for piet-gpu-hal].
 
-A [vision](https://github.com/linebender/vello/tree/main/research/doc/vision.md) document dated December 2020 explained the longer-term goals of the project, and how we might get there.
-Many of these items are out-of-date or completed, but it still may provide some useful background.
+A [vision](https://github.com/linebender/vello/tree/main/research/doc/vision.md)
+document dated December 2020 explained the longer-term goals of the project, and
+how we might get there. Many of these items are out-of-date or completed, but it
+still may provide some useful background.
 
 ## Related projects
 
@@ -279,19 +326,26 @@ Vello takes inspiration from many other rendering projects, including:
 
 Licensed under either of
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](../../LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
-- MIT license ([LICENSE-MIT](../../LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+- Apache License, Version 2.0 ([LICENSE-APACHE](../../LICENSE-APACHE) or
+  <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](../../LICENSE-MIT) or
+  <http://opensource.org/licenses/MIT>)
 
 at your option.
 
 [piet-metal]: https://github.com/linebender/piet-metal
 [`wgpu`]: https://wgpu.rs/
 [Rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct
-[`custom-hal-archive-with-shaders`]: https://github.com/linebender/piet-gpu/tree/custom-hal-archive-with-shaders
-[`custom-hal-archive`]: https://github.com/linebender/piet-gpu/tree/custom-hal-archive
+[`custom-hal-archive-with-shaders`]:
+  https://github.com/linebender/piet-gpu/tree/custom-hal-archive-with-shaders
+[`custom-hal-archive`]:
+  https://github.com/linebender/piet-gpu/tree/custom-hal-archive
 [piet-dx12]: https://github.com/bzm3r/piet-dx12
-[GhostScript tiger]: https://commons.wikimedia.org/wiki/File:Ghostscript_Tiger.svg
+[GhostScript tiger]:
+  https://commons.wikimedia.org/wiki/File:Ghostscript_Tiger.svg
 [winit]: https://github.com/rust-windowing/winit
 [Bevy]: https://bevyengine.org/
-[Requiem for piet-gpu-hal]: https://raphlinus.github.io/rust/gpu/2023/01/07/requiem-piet-gpu-hal.html
-[the changelog]: https://github.com/linebender/vello/tree/main/research/CHANGELOG.md
+[Requiem for piet-gpu-hal]:
+  https://raphlinus.github.io/rust/gpu/2023/01/07/requiem-piet-gpu-hal.html
+[the changelog]:
+  https://github.com/linebender/vello/tree/main/research/CHANGELOG.md

--- a/research/vello_research/README.md
+++ b/research/vello_research/README.md
@@ -2,12 +2,12 @@
 
 # Vello
 
-**A GPU compute-centric 2D renderer**
+**Compute-centric 2D renderer research**
 
 [![Latest published version.](https://img.shields.io/crates/v/vello.svg)](https://crates.io/crates/vello)
 [![Documentation build status.](https://img.shields.io/docsrs/vello.svg)](https://docs.rs/vello)
 [![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
-[![Required wgpu version.](https://img.shields.io/badge/wgpu-v29.0.1-orange.svg)](https://crates.io/crates/wgpu)
+[![Required wgpu version.](https://img.shields.io/badge/wgpu-v29.0.3-orange.svg)](https://crates.io/crates/wgpu)
 \
 [![Linebender Zulip chat.](https://img.shields.io/badge/Linebender-%23vello-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/197075-vello)
 [![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/linebender/vello/ci.yml?logo=github&label=CI)](https://github.com/linebender/vello/actions)
@@ -18,6 +18,8 @@
 Vello is a 2D graphics rendering engine written in Rust, with a focus on GPU compute.
 It can draw large 2D scenes with interactive or near-interactive performance, using [`wgpu`] for GPU access.
 
+The source for this package now lives in `research/vello_research/` to identify its compute-centric research role within the repository. Its published Cargo package and Rust crate name remain `vello`; existing crates.io users do not need to rename their dependencies or imports. See the [research overview](../README.md) for the folder map and migration details.
+
 Quickstart to run an example program:
 
 ```shell
@@ -25,8 +27,6 @@ cargo run -p with_winit
 ```
 
 ![image](https://github.com/linebender/vello/assets/8573618/cc2b742e-2135-4b70-8051-c49aeddb5d19)
-
-It is used as the rendering backend for [Xilem], a Rust GUI toolkit.
 
 ## Features
 
@@ -226,7 +226,7 @@ VELLO_STATIC_LOG="vello=trace" VELLO_STATIC_ARGS="--test-scenes" cargo apk run -
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Vello has been verified to compile with **Rust 1.92** and later.
+This version of Vello has been verified to compile with **Rust 1.89** and later.
 
 Future versions of Vello might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.
@@ -279,14 +279,13 @@ Vello takes inspiration from many other rendering projects, including:
 
 Licensed under either of
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+- Apache License, Version 2.0 ([LICENSE-APACHE](../../LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](../../LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.
 
 [piet-metal]: https://github.com/linebender/piet-metal
 [`wgpu`]: https://wgpu.rs/
-[Xilem]: https://github.com/linebender/xilem/
 [Rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct
 [`custom-hal-archive-with-shaders`]: https://github.com/linebender/piet-gpu/tree/custom-hal-archive-with-shaders
 [`custom-hal-archive`]: https://github.com/linebender/piet-gpu/tree/custom-hal-archive

--- a/research/vello_research/src/lib.rs
+++ b/research/vello_research/src/lib.rs
@@ -1,8 +1,13 @@
 // Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-//! Vello is a 2d graphics rendering engine written in Rust, using [`wgpu`].
-//! It efficiently draws large 2d scenes with interactive or near-interactive performance.
+//! Vello is a compute-centric 2D graphics rendering engine written in Rust,
+//! using [`wgpu`].
+//! It efficiently draws large 2D scenes with interactive or near-interactive
+//! performance.
+//!
+//! The source lives in the repository's `research/vello_research/` directory,
+//! but its published package and Rust crate name remain `vello`.
 //!
 //! ![image](https://github.com/linebender/vello/assets/8573618/cc2b742e-2135-4b70-8051-c49aeddb5d19)
 //!

--- a/research/vello_research/src/lib.rs
+++ b/research/vello_research/src/lib.rs
@@ -6,9 +6,6 @@
 //! It efficiently draws large 2D scenes with interactive or near-interactive
 //! performance.
 //!
-//! The source lives in the repository's `research/vello_research/` directory,
-//! but its published package and Rust crate name remain `vello`.
-//!
 //! ![image](https://github.com/linebender/vello/assets/8573618/cc2b742e-2135-4b70-8051-c49aeddb5d19)
 //!
 //!

--- a/research/vello_research_tests/README.md
+++ b/research/vello_research_tests/README.md
@@ -1,11 +1,12 @@
-# Vello Tests
+# Vello Research Tests
 
-This folder contains the infrastructure used for testing Vello.
-The kinds of test currently used are:
+This development-only package contains test infrastructure for the compute-centric [`vello`](../vello_research) renderer. Its package name is `vello_research_tests`; it is distinct from the root-level [`vello_tests`](../../vello_tests) package used by Vello CPU and Vello GPU.
+
+The kinds of tests currently used are:
 
 - Property tests
     - These tests are run on both the GPU and CPU.
-    - These create scenes with
+    - These generate scenes and compare the renderer pathways.
 - Snapshot tests
     - These tests use the GPU shaders as a source of truth, but the CPU shaders are also ran for these tests.
     - These have a non-exact comparison metric, because of small differences between rendering on different platforms.

--- a/research/vello_shaders/README.md
+++ b/research/vello_shaders/README.md
@@ -8,34 +8,39 @@
 [![Documentation build status.](https://img.shields.io/docsrs/vello_shaders.svg)](https://docs.rs/vello_shaders)
 [![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
 \
-[![Linebender Zulip chat.](https://img.shields.io/badge/Linebender-%23vello-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/197075-vello)
-[![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/linebender/vello/ci.yml?logo=github&label=CI)](https://github.com/linebender/vello/actions)
+[![Linebender Zulip chat.](https://img.shields.io/badge/Linebender-%23vello-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/197075-vello) [![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/linebender/vello/ci.yml?logo=github&label=CI)](https://github.com/linebender/vello/actions)
 [![Dependency staleness status.](https://deps.rs/crate/vello_shaders/latest/status.svg)](https://deps.rs/crate/vello_shaders)
 
 </div>
 
-This is a utility library to help integrate the [Vello] shader modules into any renderer project.
-It provides the necessary metadata to construct the individual compute pipelines on any GPU API while leaving the responsibility of all API interactions (such as resource management and command encoding) up to the client.
+This is a utility library to help integrate the [Vello] shader modules into any
+renderer project. It provides the necessary metadata to construct the individual
+compute pipelines on any GPU API while leaving the responsibility of all API
+interactions (such as resource management and command encoding) up to the
+client.
 
-Its source now lives under `research/`, but its published package and Rust crate name remain `vello_shaders`.
-
-The shaders can be pre-compiled to any target shading language at build time based on feature flags.
-Currently only WGSL and Metal Shading Language are supported.
+The shaders can be pre-compiled to any target shading language at build time
+based on feature flags. Currently only WGSL and Metal Shading Language are
+supported.
 
 Significant changes are documented in [the changelog].
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Vello Shaders has been verified to compile with **Rust 1.89** and later.
+This version of Vello Shaders has been verified to compile with **Rust 1.89**
+and later.
 
-Future versions of Vello Shaders might increase the Rust version requirement.
-It will not be treated as a breaking change and as such can even happen with small patch releases.
+Future versions of Vello Shaders might increase the Rust version requirement. It
+will not be treated as a breaking change and as such can even happen with small
+patch releases.
 
 <details>
 <summary>Click here if compiling fails.</summary>
 
-As time has passed, some of Vello Shaders' dependencies could have released versions with a higher Rust requirement.
-If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
+As time has passed, some of Vello Shaders' dependencies could have released
+versions with a higher Rust requirement. If you encounter a compilation issue
+due to a dependency and don't want to upgrade your Rust toolchain, then you
+could downgrade the dependency.
 
 ```sh
 # Use the problematic dependency's name and version
@@ -46,25 +51,34 @@ cargo update -p package_name --precise 0.1.1
 
 ## Community
 
-Discussion of Vello Shaders development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#vello channel](https://xi.zulipchat.com/#narrow/channel/197075-vello).
-All public content can be read without logging in.
+Discussion of Vello Shaders development happens in the
+[Linebender Zulip](https://xi.zulipchat.com/), specifically the
+[#vello channel](https://xi.zulipchat.com/#narrow/channel/197075-vello). All
+public content can be read without logging in.
 
-Contributions are welcome by pull request.
-The [Rust code of conduct] applies.
+Contributions are welcome by pull request. The [Rust code of conduct] applies.
 
 ## License
 
 Licensed under either of
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](../../LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
-- MIT license ([LICENSE-MIT](../../LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+- Apache License, Version 2.0 ([LICENSE-APACHE](../../LICENSE-APACHE) or
+  <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](../../LICENSE-MIT) or
+  <http://opensource.org/licenses/MIT>)
 
 at your option.
 
-In addition, all files in the [`shader`](https://github.com/linebender/vello/tree/main/research/vello_shaders/shader) and [`src/cpu`](https://github.com/linebender/vello/tree/main/research/vello_shaders/src/cpu) directories and subdirectories thereof are alternatively licensed under the Unlicense ([shader/UNLICENSE](shader/UNLICENSE) or <http://unlicense.org/>).
-For clarity, these files are also licensed under either of the above licenses.
-The intent is for this research to be used in as broad a context as possible.
+In addition, all files in the
+[`shader`](https://github.com/linebender/vello/tree/main/research/vello_shaders/shader)
+and
+[`src/cpu`](https://github.com/linebender/vello/tree/main/research/vello_shaders/src/cpu)
+directories and subdirectories thereof are alternatively licensed under the
+Unlicense ([shader/UNLICENSE](shader/UNLICENSE) or <http://unlicense.org/>). For
+clarity, these files are also licensed under either of the above licenses. The
+intent is for this research to be used in as broad a context as possible.
 
 [Rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct
 [Vello]: ../vello_research
-[the changelog]: https://github.com/linebender/vello/tree/main/research/CHANGELOG.md
+[the changelog]:
+  https://github.com/linebender/vello/tree/main/research/CHANGELOG.md

--- a/research/vello_shaders/README.md
+++ b/research/vello_shaders/README.md
@@ -17,6 +17,8 @@
 This is a utility library to help integrate the [Vello] shader modules into any renderer project.
 It provides the necessary metadata to construct the individual compute pipelines on any GPU API while leaving the responsibility of all API interactions (such as resource management and command encoding) up to the client.
 
+Its source now lives under `research/`, but its published package and Rust crate name remain `vello_shaders`.
+
 The shaders can be pre-compiled to any target shading language at build time based on feature flags.
 Currently only WGSL and Metal Shading Language are supported.
 
@@ -24,7 +26,7 @@ Significant changes are documented in [the changelog].
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Vello Shaders has been verified to compile with **Rust 1.92** and later.
+This version of Vello Shaders has been verified to compile with **Rust 1.89** and later.
 
 Future versions of Vello Shaders might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.
@@ -54,15 +56,15 @@ The [Rust code of conduct] applies.
 
 Licensed under either of
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+- Apache License, Version 2.0 ([LICENSE-APACHE](../../LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](../../LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.
 
-In addition, all files in the [`shader`](https://github.com/linebender/vello/tree/main/research/vello_shaders/shader) and [`src/cpu`](https://github.com/linebender/vello/tree/main/research/vello_shaders/src/cpu) directories and subdirectories thereof are alternatively licensed under the Unlicense ([shader/UNLICENSE](https://github.com/linebender/vello/tree/main/research/vello_shaders/shader/UNLICENSE) or <http://unlicense.org/>).
+In addition, all files in the [`shader`](https://github.com/linebender/vello/tree/main/research/vello_shaders/shader) and [`src/cpu`](https://github.com/linebender/vello/tree/main/research/vello_shaders/src/cpu) directories and subdirectories thereof are alternatively licensed under the Unlicense ([shader/UNLICENSE](shader/UNLICENSE) or <http://unlicense.org/>).
 For clarity, these files are also licensed under either of the above licenses.
 The intent is for this research to be used in as broad a context as possible.
 
 [Rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct
-[Vello]: https://github.com/linebender/vello
+[Vello]: ../vello_research
 [the changelog]: https://github.com/linebender/vello/tree/main/research/CHANGELOG.md

--- a/vello_common/README.md
+++ b/vello_common/README.md
@@ -26,16 +26,12 @@ See https://linebender.org/blog/doc-include/ for related discussion. -->
 [crate::pixmap::Pixmap]: https://docs.rs/vello_common/latest/vello_common/pixmap/struct.Pixmap.html
 <!-- cargo-rdme start -->
 
-This crate includes common geometry representations, tiling logic, and other fundamental components used by both [Vello CPU][vello_cpu] and Vello GPU.
+This crate includes common geometry representations, tiling logic, and other fundamental components used by both [Vello CPU][vello_cpu] and [Vello GPU][vello_gpu].
 
 ## Usage
 
 This crate should not be used on its own, and you should instead use one of the renderers which use it.
-At the moment, only [Vello CPU][vello_cpu] is published, and you probably want to use that.
-
-We also develop [Vello](https://crates.io/crates/vello), which makes use of the GPU for 2D rendering and has higher performance than Vello CPU.
-Vello CPU is being developed as part of work to address shortcomings in Vello.
-Vello does not use this crate.
+Choose [Vello CPU][vello_cpu] for CPU-only rendering or [Vello GPU][vello_gpu] for GPU rasterization with CPU-side preprocessing. The compute-centric [`vello`](https://crates.io/crates/vello) renderer is a separate architecture and does not use this crate.
 
 ## Features
 
@@ -57,6 +53,7 @@ At least one of `std` and `libm` is required; `std` overrides `libm`.
 This crate acts as a foundation for `vello_cpu` and `vello_gpu`, providing essential components to minimize duplication.
 
 [vello_cpu]: https://crates.io/crates/vello_cpu
+[vello_gpu]: https://crates.io/crates/vello_gpu
 
 <!-- cargo-rdme end -->
 

--- a/vello_common/src/lib.rs
+++ b/vello_common/src/lib.rs
@@ -4,16 +4,12 @@
 // After you edit the crate's doc comment, run this command, then check README.md for any missing links
 // cargo rdme --workspace-project=vello_common
 
-//! This crate includes common geometry representations, tiling logic, and other fundamental components used by both [Vello CPU][vello_cpu] and Vello GPU.
+//! This crate includes common geometry representations, tiling logic, and other fundamental components used by both [Vello CPU][vello_cpu] and [Vello GPU][vello_gpu].
 //!
 //! # Usage
 //!
 //! This crate should not be used on its own, and you should instead use one of the renderers which use it.
-//! At the moment, only [Vello CPU][vello_cpu] is published, and you probably want to use that.
-//!
-//! We also develop [Vello](https://crates.io/crates/vello), which makes use of the GPU for 2D rendering and has higher performance than Vello CPU.
-//! Vello CPU is being developed as part of work to address shortcomings in Vello.
-//! Vello does not use this crate.
+//! Choose [Vello CPU][vello_cpu] for CPU-only rendering or [Vello GPU][vello_gpu] for GPU rasterization with CPU-side preprocessing. The compute-centric [`vello`](https://crates.io/crates/vello) renderer is a separate architecture and does not use this crate.
 //!
 //! # Features
 //!
@@ -35,6 +31,7 @@
 //! This crate acts as a foundation for `vello_cpu` and `vello_gpu`, providing essential components to minimize duplication.
 //!
 //! [vello_cpu]: https://crates.io/crates/vello_cpu
+//! [vello_gpu]: https://crates.io/crates/vello_gpu
 #![cfg_attr(feature = "libm", doc = "[libm]: libm")]
 #![cfg_attr(not(feature = "libm"), doc = "[libm]: https://crates.io/crates/libm")]
 // LINEBENDER LINT SET - lib.rs - v3

--- a/vello_cpu/README.md
+++ b/vello_cpu/README.md
@@ -35,10 +35,9 @@ See https://linebender.org/blog/doc-include/ for related discussion. -->
 
 <!-- cargo-rdme start -->
 
-Vello CPU is a 2D graphics rendering engine written in Rust, for devices with no or underpowered GPUs.
+Vello CPU is a 2D graphics rendering engine written in Rust for devices with no or underpowered GPUs.
 
-We also develop [Vello](https://crates.io/crates/vello), which makes use of the GPU for 2D rendering and has higher performance than Vello CPU.
-Vello CPU is being developed as part of work to address shortcomings in Vello.
+Vello CPU shares its Sparse Strips architecture and common infrastructure with [Vello GPU](https://github.com/linebender/vello/tree/main/vello_gpu), which moves rasterization and compositing to the GPU. The separate compute-centric [`vello`](https://crates.io/crates/vello) renderer is developed under the repository's `research/` directory.
 
 ## Usage
 

--- a/vello_cpu/README.md
+++ b/vello_cpu/README.md
@@ -8,8 +8,7 @@
 [![Documentation build status.](https://img.shields.io/docsrs/vello_cpu.svg)](https://docs.rs/vello_cpu)
 [![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
 \
-[![Linebender Zulip chat.](https://img.shields.io/badge/Linebender-%23vello-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/197075-vello)
-[![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/linebender/vello/ci.yml?logo=github&label=CI)](https://github.com/linebender/vello/actions)
+[![Linebender Zulip chat.](https://img.shields.io/badge/Linebender-%23vello-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/197075-vello) [![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/linebender/vello/ci.yml?logo=github&label=CI)](https://github.com/linebender/vello/actions)
 [![Dependency staleness status.](https://deps.rs/crate/vello_cpu/latest/status.svg)](https://deps.rs/crate/vello_cpu)
 
 </div>
@@ -22,32 +21,50 @@ Full documentation at https://github.com/orium/cargo-rdme -->
 <!-- Intra-doc links used in lib.rs should be evaluated here.
 See https://linebender.org/blog/doc-include/ for related discussion. -->
 
-[`RenderContext`]: https://docs.rs/vello_cpu/latest/vello_cpu/struct.RenderContext.html
-[RenderContext::set_paint]: https://docs.rs/vello_cpu/latest/vello_cpu/struct.RenderContext.html#method.set_paint
-[RenderContext::fill_path]: https://docs.rs/vello_cpu/latest/vello_cpu/struct.RenderContext.html#method.fill_path
-[RenderContext::stroke_path]: https://docs.rs/vello_cpu/latest/vello_cpu/struct.RenderContext.html#method.stroke_path
-[RenderContext::glyph_run]: https://docs.rs/vello_cpu/latest/vello_cpu/struct.RenderContext.html#method.glyph_run
-[RenderMode::OptimizeSpeed]: https://docs.rs/vello_cpu/latest/vello_cpu/enum.RenderMode.html#variant.OptimizeSpeed
-[RenderMode::OptimizeQuality]: https://docs.rs/vello_cpu/latest/vello_cpu/enum.RenderMode.html#variant.OptimizeQuality
-[`RenderContext::render`]: https://docs.rs/vello_cpu/latest/vello_cpu/struct.RenderContext.html#method.render
+[`RenderContext`]:
+  https://docs.rs/vello_cpu/latest/vello_cpu/struct.RenderContext.html
+[RenderContext::set_paint]:
+  https://docs.rs/vello_cpu/latest/vello_cpu/struct.RenderContext.html#method.set_paint
+[RenderContext::fill_path]:
+  https://docs.rs/vello_cpu/latest/vello_cpu/struct.RenderContext.html#method.fill_path
+[RenderContext::stroke_path]:
+  https://docs.rs/vello_cpu/latest/vello_cpu/struct.RenderContext.html#method.stroke_path
+[RenderContext::glyph_run]:
+  https://docs.rs/vello_cpu/latest/vello_cpu/struct.RenderContext.html#method.glyph_run
+[RenderMode::OptimizeSpeed]:
+  https://docs.rs/vello_cpu/latest/vello_cpu/enum.RenderMode.html#variant.OptimizeSpeed
+[RenderMode::OptimizeQuality]:
+  https://docs.rs/vello_cpu/latest/vello_cpu/enum.RenderMode.html#variant.OptimizeQuality
+[`RenderContext::render`]:
+  https://docs.rs/vello_cpu/latest/vello_cpu/struct.RenderContext.html#method.render
 [`Pixmap`]: https://docs.rs/vello_cpu/latest/vello_cpu/struct.Pixmap.html
 [`Resources`]: https://docs.rs/vello_cpu/latest/vello_cpu/struct.Resources.html
 
 <!-- cargo-rdme start -->
 
-Vello CPU is a 2D graphics rendering engine written in Rust for devices with no or underpowered GPUs.
+Vello CPU is a 2D graphics rendering engine written in Rust for devices with no
+or underpowered GPUs.
 
-Vello CPU shares its Sparse Strips architecture and common infrastructure with [Vello GPU](https://github.com/linebender/vello/tree/main/vello_gpu), which moves rasterization and compositing to the GPU. The separate compute-centric [`vello`](https://crates.io/crates/vello) renderer is developed under the repository's `research/` directory.
+We also develop:
 
-## Usage
+1. [Vello GPU](https://crates.io/crates/vello_gpu), which shares Vello CPU's
+   architecture but moves rasterization and compositing to the GPU.
+2. [Vello Research], an experimental, high-performance, compute-centric GPU
+   renderer.
+
+### Usage
 
 To use Vello CPU, you need to:
 
-- Create a [`RenderContext`][], a 2D drawing context for a fixed-size scene area.
+- Create a [`RenderContext`][], a 2D drawing context for a fixed-size scene
+  area.
 - For each object in your scene:
-  - Set how the object will be painted, using [`set_paint`][RenderContext::set_paint].
-  - Set the shape to be drawn for that object, using methods like [`fill_path`][RenderContext::fill_path],
-    [`stroke_path`][RenderContext::stroke_path], or [`glyph_run`][RenderContext::glyph_run].
+  - Set how the object will be painted, using
+    [`set_paint`][RenderContext::set_paint].
+  - Set the shape to be drawn for that object, using methods like
+    [`fill_path`][RenderContext::fill_path],
+    [`stroke_path`][RenderContext::stroke_path], or
+    [`glyph_run`][RenderContext::glyph_run].
 - Render it to an image using [`RenderContext::render`][].
 
 ```rust
@@ -88,84 +105,96 @@ assert_eq!(&result, expected_render);
 ```
 
 See the
-[examples](https://github.com/linebender/vello/tree/main/vello_cpu/examples)
-for more complete demonstrations of Vello CPU's API.
+[examples](https://github.com/linebender/vello/tree/main/vello_cpu/examples) for
+more complete demonstrations of Vello CPU's API.
 
-## Features
+### Features
 
-- `std` (enabled by default): Get floating point functions from the standard library
-  (likely using your target's libc).
+- `std` (enabled by default): Get floating point functions from the standard
+  library (likely using your target's libc).
 - `libm`: Use floating point implementations from [libm][].
-- `png`(enabled by default): Allow loading [`Pixmap`]s from PNG images.
-  Also required for rendering glyphs with an embedded PNG. Implies `std`.
+- `png`(enabled by default): Allow loading [`Pixmap`]s from PNG images. Also
+  required for rendering glyphs with an embedded PNG. Implies `std`.
 - `multithreading`: Enable multi-threaded rendering. Implies `std`.
-- `text` (enabled by default): Enables glyph rendering ([`glyph_run`][RenderContext::glyph_run]).
-- `u8_pipeline` (enabled by default): Enable the u8 pipeline, for speed focused rendering using u8 math.
-  The `u8` pipeline will be used for [`OptimizeSpeed`][RenderMode::OptimizeSpeed], if both pipelines are enabled.
-  If you're using Vello CPU for application rendering, you should prefer this pipeline.
-- `f32_pipeline`: Enable the `f32` pipeline, which is slower but has more accurate
-  results. This is espectially useful for rendering test snapshots.
-  The `f32` pipeline will be used for [`OptimizeQuality`][RenderMode::OptimizeQuality], if both pipelines are enabled.
+- `text` (enabled by default): Enables glyph rendering
+  ([`glyph_run`][RenderContext::glyph_run]).
+- `u8_pipeline` (enabled by default): Enable the u8 pipeline, for speed focused
+  rendering using u8 math. The `u8` pipeline will be used for
+  [`OptimizeSpeed`][RenderMode::OptimizeSpeed], if both pipelines are enabled.
+  If you're using Vello CPU for application rendering, you should prefer this
+  pipeline.
+- `f32_pipeline`: Enable the `f32` pipeline, which is slower but has more
+  accurate results. This is espectially useful for rendering test snapshots. The
+  `f32` pipeline will be used for
+  [`OptimizeQuality`][RenderMode::OptimizeQuality], if both pipelines are
+  enabled.
 
-At least one of `std` and `libm` is required; `std` overrides `libm`.
-At least one of `u8_pipeline` and `f32_pipeline` must be enabled.
-You might choose to disable one of these pipelines if your application
-won't use it, so as to reduce binary size.
+At least one of `std` and `libm` is required; `std` overrides `libm`. At least
+one of `u8_pipeline` and `f32_pipeline` must be enabled. You might choose to
+disable one of these pipelines if your application won't use it, so as to reduce
+binary size.
 
-## Current state
+### Current state
 
-Vello CPU is a solid CPU-only 2D renderer with broad, reliable feature
-support. It provides excellent performance across a wide range of workloads,
-with optimized SIMD implementations for all major architectures. The
-renderer is still under active development, however, and a few limitations
-remain:
+Vello CPU is a solid CPU-only 2D renderer with broad, reliable feature support.
+It provides excellent performance across a wide range of workloads, with
+optimized SIMD implementations for all major architectures. The renderer is
+still under active development, however, and a few limitations remain:
 
-- Complex filter graphs are currently not supported at all and will panic.
-  In multi-threaded mode, even simple filters are currently unsupported.
-- Parts of the API and its documentation are still suboptimal, for example
-  the [`Resources`][] lifecycle.
+- Complex filter graphs are currently not supported at all and will panic. In
+  multi-threaded mode, even simple filters are currently unsupported.
+- Parts of the API and its documentation are still suboptimal, for example the
+  [`Resources`][] lifecycle.
 - Some exposed features remain experimental and are not recommended for use,
   including glyph caching. Experimental APIs are identified in their method
   documentation.
-- There is still more room for performance improvements, in particular on
-  x86 systems and also for multi-threaded rendering.
+- There is still more room for performance improvements, in particular on x86
+  systems and also for multi-threaded rendering.
 
-With that said, we are continuously improving Vello CPU and will address
-these and other limitations in future releases.
+With that said, we are continuously improving Vello CPU and will address these
+and other limitations in future releases.
 
-## Performance
+### Performance
 
-Performance benchmarks can be found [here](https://laurenzv.github.io/vello_chart/),
-As can be seen, Vello CPU achieves compelling performance on both,
-aarch64 and x86 platforms. We also have SIMD optimizations for WASM SIMD,
-meaning that you can expect good performance there as well.
+Performance benchmarks can be found
+[here](https://laurenzv.github.io/vello_chart/), As can be seen, Vello CPU
+achieves compelling performance on both, aarch64 and x86 platforms. We also have
+SIMD optimizations for WASM SIMD, meaning that you can expect good performance
+there as well.
 
-## Implementation
+### Implementation
 
-If you want to gain a better understanding of Vello CPU and the
-sparse strips paradigm, you can take a look at the [accompanying
-master's thesis](https://ethz.ch/content/dam/ethz/special-interest/infk/inst-pls/plf-dam/documents/StudentProjects/MasterTheses/2025-Laurenz-Thesis.pdf)
-that was written on the topic. Note that parts of the descriptions might
-become outdated as the implementation changes, but it should give a good
-overview nevertheless.
+If you want to gain a better understanding of Vello CPU and the sparse strips
+paradigm, you can take a look at the
+[accompanying master's thesis](https://ethz.ch/content/dam/ethz/special-interest/infk/inst-pls/plf-dam/documents/StudentProjects/MasterTheses/2025-Laurenz-Thesis.pdf)
+that was written on the topic. Note that parts of the descriptions might become
+outdated as the implementation changes, but it should give a good overview
+nevertheless.
 
 <!-- We can't directly link to the libm crate built locally, because our feature is only a pass-through  -->
+
 [libm]: https://crates.io/crates/libm
+[Vello Research]:
+  https://github.com/linebender/vello/tree/main/research/vello_research
 
 <!-- cargo-rdme end -->
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Vello CPU has been verified to compile with **Rust 1.89** and later.
+This version of Vello CPU has been verified to compile with **Rust 1.89** and
+later.
 
-Future versions of Vello CPU might increase the Rust version requirement.
-It will not be treated as a breaking change and as such can even happen with small patch releases.
+Future versions of Vello CPU might increase the Rust version requirement. It
+will not be treated as a breaking change and as such can even happen with small
+patch releases.
 
 <details>
 <summary>Click here if compiling fails.</summary>
 
-As time has passed, some of Vello CPU's dependencies could have released versions with a higher Rust requirement.
-If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
+As time has passed, some of Vello CPU's dependencies could have released
+versions with a higher Rust requirement. If you encounter a compilation issue
+due to a dependency and don't want to upgrade your Rust toolchain, then you
+could downgrade the dependency.
 
 ```sh
 # Use the problematic dependency's name and version
@@ -176,18 +205,21 @@ cargo update -p package_name --precise 0.1.1
 
 ## Community
 
-Discussion of Vello CPU development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#vello channel](https://xi.zulipchat.com/#narrow/channel/197075-vello).
-All public content can be read without logging in.
+Discussion of Vello CPU development happens in the
+[Linebender Zulip](https://xi.zulipchat.com/), specifically the
+[#vello channel](https://xi.zulipchat.com/#narrow/channel/197075-vello). All
+public content can be read without logging in.
 
-Contributions are welcome by pull request.
-The [Rust code of conduct] applies.
+Contributions are welcome by pull request. The [Rust code of conduct] applies.
 
 ## License
 
 Licensed under either of
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or
+  <http://opensource.org/licenses/MIT>)
 
 at your option.
 

--- a/vello_cpu/src/lib.rs
+++ b/vello_cpu/src/lib.rs
@@ -4,10 +4,9 @@
 // After you edit the crate's doc comment, run this command, then check README.md for any missing links
 // cargo rdme --workspace-project=vello_cpu
 
-//! Vello CPU is a 2D graphics rendering engine written in Rust, for devices with no or underpowered GPUs.
+//! Vello CPU is a 2D graphics rendering engine written in Rust for devices with no or underpowered GPUs.
 //!
-//! We also develop [Vello](https://crates.io/crates/vello), which makes use of the GPU for 2D rendering and has higher performance than Vello CPU.
-//! Vello CPU is being developed as part of work to address shortcomings in Vello.
+//! Vello CPU shares its Sparse Strips architecture and common infrastructure with [Vello GPU](https://github.com/linebender/vello/tree/main/vello_gpu), which moves rasterization and compositing to the GPU. The separate compute-centric [`vello`](https://crates.io/crates/vello) renderer is developed under the repository's `research/` directory.
 //!
 //! # Usage
 //!

--- a/vello_cpu/src/lib.rs
+++ b/vello_cpu/src/lib.rs
@@ -1,22 +1,33 @@
 // Copyright 2025 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// After you edit the crate's doc comment, run this command, then check README.md for any missing links
+// After you edit the crate's doc comment, run this command, then check
+// README.md for any missing links
 // cargo rdme --workspace-project=vello_cpu
 
-//! Vello CPU is a 2D graphics rendering engine written in Rust for devices with no or underpowered GPUs.
+//! Vello CPU is a 2D graphics rendering engine written in Rust for devices with no
+//! or underpowered GPUs.
 //!
-//! Vello CPU shares its Sparse Strips architecture and common infrastructure with [Vello GPU](https://github.com/linebender/vello/tree/main/vello_gpu), which moves rasterization and compositing to the GPU. The separate compute-centric [`vello`](https://crates.io/crates/vello) renderer is developed under the repository's `research/` directory.
+//! We also develop:
 //!
-//! # Usage
+//! 1. [Vello GPU](https://crates.io/crates/vello_gpu), which shares Vello CPU's
+//!    architecture but moves rasterization and compositing to the GPU.
+//! 2. [Vello Research], an experimental, high-performance, compute-centric GPU
+//!    renderer.
+//!
+//! ## Usage
 //!
 //! To use Vello CPU, you need to:
 //!
-//! - Create a [`RenderContext`][], a 2D drawing context for a fixed-size scene area.
+//! - Create a [`RenderContext`][], a 2D drawing context for a fixed-size scene
+//!   area.
 //! - For each object in your scene:
-//!   - Set how the object will be painted, using [`set_paint`][RenderContext::set_paint].
-//!   - Set the shape to be drawn for that object, using methods like [`fill_path`][RenderContext::fill_path],
-//!     [`stroke_path`][RenderContext::stroke_path], or [`glyph_run`][RenderContext::glyph_run].
+//!   - Set how the object will be painted, using
+//!     [`set_paint`][RenderContext::set_paint].
+//!   - Set the shape to be drawn for that object, using methods like
+//!     [`fill_path`][RenderContext::fill_path],
+//!     [`stroke_path`][RenderContext::stroke_path], or
+//!     [`glyph_run`][RenderContext::glyph_run].
 //! - Render it to an image using [`RenderContext::render`][].
 //!
 //! ```rust
@@ -57,69 +68,77 @@
 //! ```
 //!
 //! See the
-//! [examples](https://github.com/linebender/vello/tree/main/vello_cpu/examples)
-//! for more complete demonstrations of Vello CPU's API.
+//! [examples](https://github.com/linebender/vello/tree/main/vello_cpu/examples) for
+//! more complete demonstrations of Vello CPU's API.
 //!
-//! # Features
+//! ## Features
 //!
-//! - `std` (enabled by default): Get floating point functions from the standard library
-//!   (likely using your target's libc).
+//! - `std` (enabled by default): Get floating point functions from the standard
+//!   library (likely using your target's libc).
 //! - `libm`: Use floating point implementations from [libm][].
-//! - `png`(enabled by default): Allow loading [`Pixmap`]s from PNG images.
-//!   Also required for rendering glyphs with an embedded PNG. Implies `std`.
+//! - `png`(enabled by default): Allow loading [`Pixmap`]s from PNG images. Also
+//!   required for rendering glyphs with an embedded PNG. Implies `std`.
 //! - `multithreading`: Enable multi-threaded rendering. Implies `std`.
-//! - `text` (enabled by default): Enables glyph rendering ([`glyph_run`][RenderContext::glyph_run]).
-//! - `u8_pipeline` (enabled by default): Enable the u8 pipeline, for speed focused rendering using u8 math.
-//!   The `u8` pipeline will be used for [`OptimizeSpeed`][RenderMode::OptimizeSpeed], if both pipelines are enabled.
-//!   If you're using Vello CPU for application rendering, you should prefer this pipeline.
-//! - `f32_pipeline`: Enable the `f32` pipeline, which is slower but has more accurate
-//!   results. This is espectially useful for rendering test snapshots.
-//!   The `f32` pipeline will be used for [`OptimizeQuality`][RenderMode::OptimizeQuality], if both pipelines are enabled.
+//! - `text` (enabled by default): Enables glyph rendering
+//!   ([`glyph_run`][RenderContext::glyph_run]).
+//! - `u8_pipeline` (enabled by default): Enable the u8 pipeline, for speed focused
+//!   rendering using u8 math. The `u8` pipeline will be used for
+//!   [`OptimizeSpeed`][RenderMode::OptimizeSpeed], if both pipelines are enabled.
+//!   If you're using Vello CPU for application rendering, you should prefer this
+//!   pipeline.
+//! - `f32_pipeline`: Enable the `f32` pipeline, which is slower but has more
+//!   accurate results. This is espectially useful for rendering test snapshots. The
+//!   `f32` pipeline will be used for
+//!   [`OptimizeQuality`][RenderMode::OptimizeQuality], if both pipelines are
+//!   enabled.
 //!
-//! At least one of `std` and `libm` is required; `std` overrides `libm`.
-//! At least one of `u8_pipeline` and `f32_pipeline` must be enabled.
-//! You might choose to disable one of these pipelines if your application
-//! won't use it, so as to reduce binary size.
+//! At least one of `std` and `libm` is required; `std` overrides `libm`. At least
+//! one of `u8_pipeline` and `f32_pipeline` must be enabled. You might choose to
+//! disable one of these pipelines if your application won't use it, so as to reduce
+//! binary size.
 //!
-//! # Current state
+//! ## Current state
 //!
-//! Vello CPU is a solid CPU-only 2D renderer with broad, reliable feature
-//! support. It provides excellent performance across a wide range of workloads,
-//! with optimized SIMD implementations for all major architectures. The
-//! renderer is still under active development, however, and a few limitations
-//! remain:
+//! Vello CPU is a solid CPU-only 2D renderer with broad, reliable feature support.
+//! It provides excellent performance across a wide range of workloads, with
+//! optimized SIMD implementations for all major architectures. The renderer is
+//! still under active development, however, and a few limitations remain:
 //!
-//! - Complex filter graphs are currently not supported at all and will panic.
-//!   In multi-threaded mode, even simple filters are currently unsupported.
-//! - Parts of the API and its documentation are still suboptimal, for example
-//!   the [`Resources`][] lifecycle.
+//! - Complex filter graphs are currently not supported at all and will panic. In
+//!   multi-threaded mode, even simple filters are currently unsupported.
+//! - Parts of the API and its documentation are still suboptimal, for example the
+//!   [`Resources`][] lifecycle.
 //! - Some exposed features remain experimental and are not recommended for use,
 //!   including glyph caching. Experimental APIs are identified in their method
 //!   documentation.
-//! - There is still more room for performance improvements, in particular on
-//!   x86 systems and also for multi-threaded rendering.
+//! - There is still more room for performance improvements, in particular on x86
+//!   systems and also for multi-threaded rendering.
 //!
-//! With that said, we are continuously improving Vello CPU and will address
-//! these and other limitations in future releases.
+//! With that said, we are continuously improving Vello CPU and will address these
+//! and other limitations in future releases.
 //!
-//! # Performance
+//! ## Performance
 //!
-//! Performance benchmarks can be found [here](https://laurenzv.github.io/vello_chart/),
-//! As can be seen, Vello CPU achieves compelling performance on both,
-//! aarch64 and x86 platforms. We also have SIMD optimizations for WASM SIMD,
-//! meaning that you can expect good performance there as well.
+//! Performance benchmarks can be found
+//! [here](https://laurenzv.github.io/vello_chart/), As can be seen, Vello CPU
+//! achieves compelling performance on both, aarch64 and x86 platforms. We also have
+//! SIMD optimizations for WASM SIMD, meaning that you can expect good performance
+//! there as well.
 //!
-//! # Implementation
+//! ## Implementation
 //!
-//! If you want to gain a better understanding of Vello CPU and the
-//! sparse strips paradigm, you can take a look at the [accompanying
-//! master's thesis](https://ethz.ch/content/dam/ethz/special-interest/infk/inst-pls/plf-dam/documents/StudentProjects/MasterTheses/2025-Laurenz-Thesis.pdf)
-//! that was written on the topic. Note that parts of the descriptions might
-//! become outdated as the implementation changes, but it should give a good
-//! overview nevertheless.
+//! If you want to gain a better understanding of Vello CPU and the sparse strips
+//! paradigm, you can take a look at the
+//! [accompanying master's thesis](https://ethz.ch/content/dam/ethz/special-interest/infk/inst-pls/plf-dam/documents/StudentProjects/MasterTheses/2025-Laurenz-Thesis.pdf)
+//! that was written on the topic. Note that parts of the descriptions might become
+//! outdated as the implementation changes, but it should give a good overview
+//! nevertheless.
 //!
 //! <!-- We can't directly link to the libm crate built locally, because our feature is only a pass-through  -->
+//!
 //! [libm]: https://crates.io/crates/libm
+//! [Vello Research]:
+//!   https://github.com/linebender/vello/tree/main/research/vello_research
 // LINEBENDER LINT SET - lib.rs - v3
 // See https://linebender.org/wiki/canonical-lints/
 // These lints shouldn't apply to examples or tests.

--- a/vello_gpu/README.md
+++ b/vello_gpu/README.md
@@ -2,7 +2,7 @@
 
 # Vello GPU
 
-**Hybrid CPU/GPU renderer**
+**GPU renderer with CPU-side preprocessing**
 
 [![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
 \
@@ -24,15 +24,13 @@ See https://linebender.org/blog/doc-include/ for related discussion. -->
 
 <!-- cargo-rdme start -->
 
-A hybrid CPU/GPU renderer for 2D vector graphics.
+A GPU renderer for 2D vector graphics with CPU-side preprocessing.
 
-This crate provides a rendering API that combines CPU and GPU operations for efficient
-vector graphics processing.
-The hybrid approach balances flexibility and performance by:
+Vello GPU uses the Sparse Strips architecture to divide work between CPU preprocessing and GPU rendering:
 
-- Using the CPU for path processing and initial geometry setup
-- Leveraging the GPU for fast rendering and compositing
-- Minimizing data transfer between CPU and GPU
+- The CPU processes paths, tiles, and schedules sparse strips.
+- The GPU rasterizes those strips and performs compositing.
+- The compact strip representation limits data transfer between them.
 
 ## Key Features
 
@@ -42,7 +40,7 @@ The hybrid approach balances flexibility and performance by:
 
 ## Feature Flags
 
-- `wgpu` (enabled by default): Enables the GPU rendering backend via wgpu and includes the required sparse shaders.
+- `wgpu` (enabled by default): Enables the GPU rendering backend via wgpu and includes the required Vello GPU shaders.
 - `wgpu_default` (enabled by default): Enables wgpu with its default hardware backends (such as Vulkan, Metal, and DX12).
 - `text` (enabled by default): Enables glyph rendering ([`Scene::glyph_run`]).
 - `webgl`: Enables the WebGL rendering backend for browser support, using GLSL shaders for compatibility.
@@ -60,14 +58,13 @@ The renderer is split into several key components:
 
 See the individual module documentation for more details on usage and implementation.
 
+## Package rename
+
+This package was previously named `vello_hybrid`. New dependencies and Rust imports should use `vello_gpu`; no compatibility re-export package is provided in this repository. Existing crates.io releases under `vello_hybrid` remain available, and publication under the new name may lag behind the repository rename.
+
 ## Current state
 
-Vello GPU is a solid GPU-accelerated 2D renderer with broad, reliable
-feature support. Although it does not match Vello Classic's raw performance
-on dynamic and vector-heavy workloads, it provides excellent performance
-on workloads that benefit from GPU acceleration, such as images,
-gradients, and filters. Overall, we still consider it to be slightly less
-mature than its CPU-only counterpart Vello CPU.
+Vello GPU is a solid GPU-accelerated 2D renderer with broad, reliable feature support. Although it does not match the compute-centric `vello` renderer's raw performance on dynamic and vector-heavy workloads, it provides excellent performance on workloads that benefit from GPU acceleration, such as images, gradients, and filters. Overall, we still consider it to be slightly less mature than its CPU-only counterpart Vello CPU.
 
 Vello GPU remains under active development. Known limitations include:
 

--- a/vello_gpu/README.md
+++ b/vello_gpu/README.md
@@ -6,8 +6,7 @@
 
 [![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
 \
-[![Linebender Zulip chat.](https://img.shields.io/badge/Linebender-%23vello-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/197075-vello)
-[![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/linebender/vello/ci.yml?logo=github&label=CI)](https://github.com/linebender/vello/actions)
+[![Linebender Zulip chat.](https://img.shields.io/badge/Linebender-%23vello-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/197075-vello) [![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/linebender/vello/ci.yml?logo=github&label=CI)](https://github.com/linebender/vello/actions)
 
 </div>
 
@@ -20,83 +19,104 @@ Full documentation at https://github.com/orium/cargo-rdme -->
 See https://linebender.org/blog/doc-include/ for related discussion. -->
 
 [`Resources`]: https://docs.rs/vello_gpu/latest/vello_gpu/struct.Resources.html
-[`Scene::glyph_run`]: https://docs.rs/vello_gpu/latest/vello_gpu/struct.Scene.html#method.glyph_run
+[`Scene::glyph_run`]:
+  https://docs.rs/vello_gpu/latest/vello_gpu/struct.Scene.html#method.glyph_run
 
 <!-- cargo-rdme start -->
 
 A GPU renderer for 2D vector graphics with CPU-side preprocessing.
 
-Vello GPU uses the Sparse Strips architecture to divide work between CPU preprocessing and GPU rendering:
+Vello GPU uses the Sparse Strips architecture to divide work between CPU
+preprocessing and GPU rendering:
 
 - The CPU processes paths, tiles, and schedules sparse strips.
 - The GPU rasterizes those strips and performs compositing.
 - The compact strip representation limits data transfer between them.
 
-## Key Features
+### Key Features
 
 - Efficient path rendering with CPU-side processing
 - GPU-accelerated compositing and blending
 - Support for both windowed and headless rendering
 
-## Feature Flags
+### Feature Flags
 
-- `wgpu` (enabled by default): Enables the GPU rendering backend via wgpu and includes the required Vello GPU shaders.
-- `wgpu_default` (enabled by default): Enables wgpu with its default hardware backends (such as Vulkan, Metal, and DX12).
+- `wgpu` (enabled by default): Enables the GPU rendering backend via wgpu and
+  includes the required Vello GPU shaders.
+- `wgpu_default` (enabled by default): Enables wgpu with its default hardware
+  backends (such as Vulkan, Metal, and DX12).
 - `text` (enabled by default): Enables glyph rendering ([`Scene::glyph_run`]).
-- `webgl`: Enables the WebGL rendering backend for browser support, using GLSL shaders for compatibility.
+- `webgl`: Enables the WebGL rendering backend for browser support, using GLSL
+  shaders for compatibility.
 
-If you need to customize the set of enabled wgpu features, disable this crate's default features then enable its `wgpu` feature.
-You can then depend on wgpu directly, setting the specific features you require.
-Don't forget to also disable wgpu's default features.
+If you need to customize the set of enabled wgpu features, disable this crate's
+default features then enable its `wgpu` feature. You can then depend on wgpu
+directly, setting the specific features you require. Don't forget to also
+disable wgpu's default features.
 
-## Architecture
+### Architecture
 
 The renderer is split into several key components:
 
 - `Scene`: Manages the render context and path processing on the CPU
-- `Renderer` or `WebGlRenderer`: Handles GPU resource management and executes draw operations
+- `Renderer` or `WebGlRenderer`: Handles GPU resource management and executes
+  draw operations
 
-See the individual module documentation for more details on usage and implementation.
+See the individual module documentation for more details on usage and
+implementation.
 
-## Package rename
+### Current state
 
-This package was previously named `vello_hybrid`. New dependencies and Rust imports should use `vello_gpu`; no compatibility re-export package is provided in this repository. Existing crates.io releases under `vello_hybrid` remain available, and publication under the new name may lag behind the repository rename.
-
-## Current state
-
-Vello GPU is a solid GPU-accelerated 2D renderer with broad, reliable feature support. Although it does not match the compute-centric `vello` renderer's raw performance on dynamic and vector-heavy workloads, it provides excellent performance on workloads that benefit from GPU acceleration, such as images, gradients, and filters. Overall, we still consider it to be slightly less mature than its CPU-only counterpart Vello CPU.
+Vello GPU is a solid GPU-accelerated 2D renderer with broad, reliable feature
+support. Although it does not match the compute-centric `vello` renderer's raw
+performance on dynamic and vector-heavy workloads, it provides excellent
+performance on workloads that benefit from GPU acceleration, such as images,
+gradients, and filters. Overall, we still consider it to be slightly less mature
+than its CPU-only counterpart Vello CPU.
 
 Vello GPU remains under active development. Known limitations include:
 
 - The following features are not yet supported and will panic: Mask layers,
   complex filter graphs as well as certain blend modes for non-isolated
   blending.
-- Parts of the API and its documentation are still suboptimal, for example
-  the lifecycle and ownership of external resources through [`Resources`][].
+- Parts of the API and its documentation are still suboptimal, for example the
+  lifecycle and ownership of external resources through [`Resources`][].
 - Some exposed features remain experimental and are not recommended for use,
   including glyph caching. Experimental APIs are identified in their method
   documentation.
-- Parts of the rendering pipeline are not yet fully optimized, particularly
-  the wgpu backend, but also other aspects.
+- Parts of the rendering pipeline are not yet fully optimized, particularly the
+  wgpu backend, but also other aspects.
 - Some failures panic instead of being reported through a user-facing error.
 
-With that said, we are continuously improving Vello GPU and will address
-these and other limitations in future releases.
+With that said, we are continuously improving Vello GPU and will address these
+and other limitations in future releases.
+
+### Package rename
+
+This package was previously named `vello_hybrid`. New dependencies and Rust
+imports should use `vello_gpu`; no compatibility re-export package is provided
+in this repository. Existing crates.io releases under `vello_hybrid` remain
+available, and publication under the new name may lag behind the repository
+rename.
 
 <!-- cargo-rdme end -->
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Vello GPU has been verified to compile with **Rust 1.89** and later.
+This version of Vello GPU has been verified to compile with **Rust 1.89** and
+later.
 
-Future versions of Vello GPU might increase the Rust version requirement.
-It will not be treated as a breaking change and as such can even happen with small patch releases.
+Future versions of Vello GPU might increase the Rust version requirement. It
+will not be treated as a breaking change and as such can even happen with small
+patch releases.
 
 <details>
 <summary>Click here if compiling fails.</summary>
 
-As time has passed, some of Vello GPU's dependencies could have released versions with a higher Rust requirement.
-If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
+As time has passed, some of Vello GPU's dependencies could have released
+versions with a higher Rust requirement. If you encounter a compilation issue
+due to a dependency and don't want to upgrade your Rust toolchain, then you
+could downgrade the dependency.
 
 ```sh
 # Use the problematic dependency's name and version
@@ -107,18 +127,21 @@ cargo update -p package_name --precise 0.1.1
 
 ## Community
 
-Discussion of Vello GPU development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#vello channel](https://xi.zulipchat.com/#narrow/channel/197075-vello).
-All public content can be read without logging in.
+Discussion of Vello GPU development happens in the
+[Linebender Zulip](https://xi.zulipchat.com/), specifically the
+[#vello channel](https://xi.zulipchat.com/#narrow/channel/197075-vello). All
+public content can be read without logging in.
 
-Contributions are welcome by pull request.
-The [Rust code of conduct] applies.
+Contributions are welcome by pull request. The [Rust code of conduct] applies.
 
 ## License
 
 Licensed under either of
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or
+  <http://opensource.org/licenses/MIT>)
 
 at your option.
 

--- a/vello_gpu/src/lib.rs
+++ b/vello_gpu/src/lib.rs
@@ -4,15 +4,13 @@
 // After you edit the crate's doc comment, run this command, then check README.md for any missing links
 // cargo rdme --workspace-project=vello_gpu
 
-//! A hybrid CPU/GPU renderer for 2D vector graphics.
+//! A GPU renderer for 2D vector graphics with CPU-side preprocessing.
 //!
-//! This crate provides a rendering API that combines CPU and GPU operations for efficient
-//! vector graphics processing.
-//! The hybrid approach balances flexibility and performance by:
+//! Vello GPU uses the Sparse Strips architecture to divide work between CPU preprocessing and GPU rendering:
 //!
-//! - Using the CPU for path processing and initial geometry setup
-//! - Leveraging the GPU for fast rendering and compositing
-//! - Minimizing data transfer between CPU and GPU
+//! - The CPU processes paths, tiles, and schedules sparse strips.
+//! - The GPU rasterizes those strips and performs compositing.
+//! - The compact strip representation limits data transfer between them.
 //!
 //! # Key Features
 //!
@@ -22,7 +20,7 @@
 //!
 //! # Feature Flags
 //!
-//! - `wgpu` (enabled by default): Enables the GPU rendering backend via wgpu and includes the required sparse shaders.
+//! - `wgpu` (enabled by default): Enables the GPU rendering backend via wgpu and includes the required Vello GPU shaders.
 //! - `wgpu_default` (enabled by default): Enables wgpu with its default hardware backends (such as Vulkan, Metal, and DX12).
 //! - `text` (enabled by default): Enables glyph rendering ([`Scene::glyph_run`]).
 //! - `webgl`: Enables the WebGL rendering backend for browser support, using GLSL shaders for compatibility.
@@ -40,14 +38,13 @@
 //!
 //! See the individual module documentation for more details on usage and implementation.
 //!
+//! # Package rename
+//!
+//! This package was previously named `vello_hybrid`. New dependencies and Rust imports should use `vello_gpu`; no compatibility re-export package is provided in this repository. Existing crates.io releases under `vello_hybrid` remain available, and publication under the new name may lag behind the repository rename.
+//!
 //! # Current state
 //!
-//! Vello GPU is a solid GPU-accelerated 2D renderer with broad, reliable
-//! feature support. Although it does not match Vello Classic's raw performance
-//! on dynamic and vector-heavy workloads, it provides excellent performance
-//! on workloads that benefit from GPU acceleration, such as images,
-//! gradients, and filters. Overall, we still consider it to be slightly less
-//! mature than its CPU-only counterpart Vello CPU.
+//! Vello GPU is a solid GPU-accelerated 2D renderer with broad, reliable feature support. Although it does not match the compute-centric `vello` renderer's raw performance on dynamic and vector-heavy workloads, it provides excellent performance on workloads that benefit from GPU acceleration, such as images, gradients, and filters. Overall, we still consider it to be slightly less mature than its CPU-only counterpart Vello CPU.
 //!
 //! Vello GPU remains under active development. Known limitations include:
 //!

--- a/vello_gpu/src/lib.rs
+++ b/vello_gpu/src/lib.rs
@@ -1,67 +1,84 @@
 // Copyright 2025 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// After you edit the crate's doc comment, run this command, then check README.md for any missing links
+// After you edit the crate's doc comment, run this command, then check
+// README.md for any missing links
 // cargo rdme --workspace-project=vello_gpu
 
 //! A GPU renderer for 2D vector graphics with CPU-side preprocessing.
 //!
-//! Vello GPU uses the Sparse Strips architecture to divide work between CPU preprocessing and GPU rendering:
+//! Vello GPU uses the Sparse Strips architecture to divide work between CPU
+//! preprocessing and GPU rendering:
 //!
 //! - The CPU processes paths, tiles, and schedules sparse strips.
 //! - The GPU rasterizes those strips and performs compositing.
 //! - The compact strip representation limits data transfer between them.
 //!
-//! # Key Features
+//! ## Key Features
 //!
 //! - Efficient path rendering with CPU-side processing
 //! - GPU-accelerated compositing and blending
 //! - Support for both windowed and headless rendering
 //!
-//! # Feature Flags
+//! ## Feature Flags
 //!
-//! - `wgpu` (enabled by default): Enables the GPU rendering backend via wgpu and includes the required Vello GPU shaders.
-//! - `wgpu_default` (enabled by default): Enables wgpu with its default hardware backends (such as Vulkan, Metal, and DX12).
+//! - `wgpu` (enabled by default): Enables the GPU rendering backend via wgpu and
+//!   includes the required Vello GPU shaders.
+//! - `wgpu_default` (enabled by default): Enables wgpu with its default hardware
+//!   backends (such as Vulkan, Metal, and DX12).
 //! - `text` (enabled by default): Enables glyph rendering ([`Scene::glyph_run`]).
-//! - `webgl`: Enables the WebGL rendering backend for browser support, using GLSL shaders for compatibility.
+//! - `webgl`: Enables the WebGL rendering backend for browser support, using GLSL
+//!   shaders for compatibility.
 //!
-//! If you need to customize the set of enabled wgpu features, disable this crate's default features then enable its `wgpu` feature.
-//! You can then depend on wgpu directly, setting the specific features you require.
-//! Don't forget to also disable wgpu's default features.
+//! If you need to customize the set of enabled wgpu features, disable this crate's
+//! default features then enable its `wgpu` feature. You can then depend on wgpu
+//! directly, setting the specific features you require. Don't forget to also
+//! disable wgpu's default features.
 //!
-//! # Architecture
+//! ## Architecture
 //!
 //! The renderer is split into several key components:
 //!
 //! - `Scene`: Manages the render context and path processing on the CPU
-//! - `Renderer` or `WebGlRenderer`: Handles GPU resource management and executes draw operations
+//! - `Renderer` or `WebGlRenderer`: Handles GPU resource management and executes
+//!   draw operations
 //!
-//! See the individual module documentation for more details on usage and implementation.
+//! See the individual module documentation for more details on usage and
+//! implementation.
 //!
-//! # Package rename
+//! ## Current state
 //!
-//! This package was previously named `vello_hybrid`. New dependencies and Rust imports should use `vello_gpu`; no compatibility re-export package is provided in this repository. Existing crates.io releases under `vello_hybrid` remain available, and publication under the new name may lag behind the repository rename.
-//!
-//! # Current state
-//!
-//! Vello GPU is a solid GPU-accelerated 2D renderer with broad, reliable feature support. Although it does not match the compute-centric `vello` renderer's raw performance on dynamic and vector-heavy workloads, it provides excellent performance on workloads that benefit from GPU acceleration, such as images, gradients, and filters. Overall, we still consider it to be slightly less mature than its CPU-only counterpart Vello CPU.
+//! Vello GPU is a solid GPU-accelerated 2D renderer with broad, reliable feature
+//! support. Although it does not match the compute-centric `vello` renderer's raw
+//! performance on dynamic and vector-heavy workloads, it provides excellent
+//! performance on workloads that benefit from GPU acceleration, such as images,
+//! gradients, and filters. Overall, we still consider it to be slightly less mature
+//! than its CPU-only counterpart Vello CPU.
 //!
 //! Vello GPU remains under active development. Known limitations include:
 //!
 //! - The following features are not yet supported and will panic: Mask layers,
 //!   complex filter graphs as well as certain blend modes for non-isolated
 //!   blending.
-//! - Parts of the API and its documentation are still suboptimal, for example
-//!   the lifecycle and ownership of external resources through [`Resources`][].
+//! - Parts of the API and its documentation are still suboptimal, for example the
+//!   lifecycle and ownership of external resources through [`Resources`][].
 //! - Some exposed features remain experimental and are not recommended for use,
 //!   including glyph caching. Experimental APIs are identified in their method
 //!   documentation.
-//! - Parts of the rendering pipeline are not yet fully optimized, particularly
-//!   the wgpu backend, but also other aspects.
+//! - Parts of the rendering pipeline are not yet fully optimized, particularly the
+//!   wgpu backend, but also other aspects.
 //! - Some failures panic instead of being reported through a user-facing error.
 //!
-//! With that said, we are continuously improving Vello GPU and will address
-//! these and other limitations in future releases.
+//! With that said, we are continuously improving Vello GPU and will address these
+//! and other limitations in future releases.
+//!
+//! ## Package rename
+//!
+//! This package was previously named `vello_hybrid`. New dependencies and Rust
+//! imports should use `vello_gpu`; no compatibility re-export package is provided
+//! in this repository. Existing crates.io releases under `vello_hybrid` remain
+//! available, and publication under the new name may lag behind the repository
+//! rename.
 
 #![no_std]
 #![cfg_attr(

--- a/vello_gpu/src/render/webgl/mod.rs
+++ b/vello_gpu/src/render/webgl/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-//! Native WebGL2 rendering module for the sparse strips CPU/GPU rendering engine.
+//! Native WebGL2 backend for Vello GPU's Sparse Strips renderer.
 //!
 //! This module provides identical functionality as the [`wgpu`] module, however the graphics
 //! context is the browser's native [`WebGl2RenderingContext`]. Hence, this module is only available

--- a/vello_gpu/src/render/wgpu/mod.rs
+++ b/vello_gpu/src/render/wgpu/mod.rs
@@ -1,16 +1,14 @@
 // Copyright 2025 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-//! GPU rendering module for the sparse strips CPU/GPU rendering engine.
+//! wgpu backend for Vello GPU's Sparse Strips renderer.
 //!
-//! This module provides the GPU-side implementation of the hybrid rendering system.
+//! This module consumes paths and strips prepared on the CPU and performs
+//! rasterization and compositing on the GPU.
 //! It handles:
 //! - GPU resource management (buffers, textures, pipelines)
 //! - Surface/window management and presentation
 //! - Shader execution and rendering
-//!
-//! The hybrid approach combines CPU-side path processing with efficient GPU rendering
-//! to balance flexibility and performance.
 
 #![expect(
     clippy::cast_possible_truncation,

--- a/vello_gpu/src/render/wgpu/mod.rs
+++ b/vello_gpu/src/render/wgpu/mod.rs
@@ -1,14 +1,7 @@
 // Copyright 2025 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-//! wgpu backend for Vello GPU's Sparse Strips renderer.
-//!
-//! This module consumes paths and strips prepared on the CPU and performs
-//! rasterization and compositing on the GPU.
-//! It handles:
-//! - GPU resource management (buffers, textures, pipelines)
-//! - Surface/window management and presentation
-//! - Shader execution and rendering
+//! `wgpu` backend for Vello GPU.
 
 #![expect(
     clippy::cast_possible_truncation,

--- a/vello_gpu/src/util.rs
+++ b/vello_gpu/src/util.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// This file is a modified version of the vello/src/util.rs file.
+// This file is a modified version of research/vello_research/src/util.rs.
 
 //! A number of utility helper methods.
 

--- a/vello_gpu_shaders/README.md
+++ b/vello_gpu_shaders/README.md
@@ -4,29 +4,32 @@
 
 [![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
 \
-[![Linebender Zulip chat.](https://img.shields.io/badge/Linebender-%23vello-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/197075-vello)
-[![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/linebender/vello/ci.yml?logo=github&label=CI)](https://github.com/linebender/vello/actions)
+[![Linebender Zulip chat.](https://img.shields.io/badge/Linebender-%23vello-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/197075-vello) [![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/linebender/vello/ci.yml?logo=github&label=CI)](https://github.com/linebender/vello/actions)
 
 </div>
 
-This crate contains the WESL programs and linked WGSL output, plus optionally generated GLSL
-shader programs, used by the Vello GPU renderer.
+This crate contains the WESL programs and linked WGSL output, plus optionally
+generated GLSL shader programs, used by the Vello GPU renderer.
 
 ## Features
+
 - Single source of truth authored as [WESL](https://wesl-lang.dev/) programs.
 - Automated build step that links WESL, then uses
-  [naga](https://github.com/gfx-rs/wgpu/tree/trunk/naga) to minify the resulting WGSL.
+  [naga](https://github.com/gfx-rs/wgpu/tree/trunk/naga) to minify the resulting
+  WGSL.
 - Optional generation of minified GLSL and reflection metadata for WebGL.
 
 ## Usage
-This crate provides linked WGSL programs and the build step for GLSL programs used by Vello GPU.
 
-Whenever the WESL shaders are updated, the build script automatically relinks and minifies the
-WGSL. When the `glsl` feature is enabled, it also regenerates the minified GLSL programs and
-reflection metadata used by `vello_gpu`.
+This crate provides linked WGSL programs and the build step for GLSL programs
+used by Vello GPU.
 
-To inspect the generated WebGL GLSL and the embedded `compiled_shaders.rs` module used by
-`vello_gpu`, create local copies by running:
+Whenever the WESL shaders are updated, the build script automatically relinks
+and minifies the WGSL. When the `glsl` feature is enabled, it also regenerates
+the minified GLSL programs and reflection metadata used by `vello_gpu`.
+
+To inspect the generated WebGL GLSL and the embedded `compiled_shaders.rs`
+module used by `vello_gpu`, create local copies by running:
 
 ```sh
 cargo run -p vello_gpu_shaders --features glsl
@@ -34,29 +37,29 @@ cargo run -p vello_gpu_shaders --features glsl
 
 The generated files will be written into the `generated_glsl` folder.
 
-To retain authored identifiers and Naga's readable formatting for debugging, enable the diagnostic
-`unminified` feature as well:
+To retain authored identifiers and Naga's readable formatting for debugging,
+enable the diagnostic `unminified` feature as well:
 
 ```sh
 cargo run -p vello_gpu_shaders --features glsl,unminified
 ```
 
-## Package rename
-
-This package was previously named `vello_sparse_shaders`. Dependencies and commands that track this repository should now use `vello_gpu_shaders`. Existing crates.io releases under the old name remain available, and publication under the new name may lag behind the repository rename.
-
 ## Minimum supported Rust Version (MSRV)
 
-This version of Vello GPU Shaders has been verified to compile with **Rust 1.89** and later.
+This version of Vello GPU Shaders has been verified to compile with **Rust
+1.89** and later.
 
-Future versions of Vello GPU Shaders might increase the Rust version requirement.
-It will not be treated as a breaking change and as such can even happen with small patch releases.
+Future versions of Vello GPU Shaders might increase the Rust version
+requirement. It will not be treated as a breaking change and as such can even
+happen with small patch releases.
 
 <details>
 <summary>Click here if compiling fails.</summary>
 
-As time has passed, some of Vello GPU's dependencies could have released versions with a higher Rust requirement.
-If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
+As time has passed, some of Vello GPU's dependencies could have released
+versions with a higher Rust requirement. If you encounter a compilation issue
+due to a dependency and don't want to upgrade your Rust toolchain, then you
+could downgrade the dependency.
 
 ```sh
 # Use the problematic dependency's name and version
@@ -67,18 +70,21 @@ cargo update -p package_name --precise 0.1.1
 
 ## Community
 
-Discussion of Vello GPU development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#vello channel](https://xi.zulipchat.com/#narrow/channel/197075-vello).
-All public content can be read without logging in.
+Discussion of Vello GPU development happens in the
+[Linebender Zulip](https://xi.zulipchat.com/), specifically the
+[#vello channel](https://xi.zulipchat.com/#narrow/channel/197075-vello). All
+public content can be read without logging in.
 
-Contributions are welcome by pull request.
-The [Rust code of conduct] applies.
+Contributions are welcome by pull request. The [Rust code of conduct] applies.
 
 ## License
 
 Licensed under either of
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or
+  <http://opensource.org/licenses/MIT>)
 
 at your option.
 

--- a/vello_gpu_shaders/README.md
+++ b/vello_gpu_shaders/README.md
@@ -19,8 +19,7 @@ shader programs, used by the Vello GPU renderer.
 - Optional generation of minified GLSL and reflection metadata for WebGL.
 
 ## Usage
-This crate provides linked WGSL programs and the build step for GLSL programs used by the optimized
-hybrid rendering engine.
+This crate provides linked WGSL programs and the build step for GLSL programs used by Vello GPU.
 
 Whenever the WESL shaders are updated, the build script automatically relinks and minifies the
 WGSL. When the `glsl` feature is enabled, it also regenerates the minified GLSL programs and
@@ -42,11 +41,15 @@ To retain authored identifiers and Naga's readable formatting for debugging, ena
 cargo run -p vello_gpu_shaders --features glsl,unminified
 ```
 
+## Package rename
+
+This package was previously named `vello_sparse_shaders`. Dependencies and commands that track this repository should now use `vello_gpu_shaders`. Existing crates.io releases under the old name remain available, and publication under the new name may lag behind the repository rename.
+
 ## Minimum supported Rust Version (MSRV)
 
 This version of Vello GPU Shaders has been verified to compile with **Rust 1.89** and later.
 
-Future versions of Vello GPU might increase the Rust version requirement.
+Future versions of Vello GPU Shaders might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.
 
 <details>
@@ -80,5 +83,3 @@ Licensed under either of
 at your option.
 
 [Rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct
-[Vello]: https://github.com/linebender/vello
-[the changelog]: https://github.com/linebender/vello/tree/main/research/CHANGELOG.md

--- a/vello_tests/README.md
+++ b/vello_tests/README.md
@@ -9,11 +9,13 @@
 
 </div>
 
-This is a development-only crate for testing the sparse_strip renderers across a corpus of reference
+This is a development-only crate for testing the Sparse Strips renderers across a corpus of reference
 images:
 - CPU
 - WGPU
 - WASM32 WebGL
+
+It is distinct from [`research/vello_research_tests`](../research/vello_research_tests), which tests the compute-centric `vello` renderer.
 
 The `vello_test` proc macro will create a snapshot test for each supported renderer target. See the
 below example usage.
@@ -37,7 +39,7 @@ fn filled_triangle(ctx: &mut impl Renderer) {
 }
 ```
 
-See all the attributes that can be passed to `vello_test` in `vello_dev_macros/test.rs`.
+See all the attributes that can be passed to `vello_test` in [`vello_dev_macros/src/test.rs`](vello_dev_macros/src/test.rs).
 
 ## Testing WebGL on the Browser
 

--- a/vello_tests/README.md
+++ b/vello_tests/README.md
@@ -4,21 +4,19 @@
 
 [![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
 \
-[![Linebender Zulip chat.](https://img.shields.io/badge/Linebender-%23vello-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/197075-vello)
-[![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/linebender/vello/ci.yml?logo=github&label=CI)](https://github.com/linebender/vello/actions)
+[![Linebender Zulip chat.](https://img.shields.io/badge/Linebender-%23vello-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/197075-vello) [![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/linebender/vello/ci.yml?logo=github&label=CI)](https://github.com/linebender/vello/actions)
 
 </div>
 
-This is a development-only crate for testing the Sparse Strips renderers across a corpus of reference
-images:
+This is a development-only crate for testing the Sparse Strips renderers across
+a corpus of reference images:
+
 - CPU
 - WGPU
 - WASM32 WebGL
 
-It is distinct from [`research/vello_research_tests`](../research/vello_research_tests), which tests the compute-centric `vello` renderer.
-
-The `vello_test` proc macro will create a snapshot test for each supported renderer target. See the
-below example usage.
+The `vello_test` proc macro will create a snapshot test for each supported
+renderer target. See the below example usage.
 
 ```rs
 // Draws a filled triangle into a 125x125 scene.
@@ -39,12 +37,14 @@ fn filled_triangle(ctx: &mut impl Renderer) {
 }
 ```
 
-See all the attributes that can be passed to `vello_test` in [`vello_dev_macros/src/test.rs`](vello_dev_macros/src/test.rs).
+See all the attributes that can be passed to `vello_test` in
+[`vello_dev_macros/src/test.rs`](vello_dev_macros/src/test.rs).
 
 ## Testing WebGL on the Browser
 
 Requirements:
- - on MacOS, a minimum Clang major version of 20 is required.
+
+- on MacOS, a minimum Clang major version of 20 is required.
 
 To run the `vello_tests` suite including the WebGL tests:
 
@@ -52,5 +52,6 @@ To run the `vello_tests` suite including the WebGL tests:
 wasm-pack test --headless --chrome --features webgl --release
 ```
 
-To debug the output images in webgl, run the same command without `--headless`. Any tests that fail
-will have their diff image appended to the bottom of the page.
+To debug the output images in webgl, run the same command without `--headless`.
+Any tests that fail will have their diff image appended to the bottom of the
+page.

--- a/vello_tests/vello_example_scenes/README.md
+++ b/vello_tests/vello_example_scenes/README.md
@@ -1,6 +1,6 @@
 # vello_example_scenes
 
-A collection of scenes used for Vello Sparse Strips examples.
+A collection of scenes shared by Vello CPU and Vello GPU examples.
 
 This crate provides various scene implementations including:
 - Basic shapes and paths

--- a/vello_tests/vello_example_scenes/src/lib.rs
+++ b/vello_tests/vello_example_scenes/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-//! Example scenes for Vello Sparse Strips.
+//! Example scenes shared by Vello CPU and Vello GPU.
 
 pub mod blend;
 pub mod blurred_rounded_rect;


### PR DESCRIPTION
#### Summary
- Turn the root README into a renderer-selection guide and repository map.
- Document the Sparse Strips and compute-centric architectures.
- Explain renamed source folders, preserved published crate names, and GPU package migration.
- Add a research overview and update package documentation and links.

Part of #1871.

Created with assistance from GPT-5.6 Sol.