### PR TITLE
vello_gpu: Refactor WebGL root framebuffer selection

### DIFF
--- a/vello_gpu/src/render/webgl/mod.rs
+++ b/vello_gpu/src/render/webgl/mod.rs
@@ -137,7 +137,6 @@ pub struct WebGlRenderer {
     schedule_storage: ScheduleStorage,
     scratch_buffers: ScratchBuffers,
     layers_config: LayersConfig,
-    use_depth_buffer: bool,
 }
 
 /// WebGL renderer initialization that may still be compiling shader programs.
@@ -151,7 +150,6 @@ pub struct WebGlRendererInit {
     gl: WebGl2RenderingContext,
     gradient_cache: GradientRampCache,
     layers_config: LayersConfig,
-    use_depth_buffer: bool,
 }
 
 /// Runtime bindings for [externally owned textures](`TextureId`) sampled by image paints.
@@ -390,11 +388,11 @@ impl WebGlRenderer {
                 &resources.image_cache,
                 layer_config,
                 resource_texture_dimension_2d,
+                use_depth_buffer,
             ),
             gl,
             gradient_cache,
             layers_config: layer_config,
-            use_depth_buffer,
         };
 
         (init, resources)
@@ -535,9 +533,10 @@ impl WebGlRenderer {
             0,
         );
 
-        // Set the view framebuffer override so the scheduler renders to the
-        // atlas layer instead of the default framebuffer.
-        self.programs.resources.view_framebuffer_override = Some(atlas_framebuffer);
+        let previous_view_framebuffer = core::mem::replace(
+            &mut self.programs.resources.view_framebuffer,
+            ViewFramebuffer::offscreen(atlas_framebuffer, false),
+        );
 
         // TODO: Explore using an option instead of a dummy image cache.
         let dummy_image_cache = self
@@ -555,9 +554,14 @@ impl WebGlRenderer {
         );
         self.dummy_image_cache = Some(dummy_image_cache);
 
-        // Restore the default view framebuffer and cache the atlas FBO for reuse.
-        self.programs.resources.atlas_render_framebuffer =
-            self.programs.resources.view_framebuffer_override.take();
+        // Restore the previous view framebuffer and cache the atlas FBO for reuse.
+        let atlas_framebuffer = core::mem::replace(
+            &mut self.programs.resources.view_framebuffer,
+            previous_view_framebuffer,
+        )
+        .into_framebuffer()
+        .unwrap();
+        self.programs.resources.atlas_render_framebuffer = Some(atlas_framebuffer);
 
         result
     }
