### PR TITLE
vello_gpu: Add optional support for a depth buffer to the WebGL probe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ env:
   LFS_FILES: '["research/vello_research_tests/snapshots/*.png", "vello_tests/snapshots/*.png"]'
 
 
+
 # Rationale
 #
 # We don't run clippy with --all-targets because then even --lib and --bins are compiled with

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ env:
   LFS_FILES: '["research/vello_research_tests/snapshots/*.png", "vello_tests/snapshots/*.png"]'
 
 
-
 # Rationale
 #
 # We don't run clippy with --all-targets because then even --lib and --bins are compiled with

--- a/vello_gpu/src/render/webgl/probe.rs
+++ b/vello_gpu/src/render/webgl/probe.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use crate::render::webgl::resource::Framebuffer;
+use crate::render::webgl::resource::{Framebuffer, Renderbuffer};
 use crate::render::webgl::{
     ViewFramebuffer, WebGlStateConfig, WebGlStateGuard, WebGlTextureBindings,
     create_framebuffer_for_texture, create_texture_storage,
@@ -73,9 +73,6 @@ impl WebGlRenderer {
     }
 
     fn probe_inner(&mut self) -> Result<WebGlPendingProbe, RenderError> {
-        // IMPORTANT NOTE: When making any changes to the probe, make sure to
-        // unignore and rerun the "webgl_probe_succeeds" test locally.
-
         let _state_guard = WebGlStateGuard::with_config(
             &self.gl,
             WebGlStateConfig {
@@ -87,6 +84,9 @@ impl WebGlRenderer {
 
         let (width, height) = vello_common::probe::canvas_size();
         let render_size = RenderSize { width, height };
+        // Check whether the canvas framebuffer was configured by the user to
+        // hold a depth buffer, and apply the same to the probe.
+        let use_depth_buffer = self.programs.resources.view_framebuffer.use_depth_buffer();
 
         let probe_texture = create_texture_storage(
             &self.gl,
@@ -97,6 +97,27 @@ impl WebGlRenderer {
             WebGl2RenderingContext::NEAREST,
         );
         let probe_framebuffer = create_framebuffer_for_texture(&self.gl, &probe_texture);
+        // We need to keep the renderbuffer around until we finished rendering!
+        let _probe_depth = if use_depth_buffer {
+            let probe_depth = Renderbuffer::new(&self.gl);
+            self.gl
+                .bind_renderbuffer(WebGl2RenderingContext::RENDERBUFFER, Some(&probe_depth));
+            self.gl.renderbuffer_storage(
+                WebGl2RenderingContext::RENDERBUFFER,
+                WebGl2RenderingContext::DEPTH_COMPONENT24,
+                i32::from(width),
+                i32::from(height),
+            );
+            self.gl.framebuffer_renderbuffer(
+                WebGl2RenderingContext::FRAMEBUFFER,
+                WebGl2RenderingContext::DEPTH_ATTACHMENT,
+                WebGl2RenderingContext::RENDERBUFFER,
+                Some(&probe_depth),
+            );
+            Some(probe_depth)
+        } else {
+            None
+        };
 
         let probe_image = vello_common::probe::probe_image_pixmap();
         let probe_image_texture = create_texture_storage(
@@ -137,14 +158,14 @@ impl WebGlRenderer {
 
         let previous_view_framebuffer = core::mem::replace(
             &mut self.programs.resources.view_framebuffer,
-            ViewFramebuffer::offscreen(probe_framebuffer, false),
+            ViewFramebuffer::offscreen(probe_framebuffer, use_depth_buffer),
         );
         let render_result = self.render_scene(
             &scene,
             &ImageCache::new_dummy(),
             &render_size,
             TargetInit::Clear(ClearSettings::Viewport { color: css::WHITE }),
-            RootTarget::AtlasLayer,
+            RootTarget::UserSurface,
             &texture_bindings,
             Some(&probe_texture),
         );
@@ -216,6 +237,16 @@ impl WebGlPendingProbe {
             &readback,
         );
         readback.copy_to(pixmap.data_as_u8_slice_mut());
+
+        // Need to flip the resulting image upside down.
+        let row_len = usize::from(self.width) * 4;
+        let height = usize::from(self.height);
+        let pixels = pixmap.data_as_u8_slice_mut();
+        for row in 0..height / 2 {
+            let opposite_row = height - 1 - row;
+            let (top, bottom) = pixels.split_at_mut(opposite_row * row_len);
+            top[row * row_len..(row + 1) * row_len].swap_with_slice(&mut bottom[..row_len]);
+        }
 
         Probe::from_actual(pixmap)
     }

--- a/vello_gpu/src/render/webgl/resource.rs
+++ b/vello_gpu/src/render/webgl/resource.rs
@@ -7,6 +7,8 @@ use super::{
     WebGl2RenderingContext, WebGlBuffer, WebGlFramebuffer, WebGlProgram, WebGlShader, WebGlTexture,
     WebGlVertexArrayObject,
 };
+#[cfg(feature = "probe")]
+use web_sys::WebGlRenderbuffer;
 
 pub(crate) trait GlResource {
     const LABEL: &'static str;
@@ -110,6 +112,19 @@ impl GlResource for WebGlFramebuffer {
     }
 }
 
+#[cfg(feature = "probe")]
+impl GlResource for WebGlRenderbuffer {
+    const LABEL: &'static str = "renderbuffer";
+
+    fn create(gl: &WebGl2RenderingContext) -> Option<Self> {
+        gl.create_renderbuffer()
+    }
+
+    fn delete(gl: &WebGl2RenderingContext, raw: &Self) {
+        gl.delete_renderbuffer(Some(raw));
+    }
+}
+
 impl GlResource for WebGlProgram {
     const LABEL: &'static str = "program";
 
@@ -163,6 +178,8 @@ impl GlResource for WebGlVertexArrayObject {
 pub(crate) type Texture = Resource<WebGlTexture>;
 pub(crate) type Buffer = Resource<WebGlBuffer>;
 pub(crate) type Framebuffer = Resource<WebGlFramebuffer>;
+#[cfg(feature = "probe")]
+pub(crate) type Renderbuffer = Resource<WebGlRenderbuffer>;
 pub(crate) type Program = Resource<WebGlProgram>;
 pub(crate) type VertexShader = Resource<WebGlVertexShader>;
 pub(crate) type FragmentShader = Resource<WebGlFragmentShader>;

--- a/vello_tests/tests/wasm_binary_invariants.rs
+++ b/vello_tests/tests/wasm_binary_invariants.rs
@@ -42,7 +42,18 @@ async fn no_simd_instruction_inclusion() {
 
 #[cfg(feature = "webgl")]
 #[wasm_bindgen_test]
-async fn webgl_probe_succeeds() {
+async fn webgl_probe_succeeds_with_depth_buffer() {
+    run_webgl_probe(true).await;
+}
+
+#[cfg(feature = "webgl")]
+#[wasm_bindgen_test]
+async fn webgl_probe_succeeds_without_depth_buffer() {
+    run_webgl_probe(false).await;
+}
+
+#[cfg(feature = "webgl")]
+async fn run_webgl_probe(use_depth_buffer: bool) {
     use vello_gpu::WebGlProbeStatus;
     use wasm_bindgen::JsCast;
     use wasm_bindgen_futures::JsFuture;
@@ -67,7 +78,11 @@ async fn webgl_probe_succeeds() {
     canvas.set_width(200);
     canvas.set_height(200);
 
-    let (mut renderer, _) = vello_gpu::WebGlRenderer::new(&canvas);
+    let (mut renderer, _) = vello_gpu::WebGlRenderer::new_with(
+        &canvas,
+        vello_gpu::RenderSettings::default(),
+        use_depth_buffer,
+    );
     let mut pending = renderer
         .probe()
         .unwrap_or_else(|error| panic!("WebGlRenderer::probe() failed to render: {error:?}"));


### PR DESCRIPTION
This PR enables the depth buffer in the Vello Hybrid probe, depending on whether the user enabled the depth buffer originally.

I've decided to not add the new render buffer to the WebGL state guard since we are trying to move away from this, anyway. Let me know if I should change this.
