### PR TITLE
fix: links to wasm-pack

### DIFF
--- a/vello_gpu/examples/native_webgl/README.md
+++ b/vello_gpu/examples/native_webgl/README.md
@@ -11,7 +11,7 @@ If you don't want to enable SIMD, you can remove the `RUSTFLAGS="-Ctarget-featur
 ## Testing
 
 In order to test this crate, you need to have [`wasm-pack`] installed. Install it using
-the steps found in https://rustwasm.github.io/wasm-pack/installer/.
+the steps found in https://wasm-bindgen.github.io/wasm-pack/installer/.
 
 Thereafter, for interactive test sessions, run:
 
@@ -20,4 +20,4 @@ wasm-pack test --chrome
 # Navigate to printed URL
 ```
 
-[`wasm-pack`]: https://rustwasm.github.io/wasm-pack/
+[`wasm-pack`]: https://wasm-bindgen.github.io/wasm-pack/

--- a/vello_gpu/examples/wgpu_webgl/README.md
+++ b/vello_gpu/examples/wgpu_webgl/README.md
@@ -9,7 +9,7 @@ Run with `cargo run_wasm -p wgpu_webgl --release`.
 ## Testing
 
 In order to test this crate, you need to have [`wasm-pack`] installed. Install it using
-the steps found in https://rustwasm.github.io/wasm-pack/installer/.
+the steps found in https://wasm-bindgen.github.io/wasm-pack/installer/.
 
 Thereafter, for interactive test sessions, run:
 
@@ -18,4 +18,4 @@ wasm-pack test --chrome
 # Navigate to printed URL
 ```
 
-[`wasm-pack`]: https://rustwasm.github.io/wasm-pack/
+[`wasm-pack`]: https://wasm-bindgen.github.io/wasm-pack/


### PR DESCRIPTION
wasm-pack has transferred ownership from rustwasm to wasm-bindgen. The old links were not working anymore and returned 404 - not found. Fixed by updating links.