@@ -588,6 +592,7 @@ impl WebGlRenderer {
         render_target_texture: Option<&WebGlTexture>,
     ) -> Result<(), RenderError> {
         let encoded_paints = &scene.encoded_paints;
+        let use_depth_buffer = self.programs.resources.view_framebuffer.use_depth_buffer();
 
         self.prepare_gpu_encoded_paints(
             encoded_paints,
@@ -616,7 +621,7 @@ impl WebGlRenderer {
             &mut self.schedule_storage,
             scene,
             root_output_target,
-            self.use_depth_buffer,
+            use_depth_buffer,
             paint_resolver,
             required_texture_size,
             current_allocations,
@@ -644,7 +649,7 @@ impl WebGlRenderer {
             gl: &self.gl,
             texture_bindings,
             scratch_buffers: &mut self.scratch_buffers,
-            use_depth_buffer: self.use_depth_buffer,
+            use_depth_buffer,
         };
         if let TargetInit::Clear(clear) = target_init {
             ctx.clear_pass_inner(DrawPassTarget::Root(root_output_target), clear);
@@ -659,7 +664,7 @@ impl WebGlRenderer {
 
         self.gl.bind_framebuffer(
             WebGl2RenderingContext::FRAMEBUFFER,
-            self.programs.resources.view_framebuffer_override.as_deref(),
+            self.programs.resources.view_framebuffer.binding(),
         );
         if self.programs.resources.depth_cleared_this_frame {
             // See: https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices#use_invalidateframebuffer
@@ -668,7 +673,11 @@ impl WebGlRenderer {
             self.gl
                 .invalidate_framebuffer(
                     WebGl2RenderingContext::FRAMEBUFFER,
-                    &self.programs.resources.depth_attachment_array,
+                    if self.programs.resources.view_framebuffer.is_offscreen() {
+                        &self.programs.resources.offscreen_depth_attachment_array
+                    } else {
+                        &self.programs.resources.default_depth_attachment_array
+                    },
                 )
                 .unwrap();
         }
@@ -1047,7 +1056,6 @@ impl WebGlRendererInit {
             schedule_storage: ScheduleStorage::default(),
             scratch_buffers: ScratchBuffers::default(),
             layers_config: self.layers_config,
-            use_depth_buffer: self.use_depth_buffer,
         }
     }
 }
@@ -1135,6 +1143,64 @@ struct StripUniforms {
     external_textures: [WebGlUniformLocation; EXTERNAL_TEXTURE_SLOT_COUNT],
 }
 
+/// The framebuffer used for root-target rendering.
+#[derive(Debug)]
+pub(crate) enum ViewFramebuffer {
+    /// The canvas framebuffer created with the WebGL context.
+    Default {
+        /// Whether the context's depth buffer is enabled and should be used.
+        use_depth_buffer: bool,
+    },
+    /// An offscreen framebuffer object.
+    Offscreen {
+        /// The framebuffer object to bind.
+        framebuffer: Framebuffer,
+        /// Whether the framebuffer has a usable depth attachment.
+        use_depth_buffer: bool,
+    },
+}
+
+impl ViewFramebuffer {
+    pub(crate) const fn default(use_depth_buffer: bool) -> Self {
+        Self::Default { use_depth_buffer }
+    }
+
+    /// If `use_depth_buffer` is true, the framebuffer must have a valid depth attachment!
+    pub(crate) fn offscreen(framebuffer: Framebuffer, use_depth_buffer: bool) -> Self {
+        Self::Offscreen {
+            framebuffer,
+            use_depth_buffer,
+        }
+    }
+
+    fn binding(&self) -> Option<&WebGlFramebuffer> {
+        match self {
+            Self::Default { .. } => None,
+            Self::Offscreen { framebuffer, .. } => Some(framebuffer),
+        }
+    }
+
+    const fn use_depth_buffer(&self) -> bool {
+        match self {
+            Self::Default { use_depth_buffer }
+            | Self::Offscreen {
+                use_depth_buffer, ..
+            } => *use_depth_buffer,
+        }
+    }
+
+    const fn is_offscreen(&self) -> bool {
+        matches!(self, Self::Offscreen { .. })
+    }
+
+    pub(crate) fn into_framebuffer(self) -> Option<Framebuffer> {
+        match self {
+            Self::Default { .. } => None,
+            Self::Offscreen { framebuffer, .. } => Some(framebuffer),
+        }
+    }
+}
+
 /// Contains all WebGL resources needed for rendering.
 #[derive(Debug)]
 pub(crate) struct WebGlResources {
@@ -1165,12 +1231,14 @@ pub(crate) struct WebGlResources {
 
     /// Config buffer for rendering strips into the root target.
     view_config_buffer: Buffer,
-
-    pub(crate) view_framebuffer_override: Option<Framebuffer>,
+    /// The root framebuffer and whether its depth buffer may be used.
+    pub(crate) view_framebuffer: ViewFramebuffer,
     /// Whether the depth buffer has been cleared this frame.
     depth_cleared_this_frame: bool,
-    /// Pre-allocated JS array for `invalidateFramebuffer` calls.
-    depth_attachment_array: js_sys::Array,
+    /// Pre-allocated depth attachment list for the default framebuffer.
+    default_depth_attachment_array: js_sys::Array,
+    /// Pre-allocated depth attachment list for offscreen framebuffers.
+    offscreen_depth_attachment_array: js_sys::Array,
 
     /// Maximum width or height of packed resource textures.
     resource_texture_dimension_2d: u32,
@@ -1345,6 +1413,7 @@ impl PendingWebGlPrograms {
         image_cache: &ImageCache,
         layer_config: LayersConfig,
         resource_texture_dimension_2d: u32,
+        use_depth_buffer: bool,
     ) -> Self {
         let parallel_shader_compile = gl
             .get_extension("KHR_parallel_shader_compile")
@@ -1368,6 +1437,7 @@ impl PendingWebGlPrograms {
             image_cache,
             layer_config,
             resource_texture_dimension_2d,
+            use_depth_buffer,
         );
 
         initialize_strip_vao(&gl, &resources);
@@ -2343,6 +2413,7 @@ fn create_webgl_resources(
     image_cache: &ImageCache,
     layer_config: LayersConfig,
     resource_texture_dimension_2d: u32,
+    use_depth_buffer: bool,
 ) -> WebGlResources {
     let quad_index_buffer = Buffer::new(gl);
     let strip_vao = VertexArray::new(gl);
@@ -2425,12 +2496,12 @@ fn create_webgl_resources(
         placeholder_external_texture,
         gradient_texture_height: 0,
         view_config_buffer,
-        view_framebuffer_override: None,
+        view_framebuffer: ViewFramebuffer::default(use_depth_buffer),
         depth_cleared_this_frame: false,
-        // Note: we use DEPTH (not DEPTH_ATTACHMENT) because we render to the default
-        // framebuffer. If we ever support non-default framebuffers, this must change
-        // to DEPTH_ATTACHMENT.
-        depth_attachment_array: js_sys::Array::of1(&WebGl2RenderingContext::DEPTH.into()),
+        default_depth_attachment_array: js_sys::Array::of1(&WebGl2RenderingContext::DEPTH.into()),
+        offscreen_depth_attachment_array: js_sys::Array::of1(
+            &WebGl2RenderingContext::DEPTH_ATTACHMENT.into(),
+        ),
         resource_texture_dimension_2d,
         texture_size,
         atlas_render_framebuffer: None,
@@ -2667,7 +2738,7 @@ impl WebGlRendererContext<'_> {
             DrawPassTarget::Root(_) => {
                 self.gl.bind_framebuffer(
                     WebGl2RenderingContext::FRAMEBUFFER,
-                    self.programs.resources.view_framebuffer_override.as_deref(),
+                    self.programs.resources.view_framebuffer.binding(),
                 );
                 let width = self.programs.render_size.width;
                 let height = self.programs.render_size.height;
@@ -3066,7 +3137,7 @@ impl WebGlRendererContext<'_> {
             DrawPassTarget::Root(_) => {
                 self.gl.bind_framebuffer(
                     WebGl2RenderingContext::FRAMEBUFFER,
-                    self.programs.resources.view_framebuffer_override.as_deref(),
+                    self.programs.resources.view_framebuffer.binding(),
                 );
                 (
                     self.programs.render_size.width,

--- a/vello_gpu/src/render/webgl/probe.rs
+++ b/vello_gpu/src/render/webgl/probe.rs
@@ -3,8 +3,8 @@
 
 use crate::render::webgl::resource::Framebuffer;
 use crate::render::webgl::{
-    WebGlStateConfig, WebGlStateGuard, WebGlTextureBindings, create_framebuffer_for_texture,
-    create_texture_storage,
+    ViewFramebuffer, WebGlStateConfig, WebGlStateGuard, WebGlTextureBindings,
+    create_framebuffer_for_texture, create_texture_storage,
 };
 use crate::target::RootTarget;
 use crate::{ClearSettings, RenderError, RenderSize, Scene, TargetInit, WebGlRenderer};
@@ -134,11 +134,10 @@ impl WebGlRenderer {
             ),
         );
 
-        let previous_view_framebuffer = self
-            .programs
-            .resources
-            .view_framebuffer_override
-            .replace(probe_framebuffer);
+        let previous_view_framebuffer = core::mem::replace(
+            &mut self.programs.resources.view_framebuffer,
+            ViewFramebuffer::offscreen(probe_framebuffer, false),
+        );
         let render_result = self.render_scene(
             &scene,
             &ImageCache::new_dummy(),
@@ -148,15 +147,14 @@ impl WebGlRenderer {
             &texture_bindings,
             Some(&probe_texture),
         );
-        let probe_framebuffer = self
-            .programs
-            .resources
-            .view_framebuffer_override
-            .take()
-            .expect("probe framebuffer must be restored after rendering");
-        self.programs.resources.view_framebuffer_override = previous_view_framebuffer;
+        let probe_framebuffer = core::mem::replace(
+            &mut self.programs.resources.view_framebuffer,
+            previous_view_framebuffer,
+        )
+        .into_framebuffer()
+        .unwrap();
 
-        // Propagate render failures only after restoring the framebuffer override.
+        // Propagate render failures only after restoring the previous framebuffer.
         render_result?;
 
         let pending = launch_probe(&self.gl, &probe_framebuffer, width, height);


### PR DESCRIPTION
This PR

- Replaces our previous `framebuffer_override` option with a more elaborate `ViewFramebuffer` enum that also stores information about depth buffers.
- Adds support for using depth buffers in a non-default framebuffer, but doesn't actually use it anywhere yet.
